### PR TITLE
quickstart-vdk: release docker image with bundled vdk

### DIFF
--- a/projects/vdk-core/.gitlab-ci.yml
+++ b/projects/vdk-core/.gitlab-ci.yml
@@ -7,10 +7,6 @@ include:
 
 image: "python:3.9"
 
-#variables:
-#  EXAMPLE: database_name
-
-
 .vdk_core_changes: &vdk_core_locations
   - "projects/vdk-core/*"
   - "projects/vdk-core/cicd/**/*"

--- a/projects/vdk-core/cicd/Dockerfile-vdk-base
+++ b/projects/vdk-core/cicd/Dockerfile-vdk-base
@@ -1,13 +1,11 @@
 # Specifies a base image containing installed and ready to use VDK
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices
 
-FROM harbor-repo.vmware.com/dockerhub-proxy-cache/library/python:3.7-slim
+FROM python:3.7-slim
 
 WORKDIR /vdk
 
-# necessary for non-interactive install of krb5-user (kinit)
-ENV DEBIAN_FRONTEND noninteractive
-ENV VDK_VERSION $vdk_versions
+ENV VDK_VERSION $vdk_version
 
 # Install VDK
 ARG vdk_version

--- a/projects/vdk-core/plugins/.plugin-common.yml
+++ b/projects/vdk-core/plugins/.plugin-common.yml
@@ -17,7 +17,7 @@
     - pip install -U pip setuptools pre-commit
     - pre-commit install
     - pip install --extra-index-url $PIP_EXTRA_INDEX_URL -r requirements.txt
-    - extra_index_url=$([[ -n "$PIP_REPO_URL" ]] && echo "--extra-index-url $PIP_REPO_URL" || echo "")
+    - extra_index_url=$([[ -n "$PIP_EXTRA_INDEX_URL" ]] && echo "--extra-index-url $PIP_EXTRA_INDEX_URL" || echo "")
     - pip install -e . $extra_index_url
     - pip install pytest-cov
     - pytest --junitxml=tests.xml --cov taurus --cov-report term-missing --cov-report xml:coverage.xml
@@ -53,9 +53,13 @@
 
 .release-vdk-image:
   stage: release_image
+  image: docker:19.03.8
   services:
-    - harbor-repo.vmware.com/dockerhub-proxy-cache/library/docker:19.03.8-dind
-  image: harbor-repo.vmware.com/dockerhub-proxy-cache/library/docker:19.03.8
+    - docker:19.03.8-dind
+  variables:
+    DOCKER_HOST: tcp://localhost:2375
+    DOCKER_DRIVER: overlay2
+    DOCKER_TLS_CERTDIR: ""
   before_script:
     - cd projects/vdk-core/
   script:
@@ -68,7 +72,6 @@
     - export VDK_PACKAGE=$(python3 setup.py --name)
     - export VDK_VERSION=$(python3 setup.py --version)
     - export BUILD_TYPE=release
-    - export PIP_EXTRA_INDEX_URL="$PIP_REPO_URL"
     - bash -x ../../cicd/deploy-base-vdk-image.sh
   retry: !reference [.retry, retry_options]
   rules:

--- a/projects/vdk-core/plugins/quickstart-vdk/.plugin-ci.yml
+++ b/projects/vdk-core/plugins/quickstart-vdk/.plugin-ci.yml
@@ -35,7 +35,7 @@ release-quickstart-vdk:
     PLUGIN_NAME: quickstart-vdk
   extends: .release-plugin
 
-release_vdk_image:
+release-vdk-image-quickstart-vdk:
   variables:
     PLUGIN_NAME: quickstart-vdk
   extends: .release-vdk-image

--- a/projects/vdk-core/plugins/quickstart-vdk/setup.py
+++ b/projects/vdk-core/plugins/quickstart-vdk/setup.py
@@ -4,7 +4,7 @@ import pathlib
 
 import setuptools
 
-__version__ = "0.1.2"
+__version__ = "0.1.dev1"
 
 setuptools.setup(
     name="quickstart-vdk",
@@ -17,6 +17,7 @@ setuptools.setup(
         "vdk-core",
         "vdk-plugin-control-cli",
         "vdk-trino",
+        "vdk-sqlite",
         "vdk-ingest-http",
         "vdk-ingest-file",
     ],


### PR DESCRIPTION
In order to be used by Control Service runtime environment a
distribution or packaging of vdk need to also release a docker image.

We are doing this for quickstart-vdk here.

Testing Done: Gitlab CI - temporarily changed release stage to trigger
on pull requests in order to verify image is built correctly.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>