### PR TITLE
control service cicd: add deploy demo/cicd environment scripts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,8 +11,9 @@ include:
 
 stages:
   - build
-  - pre_release
   - publish_artifacts
+  - pre_release
+  - pre_release_test
   - release
   - release_image
   - end

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -164,11 +164,12 @@ publish_control_service_api_client:
 # (there are docker KDC servers that can be used for demo? but it will not work with Impala ?)
 # The cockroach storage class is taken from DECC https://devhub.eng.vmware.com/console/resources/namespaces
 # Go to the namespace -> StorageClass
-.deploy_testing_data_pipelines:
-  stage: deploy_testing
+deploy_testing_data_pipelines:
+  stage: pre_release
+  image: proum/aws-iam-authenticator
   script:
     - apk --no-cache add bash openssl curl git gettext
-    - bash projects/control-service/cicd/install-helm.sh
+    - curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
     - bash -ex ./projects/control-service/cicd/deploy-testing-pipelines-service.sh
   retry: !reference [.control_service_retry, retry_options]
   only:
@@ -180,16 +181,15 @@ publish_control_service_api_client:
       - projects/control-service/projects/helm_charts/pipelines-control-service/version.txt
 
 # vdk-heartbeat source: https://github.com/vmware/versatile-data-kit/tree/main/projects/vdk-heartbeat
-.post_deployment_test:
-  stage: test
+post_deployment_test:
+  stage: pre_release_test
   image: python:3.7
   script:
     - set -x
-    - pip install vdk-heartbeat[taurus] --extra-index-url https://build-artifactory.eng.vmware.com/api/pypi/Taurus-PyPI-local/simple
-    - vdkcli version
-    - export DATABASE_USER="data-pipelines-cicd"
-    - export DATABASE_PASS="" # no password in http
-    - export VDKCLI_OAUTH2_REFRESH_TOKEN=$STAGING_CSP_REFRESH_TOKEN
+    - pip install quickstart-vdk
+    - pip install vdk-heartbeat
+    - vdk version
+    - export VDKCLI_OAUTH2_REFRESH_TOKEN=$VDK_API_TOKEN
     - vdk-heartbeat -f projects/control-service/cicd/post_deploy_test_heartbeat_config.ini
   retry: !reference [.control_service_retry, retry_options]
   only:

