### PR TITLE
control-service: publish job-builder image

### DIFF
--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -86,7 +86,7 @@ build_control_service_image:
     changes:
       - projects/control-service/projects/helm_charts/pipelines-control-service/version.txt
 
-.publish_vdk_job_builder_image:
+publish_vdk_job_builder_image:
   image: docker:19.03.8
   services:
     - docker:19.03.8-dind
@@ -97,7 +97,7 @@ build_control_service_image:
   stage: publish_artifacts
   script:
     - apk add --no-cache bash
-    - docker login --username "${HARBOR_REGISTRY_ROBOT_PIPELINES_USER}" --password "${HARBOR_REGISTRY_ROBOT_PIPELINES_TOKEN}" "${PIPELINES_DOCKER_REGISTRY}"
+    - docker login --username "${VDK_DOCKER_REGISTRY_USERNAME}" --password "${VDK_DOCKER_REGISTRY_PASSWORD}" "${VDK_DOCKER_REGISTRY_URL}"
     - cd projects/control-service/projects/vdk_job_builder
     - bash -ex ./publish-vdk-job-builder.sh
   retry: !reference [.control_service_retry, retry_options]

--- a/projects/control-service/projects/vdk_job_builder/publish-vdk-job-builder.sh
+++ b/projects/control-service/projects/vdk_job_builder/publish-vdk-job-builder.sh
@@ -5,14 +5,14 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 VERSION_TAG=$(cat "$SCRIPT_DIR/version.txt")
-PIPELINES_DOCKER_REGISTRY=${PIPELINES_DOCKER_REGISTRY:-"hub.docker.com/versatiledatakit"}
+VDK_DOCKER_REGISTRY_URL=${VDK_DOCKER_REGISTRY_URL:-"registry.hub.docker.com/versatiledatakit"}
 
 function build_and_push_image() {
     name="$1"
     docker_file="$2"
     arguments="$3"
 
-    image_repo="$PIPELINES_DOCKER_REGISTRY/$name"
+    image_repo="$VDK_DOCKER_REGISTRY_URL/$name"
     image_tag="$image_repo:$VERSION_TAG"
 
     docker build -t $image_tag -t $image_repo:latest -f "$SCRIPT_DIR/k8s_vdk_job_builder/$docker_file" $arguments "$SCRIPT_DIR"


### PR DESCRIPTION
Job Builder Image is used by Control Service to build the data job image
when a new data job is being deployed. It's started in kubernetes job -
this way the operation can be done asyncrounously and also enables
certain level of extensibility as the job-builder image can be
configured.

We need to publish the image to dockerhub on each change . This is
enabling the publish step and setting correct variables to use.

Testing Done executed locally ./publish-vdk-job-builder.sh (and verified images are in dockerhub: https://hub.docker.com/search?q=versatiledatakit&type=image) , tested in
CI by starting step in PR (temporarily)