### PR TITLE
control-service: Update Helm chart

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/NOTES.txt
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/NOTES.txt
@@ -32,6 +32,12 @@ To access Data Jobs API from outside your K8s cluster, follow the steps below:
 
 {{- end }}
 
+{{- if not .Values.deploymentGitUrl }}
+
+This installation uses public git repository to store the source code of data jobs.
+
+{{- end }}
+
 # TODO: allow people to install with defaults including required properties (like credentials) but print warnings on what functionality is disabled and why.
 # TODO: if deploymentK8sNamespace == "" and deploymentK8sKubeconfig = "" not recommended warning
 # TODO: if kubeConfig is missing automated provisioning of users will be disabled

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -135,8 +135,10 @@ spec:
               value: "{{ .Values.controlK8sNamespace }}"
             - name: FEATUREFLAG_SECURITY_ENABLED
               value: "{{ .Values.security.enabled }}"
+            {{- if .Values.security.oauth2.jwtJwkSetUri }}
             - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI
               value: "{{ .Values.security.oauth2.jwtJwkSetUri }}"
+            {{- end }}
             - name: FEATUREFLAG_AUTHORIZATION_ENABLED
               value: "{{ .Values.security.authorizationEnabled }}"
             - name: DATAJOBS_AUTHORIZATION_WEBHOOK_ENDPOINT

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -374,7 +374,7 @@ metrics:
    ## Prometheus Operator ServiceMonitor configuration
    ##
    serviceMonitor:
-      enabled: true
+      enabled: false
       ## Namespace in which Prometheus is running
       ##
       # namespace: monitoring
@@ -407,7 +407,7 @@ metrics:
 ## Alerting configuration
 ##
 alerting:
-   enabled: true
+   enabled: false
 
    ## Custom PrometheusRule to be defined
    ## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions


### PR DESCRIPTION
In order to simplify the installation of the Helm chart some
features are disabled by default.

The serviceMonitor and alerting are disabled by default.
WARNING: When this change is adopted, the respective values must
be switched back to true: `metrics.serviceMonitor.enabled` and
`alerting.enabled'.

The `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI` is not
set if the respective jwtJwkSetUri property is empty, to prevent
Spring security from throwing an exception.

Clean up the README file. Update the NOTES.txt file to indicate
that the installation will use a public Git repository.

Signed-off-by: Tsvetomir Palashki <tpalashki@vmware.com>