### PR TITLE
control-service: add telemetry webhook

### DIFF
--- a/projects/control-service/projects/base/build.gradle
+++ b/projects/control-service/projects/base/build.gradle
@@ -67,6 +67,8 @@ dependencies {
    implementation versions.'io.swagger:swagger-annotations'
    implementation versions.'io.swagger:swagger-models'
    implementation versions.'io.micrometer:micrometer-core'
+   testImplementation versions.'org.awaitility:awaitility'
+   testImplementation versions.'com.github.tomakehurst:wiremock'
    testImplementation versions.'org.mockito:mockito-core'
    testImplementation 'junit:junit'
 }

--- a/projects/control-service/projects/base/src/test/java/com/vmware/taurus/service/diag/telemetry/TelemetryTest.java
+++ b/projects/control-service/projects/base/src/test/java/com/vmware/taurus/service/diag/telemetry/TelemetryTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.diag.telemetry;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
+import static org.awaitility.Awaitility.await;
+
+public class TelemetryTest {
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
+
+    @Test
+    public void test_telemetry_being_send() {
+        stubFor(post(urlEqualTo("/test")).willReturn(aResponse().withBody("OK")));
+
+        var telemetry = new Telemetry(wireMockRule.url("/test"));
+        telemetry.sendAsync("{'key': 'value'}");
+
+        await().atMost(5, TimeUnit.SECONDS)
+                .with().pollInterval(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(postRequestedFor(urlEqualTo("/test"))
+                        .withRequestBody(containing("{'key': 'value'}"))));
+    }
+
+    @Test
+    public void test_telemetry_being_send_single_retry() {
+        // http://wiremock.org/docs/stateful-behaviour/
+        stubFor(post(urlEqualTo("/test"))
+                .inScenario("retry")
+                .whenScenarioStateIs(STARTED)
+                .willReturn(aResponse().withStatus(500))
+                .willSetStateTo("request succeeds")
+        );
+        stubFor(post(urlEqualTo("/test"))
+                .inScenario("retry")
+                .whenScenarioStateIs("request succeeds")
+                .willReturn(aResponse().withStatus(500))
+        );
+
+        var telemetry = new Telemetry(wireMockRule.url("/test"));
+        telemetry.sendAsync("{'key': 'value'}");
+
+        await().atMost(5, TimeUnit.SECONDS)
+                .with().pollInterval(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(exactly(2), postRequestedFor(urlEqualTo("/test"))
+                        .withRequestBody(containing("{'key': 'value'}"))));
+    }
+
+    @Test
+    public void test_telemetry_being_send_failed_client_error() {
+        stubFor(post(urlEqualTo("/test")).willReturn(aResponse().withStatus(401)));
+
+        var telemetry = new Telemetry(wireMockRule.url("/test"));
+        telemetry.sendAsync("{'key': 'value'}");
+
+        await().atMost(5, TimeUnit.SECONDS)
+                .with().pollInterval(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(postRequestedFor(urlEqualTo("/test"))
+                        .withRequestBody(containing("{'key': 'value'}"))));
+    }
+
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application-dev.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application-dev.properties
@@ -60,3 +60,7 @@ datajobs.git.read.write.password=
 # Note that this location is expected to be set via the environment
 # variable 'K8S_DATA_JOB_TEMPLATE_FILE'.
 #datajobs.control.k8s.data.job.template.file=${K8S_DATA_JOB_TEMPLATE_FILE:#{null}}
+
+# Webhook URL to send telemetry events via HTTP POST requests with a JSON payload
+# like http requests ; important api calls, etc
+# datajobs.telemetry.webhook.endpoint

--- a/projects/control-service/projects/versions-of-external-dependencies.gradle
+++ b/projects/control-service/projects/versions-of-external-dependencies.gradle
@@ -37,6 +37,7 @@ project.ext {
             'org.awaitility:awaitility'                                          : 'org.awaitility:awaitility:4.1.0',
             'org.tuckey:urlrewritefilter'                                        : 'org.tuckey:urlrewritefilter:4.0.4',
             'org.apache.commons:commons-lang3'                                   : 'org.apache.commons:commons-lang3:3.12.0',
+            'com.github.tomakehurst:wiremock'                                    : 'com.github.tomakehurst:wiremock:2.27.2',
 
             // transitive dependencies version force (freeze)
             // on next upgrade, revise if those still need to be set explicitly


### PR DESCRIPTION
Telemetry Webhook is used to send telemetry data to subscribed http
endpoint as POST request. It is used to send data to OLAP database for
reporting purposes in order to understand better the usage of Control
Service and Versatile Data Kit. Primarily expected users are operators
of Control Service but possibly also data engineers analyzing their own
usage.
We send telemetry for each API reqeusts (in type taurus_httptrace) and
for some special events (like deployment progress) (in type
taurus_apicall)

The way webhook is configured is through application property
telemetry.webhook.endpoint .

When conifgured it will send POST requests in JSON format with a
special attribute "@type" containing the type (aka table) of the object.

Testing Done: unit tests.
Also tested end to end by setitng in application-dev.properties:

telemetry.webhook.endpoint =
https://vcsa.vmware.com/ph-stg/api/hyper/send?_c=taurus.v0&_i=test-aivanov-github-telemetry

and starting the Control Service locally, executing a few requests and
verified through Ingester Debug Interface that telemetry is sent
correctly to the webhook endpoint. They look like this:

```
{
  "timestamp": 1628580279.118701,
  "principal": null,
  "session": null,
  "request": {
    "method": "GET",
    "uri": "http://localhost:8092/",
    "headers": { ... },
    "remoteAddress": null
  },
  "response": {
    "status": 404,
    "headers": { ...}
  },
  "timeTaken": 0,
  "@type": "taurus_httptrace",
  "deployment_mode": "dev",
  "@id": "01628580279119",
  "request_mapping": "/**"
}
```

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>