### PR TITLE
vdk-core: build script extra URLs of package indexes fix

### DIFF
--- a/projects/vdk-core/cicd/build.sh
+++ b/projects/vdk-core/cicd/build.sh
@@ -8,6 +8,7 @@ cd ..
 
 
 echo "install dependencies from requirements.txt (used for development and testing)"
+export PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL:-https://test.pypi.org/simple/}
 pip install --extra-index-url $PIP_EXTRA_INDEX_URL -r requirements.txt
 
 echo "Setup git hook scripts with pre-commit install"


### PR DESCRIPTION
Enabling building vdk-core out-of-the-box.

Build script default extra URLs of package indexes added
when installing requirements, if explicit value missing.