### PR TITLE
cicd: fix gitlab runners

### DIFF
--- a/support/gitlab-runners/README.md
+++ b/support/gitlab-runners/README.md
@@ -5,16 +5,18 @@ Gitlab is in https://gitlab.com/vmware-analytics/versatile-data-kit
 
 ## Prerequisites
 
-Access to `cicd` namespace in the AWS https://us-west-1.console.aws.amazon.com/eks/home?region=us-west-1#/clusters/vdk-cicd. 
+Access to `cicd` namespace in the AWS https://us-west-1.console.aws.amazon.com/eks/home?region=us-west-1#/clusters/vdk-cicd.
+
 To get the KUBECONFIG, it's currently stored either in LastPass or Gitlab CI Variable
 
-To authenticate to AWS you need: 
+To authenticate to AWS you need:
+```
 export AWS_DEFAULT_REGION=us-west-1
 export AWS_SECRET_ACCESS_KEY=<get-from-gitlab-ci-variables>
 export AWS_ACCESS_KEY_ID=<get-from-gitlab-ci-variables>
 
-export RUNNER_REGISTRATION_TOKEN= # Get the Gitlab token from 
-
+export RUNNER_REGISTRATION_TOKEN= # Get the Gitlab token from
+```
 The only prerequisite in order to run the scripts and deploy the runners is installed [helm 3](https://helm.sh/docs/).
 
 ## Install runners

--- a/support/gitlab-runners/values.yaml
+++ b/support/gitlab-runners/values.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 ## The GitLab Server URL (with protocol) that want to register the runner against
 ## ref: https://docs.gitlab.com/runner/commands/README.html#gitlab-runner-register
 ##
@@ -30,7 +33,7 @@ checkInterval: 30
 
 ## For RBAC support:
 rbac:
-  create: false
+  create: true
 
   ## Run the gitlab-bastion container with the ability to deploy/manage containers of jobs
   ## cluster-wide or only within namespace
@@ -66,18 +69,18 @@ runners:
   ##
   ## TODO: Have runners for big and small jobs.
   builds:
-    cpuLimit: 5000m
+    cpuLimit: 1000m
     memoryLimit: 4Gi
-    cpuRequests: 5000m
-    memoryRequests: 4Gi
+    cpuRequests: 500m
+    memoryRequests: 2Gi
 
   ## Service Container specific configuration
   ##
   ## Services in our case is docker:dind. Uses a lot since some jobs run several containers in it.
   services:
-    cpuLimit: 3000m
+    cpuLimit: 1000m
     memoryLimit: 3Gi
-    cpuRequests: 3000m
+    cpuRequests: 1000m
     memoryRequests: 3Gi
 
   ## Helper Container specific configuration


### PR DESCRIPTION
Gitlab runners were not working because permissions weren not set,
Changes rbac to True to enable the helm chart to setup correct
permissions during installation

Revised the resoruce requirements as they were taking unnecessary too
much.

Testing Done: succesfully ran jobs in Gitlab CI with this runner.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>