### PR TITLE
vdk plugins: add descriptions to setup.py

### DIFF
--- a/projects/vdk-core/plugins/plugin-template/setup.py
+++ b/projects/vdk-core/plugins/plugin-template/setup.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import pathlib
+
 import setuptools
 
 """
@@ -17,6 +19,8 @@ __version__ = "0.1.0"
 setuptools.setup(
     name="plugin-package-template",
     version=__version__,
+    description="Plugin template project used to quick start development of a new Versatile Data Kit SDK plugin.",
+    long_description=pathlib.Path("README.md").read_text(),
     install_requires=["vdk-core"],
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),

--- a/projects/vdk-core/plugins/vdk-ingest-file/setup.py
+++ b/projects/vdk-core/plugins/vdk-ingest-file/setup.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import pathlib
+
 import setuptools
 
 __version__ = "0.1.0"
@@ -7,6 +9,8 @@ __version__ = "0.1.0"
 setuptools.setup(
     name="vdk-ingest-file",
     version=__version__,
+    description="Versatile Data Kit SDK ingestion plugin to ingest data into a file.",
+    long_description=pathlib.Path("README.md").read_text(),
     install_requires=["vdk-core"],
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),

--- a/projects/vdk-core/plugins/vdk-ingest-http/setup.py
+++ b/projects/vdk-core/plugins/vdk-ingest-http/setup.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import pathlib
+
 import setuptools
 
 __version__ = "0.1.0"
@@ -7,6 +9,8 @@ __version__ = "0.1.0"
 setuptools.setup(
     name="vdk-ingest-http",
     version=__version__,
+    description="Versatile Data Kit SDK ingestion plugin to ingest data via http requests.",
+    long_description=pathlib.Path("README.md").read_text(),
     install_requires=["vdk-core"],
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),

--- a/projects/vdk-core/plugins/vdk-logging-ltsv/setup.py
+++ b/projects/vdk-core/plugins/vdk-logging-ltsv/setup.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import pathlib
+
 import setuptools
 
 __version__ = "0.1.0"
@@ -7,6 +9,8 @@ __version__ = "0.1.0"
 setuptools.setup(
     name="vdk-logging-ltsv",
     version=__version__,
+    description="Versatile Data Kit SDK plugin that changes logging output to LTSV format.",
+    long_description=pathlib.Path("README.md").read_text(),
     install_requires=["vdk-core"],
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),

--- a/projects/vdk-core/plugins/vdk-plugin-control-cli/setup.py
+++ b/projects/vdk-core/plugins/vdk-plugin-control-cli/setup.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import pathlib
+
 import setuptools
 
 """
@@ -10,6 +12,8 @@ __version__ = "0.1.2"
 setuptools.setup(
     name="vdk-plugin-control-cli",
     version=__version__,
+    description="Versatile Data Kit SDK plugin exposing CLI commands for managing the lifecycle of a Data Jobs.",
+    long_description=pathlib.Path("README.md").read_text(),
     install_requires=["vdk-core", "vdk-control-cli", "requests"],
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),

--- a/projects/vdk-core/plugins/vdk-test-utils/setup.py
+++ b/projects/vdk-core/plugins/vdk-test-utils/setup.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import pathlib
+
 import setuptools
 
 
@@ -9,6 +11,8 @@ __version__ = "0.1.2"
 setuptools.setup(
     name="vdk-test-utils",
     version=__version__,
+    description="Provides utilities for testing Versatile Data Kit SDK plugins.",
+    long_description=pathlib.Path("README.md").read_text(),
     install_requires=["vdk-core"],
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),

--- a/projects/vdk-core/plugins/vdk-trino/setup.py
+++ b/projects/vdk-core/plugins/vdk-trino/setup.py
@@ -1,15 +1,16 @@
 # Copyright (c) 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import pathlib
+
 import setuptools
 
-"""
-Builds a package with the help of setuptools in order for this package to be imported in other projects
-"""
 __version__ = "0.1.3"
 
 setuptools.setup(
     name="vdk-trino",
     version=__version__,
+    description="Versatile Data Kit SDK plugin provides support for trino database and trino transformation templates.",
+    long_description=pathlib.Path("README.md").read_text(),
     install_requires=["vdk-core", "trino"],
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),


### PR DESCRIPTION
Description and long description options of setup.py are missing. 
Those are shown in the PyPY UI as Project Description - 
similarly to how it is for https://test.pypi.org/project/vdk-control-cli

But our plugins do not set any description field so it looks like this
: https://test.pypi.org/project/vdk-trino/0.1.347213486/ (empty).

This is not very friendly nor useful to end-users.

Added to setup.py of all plugins to set long description their README.md
file. This is pretty standard practice for this

Testing Done: For all of the plugins installed them locally using pip install -e .
 and verified long description is set using 
python setup.py --long-description and python setup.py --description
Also uploaded one of the plugins manually to test.pipy.org: E.g:
https://test.pypi.org/project/vdk-test-utils/0.1.dev1

Signed-off-by: Antoni Ivanov aivanov@vmware.com