### PR TITLE
vdk-sqlite: add new plugin

### DIFF
--- a/projects/vdk-core/plugins/vdk-sqlite/.plugin-ci.yml
+++ b/projects/vdk-core/plugins/vdk-sqlite/.plugin-ci.yml
@@ -1,0 +1,33 @@
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+image: "python:3.7"
+
+stages:
+  - build
+  - release
+
+.build-vdk-sqlite:
+  variables:
+    PLUGIN_NAME: vdk-sqlite
+  extends: .build-plugin
+
+build-py37-vdk-sqlite:
+  extends: .build-vdk-sqlite
+  image: "python:3.7"
+
+
+build-py38-vdk-sqlite:
+  extends: .build-vdk-sqlite
+  image: "python:3.8"
+
+
+build-py39-vdk-sqlite:
+  extends: .build-vdk-sqlite
+  image: "python:3.9"
+
+
+release-vdk-sqlite:
+  variables:
+    PLUGIN_NAME: vdk-sqlite
+  extends: .release-plugin

--- a/projects/vdk-core/plugins/vdk-sqlite/README.md
+++ b/projects/vdk-core/plugins/vdk-sqlite/README.md
@@ -1,0 +1,30 @@
+This plugin allows vdk-core to interface with and execute queries against a Sqlite database.
+
+# Usage
+
+Run
+```bash
+pip install vdk-sqlite
+```
+
+After this data jobs will have access to sqlite database connection managed by Versatile Data Kit SDK.
+
+If it is the only database plugin installed , vdk would automatically use it.
+Otherwise, users need to set VDK_DB_DEFAULT_TYPE=SQLITE as an environment variable or set 'db_default_type' option in the data job config file (config.ini).
+
+For example
+
+```python
+    def run(job_input: IJobInput):
+        job_input.execute_query("select 'Hi SqLite!'")
+```
+
+## Configuration
+
+When set as environment variables those options are prefixed with "VDK_"
+
+| Name | Description | (most likely) value |
+|---|---|---|
+| DB_DEFAULT_TYPE | The type of database used in data job queries by default | SQLITE |
+| SQLITE_DIRECTORY | Where on local file system the database files will be stored  | Temp directory |
+|  |  |  |

--- a/projects/vdk-core/plugins/vdk-sqlite/requirements.txt
+++ b/projects/vdk-core/plugins/vdk-sqlite/requirements.txt
@@ -1,0 +1,7 @@
+vdk-core
+click
+
+# testing requirements
+vdk-test-utils
+pytest
+pytest-cov

--- a/projects/vdk-core/plugins/vdk-sqlite/setup.py
+++ b/projects/vdk-core/plugins/vdk-sqlite/setup.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import setuptools
+
+"""
+Builds a package with the help of setuptools in order for this package to be imported in other projects
+"""
+__version__ = "0.1.3"
+
+setuptools.setup(
+    name="vdk-sqlite",
+    version=__version__,
+    install_requires=["vdk-core", "tabulate"],
+    package_dir={"": "src"},
+    packages=setuptools.find_namespace_packages(where="src"),
+    include_package_data=True,
+    entry_points={"vdk.plugin.run": ["vdk-sqlite = taurus.vdk.sqlite_plugin"]},
+)

--- a/projects/vdk-core/plugins/vdk-sqlite/src/taurus/vdk/sqlite_plugin.py
+++ b/projects/vdk-core/plugins/vdk-sqlite/src/taurus/vdk/sqlite_plugin.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+import os
+import pathlib
+import tempfile
+
+import click
+from tabulate import tabulate
+from taurus.api.plugin.hook_markers import hookimpl
+from taurus.vdk.builtin_plugins.run.job_context import JobContext
+from taurus.vdk.core.config import Configuration
+from taurus.vdk.core.config import ConfigurationBuilder
+from taurus.vdk.sqllite_connection import SqLiteConnection
+
+SQLITE_DIRECTORY = "SQLITE_DIRECTORY"
+
+log = logging.getLogger(__name__)
+
+
+class SqLiteConfiguration:
+    def __init__(self, configuration: Configuration):
+        self.__config = configuration
+
+    def get_sqlite_directory(self) -> pathlib.Path:
+        return pathlib.Path(self.__config.get_value(SQLITE_DIRECTORY))
+
+
+def add_definitions(config_builder: ConfigurationBuilder):
+    config_builder.add(
+        key=SQLITE_DIRECTORY,
+        default_value=tempfile.gettempdir(),
+        description="The directory where the sqlite database would be found.",
+    )
+
+
+@hookimpl
+def vdk_configure(config_builder: ConfigurationBuilder) -> None:
+    """
+    Here we define what configuration settings are needed for sqlite with reasonable defaults
+    """
+    add_definitions(config_builder)
+
+
+@hookimpl
+def initialize_job(context: JobContext) -> None:
+    conf = SqLiteConfiguration(context.core_context.configuration)
+    context.connections.add_open_connection_factory_method(
+        "SQLITE",
+        lambda: SqLiteConnection(
+            pathlib.Path(conf.get_sqlite_directory())
+        ).new_connection(),
+    )
+
+
+@click.command(
+    name="sqlite-query", help="executes SQL query against local SQlite database."
+)
+@click.option("-q", "--query", type=click.STRING, required=True)
+@click.pass_context
+def sqlite_query(ctx: click.Context, query):
+    conf = SqLiteConfiguration(ctx.obj.configuration)
+    conn = SqLiteConnection(conf.get_sqlite_directory())
+    res = conn.execute_query(query)
+    click.echo(tabulate(res))
+
+
+@hookimpl
+def vdk_command_line(root_command: click.Group):
+    """
+    Here we extend vdk with new command called "sqlite-query" enabling users to execute
+    """
+    root_command.add_command(sqlite_query)

