### PR TITLE
vdk cicd: remove stages overrides

### DIFF
--- a/projects/vdk-core/plugins/plugin-template/.plugin-ci.yml
+++ b/projects/vdk-core/plugins/plugin-template/.plugin-ci.yml
@@ -3,10 +3,6 @@
 
 image: "python:3.7"
 
-stages:
-  - build
-  - release
-
 .build-plugin-template: # change name here to the name of the plugin
   variables:
     PLUGIN_NAME: plugin-template # change name here to the name of the plugin

--- a/projects/vdk-core/plugins/quickstart-vdk/.plugin-ci.yml
+++ b/projects/vdk-core/plugins/quickstart-vdk/.plugin-ci.yml
@@ -8,9 +8,6 @@ variables:
   DOCKER_DRIVER: overlay2
   DOCKER_TLS_CERTDIR: ""
 
-stages:
-  - build
-  - release
 
 .build-quickstart-vdk:
   variables:

--- a/projects/vdk-core/plugins/taurus-vdk/.plugin-ci.yml
+++ b/projects/vdk-core/plugins/taurus-vdk/.plugin-ci.yml
@@ -8,9 +8,6 @@ variables:
   DOCKER_DRIVER: overlay2
   DOCKER_TLS_CERTDIR: ""
 
-stages:
-  - build
-  - release
 
 .build-taurus-vdk:
   variables:

--- a/projects/vdk-core/plugins/vdk-ingest-file/.plugin-ci.yml
+++ b/projects/vdk-core/plugins/vdk-ingest-file/.plugin-ci.yml
@@ -3,10 +3,6 @@
 
 image: "python:3.7"
 
-stages:
-  - build
-  - release
-
 .build-vdk-ingest-file:
   variables:
     PLUGIN_NAME: vdk-ingest-file

--- a/projects/vdk-core/plugins/vdk-ingest-http/.plugin-ci.yml
+++ b/projects/vdk-core/plugins/vdk-ingest-http/.plugin-ci.yml
@@ -3,10 +3,6 @@
 
 image: "python:3.7"
 
-stages:
-  - build
-  - release
-
 .build-vdk-ingest-http:
   variables:
     PLUGIN_NAME: vdk-ingest-http

--- a/projects/vdk-core/plugins/vdk-logging-json/.plugin-ci.yml
+++ b/projects/vdk-core/plugins/vdk-logging-json/.plugin-ci.yml
@@ -3,10 +3,6 @@
 
 image: "python:3.7"
 
-stages:
-  - build
-  - release
-
 .build-vdk-logging-json:
   variables:
     PLUGIN_NAME: vdk-logging-json

--- a/projects/vdk-core/plugins/vdk-logging-ltsv/.plugin-ci.yml
+++ b/projects/vdk-core/plugins/vdk-logging-ltsv/.plugin-ci.yml
@@ -3,9 +3,6 @@
 
 image: "python:3.7"
 
-stages:
-  - build
-  - release
 
 .build-vdk-logging-ltsv:
   variables:

--- a/projects/vdk-core/plugins/vdk-plugin-control-cli/.plugin-ci.yml
+++ b/projects/vdk-core/plugins/vdk-plugin-control-cli/.plugin-ci.yml
@@ -3,10 +3,6 @@
 
 image: "python:3.7"
 
-stages:
-  - build
-  - release
-
 .build-vdk-plugin-control-cli:
   variables:
     PLUGIN_NAME: vdk-plugin-control-cli

--- a/projects/vdk-core/plugins/vdk-sqlite/.plugin-ci.yml
+++ b/projects/vdk-core/plugins/vdk-sqlite/.plugin-ci.yml
@@ -3,9 +3,6 @@
 
 image: "python:3.7"
 
-stages:
-  - build
-  - release
 
 .build-vdk-sqlite:
   variables:

--- a/projects/vdk-core/plugins/vdk-test-utils/.plugin-ci.yml
+++ b/projects/vdk-core/plugins/vdk-test-utils/.plugin-ci.yml
@@ -3,10 +3,6 @@
 
 image: "python:3.7"
 
-stages:
-  - build
-  - release
-
 .build-vdk-test-utils:
   variables:
     PLUGIN_NAME: vdk-test-utils

--- a/projects/vdk-core/plugins/vdk-trino/.plugin-ci.yml
+++ b/projects/vdk-core/plugins/vdk-trino/.plugin-ci.yml
@@ -3,10 +3,6 @@
 
 image: "python:3.7"
 
-stages:
-  - build
-  - release
-
 .build-vdk-trino:
   services:
     - name: trinodb/trino

--- a/projects/vdk-heartbeat/.gitlab-ci.yml
+++ b/projects/vdk-heartbeat/.gitlab-ci.yml
@@ -7,10 +7,6 @@ image: "python:3.9"
 #variables:
 #  POSTGRES_DB: database_name
 
-stages:
-  - build
-  - release
-
 vdk-heartbeat-test:
   image: "python:3.9"
   stage: build


### PR DESCRIPTION
stages should be defined once globally for the pipeline.
We do not need to override them as this create issue where we can get
the wrong stages and jobs are skipped

Testing Done: this PR CI 

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>