### PR TITLE
vdk-plugin-control-cli: change long_description_content_type to markdown

### DIFF
--- a/projects/vdk-core/plugins/vdk-plugin-control-cli/setup.py
+++ b/projects/vdk-core/plugins/vdk-plugin-control-cli/setup.py
@@ -7,13 +7,14 @@ import setuptools
 """
 Builds a package with the help of setuptools in order for this package to be imported in other projects
 """
-__version__ = "0.1.2"
+__version__ = "0.1.dev2"
 
 setuptools.setup(
     name="vdk-plugin-control-cli",
     version=__version__,
     description="Versatile Data Kit SDK plugin exposing CLI commands for managing the lifecycle of a Data Jobs.",
     long_description=pathlib.Path("README.md").read_text(),
+    long_description_content_type="text/markdown",
     install_requires=["vdk-core", "vdk-control-cli", "requests"],
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),


### PR DESCRIPTION
Upon upload to pipy.org it expects that README.md is correctly formatted
restructuredtext format. And we were not
-https://gitlab.com/vmware-analytics/versatile-data-kit/-/jobs/1477157238

But this can be overriden. And we override it.

Alternative approach I considered was adding a hook to validate synxtax
of markdown files to be correct restructuredtext format:

I tried using https://github.com/Lucas-C/pre-commit-hooks-markup but it
didn't work it validated the file ok but twine upload still failed.
I guess they are not pypi compatible as they say or I did something
wrong.

I tried also https://github.com/myint/rstcheck but this was even worse
it was a lot of more spammy but did not catch the issue pypi linters
catches.

Testing Done: twine upload of it successfully.