--- a/projects/vdk-core/plugins/vdk-sqlite/src/taurus/vdk/sqllite_connection.py
+++ b/projects/vdk-core/plugins/vdk-sqlite/src/taurus/vdk/sqllite_connection.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+import pathlib
+import tempfile
+from typing import List
+
+from taurus.vdk.util.decorators import closing_noexcept_on_close
+
+log = logging.getLogger(__name__)
+
+
+class SqLiteConnection:
+    """
+    Create file based sqlite database.
+    """
+
+    def __init__(
+        self, temp_directory: pathlib.Path = pathlib.Path(tempfile.gettempdir())
+    ):
+        self.__db_name = "vdk-sqlite"
+        self.__db_file = temp_directory.joinpath(self.__db_name + ".db")
+
+    def new_connection(self):
+        import sqlite3
+
+        log.info(f"Create new connection against local file db: {self.__db_name}")
+        return sqlite3.connect(f"{self.__db_file}")
+
+    def execute_query(self, query: str) -> List[List]:
+        conn = self.new_connection()
+        with closing_noexcept_on_close(conn.cursor()) as cursor:
+            cursor.execute(query)
+            return cursor.fetchall()

--- a/projects/vdk-core/plugins/vdk-sqlite/tests/jobs/sql-job/10_create_table.sql
+++ b/projects/vdk-core/plugins/vdk-sqlite/tests/jobs/sql-job/10_create_table.sql
@@ -1,0 +1,2 @@
+
+CREATE TABLE stocks (date text, symbol text, price real)

--- a/projects/vdk-core/plugins/vdk-sqlite/tests/jobs/sql-job/20_populate_table.sql
+++ b/projects/vdk-core/plugins/vdk-sqlite/tests/jobs/sql-job/20_populate_table.sql
@@ -1,0 +1,1 @@
+INSERT INTO stocks VALUES ('2020-01-01', 'GOOG', 123.0), ('2020-01-01', 'GOOG', 123.0)

--- a/projects/vdk-core/plugins/vdk-sqlite/tests/test_sqlite_plugin.py
+++ b/projects/vdk-core/plugins/vdk-sqlite/tests/test_sqlite_plugin.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import os
+from unittest import mock
+
+from click.testing import Result
+from taurus.vdk import sqlite_plugin
+from taurus.vdk.test_utils.util_funcs import cli_assert_equal
+from taurus.vdk.test_utils.util_funcs import CliEntryBasedTestRunner
+from taurus.vdk.test_utils.util_funcs import jobs_path_from_caller_directory
+
+
+def test_sqlite_plugin(tmpdir):
+    with mock.patch.dict(
+        os.environ,
+        {"VDK_DB_DEFAULT_TYPE": "SQLITE", "VDK_SQLITE_DIRECTORY": str(tmpdir)},
+    ):
+        runner = CliEntryBasedTestRunner(sqlite_plugin)
+
+        result: Result = runner.invoke(
+            ["run", jobs_path_from_caller_directory("sql-job")]
+        )
+
+        cli_assert_equal(0, result)
+
+        actual_rs: Result = runner.invoke(
+            ["sqlite-query", "--query", f"SELECT * FROM stocks"]
+        )
+
+        cli_assert_equal(0, actual_rs)
+        assert "GOOG" in actual_rs.output


### PR DESCRIPTION
It was agreed that we need a very simple example for executing sql
transformations which will not require external database. Setting up
external database may take time and using sqlite db would make first sql
job easier to get started with. This would also showing integration with
multiple databases is easy.

Testing Done: added function test (test_sqlite_plugin)

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>