### PR TITLE
vdk-core: vdk-logging-json

### DIFF
--- a/projects/vdk-core/plugins/vdk-logging-json/.plugin-ci.yml
+++ b/projects/vdk-core/plugins/vdk-logging-json/.plugin-ci.yml
@@ -1,0 +1,33 @@
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+image: "python:3.7"
+
+stages:
+  - build
+  - release
+
+.build-vdk-logging-json:
+  variables:
+    PLUGIN_NAME: vdk-logging-json
+  extends: .build-plugin
+
+build-py37-vdk-logging-json:
+  extends: .build-vdk-logging-json
+  image: "python:3.7"
+
+
+build-py38-vdk-logging-json:
+  extends: .build-vdk-logging-json
+  image: "python:3.8"
+
+
+build-py39-vdk-logging-json:
+  extends: .build-vdk-logging-json
+  image: "python:3.9"
+
+
+release-vdk-logging-json:
+  variables:
+    PLUGIN_NAME: vdk-logging-json
+  extends: .release-plugin

--- a/projects/vdk-core/plugins/vdk-logging-json/README.md
+++ b/projects/vdk-core/plugins/vdk-logging-json/README.md
@@ -1,0 +1,31 @@
+This is a POC level implementation of a plugin which changes the logging format of vdk-core to JSON for the purposes of structured data visualization.
+
+The new format has the following fields, separated by tabs:
+ * timestamp: a timestamp of when the log is made;
+ * created: the same timestamp in the unix epoch format;
+ * jobname: the name of the data job;
+ * level: the logging level - one of INFO, WARNING, DEBUG, ERROR;
+ * modulename: the name of the module, inside of which the logging call is made;
+ * filename: the name of the file containing the logging call being made;
+ * lineno: the number of the line of code, at which the logging call is made;
+ * funcname: the name of the function, inside which the loggin call is made;
+ * attemptid: string identifying this particular execution of the data job;
+ * message: any additional logged information.
+
+The label names follow the labelling recommendations found at http://ltsv.org/.
+The reason we chose the LTSV naming standard is due to the fact that this plugin was based on a previous LTSV-formatting plugin,
+as well as the fact that there is no single JSON naming standard.
+
+# Usage
+
+Switching vdk logging can be done by simply installing the plugin:
+
+```python
+pip install vdk-logging-json
+```
+
+And all logs will be automatically formatted to JSON. They will appear like this:
+```
+{"@timestamp":"2021-08-04T12:51:11.532Z","created":"1628070671","jobname":"example-job","level":"DEBUG","modulename":"taurus.vdk.trino_connection","filename":"managed_connection_base.py","lineno":"69","funcname":"connect","attemptid":"1628070671-452613-739749","message":"Established <trino.dbapi.Connection object at 0x10b9b1d30>"}
+{"@timestamp":"2021-08-04T12:51:11.532Z","created:1628070671","jobname":"example-job","level":"DEBUG","modulename":"taurus.vdk.trino_connection","filename":"managed_cursor.py","lineno":"29","funcname":"execute","attemptid":"1628070671-452613-739749","message":"Executing query: select 1"}
+```

--- a/projects/vdk-core/plugins/vdk-logging-json/requirements.txt
+++ b/projects/vdk-core/plugins/vdk-logging-json/requirements.txt
@@ -1,0 +1,2 @@
+vdk-core
+vdk-test-utils

--- a/projects/vdk-core/plugins/vdk-logging-json/setup.py
+++ b/projects/vdk-core/plugins/vdk-logging-json/setup.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import pathlib
+
+import setuptools
+
+__version__ = "0.1.0"
+
+setuptools.setup(
+    name="vdk-logging-json",
+    version=__version__,
+    url="https://github.com/vmware/versatile-data-kit",
+    description="Versatile Data Kit SDK plugin that changes logging output to JSON format.",
+    long_description=pathlib.Path("README.md").read_text(),
+    long_description_content_type="text/markdown",
+    install_requires=["vdk-core"],
+    package_dir={"": "src"},
+    packages=setuptools.find_namespace_packages(where="src"),
+    entry_points={"vdk.plugin.run": ["vdk-logging-json = taurus.vdk.logging_json"]},
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+    ],
+)

--- a/projects/vdk-core/plugins/vdk-logging-json/src/taurus/vdk/logging_json.py
+++ b/projects/vdk-core/plugins/vdk-logging-json/src/taurus/vdk/logging_json.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+from taurus.api.plugin.hook_markers import hookimpl
+from taurus.vdk.builtin_plugins.run.job_context import JobContext
+from taurus.vdk.core.statestore import CommonStoreKeys
+
+# the labels follow the labelling recommendations found here: http://ltsv.org/
+format_template = (
+    '"@timestamp":"%(asctime)s","created":"%(created)f","jobname":"{job_name}",'
+    '"level":"%(levelname)s","modulename":"%(name)s","filename":"%(filename)s",'
+    '"lineno":"%(lineno)s","funcname":"%(funcName)s","attemptid":"{attempt_id}","message":"%(message)s"'
+)
+
+
+@hookimpl(trylast=True)
+def initialize_job(context: JobContext) -> None:
+    attempt_id = context.core_context.state.get(CommonStoreKeys.ATTEMPT_ID)
+    job_name = context.name
+
+    detailed_format = format_template.format(
+        job_name=job_name, attempt_id=attempt_id
+    )  # appending braces is separated due to issue with
+    detailed_format = (
+        "{" + detailed_format + "}"
+    )  # formatting a string containing curly braces
+
+    for handler in logging.getLogger().handlers:
+        formatter = logging.Formatter(fmt=detailed_format)
+        formatter.default_time_format = "%Y-%m-%dT%H:%M:%S"
+        formatter.default_msec_format = "%s.%03dZ"
+
+        handler.setFormatter(formatter)

--- a/projects/vdk-core/plugins/vdk-logging-json/tests/test_logging_json.py
+++ b/projects/vdk-core/plugins/vdk-logging-json/tests/test_logging_json.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+from taurus.vdk.logging_json import format_template
+
+
+def test_json_logging():
+    for handler in logging.getLogger(__name__).handlers:
+        assert handler.formatter._fmt == format_template


### PR DESCRIPTION
note: new PR due to the CLA issue

Implement plugin which changes the logging format to conform
to JSON.

Testing done: unit test, pipelines passed
After installing, data job logs appear like so:
```
{"@timestamp":"2021-08-04T12:51:11.532Z","created":"1628070671","jobname":"example-job","level":"DEBUG","modulename":"taurus.vdk.trino_connection","filename":"managed_connection_base.py","lineno":"69","funcname":"connect","attemptid":"1628070671-452613-739749","message":"Established <trino.dbapi.Connection object at 0x10b9b1d30>"}
```

Signed-off-by: gageorgiev <gageorgiev@vmware.com>