### PR TITLE
control-service: remove comments at astart of helm templates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,13 +77,15 @@ repos:
       args:
         - --license-filepath
         - NOTICE.txt
-    - id: insert-license
-      files: \.yml$
-      args:
-        - --license-filepath
-        - NOTICE.txt
-    - id: insert-license
-      files: \.yaml$
-      args:
-          - --license-filepath
-          - NOTICE.txt
+# License header create issues in helm chart yaml files
+# https://github.com/helm/helm/issues/4409
+#    - id: insert-license
+#      files: \.yml$
+#      args:
+#        - --license-filepath
+#        - NOTICE.txt
+#    - id: insert-license
+#      files: \.yaml$
+#      args:
+#          - --license-filepath
+#          - NOTICE.txt

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/Chart.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/Chart.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) 2021 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 apiVersion: v2
 name: pipelines-control-service
 description: A Helm chart for Versatile Data Kit Control Service

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/configmap_datajob_template_file.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/configmap_datajob_template_file.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) 2021 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 {{- if .Values.datajobTemplate.enabled }}
 apiVersion: v1
 kind: ConfigMap

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) 2021 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/fluentdconfig.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/fluentdconfig.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) 2021 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 {{- if .Values.fluentd.enabled }}
 apiVersion: logs.vdp.vmware.com/v1beta1
 kind: FluentdConfig

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/ingress.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/ingress.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) 2021 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 {{- if .Values.ingress.enabled -}}
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/prometheusrules.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/prometheusrules.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) 2021 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 {{- if .Values.alerting.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/role.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/role.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) 2021 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/role_datajobs.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/role_datajobs.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) 2021 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 {{- if and .Values.rbac.create .Values.rbac.datajobsDeployment.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/rolebindings.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/rolebindings.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) 2021 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 {{- if and .Values.serviceAccount.create .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/rolebindings_datajobs.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/rolebindings_datajobs.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) 2021 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 {{- if and .Values.serviceAccount.create .Values.rbac.create .Values.rbac.datajobsDeployment.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_jdbc.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_jdbc.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) 2021 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 ## Create a secret with JDBC credentials for CockroachDB only if externalSecretName is not supplied.
 ## If any of the fields are empty, we fall-back to defaults (f.e. local dev environment)
 {{- if not .Values.database.externalSecretName }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secrets.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secrets.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) 2021 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 apiVersion: v1
 kind: Secret
 metadata:

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/service.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/service.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) 2021 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 apiVersion: v1
 kind: Service
 metadata:

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/serviceaccount.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/serviceaccount.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) 2021 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/servicemonitor.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/servicemonitor.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) 2021 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) 2021 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
 ## Current available global Docker image parameters: imageRegistry and imagePullSecrets


### PR DESCRIPTION
It seems helm templates do not work if there are comments at start of
file: https://github.com/helm/helm/issues/4409

helm install fails. So I've removed the comments. Also I've disabled the
pre-commit hook that updates it.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>