### PR TITLE
control-service: deduplicate dependencies license report information

### DIFF
--- a/projects/control-service/projects/README.md
+++ b/projects/control-service/projects/README.md
@@ -176,13 +176,3 @@ In order to remove the service from the cluster run:
 ```
 helm uninstall taurus-data-pipelines
 ```
-
-## Licenses
-To generate licenses report for dependencies:
-```
-./gradlew :base:generateLicenseReport
-./gradlew :pipelines_control_service:generateLicenseReport
-./model/gradlew generateLicenseReport
-```
-
-Find reports in module ```build/reports/dependency-license```


### PR DESCRIPTION
Agreed to place dependencies license report generation instructions
in Wiki Installation page. Gilab CI/CD dependencies license check
https://github.com/vmware/versatile-data-kit/issues/45

License section removed from README.md.