--- a/projects/control-service/cicd/deploy-testing-pipelines-service.sh
+++ b/projects/control-service/cicd/deploy-testing-pipelines-service.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# The script will deploy/upgrade Control service using helm
+# Set RUN_ENVIRONMENT_SETUP to 'y' to setup the test environment.
+
+# For variables injected during the CICD see
+# https://github.com/vmware/versatile-data-kit/wiki/Gitlab-CICD#cicd-demo-installation-variables
+# The deployment can be run locally - you'd need to provide those variables manually
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+
+export TAG=${TAG:-$(git rev-parse --short HEAD)}
+export RELEASE_NAME=${RELEASE_NAME:-cicd-control-service}
+export VDK_OPTIONS=${VDK_OPTIONS:-"$SCRIPT_DIR/vdk-options.ini"}
+export TPCS_CHART=${TPCS_CHART:-"$SCRIPT_DIR/../projects/helm_charts/pipelines-control-service"}
+export VDK_DOCKER_REGISTRY_URL=${VDK_DOCKER_REGISTRY_URL:-"registry.hub.docker.com/versatiledatakit"}
+
+RUN_ENVIRONMENT_SETUP=${RUN_ENVIRONMENT_SETUP:-'n'}
+
+if [ "$RUN_ENVIRONMENT_SETUP" = 'y' ]; then
+  helm repo add valeriano-manassero https://valeriano-manassero.github.io/helm-charts
+  helm repo add bitnami https://charts.bitnami.com/bitnami
+  helm repo update
+
+  helm upgrade --install test-trino valeriano-manassero/trino --version 1.1.7 -f "$SCRIPT_DIR/trino-values.yaml"
+
+  # Prometheus is used for testing and monitoring our cicd (dev) environment
+  # But as it is not pre-requisite for any of the tests it's commented out
+  # install manually if necesary
+  # helm upgrade --install test-prom bitnami/kube-prometheus
+
+  # we are housing data jobs deployment container images in private repo used only for CICD purposes
+  # So we need to set credentials of the service account used to pull images when starting jobs
+  secret_name=docker-registry
+  kubectl create secret docker-registry $secret_name \
+                     --docker-server="$CICD_CONTAINER_REGISTRY_URI" \
+                     --docker-username="$CICD_CONTAINER_REGISTRY_USER_NAME" \
+                     --docker-password="$CICD_CONTAINER_REGISTRY_USER_PASSWORD" \
+                     --docker-email="versatiledatakit@groups.vmware.com" --dry-run=client -o yaml | kubectl apply -f -
+  kubectl patch serviceaccount default -p '{"imagePullSecrets":[{"name":"'$secret_name'"}]}'
+fi
+
+# this is the internal hostname of the Control Service.
+# Since all tests (gitlab runners) are installed inside it's easier if we use it.
+export CONTROL_SERVICE_URL=${CONTROL_SERVICE_URL:-"http://cicd-control-service-svc:8092"}
+# Trino host used by data jobs
+export TRINO_HOST=${TRINO_HOST:-"test-trino"}
+
+# Update vdk-options with substituted variables like sensitive configuration (passwords)
+export VDK_OPTIONS_SUBSTITUTED="${VDK_OPTIONS}.temp"
+envsubst < $VDK_OPTIONS > $VDK_OPTIONS_SUBSTITUTED
+
+cd $TPCS_CHART || exit
+helm dependency update --kubeconfig=$KUBECONFIG
+
+# TODO :change container images with official ones when they are being deployed (I've currently uploaded them once in ghcr.io/tozka)
+#
+# image.tag is fixed during release. It is set here to deploy using latest change in source code.
+# We are using here embedded database, and we need to set the storageclass since in our test k8s no default storage class is not set.
+helm upgrade --install --wait --timeout 10m0s $RELEASE_NAME . \
+      --set image.tag="$TAG" \
+      --set resources.limits.memory=2G \
+      --set credentials.repository="EMPTY" \
+      --set-file vdkOptions=$VDK_OPTIONS_SUBSTITUTED \
+      --set deploymentDockerVdkBaseImage="$VDK_DOCKER_REGISTRY_URL/quickstart-vdk:release" \
+      --set deploymentGitUrl="$CICD_GIT_URI" \
+      --set deploymentGitUsername="$CICD_GIT_USER" \
+      --set deploymentGitPassword="$CICD_GIT_PASSWORD" \
+      --set uploadGitReadWriteUsername="$CICD_GIT_USER" \
+      --set uploadGitReadWritePassword="$CICD_GIT_PASSWORD" \
+      --set deploymentDockerRegistryType=generic \
+      --set deploymentDockerRegistryUsername="$CICD_CONTAINER_REGISTRY_USER_NAME" \
+      --set deploymentDockerRegistryPassword="$CICD_CONTAINER_REGISTRY_USER_PASSWORD" \
+      --set deploymentDockerRepository="$CICD_CONTAINER_REGISTRY_URI/cicd-data-jobs/$RELEASE_NAME" \
+      --set proxyRepositoryURL="$CICD_CONTAINER_REGISTRY_URI/cicd-data-jobs/$RELEASE_NAME" \
+      --set security.enabled=true \
+      --set security.oauth2.jwtJwkSetUri=https://console-stg.cloud.vmware.com/csp/gateway/am/api/auth/token-public-key?format=jwks \
+      --set security.authorizationEnabled=true \
+      --set security.authorization.webhookUri=https://httpbin.org/post \
+      --set extraEnvVars.LOGGING_LEVEL_COM_VMWARE_TAURUS=DEBUG \
+      --set extraEnvVars.DATAJOBS_TELEMETRY_WEBHOOK_ENDPOINT="https://vcsa.vmware.com/ph-stg/api/hyper/send?_c=taurus.v0&_i=cicd-control-service" \
+      --set extraEnvVars.DATAJOBS_BUILDER_IMAGE="$VDK_DOCKER_REGISTRY_URL/job-builder:latest" \
+      --set extraEnvVars.DATAJOBS_DEPLOYMENT_DATAJOBBASEIMAGE=python:3.9-slim

