### PR TITLE
gitlab-runners: start runners in cicd namespace

### DIFF
--- a/support/gitlab-runners/install-runners.sh
+++ b/support/gitlab-runners/install-runners.sh
@@ -44,6 +44,7 @@ helm repo add gitlab https://charts.gitlab.io
 # Before updating version, review changelog at https://docs.gitlab.com/runner/install/kubernetes.html .
 helm upgrade --install \
   --set runnerRegistrationToken=$RUNNER_REGISTRATION_TOKEN \
+  --set runners.namespace=$NAMESPACE \
   --kubeconfig $KUBECONFIG --namespace $NAMESPACE --version "0.22.0" $RUNNER_NAME -f $VALUES gitlab/gitlab-runner
 
 


### PR DESCRIPTION
Until now they were started in default namespace.
For troubleshooting purposes it's better if they are visible in the
common namespace for now. If we start having too many things in the
namespace we can split them.

Testing Done: ran install-runners.sh script locally and saw runners are
started in cicd namespace

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>