### PR TITLE
vdk-control-cli: change API client to vdk-control-service-api

### DIFF
--- a/projects/vdk-control-cli/requirements.txt
+++ b/projects/vdk-control-cli/requirements.txt
@@ -6,8 +6,7 @@ pluggy~=0.13
 tabulate
 click-spinner
 
-# TODO: seems like this fails for intellij the extra-index-url is missed in fresh envronment and needs manual install
-taurus-datajob-api==3.1.3
+vdk-control-service-api==1.0.1
 requests_oauthlib
 
 # Dependencies for creating HTTP calls against the OAuth2 provider. We can potentially remove those

--- a/projects/vdk-control-cli/setup.cfg
+++ b/projects/vdk-control-cli/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     requests>=2.25
     setuptools>=47.0
     pluggy==0.*
-    taurus-datajob-api==3.1.3
+    vdk-control-service-api==1.0.1
     tabulate
     requests_oauthlib>=1.0
     urllib3>=1.26.5


### PR DESCRIPTION
We have renamed taurus-datajob-api to vdk-control-service-api (since
it's more accurate and clear name). We are adopting the change here.

Testing Done: ran ./cicd/build.sh and saw all (unit) tests pass

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>