### PR TITLE
control-service: Expose configuration properties

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -182,12 +182,10 @@ spec:
             - name: K8S_DATA_JOB_TEMPLATE_FILE
               value: "/etc/datajobs/k8s_data_job_template.yaml"
             {{- end }}
-            {{- if .Values.dataJobExecutionsCleanupTask.shouldUseHelmValues }}
             - name: DATAJOBS_EXECUTION_TTL_SECONDS
-              value: "{{ .Values.dataJobExecutionsCleanupTask.ttlSeconds }}"
+              value: "{{ .Values.dataJobExecutionsCleanupTask.executionsTtlSeconds }}"
             - name: DATAJOBS_EXECUTION_MAXIMUM_EXECUTIONS_TO_STORE
               value: "{{ .Values.dataJobExecutionsCleanupTask.maximumExecutionsToStore }}"
-            {{- end }}
 {{- if .Values.extraVars }}
 {{ toYaml .Values.extraVars | indent 12 }}
 {{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -710,13 +710,6 @@ fluentd:
 ## are providing a way to clean old information about data job executions through
 ## the following properties:
 ##
-## shouldUseHelmValues - When set to false, the default internal configuration file of control plane:
-##                       (../pipelines_control_service/src/main/resources/application.properties)
-##                       will be used to determine the values for these properties. Default values are
-##                       100 maximum executions to store and 14 days time to live. When set to true, the
-##                       corresponding values in the default configuration file are overridden with the values
-##                       specified here.
-##
 ## maximumExecutionsToStore - The maximum amount of executions per data job to keep. If data
 ##                            job executions exceed this number, the older executions are deleted.
 ##
@@ -724,6 +717,5 @@ fluentd:
 ##              specified also get deleted.
 ##
 dataJobExecutionsCleanupTask:
-  shouldUseHelmValues: false # if set to true the default values in "application.properties" file will be overridden.
   maximumExecutionsToStore: 100 # maximum number of data job executions to store in the database / default is 100.
-  ttlSeconds: 1209600 # maximum time to live seconds for each execution / default is 14 days.
+  executionsTtlSeconds: 1209600 # maximum time to live seconds for each execution / default is 14 days.

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -94,10 +94,10 @@ datajobs.deployment.dataJobBaseImage=python:3.9-slim
 
 #Configuration variables used for data job execution cleanup
 #This is a spring cron expression, used to schedule the clean up job / default is every 3 hours
-datajobs.executions.cleanupScheduleCron=0 0 */3 * * *
+datajobs.executions.cleanupJob.scheduleCron=0 0 */3 * * *
 #This variable is used to determine the maximum amount of executions the database can store / default is 100
 #exposed in helm chart, if there are more executions than maximum, older ones will be deleted when clean up job runs.
-datajobs.executions.maximumExecutionsToStore=${DATAJOBS_EXECUTION_MAXIMUM_EXECUTIONS_TO_STORE:100}
+datajobs.executions.cleanupJob.maximumExecutionsToStore=${DATAJOBS_EXECUTION_MAXIMUM_EXECUTIONS_TO_STORE:100}
 #This variable exposes the total time to live of data job execution in seconds / default is 14 days
 #executions older than that will get deleted when the clean up job runs
-datajobs.executions.ttlSeconds=${DATAJOBS_EXECUTION_TTL_SECONDS:1209600}
+datajobs.executions.cleanupJob.executionsTtlSeconds=${DATAJOBS_EXECUTION_TTL_SECONDS:1209600}


### PR DESCRIPTION
As a part of the new data job execution clean up API
we need new properties to expose total time to live,
maximum number of executions stored and a shcedule for
the new clean up job. Settings exposed as appropriate in the
helm charts and/or in the application.properties file

Signed-off-by: mzhivkov mzhivkov@vmware.com