### PR TITLE
control-service: spring job for deleting old executions from database

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobExecutionRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobExecutionRepository.java
@@ -6,8 +6,9 @@
 package com.vmware.taurus.service;
 
 import com.vmware.taurus.service.model.DataJobExecution;
+import com.vmware.taurus.service.model.DataJobExecutionIdAndEndTime;
 import com.vmware.taurus.service.model.ExecutionStatus;
-import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
@@ -24,9 +25,12 @@ import java.util.List;
  * <p>
  * JobExecutionRepositoryIT validates some aspects of the behavior
  */
-public interface JobExecutionRepository extends PagingAndSortingRepository<DataJobExecution, String> {
+public interface JobExecutionRepository extends JpaRepository<DataJobExecution, String> {
 
    List<DataJobExecution> findDataJobExecutionsByDataJobName(String jobName);
 
    List<DataJobExecution> findDataJobExecutionsByDataJobNameAndStatusIn(String jobName, List<ExecutionStatus> statuses);
+
+   List<DataJobExecutionIdAndEndTime> findByDataJobNameAndStatusNotInOrderByEndTime(String jobName, List<ExecutionStatus> statuses);
+
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionCleanupService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionCleanupService.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.execution;
+
+import com.vmware.taurus.service.JobExecutionRepository;
+import com.vmware.taurus.service.JobsRepository;
+import com.vmware.taurus.service.model.DataJob;
+import com.vmware.taurus.service.model.ExecutionStatus;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Slf4j
+public class JobExecutionCleanupService {
+
+    @Value("${datajobs.executions.cleanupJob.maximumExecutionsToStore:100}") //default value is 100
+    private int maxExecutionsToKeep;
+    @Value("${datajobs.executions.cleanupJob.executionsTtlSeconds:1209600}") //default value is 14 days
+    private long secondsCutoffAmount;
+    private JobExecutionRepository jobExecutionRepository;
+    private JobsRepository jobsRepository;
+
+    @Autowired
+    public void setJobExecutionRepository(JobExecutionRepository jobExecutionRepository) {
+        this.jobExecutionRepository = jobExecutionRepository;
+    }
+
+    @Autowired
+    public void setJobsRepository(JobsRepository jobsRepository) {
+        this.jobsRepository = jobsRepository;
+    }
+
+    @SchedulerLock(name = "cleanupExecutionsTask")
+    @Scheduled(cron = "${datajobs.executions.cleanupJob.scheduleCron:0 0 */3 * * *}") //default value is every 3 hours
+    public void cleanupExecutions() {
+        log.info("Starting DataJobExecutionCleanup");
+        var jobs = jobsRepository.findAll();
+        for (var job : jobs) {
+            try {
+                deleteDataJobExecutions(job);
+            } catch (Exception e) {
+                log.warn("Failed to delete executions for job {}", job.getName());
+                log.warn("Error:", e);
+            }
+        }
+    }
+
+    private void deleteDataJobExecutions(DataJob job) {
+
+        var statuses = List.of(ExecutionStatus.RUNNING, ExecutionStatus.SUBMITTED);
+        var jobExecutions = jobExecutionRepository.findByDataJobNameAndStatusNotInOrderByEndTime(job.getName(), statuses);
+        var jobsToDelete = new ArrayList<String>();
+        var cutOff = OffsetDateTime.now().minusSeconds(secondsCutoffAmount);
+
+        for (int i = 0; i < jobExecutions.size(); i++) { //first execution is the oldest
+            var execution = jobExecutions.get(i);
+            //ensure we add jobs for deletion only once
+            if (shouldDeleteJobExecution(i, jobExecutions.size(), cutOff, execution.getEndTime())) {
+                jobsToDelete.add(execution.getId());
+            }
+        }
+
+        log.info("Found {} job executions to delete for DataJob:'{}'. Deleting if necessary.", jobsToDelete.size(), job.getName());
+        jobExecutionRepository.deleteAllByIdInBatch(jobsToDelete);
+    }
+
+    /**
+     * Helper method which determines if a data job execution should be deleted.
+     * Assumes that executionPos is the position of a dataJobExecution in a sorted
+     * execution list by start time ASC.
+     *
+     * @param executionPos       the position of a data job execution in a sorted list.
+     * @param executionsSize     the size of the list.
+     * @param cutOff             cut off date for deletion.
+     * @param executionEndTime data job execution end time.
+     * @return boolean describing if the data job should be deleted.
+     */
+    private boolean shouldDeleteJobExecution(int executionPos, int executionsSize,
+                                             OffsetDateTime cutOff, OffsetDateTime executionEndTime) {
+        boolean shouldDelete = false;
+
+        if (executionPos < executionsSize - maxExecutionsToKeep) { //Delete by numbers
+            shouldDelete = true;
+        } else if (executionEndTime.isBefore(cutOff)) { // Delete by date
+            shouldDelete = true;
+        }
+        return shouldDelete;
+    }
+
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DataJobExecutionIdAndEndTime.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DataJobExecutionIdAndEndTime.java
@@ -1,0 +1,8 @@
+package com.vmware.taurus.service.model;
+
+import java.time.OffsetDateTime;
+
+public interface DataJobExecutionIdAndEndTime {
+    String getId();
+    OffsetDateTime getEndTime();
+}

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobExecutionCleanupServiceIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobExecutionCleanupServiceIT.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service;
+
+import com.vmware.taurus.ControlplaneApplication;
+import com.vmware.taurus.RepositoryUtil;
+import com.vmware.taurus.service.execution.JobExecutionCleanupService;
+import com.vmware.taurus.service.model.DataJob;
+import com.vmware.taurus.service.model.ExecutionStatus;
+import com.vmware.taurus.service.model.JobConfig;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+@SpringBootTest(classes = ControlplaneApplication.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(SpringExtension.class)
+public class JobExecutionCleanupServiceIT {
+
+    @Autowired
+    private JobExecutionRepository jobExecutionRepository;
+
+    @Autowired
+    private JobsRepository jobsRepository;
+
+    @Autowired
+    private JobExecutionCleanupService jobExecutionCleanupService;
+
+    @BeforeAll
+    public void populateJobsRepository() {
+        JobConfig config = new JobConfig();
+        config.setSchedule("schedule");
+
+        var jobA = new DataJob("jobA", config);
+        var jobB = new DataJob("jobB", config);
+
+        jobsRepository.save(jobA);
+        jobsRepository.save(jobB);
+    }
+
+    @BeforeEach
+    public void cleanJobExecutions() {
+        jobExecutionRepository.deleteAll();
+    }
+
+    @Test
+    public void testOneJobExecutionDeleteNotExpected() {
+        addJobExecution("jobA", OffsetDateTime.now(), ExecutionStatus.FINISHED);
+        Assertions.assertEquals(1, jobExecutionRepository.findAll().size());
+        jobExecutionCleanupService.cleanupExecutions();
+        Assertions.assertEquals(1, jobExecutionRepository.findAll().size());
+    }
+
+    @Test
+    public void testOneJobExecutionDeleteExpected() {
+        addJobExecution("jobA", OffsetDateTime.now().minusDays(14), ExecutionStatus.FINISHED);
+        Assertions.assertEquals(1, jobExecutionRepository.findAll().size());
+        jobExecutionCleanupService.cleanupExecutions();
+        Assertions.assertEquals(0, jobExecutionRepository.findAll().size());
+    }
+
+    @Test
+    public void testManyJobExecutionsDeleteExpected() {
+        for (int i = 0; i < 101; i++) {
+            addJobExecution("jobA", OffsetDateTime.now(), ExecutionStatus.FINISHED);
+        }
+        Assertions.assertEquals(101, jobExecutionRepository.findAll().size());
+        jobExecutionCleanupService.cleanupExecutions();
+        Assertions.assertEquals(100, jobExecutionRepository.findAll().size());
+    }
+
+    @Test
+    public void testManyJobExecutionsDeleteNotExpected() {
+        addExecutions(100, "jobA");
+        Assertions.assertEquals(100, jobExecutionRepository.findAll().size());
+        jobExecutionCleanupService.cleanupExecutions();
+        Assertions.assertEquals(100, jobExecutionRepository.findAll().size());
+    }
+
+    @Test
+    public void testJobExecutionOrdering() {
+        Random random = new Random();
+
+        for (int i = 0; i < 20; i++) {
+            addJobExecution("jobA", OffsetDateTime.now().minusDays(random.nextInt(60)), ExecutionStatus.FINISHED);
+        }
+        var statuses = List.of(ExecutionStatus.RUNNING, ExecutionStatus.SUBMITTED);
+        var jobs = jobExecutionRepository.findByDataJobNameAndStatusNotInOrderByEndTime("jobA", statuses);
+
+        var previous = jobExecutionRepository.findById(jobs.get(0).getId()).get();
+        for (int i = 1; i < jobs.size(); i++) {
+            var current = jobExecutionRepository.findById(jobs.get(i).getId()).get();
+            Assertions.assertTrue(previous.getEndTime().isBefore(current.getEndTime()));
+            previous = current;
+        }
+    }
+
+    @Test
+    public void testTwoJobExecutionsDeleteNotExpected() {
+        addExecutions(100, "jobA");
+        addExecutions(100, "jobB");
+
+        Assertions.assertEquals(200, jobExecutionRepository.findAll().size());
+        jobExecutionCleanupService.cleanupExecutions();
+        Assertions.assertEquals(200, jobExecutionRepository.findAll().size());
+    }
+
+    @Test
+    public void testTwoJobExecutionsDeletesExpected() {
+        addExecutions(105, "jobA");
+        addExecutions(105, "jobB");
+
+        Assertions.assertEquals(210, jobExecutionRepository.findAll().size());
+        jobExecutionCleanupService.cleanupExecutions();
+        Assertions.assertEquals(200, jobExecutionRepository.findAll().size());
+    }
+
+    @Test
+    public void testMultipleDeletes() {
+        addJobExecution("jobA", OffsetDateTime.now().minusDays(14).minusMinutes(1), ExecutionStatus.FINISHED);
+        addExecutions(101, "jobB");
+
+        Assertions.assertEquals(101, jobExecutionRepository.findDataJobExecutionsByDataJobName("jobB").size());
+        Assertions.assertEquals(1, jobExecutionRepository.findDataJobExecutionsByDataJobName("jobA").size());
+        jobExecutionCleanupService.cleanupExecutions();
+        Assertions.assertEquals(100, jobExecutionRepository.findDataJobExecutionsByDataJobName("jobB").size());
+        Assertions.assertEquals(0, jobExecutionRepository.findDataJobExecutionsByDataJobName("jobA").size());
+    }
+
+    @Test
+    public void testCutOffDeleteNotExpected() {
+        addJobExecution("jobA", OffsetDateTime.now().minusDays(13).minusHours(23).minusMinutes(59), ExecutionStatus.FINISHED);
+
+        Assertions.assertEquals(1, jobExecutionRepository.findDataJobExecutionsByDataJobName("jobA").size());
+        jobExecutionCleanupService.cleanupExecutions();
+        Assertions.assertEquals(1, jobExecutionRepository.findDataJobExecutionsByDataJobName("jobA").size());
+    }
+
+    private void addJobExecution(String jobName, OffsetDateTime time, ExecutionStatus status) {
+        var excId = UUID.randomUUID().toString();
+        var execution = RepositoryUtil.createDataJobExecution(jobExecutionRepository, excId, jobsRepository.findById(jobName).get(), status);
+        execution.setStartTime(time);
+        execution.setEndTime(time);
+        jobExecutionRepository.save(execution);
+    }
+
+    private void addExecutions(int executionsNumber, String jobName) {
+        for (int i = 0; i < executionsNumber; i++) {
+            addJobExecution(jobName, OffsetDateTime.now(), ExecutionStatus.FINISHED);
+        }
+    }
+
+}


### PR DESCRIPTION
As DataJobExecutions are stored in the database we need a scheduled job
which will regularly cleanup older executions. This commit contains a
scheduled spring job which cleans up executions older than 14 days and
if for a certaind DataJob there are more than 100 executions.

Signed-off-by: mzhivkov mzhivkov@vmware.com