### PR TITLE
vdk/cicd: add gitlab runners installer

### DIFF
--- a/support/gitlab-runners/README.md
+++ b/support/gitlab-runners/README.md
@@ -1,0 +1,34 @@
+# gitlab-runners
+
+Repository with the configuration necessary to deploy the GitLab runners used by the CI/CD across the Versatile Data Kit project.
+Gitlab is in https://gitlab.com/vmware-analytics/versatile-data-kit
+
+## Prerequisites
+
+Access to `cicd` namespace in the AWS https://us-west-1.console.aws.amazon.com/eks/home?region=us-west-1#/clusters/vdk-cicd. 
+To get the KUBECONFIG, it's currently stored either in LastPass or Gitlab CI Variable
+
+To authenticate to AWS you need: 
+export AWS_DEFAULT_REGION=us-west-1
+export AWS_SECRET_ACCESS_KEY=<get-from-gitlab-ci-variables>
+export AWS_ACCESS_KEY_ID=<get-from-gitlab-ci-variables>
+
+export RUNNER_REGISTRATION_TOKEN= # Get the Gitlab token from 
+
+The only prerequisite in order to run the scripts and deploy the runners is installed [helm 3](https://helm.sh/docs/).
+
+## Install runners
+
+The shell script `install-runners.sh` installs the runner on the kubernetes cluster:
+
+```
+bash install-runners.sh
+```
+
+## Purge runners
+
+The shell script `purge-runners` will delete the helm release from the kubernetes cluster:
+
+```
+bash purge-runners.sh
+```

--- a/support/gitlab-runners/install-runners.sh
+++ b/support/gitlab-runners/install-runners.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+NAMESPACE="cicd"
+
+if [ -z "$VALUES" ]; then
+  VALUES=$(pwd)/values.yaml
+fi
+echo "Using $VALUES gitlab configuration file "
+
+RUNNER_NAME=${RUNNER_NAME:-vdk-gitlab-runner}
+echo "Using $RUNNER_NAME as runner name "
+
+if [ -z "$KUBECONFIG" ]; then
+  KUBECONFIG=$(pwd)/kubeconfig.yaml
+fi
+
+if [ ! -e $KUBECONFIG ]; then
+  echo "KUBECONFIG file is required. Provide path to existing one as env variable KUBECONFIG"
+  echo "$KUBECONFIG does not exists."
+  exit 1
+fi
+echo "Using $KUBECONFIG as KUBECONFIG "
+
+if [ -z "$RUNNER_REGISTRATION_TOKEN" ]; then
+  echo "RUNNER_REGISTRATION_TOKEN variable is required. PLease set token of your runners"
+  echo "It can be taken from CICD page in gitlab. e.g "
+  echo "https://gitlab.com/vmware-analytics/versatile-data-kit/-/settings/ci_cd"
+  exit 1
+fi
+#echo "Using $RUNNER_REGISTRATION_TOKEN as RUNNER_REGISTRATION_TOKEN "
+
+if ! which helm; then
+    echo "helm 3 must be installed"
+    exit 1
+fi
+
+if ! helm version | grep -q 'Version:"v3'; then
+    echo "helm 3 is required"
+    exit 1
+fi
+
+helm repo add gitlab https://charts.gitlab.io
+
+# Before updating version, review changelog at https://docs.gitlab.com/runner/install/kubernetes.html .
+helm upgrade --install \
+  --set runnerRegistrationToken=$RUNNER_REGISTRATION_TOKEN \
+  --kubeconfig $KUBECONFIG --namespace $NAMESPACE --version "0.22.0" $RUNNER_NAME -f $VALUES gitlab/gitlab-runner
+
+

--- a/support/gitlab-runners/kubeconfig.yaml
+++ b/support/gitlab-runners/kubeconfig.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeE1EY3lNREl4TkRRME5Gb1hEVE14TURjeE9ESXhORFEwTkZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTDUxCkdwVW9DKzlnQlNPWENxR3UzOGxKRnh4Qzc2dEdsNEQra3BLWFlqdlNDSVI3alF4ckc3cGh4OGxpQ3NodEdPS3EKTkJraEg3dENpUTdmNm1yQUE4WWhZbkZ1eWRTNDdkUXlXMzlvNWxFZXc1SmQzdm9NTGhRRFZXZGFTSU12TmZpTwpXVVpPOHBhOEtFSkNkeWp6WVcvWmxxK0xscWlZSlRONGI4MEdQcURjUGdLMW5ZVlVHdzdkNUEwN1J4bU9DTCtjCmNwbmJTNm1VOC9UQzBhUUFKK0Rlc094dTM5KzZ0WHR4TFlNM3lsY3NyZjNiMlZwVk9paGZ1SHYvMjNBWTdDamIKTWlPK1FXUTlHWXorWXpvQThwK2xJWFpEUEYyYWlMNThRYUxhSDBmdXhpRk9DZUl6OEQ0VUZSbHRVNk9tZkZwaAp6bmdnMHkxWWFrV0o1eHZhczdjQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZFQm8rQy9pMGhwWGQranExQ2tNSllRL25CQzhNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFCY0JlcFhsa3hMWDFVSjh2R3hPY0tpT2JNZkdsQ0xqTDczZnZsYzRsZkNuWHd1NXVObgpYc3FGWUFMSTdKeFNQTTZTK0ZMMDZTcm16WVNwS3k4NkpLZTRmVVVvcjh1ckpNZ0tqK1d3aE5XdmloWWpUUWZvCjJuQS9vZHJwK0JWcitycVJCREhYN2R3aEhoTmRsZ3orZTJqRlNHdTUvbnZ5NDgrc0VqTUVhamRoWXJhaVozZmUKSTBlNnlNeW81NXc0U0RTTzNMT1UwZFFBOExsbm9PWHVjSUNsaklxY21jbDhtRytVYmVCdDRiemFwemhSWUtxWQp2cytxbkpyK2hNQVkyek1HL3hTWHorUURqMERuc1JhaE44bE9XdmprL3ZEakw1akRhRkk4ZUV0RDlZU1AvOFQ3CmNDYm5XUGhuQ3NVSHQ4VGRjUkRKaVBXUzYyU084b0VXd1VMOAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+    server: https://7BFDC95B78B10DA0CFDD84513A9424B2.yl4.us-west-1.eks.amazonaws.com
+  name: vdk-cicd.us-west-1.eksctl.io
+contexts:
+- context:
+    cluster: vdk-cicd.us-west-1.eksctl.io
+    namespace: cicd
+    user: vdk-cicd@vdk-cicd.us-west-1.eksctl.io
+  name: vdk-cicd@vdk-cicd.us-west-1.eksctl.io
+current-context: vdk-cicd@vdk-cicd.us-west-1.eksctl.io
+kind: Config
+preferences: {}
+users:
+- name: vdk-cicd@vdk-cicd.us-west-1.eksctl.io
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1alpha1
+      args:
+      - token
+      - -i
+      - vdk-cicd
+      command: aws-iam-authenticator
+      env:
+      - name: AWS_STS_REGIONAL_ENDPOINTS
+        value: regional
+      - name: AWS_DEFAULT_REGION
+        value: us-west-1
+      provideClusterInfo: false

--- a/support/gitlab-runners/purge-runners.sh
+++ b/support/gitlab-runners/purge-runners.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+RUNNER_NAME="vdk-gitlab-runner"
+
+NAMESPACE="cicd"
+
+KUBECONFIG=$(pwd)/kubeconfig.yaml
+
+if ! which helm; then
+    echo "helm 3 must be installed"
+    exit 1
+fi
+
+if ! helm version | grep -q 'Version:"v3'; then
+    echo "helm 3 is required"
+    exit 1
+fi
+
+helm delete --kubeconfig $KUBECONFIG --namespace $NAMESPACE $RUNNER_NAME

--- a/support/gitlab-runners/values.yaml
+++ b/support/gitlab-runners/values.yaml
@@ -1,0 +1,99 @@
+## The GitLab Server URL (with protocol) that want to register the runner against
+## ref: https://docs.gitlab.com/runner/commands/README.html#gitlab-runner-register
+##
+gitlabUrl: https://gitlab.com/
+
+## The registration token for adding new Runners to the GitLab server. This must
+## be retrieved from your GitLab instance.
+## ref: https://docs.gitlab.com/ee/ci/runners/
+##
+runnerRegistrationToken: ""
+
+## Set the certsSecretName in order to pass custom certificates for GitLab Runner to use
+## Provide resource name for a Kubernetes Secret Object in the same namespace,
+## this is used to populate the /etc/gitlab-runner/certs directory
+## ref: https://docs.gitlab.com/runner/configuration/tls-self-signed.html#supported-options-for-self-signed-certificates
+##
+#certsSecretName:
+
+## Configure the maximum number of concurrent jobs
+## ref: https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-global-section
+##
+# At the time of writing, we have 50 CPU core and 100 GiB RAM quota.
+#
+concurrent: 5
+
+## Defines in seconds how often to check GitLab for a new builds
+## ref: https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-global-section
+##
+checkInterval: 30
+
+## For RBAC support:
+rbac:
+  create: false
+
+  ## Run the gitlab-bastion container with the ability to deploy/manage containers of jobs
+  ## cluster-wide or only within namespace
+  clusterWideAccess: false
+
+  ## If RBAC is disabled in this Helm chart, use the following Kubernetes Service Account name.
+  ##
+  serviceAccountName: default
+
+## Configuration for the Pods that the runner launches for each new job
+##
+runners:
+  ## Default container image to use for builds when none is specified
+  ##
+  ## Noone should be using the default though.
+  image: "ubuntu:21.04"
+
+  ## Run all containers with the privileged flag enabled
+  ## This will allow the docker:stable-dind image to run if you need to run Docker
+  ## commands. Please read the docs before turning this on:
+  ## ref: https://docs.gitlab.com/runner/executors/kubernetes.html#using-docker-dind
+  ##
+  privileged: true
+
+  ## Set maximum build log size in kilobytes, by default set to 4096 (4MB)
+  ## ref: https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-runners-section
+  outputLimit: 51200
+
+  ## Namespace to run Kubernetes jobs in (defaults to 'default')
+  ## namespace: gitlab-managed-apps
+
+  ## Build Container specific configuration
+  ##
+  ## TODO: Have runners for big and small jobs.
+  builds:
+    cpuLimit: 5000m
+    memoryLimit: 4Gi
+    cpuRequests: 5000m
+    memoryRequests: 4Gi
+
+  ## Service Container specific configuration
+  ##
+  ## Services in our case is docker:dind. Uses a lot since some jobs run several containers in it.
+  services:
+    cpuLimit: 3000m
+    memoryLimit: 3Gi
+    cpuRequests: 3000m
+    memoryRequests: 3Gi
+
+  ## Helper Container specific configuration
+  ##
+  ## Helper is the container that runs git clone. Very small.
+  helpers:
+    cpuLimit: 200m
+    memoryLimit: 256Mi
+    cpuRequests: 100m
+    memoryRequests: 128Mi
+
+# Resources for the runner itself. It is very lean.
+resources:
+  limits:
+    memory: 256Mi
+    cpu: 200m
+  requests:
+    memory: 128Mi
+    cpu: 100m


### PR DESCRIPTION
As the private gitlab project have only 400 minutes per month. And
analysis showed that we need about 10,000 minutes per month we can see
that we will quickly run out of those. Hence I created gitlab runners

They can be seen at
https://gitlab.com/vmware-analytics/versatile-data-kit/-/settings/ci_cd

Testing Done: ran the script and create runners. Hopefully this pull
request cicd will verify jobs are scheduled on them