### PR TITLE
vdk/cicd: initial integration with Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,18 @@
+
+
+image: "python:3.7"
+
+variables:
+  TAURUS_PIP_URI: https://build-artifactory.eng.vmware.com/api/pypi/Taurus-PyPI-local/simple
+
+stages:
+  - build
+  - pre_release
+  - release
+
+
+
+.build:
+  stage: build
+  script:
+    - ./cicd/build.sh

--- a/cicd/build.sh
+++ b/cicd/build.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 # Copyright (c) 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+
+echo "Starting build on $(uname -a)"


### PR DESCRIPTION
We are using Gitlab CI for CICD of the project to make its transition
from gitlab to github smoother.
And this is adding this integration with very simple build.sh script