### PR TITLE
control-service: Create Github repository on Helm install

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -52,16 +52,42 @@ spec:
               value: "{{ .Values.notificationOwnerEmail }}"
             - name: NOTIFICATION_OWNER_NAME
               value: "{{ .Values.notificationOwnerName }}"
+            {{- if not .Values.deploymentGitUrl }}
+            - name: GIT_REPO_NAME
+              valueFrom:
+                 secretKeyRef:
+                    name: {{ .Release.Name }}-git-properties
+                    key: git-repo-name
+            - name: GIT_SERVER
+              valueFrom:
+                 secretKeyRef:
+                    name: {{ .Release.Name }}-git-properties
+                    key: git-server
+            {{- end }}
+            {{- if not .Values.deploymentGitUsername }}
+            - name: GIT_DEFAULT_USERNAME
+              valueFrom:
+                 secretKeyRef:
+                    name: {{ .Release.Name }}-git-properties
+                    key: git-username
+            {{- end }}
+            {{- if not .Values.deploymentGitPassword }}
+            - name: GIT_ACCESS_TOKEN
+              valueFrom:
+                 secretKeyRef:
+                    name: {{ .Release.Name }}-git-properties
+                    key: git-access-token
+            {{- end }}
             - name: GIT_URL
-              value: "{{ .Values.deploymentGitUrl }}"
+              value: {{ .Values.deploymentGitUrl | default "$(GIT_SERVER)/$(GIT_REPO_NAME).git" | quote }}
             - name: GIT_BRANCH
               value: "{{ .Values.deploymentGitBranch }}"
             - name: GIT_REMOTE
               value: "{{ .Values.deploymentGitRemote }}"
             - name: GIT_USERNAME
-              value: "{{ .Values.deploymentGitUsername }}"
+              value: {{ .Values.deploymentGitUsername | default "$(GIT_DEFAULT_USERNAME)" }}
             - name: GIT_PASSWORD
-              value: "{{ .Values.deploymentGitPassword }}"
+              value: {{ .Values.deploymentGitPassword | default "$(GIT_ACCESS_TOKEN)" }}
             - name: AWS_REGION
               value: "{{ .Values.deploymentEcrAwsRegion }}"
             - name: AWS_ACCESS_KEY_ID

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/hooks/job_create_git_repo.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/hooks/job_create_git_repo.yaml
@@ -1,0 +1,50 @@
+{{- if not .Values.deploymentGitUrl }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+   name: {{ .Release.Name }}-create-git-repo
+   labels:
+      app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+      app.kubernetes.io/instance: {{ .Release.Name | quote }}
+      app.kubernetes.io/version: {{ .Chart.AppVersion }}
+      helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+   annotations:
+      # This is what defines this resource as a hook. Without this line, the
+      # job is considered part of the release.
+      helm.sh/hook: pre-install
+      helm.sh/hook-weight: "2"
+      helm.sh/hook-delete-policy: hook-succeeded
+      helm.sh/resource-policy: keep
+spec:
+   template:
+      metadata:
+         name: "{{ .Release.Name }}"
+         labels:
+            app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+            app.kubernetes.io/instance: {{ .Release.Name | quote }}
+            helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      spec:
+         restartPolicy: Never
+         containers:
+            - name: pre-install-job
+              image: "alpine:3.3"
+              env:
+                 -  name: GIT_REPO_NAME
+                    valueFrom:
+                       secretKeyRef:
+                          name: {{ .Release.Name }}-git-properties
+                          key: git-repo-name
+                 -  name: GIT_ACCESS_TOKEN
+                    valueFrom:
+                       secretKeyRef:
+                          name: {{ .Release.Name }}-git-properties
+                          key: git-access-token
+              command:
+                 - 'sh'
+                 - '-c'
+                 - |-
+                    echo "Creating git repository: $GIT_REPO_NAME"
+                    apk --no-cache add curl
+                    curl -i -H "Authorization: token $GIT_ACCESS_TOKEN" -d "{ \"name\": \"$GIT_REPO_NAME\", \"auto_init\": false, \"private\": false }" https://api.github.com/user/repos
+                    echo "Done"
+{{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/hooks/secret_git_properties.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/hooks/secret_git_properties.yaml
@@ -1,0 +1,23 @@
+{{- if not .Values.deploymentGitUrl }}
+apiVersion: v1
+kind: Secret
+metadata:
+   name: {{ .Release.Name }}-git-properties
+   labels:
+      app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+      app.kubernetes.io/instance: {{ .Release.Name | quote }}
+      app.kubernetes.io/version: {{ .Chart.AppVersion }}
+      helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+   annotations:
+      # This is what defines this resource as a hook. Without this line, the
+      # resource is considered part of the release.
+      helm.sh/hook: pre-install
+      helm.sh/hook-weight: "1"
+      helm.sh/hook-delete-policy: before-hook-creation
+      helm.sh/resource-policy: keep
+data:
+   git-repo-name: {{ .Values.deploymentGitRepoName | default uuidv4 | b64enc | quote }}
+   git-server: {{ "github.com/versatile-data-kit-jobs" | b64enc | quote }}
+   git-username: {{ "versatile-data-kit-jobs" | b64enc | quote }}
+   git-access-token: {{ "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" | b64enc | quote }}
+{{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -119,15 +119,18 @@ deploymentK8sKubeconfig: ""
 ## It's is ok to leave it empty (by default).
 controlK8sNamespace: ""
 
-## [Required] Git repository where deployed data jobs source can be found and from where they will be deployed
+## Git repository where deployed data jobs source can be found and from where they will be deployed.
+## If not specified, the Helm installation will create a public Github repository at
+## https://github.com/versatile-data-kit-jobs with a random UUID as name.
 # Git URL (without https:// scheme)
 deploymentGitUrl: ""
+deploymentGitRepoName: ""
 deploymentGitBranch: "main"
 deploymentGitRemote: "origin"
-# Username with read-only access to Git repo
+# Credentials with read-only access to the Git repository.
 deploymentGitUsername: ""
 deploymentGitPassword: ""
-# Credentials with read and write access to the git repository.
+# Credentials with read and write access to the Git repository.
 uploadGitReadWriteUsername: ""
 uploadGitReadWritePassword: ""
 


### PR DESCRIPTION
The Git parameters of the Helm installation are now optional.

If no Git parameters are specified, the Helm installation will
automatically create a new public Git repository in
https://github.com/versatile-data-kit-jobs. The name of the
new repository can be specified via the `deploymentGitRepoName`
parameter. If no name is specified, the name will be a randomly
generated UUID.

Finally, if specified, the `deploymentGitUrl` will take precedence
over `deploymentGitRepoName`.

Signed-off-by: Tsvetomir Palashki <tpalashki@vmware.com>