--- a/projects/control-service/cicd/post_deploy_test_heartbeat_config.ini
+++ b/projects/control-service/cicd/post_deploy_test_heartbeat_config.ini
@@ -1,0 +1,19 @@
+[DEFAULT]
+# Genereate with https://console-stg.cloud.vmware.com/csp/gateway/portal/#/user/tokens
+# VDKCLI_OAUTH2_REFRESH_TOKEN= passed as environment variable
+VDKCLI_OAUTH2_URI=https://console-stg.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize
+
+DATABASE_HOST=test-trino
+DATABASE_PORT=8080
+DATABASE_TEST_DB=memory.default
+DATABASE_USER=control-service-cicd
+DATABASE_USE_SSL=false
+
+JOB_RUN_TEST_MODULE_NAME=taurus.vdk.heartbeat.trino_database_test
+JOB_RUN_TEST_CLASS_NAME=TrinoDatabaseRunTest
+DATAJOB_DIRECTORY_NAME=trino
+DB_DEFAULT_TYPE=TRINO
+
+VDK_COMMAND_NAME=vdk
+
+CONTROL_API_URL=http://cicd-control-service-svc:8092

--- a/projects/control-service/cicd/trino-values.yaml
+++ b/projects/control-service/cicd/trino-values.yaml
@@ -1,0 +1,26 @@
+
+
+image:
+  repository: trinodb/trino
+
+#service:
+#  type: LoadBalancer
+
+connectors:
+  # Connectors configuration usually contains sensitive data (like passwords, usernames, ...)
+  # so data is stored in a secret
+  # For testing purposes
+  memory.properties: |-
+    connector.name=memory
+    memory.max-data-per-node=512MB
+
+resources:
+  limits:
+    cpu: 1
+    memory: 2G
+  requests:
+    cpu: 500m
+    memory: 1G
+
+server:
+  workers: 1

--- a/projects/control-service/cicd/vdk-options.ini
+++ b/projects/control-service/cicd/vdk-options.ini
@@ -1,0 +1,16 @@
+[default]
+# this file is overriden by CICD Pipeline as whole file set in Variables section of Gitlab CI
+VDK_TRINO_HOST=${TRINO_HOST}
+VDK_TRINO_PORT=8080
+VDK_TRINO_USE_SSL=False
+VDK_TRINO_SCHEMA=default
+VDK_TRINO_CATALOG=memory
+VDK_TRINO_USER=data-job-user
+VDK_DB_DEFAULT_TYPE=TRINO
+
+VDK_PROPERTIES_API_URL=${CONTROL_SERVICE_URL}/data-jobs/for-team/{team_name}/name/{job_name}/deployments/foo/properties
+VDK_PROPERTIES_API_TOKEN_AUTHORIZATION_URL=https://console-stg.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize
+VDK_PROPERTIES_API_TOKEN=${VDK_API_TOKEN}
+VDK_TOKEN_AUTHORIZATION_SERVER_URL=https://console-stg.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize
+VDK_CONTROL_SERVICE_REST_API_URL=${CONTROL_SERVICE_URL}
+VDK_API_TOKEN=${VDK_API_TOKEN}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -9,8 +9,8 @@ global: {}
 
 # Image configuration of the Control service image. Generally those should be left as it is.
 image:
-   registry: bu6w4yoa1d.execute-api.us-west-2.amazonaws.com
-   repository: taurus/pipelines-control-service
+   registry: registry.hub.docker.com/versatiledatakit
+   repository: pipelines-control-service
    tag: "a6caa29"
 
    ## Specify a imagePullPolicy
@@ -717,5 +717,7 @@ fluentd:
 ##              specified also get deleted.
 ##
 dataJobExecutionsCleanupTask:
-  maximumExecutionsToStore: 100 # maximum number of data job executions to store in the database / default is 100.
-  executionsTtlSeconds: 1209600 # maximum time to live seconds for each execution / default is 14 days.
+  ## maximum number of data job executions to store in the database / default is 100.
+  maximumExecutionsToStore: "100"
+  ## maximum time to live seconds for each execution / default is 14 days.
+  executionsTtlSeconds: "1209600"


### PR DESCRIPTION
As part of our CICD we are starting full deployment of Control Service.
It is upgraded automatically to use the latest version of Control Service
and the latest version of vdk (we would use quickstart-vdk).

It's used to run end to end acceptance test (vdk-heartbeat) against it
to verify all happy paths from the user's point of view are working correctly.

It's used sometimes for demo purposes to demonstrate the API for
example.

Testing Done: ran the script locally and deployed it.
Control Service can be seen at
http://a5424653167db4d01b3acf66ec2ac8d9-481011980.us-west-1.elb.amazonaws.com:8092/swagger-ui.html
. It requires authorization for any operation.

The pipeline is working end-to-end here:
https://gitlab.com/vmware-analytics/versatile-data-kit/-/pipelines/353933816