### PR TITLE
control-service: fix docker registry URLs

### DIFF
--- a/projects/control-service/cicd/deploy-testing-pipelines-service.sh
+++ b/projects/control-service/cicd/deploy-testing-pipelines-service.sh
@@ -66,7 +66,6 @@ helm upgrade --install --wait --timeout 10m0s $RELEASE_NAME . \
       --set resources.limits.memory=2G \
       --set credentials.repository="EMPTY" \
       --set-file vdkOptions=$VDK_OPTIONS_SUBSTITUTED \
-      --set deploymentDockerVdkBaseImage="$VDK_DOCKER_REGISTRY_URL/quickstart-vdk:release" \
       --set deploymentGitUrl="$CICD_GIT_URI" \
       --set deploymentGitUsername="$CICD_GIT_USER" \
       --set deploymentGitPassword="$CICD_GIT_PASSWORD" \
@@ -83,5 +82,4 @@ helm upgrade --install --wait --timeout 10m0s $RELEASE_NAME . \
       --set security.authorization.webhookUri=https://httpbin.org/post \
       --set extraEnvVars.LOGGING_LEVEL_COM_VMWARE_TAURUS=DEBUG \
       --set extraEnvVars.DATAJOBS_TELEMETRY_WEBHOOK_ENDPOINT="https://vcsa.vmware.com/ph-stg/api/hyper/send?_c=taurus.v0&_i=cicd-control-service" \
-      --set extraEnvVars.DATAJOBS_BUILDER_IMAGE="$VDK_DOCKER_REGISTRY_URL/job-builder:latest" \
       --set extraEnvVars.DATAJOBS_DEPLOYMENT_DATAJOBBASEIMAGE=python:3.9-slim

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -174,7 +174,7 @@ deploymentDockerRegistryPassword: ""
 ## Everything else is effectively discarded since another image is used as base during execution.
 ## Override if you build VDK SDK yourself instead of using one provided by default.
 ## (without https:// scheme)
-deploymentDockerVdkBaseImage: "012285273210.dkr.ecr.us-west-2.amazonaws.com/taurus-vdk:latest"
+deploymentDockerVdkBaseImage: "registry.hub.docker.com/versatiledatakit/quickstart-vdk:release"
 
 
 ## ini formatted options that provides default and per-job VDK options.

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-test.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-test.properties
@@ -6,11 +6,11 @@ logging.level.com.vmware.taurus=DEBUG
 # Path to an ini config file that contains vdk runtime options
 # src/main/resources/vdk_options.ini can be used for testing
 datajobs.vdk_options_ini=
-datajobs.vdk.image=hub.docker.com/versatiledatakit/vdk:release
+datajobs.vdk.image=registry.hub.docker.com/versatiledatakit/quickstart-vdk:release
 
 datajobs.deployment.k8s.namespace=
 
-datajobs.docker.repositoryUrl=hub.docker.com/versatiledatakitjobs
+datajobs.docker.repositoryUrl=ghcr.io/versatile-data-kit-dev/dp
 datajobs.docker.registryType=generic
 
 #WebHook settings for the integration tests
@@ -38,9 +38,9 @@ datajobs.control.k8s.kubeconfig=${HOME}/.kube/config
 integrationTest.dataJobsNamespace=
 integrationTest.controlNamespace=
 
-datajobs.builder.image=hub.docker.com/versatiledatakit/job-builder:latest
-datajobs.proxy.repositoryUrl=hub.docker.com/versatiledatakit
-datajobs.deployment.dataJobBaseImage=hub.docker.com/versatiledatakit/data-job-base-python-3.7:latest
+datajobs.builder.image=registry.hub.docker.com/versatiledatakit/job-builder:latest
+datajobs.proxy.repositoryUrl=ghcr.io/versatile-data-kit-dev/dp
+datajobs.deployment.dataJobBaseImage=versatiledatakit/data-job-base-python-3.7:latest
 
 # For local run, create personal access token in gitlab with read and write access (or use your user and password)
 # and export those environmental variables in the terminal or in your IDE depending on how you run the tests .

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application-dev.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application-dev.properties
@@ -28,9 +28,9 @@ datajobs.git.username=
 datajobs.git.password=
 
 # Docker repository used to store Versatile Data Kit images (ECR)
-datajobs.docker.repositoryUrl=hub.docker.com/versatiledatakit
+datajobs.docker.repositoryUrl=ghcr.io/versatile-data-kit-dev/dp
 # Image name of VDK which will be used to run the data jobs
-datajobs.vdk.image=hub.docker.com/versatiledatakit/vdk:release
+datajobs.vdk.image=registry.hub.docker.com/versatiledatakit/quickstart-vdk:release
 
 # AWS ECR region. Needed for authenticating to ECR via the aws-cli: https://aws.amazon.com/cli/
 datajobs.aws.region=us-west-2
@@ -42,10 +42,10 @@ featureflag.authorization.enabled=true
 datajobs.authorization.webhook.endpoint=http://mockbin.org/bin/849b988f-b221-423d-aeca-6bd51049fb40
 
 # Image name of the data jobs builder
-datajobs.builder.image=hub.docker.com/versatiledatakit/job-builder:latest
+datajobs.builder.image=versatiledatakit/job-builder:latest
 
 # Public proxy which is used when pulling data jobs images
-datajobs.proxy.repositoryUrl=hub.docker.com/versatiledatakit
+datajobs.proxy.repositoryUrl=ghcr.io/versatile-data-kit-dev/dp
 
 # Credentials with read and write access to the repository containing the data jobs
 # Different public Git repositories require different approaches for access token as per:

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application-prod.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application-prod.properties
@@ -50,8 +50,8 @@ datajobs.kadmin_user=${KADMIN_USER}
 datajobs.kadmin_password=${KADMIN_PASSWORD}
 
 # This is the full image name of the data job builder
-datajobs.builder.image=hub.docker.com/versatiledatakit/job-builder:1.0.5
-datajobs.deployment.dataJobBaseImage=hub.docker.com/versatiledatakit/data-job-base-python-3.7:latest
+datajobs.builder.image=registry.hub.docker.com/versatiledatakit/job-builder:1.0.5
+datajobs.deployment.dataJobBaseImage=registry.hub.docker.com/versatiledatakit/data-job-base-python-3.7:latest
 
 # Path to an ini config file that contains vdk runtime options
 datajobs.vdk_options_ini=${VDK_OPTIONS_INI}

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -64,7 +64,7 @@ datajobs.git.remote=${GIT_REMOTE:origin}
 datajobs.docker.registryType=generic
 
 # Docker repository used to store Versatile Data Kit images
-datajobs.docker.repositoryUrl=hub.docker.com/versatiledatakitjobs
+datajobs.docker.repositoryUrl=ghcr.io/versatile-data-kit-dev/dp
 
 # open API generator is not generating example for parameters and causing noisy warnings
 logging.level.io.swagger.models.parameters.AbstractSerializableParameter=ERROR


### PR DESCRIPTION
hub.docker.com/versatiledatakit is not a valid docker URL for docker
commands (docker pull fails)
registry.hub.docker.com/versatiledatakit is the valid one or simply
versatiledatakit is also valid (the short variant)

Testing Done: did docker pull
registry.hub.docker.com/versatiledatakit/quickstart-vdk:release and
rmeoved override from deploy-testing-pipelines. We did not caught the
issue in our CI because we were overwriting the default (broken) URLs
with "correct" ones

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>