### PR TITLE
control-service: Helm ingress support for networking.k8s.io/v1/Ingress

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/ingress.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/ingress.yaml
@@ -1,23 +1,39 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
   annotations: {{- toYaml .Values.ingress.annotations | nindent 4 }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+apiVersion: networking.k8s.io/v1
 spec:
-  {{- if .Values.ingress.tls_secret }}
+  rules:
+  - host: {{ .Values.ingress.host | quote }}
+    http:
+      paths:
+      - path: {{ .Values.ingress.path | default "/" }}
+        pathType: {{ .Values.ingress.pathType | default "ImplementationSpecific" }}
+        backend:
+          service:
+            name: {{ .Release.Name }}-svc
+            port:
+              number: {{ .Values.service.internalPort }}
+{{- else }}
+apiVersion: networking.k8s.io/v1beta1
+spec:
+  rules:
+  - host: {{ .Values.ingress.host | quote }}
+    http:
+      paths:
+        - path: {{ .Values.ingress.path }}
+          backend:
+            serviceName: {{ .Release.Name }}-svc
+            servicePort: {{ .Values.service.internalPort }}
+{{- end }}
+{{- if .Values.ingress.tls_secret }}
   tls:
     - hosts:
-        - {{ .Values.ingress.host | quote }}
+      - {{ .Values.ingress.host | quote}}
       secretName: {{ .Values.ingress.tls_secret }}
-  {{ end }} {{/*-- if .Values.ingress.tls_secret --*/}}
-  rules:
-    - host: {{ .Values.ingress.host | quote }}
-      http:
-        paths:
-          - path: {{ .Values.ingress.path }}
-            backend:
-              serviceName: {{ .Release.Name }}-svc
-              servicePort: {{ .Values.service.internalPort }}
-{{ end }} {{/*-- if .Values.ingress.enabled --*/}}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
There are major changes in networking.k8s.io/v1/Ingress API. This change will try to detect the API version and use the appropriate syntax for ingress. More information is available here:
  https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122
    
Testing done:
  - v1 test against k8s version 1.20
  - v1beta1 tested against k8s version 1.16