### PR TITLE
builds: make pre-requisites explicit

### DIFF
--- a/cicd/build.sh
+++ b/cicd/build.sh
@@ -1,9 +1,52 @@
-#!/bin/bash
+#!/bin/bash -e
 # Copyright (c) 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-echo "Starting build on $(uname -a)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+echo "Starting build on $(uname -a)."
+echo "Will setup local repository"
+echo "In order to build all projects following prerequisites will be required:"
+echo " - python 3"
+echo " - Java 11+ (for control service)"
+echo " - Docker (for control service)"
+echo "For now we need only Python."
+echo ""
+
+if ! which python3 >/dev/null 2>&1 ; then
+  echo "ERROR:"
+  echo "Please install python 3. Initial setup cannot continue without it."
+  echo "If you are new to python:"
+  echo "There are some awesome tools for installing and managing python which we recommend:"
+  echo " - conda - https://conda.io/projects/conda/en/latest/user-guide/getting-started.html"
+  echo " - pyenv - https://github.com/pyenv/pyenv"
+  echo "      - If you use pyenv we also recommend https://github.com/pyenv/pyenv-virtualenv"
+  echo ""
+  exit 1
+fi
+
 
 echo "Setup git hook scripts with pre-commit install"
-pip install pre-commit
+pip install -q pre-commit
 pre-commit install
+
+echo ""
+echo "You are all setup."
+echo ""
+
+projects=($(ls "$SCRIPT_DIR/../projects")) || exit
+num_projects="${#projects[@]}"
+
+echo "This is mono repo with $num_projects separate projects for each component of Versatile Data Kit."
+echo "Each of them has its own separate and independent build and CICD."
+echo ""
+
+echo "Pick which project you want to build, cd there and run ./cicd/build.sh of the project"
+echo ""
+
+for project in "${projects[@]}"
+do
+   echo "> Go to projects/$project"
+done
+
+echo ""

--- a/projects/control-service/cicd/build.sh
+++ b/projects/control-service/cicd/build.sh
@@ -6,8 +6,30 @@
 cd "$(dirname $0)" || exit 1
 cd ..
 
+
+if ! which docker >/dev/null 2>&1 ; then
+  echo "WARNING:"
+  echo "  Did not detect docker installed on PATH."
+  echo "  Please install Docker. It is used to create Control Service container image."
+  echo "  If you are new to Docker see:"
+  echo "    - https://docs.docker.com/engine/install"
+  echo ""
+fi
+
+if ! which java >/dev/null 2>&1 && [ -z "$JAVA_HOME" ]; then
+  echo "ERROR:"
+  echo "  Did not detect java installed on PATH, nor JAVA_HOME environment variable."
+  echo "  Please install Java 11 JDK and/or set JAVA_HOME. You will need this in control-service project."
+  echo "  If you are new to Java we recommend using Open JDK:"
+  echo "    - https://openjdk.java.net/install"
+  echo ""
+  exit 1
+fi
+
+
 export TAG=${TAG:-$(git rev-parse --short HEAD)}
 
+set -x
 ./projects/gradlew -p ./projects/model build publishToMavenLocal --info --stacktrace
 ./projects/gradlew -p ./projects build jacocoTestReport -x integrationTest --info --stacktrace
 ./projects/gradlew -p ./projects :pipelines_control_service:docker --info --stacktrace -Pversion=$TAG

--- a/projects/vdk-control-cli/cicd/build.sh
+++ b/projects/vdk-control-cli/cicd/build.sh
@@ -3,9 +3,20 @@
 # Copyright (c) 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+if ! which python3 >/dev/null 2>&1 ; then
+  echo "ERROR:"
+  echo "Please install python 3.7+. Build cannot continue without it."
+  echo "If you are new to python:"
+  echo "There are some awesome tools for installing and managing python which we recommend:"
+  echo " - conda - https://conda.io/projects/conda/en/latest/user-guide/getting-started.html"
+  echo " - pyenv - https://github.com/pyenv/pyenv"
+  echo "      - If you use pyenv we also recommend https://github.com/pyenv/pyenv-virtualenv"
+  echo ""
+  exit 1
+fi
+
 cd "$(dirname $0)" || exit 1
 cd ..
-
 
 echo "install dependencies from requirements.txt (used for development and testing)"
 pip install -r requirements.txt
@@ -20,3 +31,5 @@ pip install -e .
 echo "Run unit tests and generate coverage report"
 pip install pytest-cov
 pytest --junitxml=tests.xml --cov taurus --cov-report term-missing --cov-report xml:coverage.xml
+
+echo "Done"

--- a/projects/vdk-core/cicd/build.sh
+++ b/projects/vdk-core/cicd/build.sh
@@ -3,23 +3,37 @@
 # Copyright (c) 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+if ! which python3 >/dev/null 2>&1 ; then
+  echo "ERROR:"
+  echo "Please install python 3.7+. Build cannot continue without it."
+  echo "If you are new to python:"
+  echo "There are some awesome tools for installing and managing python which we recommend:"
+  echo " - conda - https://conda.io/projects/conda/en/latest/user-guide/getting-started.html"
+  echo " - pyenv - https://github.com/pyenv/pyenv"
+  echo "      - If you use pyenv we also recommend https://github.com/pyenv/pyenv-virtualenv"
+  echo ""
+  exit 1
+fi
+
 cd "$(dirname $0)" || exit 1
 cd ..
 
+export PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL:-https://test.pypi.org/simple/}
 
 echo "install dependencies from requirements.txt (used for development and testing)"
-export PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL:-https://test.pypi.org/simple/}
 pip install --extra-index-url $PIP_EXTRA_INDEX_URL -r requirements.txt
 
 echo "Setup git hook scripts with pre-commit install"
 pre-commit install
 
-echo "Install the project in editable mode (develop mode)"
+echo "Install the vdk-core in editable mode (develop mode)"
 pip install -e .
 
-echo "Install common vdk test utils library"
+echo "Install common vdk test utils library (in editable mode)"
 pip install -e plugins/vdk-test-utils
 
 echo "Run unit tests and generate coverage report"
 pip install pytest-cov
 pytest --junitxml=tests.xml --cov taurus --cov-report term-missing --cov-report xml:coverage.xml
+
+echo "Done"


### PR DESCRIPTION
First time building of the project locally start from running
./cicd/build.sh . It's good idea to also check for any pre-requisites
required in order to buld all components.

I think that the top level build should not try to build different
projects. Each project should be independant of all other projects (as
if they were in different git repo). This would enfore keeping them
decoupled from each other (no build time dependencies) and facilitate
easer parallel development (people devloping on vdk-core would not
impact those making changes in control-service.

Testing Done: In empty env (using docker):
  docker docker run -it -v "$(pwd):/vdk" ubuntu /bin/bash
./cicd/build.sh - prompted to install python and warn me for missing
java
  After installing conda - was able to run ./cicd/build.sh succesfully
  Then ran vdk-core and vdk-control-cli build succesfully.

control-service build is failing currently and this will be fixed
separately.