### PR TITLE
vdk-control-cli: address security vulnerability

### DIFF
--- a/projects/vdk-control-cli/requirements.txt
+++ b/projects/vdk-control-cli/requirements.txt
@@ -13,8 +13,8 @@ requests_oauthlib
 # Dependencies for creating HTTP calls against the OAuth2 provider. We can potentially remove those
 # and use requests_oauthlib only, but for now it seems like there are some custom logic with the first
 # OAuth2 provider which needs to be handled that way
-urllib3~=1.25.9
-requests~=2.23.0
+urllib3>=1.26.5
+requests>=2.0
 
 # TESTING dependencies:
 

--- a/projects/vdk-control-cli/setup.cfg
+++ b/projects/vdk-control-cli/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
     taurus-datajob-api==3.1.3
     tabulate
     requests_oauthlib>=1.0
-    urllib3>=1.0
+    urllib3>=1.26.5
 
 # Require a specific Python version
 python_requires = >=3.7, <3.10


### PR DESCRIPTION
Dependabot (in github) found a security vulnerability in using old version
of urlib3 -
https://github.com/vmware/versatile-data-kit/security/dependabot/projects/vdk-control-cli/requirements.txt/urllib3/open

I am bumping the version.

Testing Done: ran end-to-end test (vdk-heartbeat -f local.ini) locally
to verify it is not broken (as it is not yet enabled in GithubCI)