### PR TITLE
vdk plugins: add url & classifiers

### DIFF
--- a/projects/vdk-core/plugins/plugin-template/setup.py
+++ b/projects/vdk-core/plugins/plugin-template/setup.py
@@ -19,6 +19,7 @@ __version__ = "0.1.0"
 setuptools.setup(
     name="plugin-package-template",
     version=__version__,
+    url="https://github.com/vmware/versatile-data-kit",
     description="Plugin template project used to quick start development of a new Versatile Data Kit SDK plugin.",
     long_description=pathlib.Path("README.md").read_text(),
     long_description_content_type="text/markdown",
@@ -27,6 +28,10 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages(where="src"),
     entry_points={"vdk.plugin.run": ["plugin-template = taurus.vdk.plugin_template"]},
     classifiers=[
+        "Development Status :: 4 - Beta",
         "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
 )

--- a/projects/vdk-core/plugins/quickstart-vdk/setup.py
+++ b/projects/vdk-core/plugins/quickstart-vdk/setup.py
@@ -8,10 +8,11 @@ __version__ = "0.1.2"
 
 setuptools.setup(
     name="quickstart-vdk",
+    version=__version__,
+    url="https://github.com/vmware/versatile-data-kit",
     description="Versatile Data Kit SDK packaging containing common plugins to get started quickly using it.",
     long_description=pathlib.Path("README.md").read_text(),
     long_description_content_type="text/markdown",
-    version=__version__,
     install_requires=[
         "vdk-core",
         "vdk-plugin-control-cli",
@@ -20,6 +21,10 @@ setuptools.setup(
         "vdk-ingest-file",
     ],
     classifiers=[
+        "Development Status :: 4 - Beta",
         "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
 )

--- a/projects/vdk-core/plugins/vdk-ingest-file/setup.py
+++ b/projects/vdk-core/plugins/vdk-ingest-file/setup.py
@@ -9,6 +9,7 @@ __version__ = "0.1.0"
 setuptools.setup(
     name="vdk-ingest-file",
     version=__version__,
+    url="https://github.com/vmware/versatile-data-kit",
     description="Versatile Data Kit SDK ingestion plugin to ingest data into a file.",
     long_description=pathlib.Path("README.md").read_text(),
     long_description_content_type="text/markdown",
@@ -19,6 +20,10 @@ setuptools.setup(
         "vdk.plugin.run": ["vdk-ingest-file = taurus.vdk.ingest_file_plugin"]
     },
     classifiers=[
+        "Development Status :: 4 - Beta",
         "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
 )

--- a/projects/vdk-core/plugins/vdk-ingest-http/setup.py
+++ b/projects/vdk-core/plugins/vdk-ingest-http/setup.py
@@ -9,6 +9,7 @@ __version__ = "0.1.0"
 setuptools.setup(
     name="vdk-ingest-http",
     version=__version__,
+    url="https://github.com/vmware/versatile-data-kit",
     description="Versatile Data Kit SDK ingestion plugin to ingest data via http requests.",
     long_description=pathlib.Path("README.md").read_text(),
     long_description_content_type="text/markdown",
@@ -19,6 +20,10 @@ setuptools.setup(
         "vdk.plugin.run": ["vdk-ingest-http = taurus.vdk.ingest_http_plugin"]
     },
     classifiers=[
+        "Development Status :: 4 - Beta",
         "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
 )

--- a/projects/vdk-core/plugins/vdk-logging-ltsv/setup.py
+++ b/projects/vdk-core/plugins/vdk-logging-ltsv/setup.py
@@ -9,6 +9,7 @@ __version__ = "0.1.0"
 setuptools.setup(
     name="vdk-logging-ltsv",
     version=__version__,
+    url="https://github.com/vmware/versatile-data-kit",
     description="Versatile Data Kit SDK plugin that changes logging output to LTSV format.",
     long_description=pathlib.Path("README.md").read_text(),
     long_description_content_type="text/markdown",
@@ -17,6 +18,10 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages(where="src"),
     entry_points={"vdk.plugin.run": ["vdk-logging-ltsv = taurus.vdk.logging_ltsv"]},
     classifiers=[
+        "Development Status :: 4 - Beta",
         "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
 )

--- a/projects/vdk-core/plugins/vdk-plugin-control-cli/setup.py
+++ b/projects/vdk-core/plugins/vdk-plugin-control-cli/setup.py
@@ -12,6 +12,7 @@ __version__ = "0.1.dev2"
 setuptools.setup(
     name="vdk-plugin-control-cli",
     version=__version__,
+    url="https://github.com/vmware/versatile-data-kit",
     description="Versatile Data Kit SDK plugin exposing CLI commands for managing the lifecycle of a Data Jobs.",
     long_description=pathlib.Path("README.md").read_text(),
     long_description_content_type="text/markdown",
@@ -25,6 +26,10 @@ setuptools.setup(
         ]
     },
     classifiers=[
+        "Development Status :: 4 - Beta",
         "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
 )

--- a/projects/vdk-core/plugins/vdk-test-utils/setup.py
+++ b/projects/vdk-core/plugins/vdk-test-utils/setup.py
@@ -9,6 +9,7 @@ __version__ = "0.1.2"
 setuptools.setup(
     name="vdk-test-utils",
     version=__version__,
+    url="https://github.com/vmware/versatile-data-kit",
     description="Provides utilities for testing Versatile Data Kit SDK plugins.",
     long_description=pathlib.Path("README.md").read_text(),
     long_description_content_type="text/markdown",
@@ -16,6 +17,10 @@ setuptools.setup(
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),
     classifiers=[
+        "Development Status :: 4 - Beta",
         "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
 )

--- a/projects/vdk-core/plugins/vdk-trino/setup.py
+++ b/projects/vdk-core/plugins/vdk-trino/setup.py
@@ -9,6 +9,7 @@ __version__ = "0.1.3"
 setuptools.setup(
     name="vdk-trino",
     version=__version__,
+    url="https://github.com/vmware/versatile-data-kit",
     description="Versatile Data Kit SDK plugin provides support for trino database and trino transformation templates.",
     long_description=pathlib.Path("README.md").read_text(),
     long_description_content_type="text/markdown",
@@ -18,6 +19,10 @@ setuptools.setup(
     include_package_data=True,
     entry_points={"vdk.plugin.run": ["vdk-trino = taurus.vdk.trino_plugin"]},
     classifiers=[
+        "Development Status :: 4 - Beta",
         "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
 )


### PR DESCRIPTION
Add some missing standard classifiers and url link to project. This way
users visiting the distribution on pypi.org (e.g
https://pypi.org/project/vdk-trino) would be able to easier naviate
to the project source or get contacts, etc.

Testing Done: unit tests

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>