### PR TITLE
vdk-heartbeat: Fix vdk-heartbeat CI/CD script

### DIFF
--- a/projects/vdk-heartbeat/.gitlab-ci.yml
+++ b/projects/vdk-heartbeat/.gitlab-ci.yml
@@ -17,7 +17,7 @@ test:
   only:
     refs:
       - external_pull_requests
-      - master
+      - main
   artifacts:
     when: always
     reports:
@@ -32,6 +32,6 @@ release:
     - twine upload --repository-url $PIP_REPO_UPLOAD_URL -u "$PIP_REPO_UPLOAD_USER_NAME" -p "$PIP_REPO_UPLOAD_USER_PASSWORD" dist/*tar.gz --verbose
   only:
     refs:
-      - master
+      - main
     changes:
       - version.txt


### PR DESCRIPTION
As part of the Continuous Delivery process of
Versatile Data Kit, we need to ensure all CI/CD
scripts work as expected.

This change fixes a bug where the name of the main
branch in the CI/CD script was specified as `master`,
instead of `main`.

Testing Done: CI/CD run

Signed-off-by: Andon Andonov <andonova@vmware.com>