### PR TITLE
vdk/cicd: initial integration with Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,14 @@
+
+
+image: "python:3.7"
+
+stages:
+  - build
+
+
+build:
+  stage: build
+  script:
+    - ./cicd/build.sh
+  only:
+    - external_pull_requests

--- a/cicd/build.sh
+++ b/cicd/build.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 # Copyright (c) 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+
+echo "Starting build on $(uname -a)"


### PR DESCRIPTION
We are using Gitlab CI for CICD of the project to make its transition
from gitlab to github smoother. Also Gitlab CI has some feature that may
not be easy to swap if we decide to change to Github Actions.
Down the road we should do analysis and if we want to continue sticking
with Gitlab CI but for now this is the best solution .

And this is adding this integration with very simple build.sh script.

The CICD can be seen at
https://gitlab.com/vmware-analytics/versatile-data-kit/-/pipelines
Currently the project is private, and require to create account and to
be added to VMware Analytics organization.
The integration with github
(https://docs.gitlab.com/ee/ci/ci_cd_for_external_repos/github_integration.html)
requires Premium Edition of Gitlab.
For now we are using a trial

We plan to apply for Open Source program
https://about.gitlab.com/solutions/open-source/

Testing Done: opened a pull request and saw the CICD pipeline started
(#4)

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>
