### PR TITLE
quickstart-vdk: add a new plugin

### DIFF
--- a/projects/vdk-core/plugins/quickstart-vdk/.plugin-ci.yml
+++ b/projects/vdk-core/plugins/quickstart-vdk/.plugin-ci.yml
@@ -1,0 +1,41 @@
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+image: "python:3.7"
+
+variables:
+  DOCKER_HOST: tcp://localhost:2375
+  DOCKER_DRIVER: overlay2
+  DOCKER_TLS_CERTDIR: ""
+
+stages:
+  - build
+  - release
+
+.build-quickstart-vdk:
+  variables:
+    PLUGIN_NAME: quickstart-vdk
+  extends: .build-plugin
+
+build-py37-quickstart-vdk:
+  extends: .build-quickstart-vdk
+  image: "python:3.7"
+
+build-py38-quickstart-vdk:
+  extends: .build-quickstart-vdk
+  image: "python:3.8"
+
+build-py39-quickstart-vdk:
+  extends: .build-quickstart-vdk
+  image: "python:3.9"
+
+
+release-quickstart-vdk:
+  variables:
+    PLUGIN_NAME: quickstart-vdk
+  extends: .release-plugin
+
+release_vdk_image:
+  variables:
+    PLUGIN_NAME: quickstart-vdk
+  extends: .release-vdk-image

--- a/projects/vdk-core/plugins/quickstart-vdk/README.md
+++ b/projects/vdk-core/plugins/quickstart-vdk/README.md
@@ -1,0 +1,9 @@
+This is the first VDK packaging that users would install to play around with it.
+
+It packages:
+
+* Plugin for a local database to get started quickly
+* Plugin for Big Data database (Presto) to start feeling the full cycle
+* Plugin for job management (vdk-control-cli)
+
+See also [Versatile Data Kit Getting Started](https://github.com/vmware/versatile-data-kit/wiki/Getting-Started).

--- a/projects/vdk-core/plugins/quickstart-vdk/requirements.txt
+++ b/projects/vdk-core/plugins/quickstart-vdk/requirements.txt
@@ -1,0 +1,2 @@
+click
+vdk-test-utils

--- a/projects/vdk-core/plugins/quickstart-vdk/setup.py
+++ b/projects/vdk-core/plugins/quickstart-vdk/setup.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import pathlib
+
+import setuptools
+
+__version__ = "0.1.2"
+
+setuptools.setup(
+    name="quickstart-vdk",
+    description="Versatile Data Kit SDK packaging containing common plugins to get started quickly using it.",
+    long_description=pathlib.Path("README.md").read_text(),
+    version=__version__,
+    install_requires=[
+        "vdk-core",
+        "vdk-plugin-control-cli",
+        "vdk-trino",
+        "vdk-ingest-http",
+        "vdk-ingest-file",
+    ],
+)

--- a/projects/vdk-core/plugins/quickstart-vdk/tests/test_dummy.py
+++ b/projects/vdk-core/plugins/quickstart-vdk/tests/test_dummy.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+
+def test_dummy():
+    assert True


### PR DESCRIPTION
We need a packaging of vdk with all necessary plugins for end users to
be able to get started using the SDK quickly. It currently contains all
the basic plugins we have implemented so far.
It's already mentioned in
https://github.com/vmware/versatile-data-kit/wiki/Getting-Started

Testing Done: pip install -e . and pytest

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>
