### PR TITLE
vdk-control-cli: fix typo in readme

### DIFF
--- a/projects/vdk-control-cli/README.md
+++ b/projects/vdk-control-cli/README.md
@@ -1,8 +1,8 @@
-# VDL Control CLI
-
-To build or contribute, see [CONTRIBUTING.md](./CONTRIBUTING.md).
+# Versatile Data Kit Control CLI
 
 VDK Control CLI is meant for Data Engineers to use to manage the lifecycle of jobs - create, delete, deploy, configure Data Jobs.
+
+To build or contribute, see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## Installation
 Install VDK Control CLI with:


### PR DESCRIPTION
It is VDK not VDL. I opted to use the fuller name as a title as well.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>