### PR TITLE
versatile-data-kit: Setup pre-commit hook

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,5 @@
-
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
 
 image: "python:3.7"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,87 @@
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.0
+    hooks:
+    -   id: check-yaml
+        args: ['--unsafe']
+    -   id: check-json
+    -   id: check-ast
+    -   id: check-added-large-files
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+    -   id: check-executables-have-shebangs
+-   repo: https://github.com/psf/black
+    rev: 21.5b1
+    hooks:
+    -   id: black
+        language_version: python3.7
+# ensure pydoc is up-to standard
+-   repo: https://github.com/pycqa/pydocstyle
+    rev: 6.0.0
+    hooks:
+        -   id: pydocstyle
+            args: # http://www.pydocstyle.org/en/stable/error_codes.html --convention=pep257 seems too much?
+                - --select=D101,D103,D300
+                - --match='(?!test_).*\.py'
+-   repo: https://github.com/pre-commit/mirrors-pylint
+    rev: 'v3.0.0a3'
+    hooks:
+        -   id: pylint
+            args: [--exit-zero]
+#-   repo: https://github.com/pre-commit/mirrors-mypy
+#    rev: v0.812
+#    hooks:
+#        -   id: mypy
+#            files: ^(src/|tests/|plugins/)
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v2.5.0
+    hooks:
+        -   id: reorder-python-imports
+            args: [--py37-plus, '--application-directories=.:src']
+# use latest python syntax
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.19.1
+    hooks:
+        -   id: pyupgrade
+            args: [--py37-plus]
+# security check
+- repo: https://github.com/PyCQA/bandit
+  rev: '1.7.0'
+  hooks:
+      - id: bandit
+        exclude: tests
+        args: [ -s, B101 ]
+# add copyright notice
+- repo: https://github.com/Lucas-C/pre-commit-hooks
+  rev: v1.1.10
+  hooks:
+    - id: insert-license
+      files: \.java$
+      args:
+        - --license-filepath
+        - NOTICE.txt
+        - --comment-style
+        - /*| *| */
+    - id: insert-license
+      files: \.py$
+      args:
+        - --license-filepath
+        - NOTICE.txt
+    - id: insert-license
+      files: \.sh$
+      args:
+        - --license-filepath
+        - NOTICE.txt
+    - id: insert-license
+      files: \.yml$
+      args:
+        - --license-filepath
+        - NOTICE.txt
+    - id: insert-license
+      files: \.yaml$
+      args:
+          - --license-filepath
+          - NOTICE.txt

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,2 @@
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: Apache-2.0

--- a/cicd/build.sh
+++ b/cicd/build.sh
@@ -3,3 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 echo "Starting build on $(uname -a)"
+
+echo "Setup git hook scripts with pre-commit install"
+pip install pre-commit
+pre-commit install


### PR DESCRIPTION
This change migrates the pre-commit hook to this repo,
and additionally includes a insert-license hook.

We use pre-commit hooks for a variety of purposes,
including enforcing code style, linting, and now
inserting a copyright notice at the start of files.