### PR TITLE
vdk-trino: Implement SCD2 template without alter table rename

### DIFF
--- a/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/dimension/scd2/00-verify-valid-target.py
+++ b/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/dimension/scd2/00-verify-valid-target.py
@@ -32,7 +32,7 @@ def run(job_input: IJobInput):
         if trino_queries.table_exists(target_schema, backup_target_table):
             log.debug("Try to recover target from backup")
             try:
-                trino_queries.alter_table(
+                trino_queries.move_data_to_table(
                     target_schema, backup_target_table, target_schema, target_table
                 )
                 log.info(

--- a/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/trino_config.py
+++ b/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/trino_config.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+trino_templates_data_to_target_strategy: str = ""

--- a/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/trino_utils.py
+++ b/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/trino_utils.py
@@ -1,7 +1,13 @@
 # Copyright (c) 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import logging
+
 from taurus.api.job_input import IJobInput
+from taurus.vdk import trino_config
+from taurus.vdk.core import errors
 from trino.exceptions import TrinoUserError
+
+log = logging.getLogger(__name__)
 
 
 class TrinoQueries:
@@ -32,22 +38,53 @@ class TrinoQueries:
 
         return result
 
-    def alter_table(
+    def get_move_data_to_table_strategy(self):
+        return trino_config.trino_templates_data_to_target_strategy
+
+    def move_data_to_table(
         self, from_db: str, from_table_name: str, to_db: str, to_table_name: str
     ):
         """
-        This method renames a table
+        This method moves data from one table to another table, using different strategies, defined in job context
+        configuration
         :param from_db: Schema of the table that we want to rename
         :param from_table_name: Name of the table we want to rename
         :param to_db: Schema of the new table we want
         :param to_table_name: Name of the new table
         :return: None if it fails, List if it succeeds
         """
-        return self.__job_input.execute_query(
-            f"""
-            ALTER TABLE {from_db}.{from_table_name} RENAME TO {to_db}.{to_table_name}
-            """
-        )
+        strategy = self.get_move_data_to_table_strategy()
+        if strategy == "RENAME":
+            return self.__job_input.execute_query(
+                f"""
+                ALTER TABLE {from_db}.{from_table_name} RENAME TO {to_db}.{to_table_name}
+                """
+            )
+        elif strategy == "INSERT_SELECT":
+            self.__job_input.execute_query(
+                f"""
+                CREATE TABLE {to_db}.{to_table_name} (LIKE {from_db}.{from_table_name})
+                """
+            )
+            self.__job_input.execute_query(
+                f"""
+                INSERT INTO {to_db}.{to_table_name} SELECT * FROM {from_db}.{from_table_name}
+                """
+            )
+            return self.__job_input.execute_query(
+                f"""
+                DROP TABLE {from_db}.{from_table_name}
+                """
+            )
+        else:
+            errors.log_and_throw(
+                to_be_fixed_by=errors.ResolvableBy.USER_ERROR,
+                log=log,
+                what_happened="Cannot move data to target",
+                why_it_happened=f"Strategy for moving data to target table is not defined: {strategy}",
+                consequences="Current Step (python file) will fail, and as a result the whole Data Job will fail.",
+                countermeasures="Provide valid value for TRINO_TEMPLATES_DATA_TO_TARGET_STRATEGY.",
+            )
 
     def drop_table(self, db: str, table_name: str):
         """

--- a/projects/vdk-core/plugins/vdk-trino/tests/jobs/test_move_data_strategy_job/01_prepare_input_data.py
+++ b/projects/vdk-core/plugins/vdk-trino/tests/jobs/test_move_data_strategy_job/01_prepare_input_data.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from taurus.api.job_input import IJobInput
+
+
+def run(job_input: IJobInput) -> None:
+    """
+    Prepare source table and insure target does not exist
+    """
+    args = job_input.get_arguments()
+    db = args.get("db")
+    src = args.get("src")
+    target = args.get("target")
+
+    job_input.execute_query(f"DROP TABLE IF EXISTS {db}.{src}")
+    job_input.execute_query(f"DROP TABLE IF EXISTS {db}.{target}")
+    job_input.execute_query(f"CREATE TABLE {db}.{src} (org_id INT, org_name VARCHAR)")
+    job_input.execute_query(
+        f"INSERT INTO {db}.{src} VALUES (1, 'first'), (2, 'second')"
+    )

--- a/projects/vdk-core/plugins/vdk-trino/tests/jobs/test_move_data_strategy_job/02_move_data_to_target.py
+++ b/projects/vdk-core/plugins/vdk-trino/tests/jobs/test_move_data_strategy_job/02_move_data_to_target.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from taurus.api.job_input import IJobInput
+from taurus.vdk.trino_utils import TrinoQueries
+
+
+def run(job_input: IJobInput) -> None:
+    """
+    Execute move_data_to_table - the function this job is created to test
+    """
+    args = job_input.get_arguments()
+    db = args.get("db")
+    src = args.get("src")
+    target = args.get("target")
+
+    trino_queries = TrinoQueries(job_input)
+    trino_queries.move_data_to_table(db, src, db, target)

--- a/projects/vdk-core/plugins/vdk-trino/tests/jobs/test_move_data_strategy_job/03_check_target.py
+++ b/projects/vdk-core/plugins/vdk-trino/tests/jobs/test_move_data_strategy_job/03_check_target.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+from taurus.api.job_input import IJobInput
+
+
+def run(job_input: IJobInput) -> None:
+    """
+    Check whether move data step successfully wrote data to target
+    """
+    args = job_input.get_arguments()
+    db = args.get("db")
+    target = args.get("target")
+
+    result = job_input.execute_query(
+        f"""
+        SELECT COUNT (1) from {db}.{target}
+        """
+    )
+    if result and result[0][0] > 0:
+        logging.getLogger(__name__).info("Job has completed successfully.")
+    else:
+        raise Exception("Job has failed. Could not get correct number of rows.")

--- a/projects/vdk-core/plugins/vdk-trino/tests/test_vdk_trino_utils.py
+++ b/projects/vdk-core/plugins/vdk-trino/tests/test_vdk_trino_utils.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import json
+import os
+import pathlib
+import unittest
+from unittest import mock
+
+import pytest
+from click.testing import Result
+from taurus.vdk import trino_plugin
+from taurus.vdk.test_utils.util_funcs import cli_assert_equal
+from taurus.vdk.test_utils.util_funcs import CliEntryBasedTestRunner
+from taurus.vdk.test_utils.util_funcs import get_test_job_path
+from taurus.vdk.trino_utils import TrinoQueries
+
+VDK_DB_DEFAULT_TYPE = "VDK_DB_DEFAULT_TYPE"
+VDK_TRINO_PORT = "VDK_TRINO_PORT"
+VDK_TRINO_USE_SSL = "VDK_TRINO_USE_SSL"
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        VDK_DB_DEFAULT_TYPE: "TRINO",
+        VDK_TRINO_PORT: "8080",
+        VDK_TRINO_USE_SSL: "False",
+    },
+)
+class TrinoUtilsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.__runner = CliEntryBasedTestRunner(trino_plugin)
+
+    def test_move_data_to_table_insert_select_strategy(self) -> None:
+        with mock.patch.object(
+            TrinoQueries,
+            "get_move_data_to_table_strategy",
+            return_value="INSERT_SELECT",
+        ) as patched:
+            self.check_move_data_to_table_for_current_strategy()
+
+    def test_move_data_to_table_rename_strategy(self) -> None:
+        with mock.patch.object(
+            TrinoQueries, "get_move_data_to_table_strategy", return_value="RENAME"
+        ) as patched:
+            self.check_move_data_to_table_for_current_strategy()
+
+    def test_move_data_to_table_invalid_strategy(self) -> None:
+        with mock.patch.object(
+            TrinoQueries,
+            "get_move_data_to_table_strategy",
+            return_value="INVALID_STRATEGY",
+        ) as patched:
+            with pytest.raises(Exception):
+                self.check_move_data_to_table_for_current_strategy()
+
+    def check_move_data_to_table_for_current_strategy(self) -> None:
+        db = "default"
+        src = "test_scr_t"
+        target = "test_target_t"
+
+        result: Result = self.__runner.invoke(
+            [
+                "run",
+                get_test_job_path(
+                    pathlib.Path(os.path.dirname(os.path.abspath(__file__))),
+                    "test_move_data_strategy_job",
+                ),
+                "--arguments",
+                json.dumps(
+                    {
+                        "db": db,
+                        "src": src,
+                        "target": target,
+                    }
+                ),
+            ]
+        )
+        cli_assert_equal(0, result)


### PR DESCRIPTION
Trino "alter table rename" operation is quite expensive
in certain cases (Hive/S3), since it requires copying the whole table
to a new location.
For this reason, the option is disabled by default for
production tables. For this reason, we add an option to
use templates without relying on table rename.

In order to preserve the "rename table" option, we introduce
a config var which defines what strategy will be used when
writing data to target table -
TRINO_TEMPLATES_DATA_TO_TARGET_STRATEGY. Possible values
for now are - "RENAME" and "INSERT_SELECT".
The newly introduced INSERT_SELECT strategy functionality
creates the target table, inserts data in it from source
and drops source.

New unit tests are added for testing different strategies.
Also, template tests are called for both possible strategies.

The commit is a non-breaking change which adds functionality.

Signed-off-by: Yana Zhivkova (yzhivkova@vmware.com)