### PR TITLE
control-service,gitlab-ci: move end job to top level project

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,14 +12,22 @@ include:
 stages:
   - build
   - pre_release
+  - publish_artifacts
   - release
   - release_image
-  - publish_artifacts
   - end
 
-build:
+build-check-prerequisites:
   stage: build
   script:
     - ./cicd/build.sh
   only:
     - external_pull_requests
+
+end:
+  stage: end
+  script:
+    - echo "Noop pipeline to enable merging changes that are not covered by any of the jobs."
+  only:
+    refs:
+      - external_pull_requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ For any questions about the CLA process, please refer to our [FAQ](https://cla.v
   * vdk-core - Python-based SDK containing data library for developing and running data jobs. Includes a powerful plugin framework .
   * vdk-heartbeat - tool for verifying deployed SDK and Control Service are functional and working correctly
   * vdk-control-cli - User friendly CLI interface over Control Service operations including login/logout.
-  * plugins - Set of plugins that we maintain and provide for different use-cases like lineage, database support, ...
+  * vdk-core/plugins - Set of plugins that we maintain and provide for different use-cases like lineage, database support, ...
 * support - helper scripts used by developers of the project during their workday
 * cicd - build and ci cd related scripts common across all projects. Each project also has its own cicd folder
 * examples - list of example use-cases. Each example directory has its README with detailed explanations
@@ -24,12 +24,16 @@ To boostrap the project run
 ./cicd/build.sh
 ```
 
-Each project has its own README.md with details on how to test (locally), build it, and run it.
+Each component project is independently buildable and has independent CICD.
+This enables people to contribute only to specific component without needing to know anything about the other components.
+
+Each component project has its own README.md with specific details on how to test (locally), build it, and run it.
+Each component project also have "build.sh" scripts in their cicd/ folder that would build the whole component.
+Each component project also have its own .gitlab-ci.yml file with CICD definition.
+
 If in doubt, open the .gitlab-ci.yml file of the project.
 Read through the Gitlab CI file to find the build process confirmed to work by an automated continuous integration (CI).
 CI runs in Docker Linux containers, so if you have docker installed, you will be able to replicate the process.
-
-Each component project also have "build.sh" scripts in their cicd/ folder that would build the whole component.
 
 # How to prepare your change
 

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -208,12 +208,3 @@ publish_control_service_api_client:
       - main
     changes:
       - projects/control-service/projects/helm_charts/pipelines-control-service/version.txt
-
-end:
-  stage: end
-  script:
-    - echo "Noop pipeline to enable merging changes that are not covered by any of the jobs."
-  retry: !reference [.control_service_retry, retry_options]
-  only:
-    refs:
-      - external_pull_requests


### PR DESCRIPTION
end job is a common job that is applicable for everything so I am
putting it in the top level gitlab-ci.yalm

Testing Done: this PR

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>