### PR TITLE
vdk-core: Fix vdk-core CICD triggering on unrelated changes

### DIFF
--- a/projects/vdk-core/.gitlab-ci.yml
+++ b/projects/vdk-core/.gitlab-ci.yml
@@ -64,6 +64,8 @@ build_with_py39:
     refs:
       - external_pull_requests
       - main
+    changes:
+      - "projects/vdk-core/**/*"
   artifacts:
     when: always
     reports:

--- a/projects/vdk-core/plugins/.plugin-common.yml
+++ b/projects/vdk-core/plugins/.plugin-common.yml
@@ -22,19 +22,11 @@
     - pip install pytest-cov
     - pytest --junitxml=tests.xml --cov taurus --cov-report term-missing --cov-report xml:coverage.xml
   retry: !reference [.retry, retry_options]
-  rules: # we want to trigger build jobs if there are changes in this plugin or
-         # the main repository, but not if there are changes to other plugins
+  rules: # we want to trigger build jobs if there are changes to this plugin,
+         # but not if there are changes to other plugins or the main directory
     - if: '$CI_COMMIT_BRANCH == "main" || $CI_PIPELINE_SOURCE == "external_pull_request_event"'
       changes:
-        - "projects/vdk-core/*"
-        - "projects/vdk-core/plugins/*"
-        - "projects/vdk-core/cicd/**/*"
         - "projects/vdk-core/plugins/$PLUGIN_NAME/**/*"
-    - if: '$CI_COMMIT_BRANCH == "main" || $CI_PIPELINE_SOURCE == "external_pull_request_event"'
-      changes:
-        - "projects/vdk-core/plugins/**/*"
-      when: never
-    - if: '$CI_COMMIT_BRANCH == "main" || $CI_PIPELINE_SOURCE == "external_pull_request_event"'
   artifacts:
     when: always
     reports:


### PR DESCRIPTION
vdk-core CICD jobs were triggered as a result of changes made to
the control-service part of the repository. This should not happen,
so this change fixes that by making sure that the simple-functional-test
and the plugin build jobs only trigger when there are changes to the
vdk-core part of the repository.

Signed-off-by: gageorgiev <gageorgiev@vmware.com>