### PR TITLE
vdk-core: dependencies license report

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,3 @@ We are using CI as a code based on Gitlab CI.
 Entrypoint of CICD is the file .gitlab-ci.yml.
 
 There you can find the full definition of the CI/CD pipeline.
-
-# Licenses
-
-See [README.md](./README.md#Licenses) for generating dependencies license report.

--- a/README.md
+++ b/README.md
@@ -48,15 +48,6 @@ Official documentation for Versatile Data Kit can be found [here](https://github
 
 If you are interested in contributing as a developer, visit [CONTRIBUTING.md](CONTRIBUTING.md).
 
-# Licenses
-
-To generate licenses report for dependencies:
-```
-pip-licenses
-```
-
-Generate HTML report, e.g. ```pip-licenses --format=html > dependency_license.html```
-
 # Contacts
 You can reach out to us through mail, or join our public Slack workspace [here](https://versatiledata-rgg2437.slack.com/).
 <!--- TODO: Set up a slackin web app to make joining easier --->


### PR DESCRIPTION
Generating license report for dependencies, to ensure
compliance.

Added CLI tool for checking the software license of
installed Python packages with pip.