### PR TITLE
plugins: set long_description_content_type to markdwon

### DIFF
--- a/projects/vdk-core/plugins/plugin-template/setup.py
+++ b/projects/vdk-core/plugins/plugin-template/setup.py
@@ -21,6 +21,7 @@ setuptools.setup(
     version=__version__,
     description="Plugin template project used to quick start development of a new Versatile Data Kit SDK plugin.",
     long_description=pathlib.Path("README.md").read_text(),
+    long_description_content_type="text/markdown",
     install_requires=["vdk-core"],
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),

--- a/projects/vdk-core/plugins/quickstart-vdk/setup.py
+++ b/projects/vdk-core/plugins/quickstart-vdk/setup.py
@@ -10,6 +10,7 @@ setuptools.setup(
     name="quickstart-vdk",
     description="Versatile Data Kit SDK packaging containing common plugins to get started quickly using it.",
     long_description=pathlib.Path("README.md").read_text(),
+    long_description_content_type="text/markdown",
     version=__version__,
     install_requires=[
         "vdk-core",

--- a/projects/vdk-core/plugins/vdk-ingest-file/setup.py
+++ b/projects/vdk-core/plugins/vdk-ingest-file/setup.py
@@ -11,6 +11,7 @@ setuptools.setup(
     version=__version__,
     description="Versatile Data Kit SDK ingestion plugin to ingest data into a file.",
     long_description=pathlib.Path("README.md").read_text(),
+    long_description_content_type="text/markdown",
     install_requires=["vdk-core"],
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),

--- a/projects/vdk-core/plugins/vdk-ingest-http/setup.py
+++ b/projects/vdk-core/plugins/vdk-ingest-http/setup.py
@@ -11,6 +11,7 @@ setuptools.setup(
     version=__version__,
     description="Versatile Data Kit SDK ingestion plugin to ingest data via http requests.",
     long_description=pathlib.Path("README.md").read_text(),
+    long_description_content_type="text/markdown",
     install_requires=["vdk-core"],
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),

--- a/projects/vdk-core/plugins/vdk-logging-ltsv/setup.py
+++ b/projects/vdk-core/plugins/vdk-logging-ltsv/setup.py
@@ -11,6 +11,7 @@ setuptools.setup(
     version=__version__,
     description="Versatile Data Kit SDK plugin that changes logging output to LTSV format.",
     long_description=pathlib.Path("README.md").read_text(),
+    long_description_content_type="text/markdown",
     install_requires=["vdk-core"],
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),

--- a/projects/vdk-core/plugins/vdk-test-utils/setup.py
+++ b/projects/vdk-core/plugins/vdk-test-utils/setup.py
@@ -13,6 +13,7 @@ setuptools.setup(
     version=__version__,
     description="Provides utilities for testing Versatile Data Kit SDK plugins.",
     long_description=pathlib.Path("README.md").read_text(),
+    long_description_content_type="text/markdown",
     install_requires=["vdk-core"],
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),

--- a/projects/vdk-core/plugins/vdk-trino/setup.py
+++ b/projects/vdk-core/plugins/vdk-trino/setup.py
@@ -11,6 +11,7 @@ setuptools.setup(
     version=__version__,
     description="Versatile Data Kit SDK plugin provides support for trino database and trino transformation templates.",
     long_description=pathlib.Path("README.md").read_text(),
+    long_description_content_type="text/markdown",
     install_requires=["vdk-core", "trino"],
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),


### PR DESCRIPTION
Setting it everywhere as another release of plugin failed because pypi
description validation failed due to "failed to render in the default
format of reStructuredText"

Also it's the correct format for the README so we shoud specify it.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>