### PR TITLE
vdk-trino: Automatically start Trino server for templates local testing

### DIFF
--- a/projects/vdk-core/CONTRIBUTING.md
+++ b/projects/vdk-core/CONTRIBUTING.md
@@ -39,11 +39,6 @@ In short:
 * Click OK to save the settings;
 *  Add tests directory as Test Sources;
 
-* Testing the `vdk-trino` plugin locally requires a manually started trino. You can do this by running:
-```bash
-docker run -p 8080:8080 --name trino trinodb/trino
-```
-
 
 ## Release
 

--- a/projects/vdk-core/plugins/vdk-trino/.plugin-ci.yml
+++ b/projects/vdk-core/plugins/vdk-trino/.plugin-ci.yml
@@ -4,9 +4,13 @@
 image: "python:3.7"
 
 .build-vdk-trino:
+  image: docker:19.03.8
   services:
-    - name: trinodb/trino
+    - docker:19.03.8-dind
   variables:
+    DOCKER_HOST: tcp://localhost:2375
+    DOCKER_DRIVER: overlay2
+    DOCKER_TLS_CERTDIR: ""
     PLUGIN_NAME: vdk-trino
   extends: .build-plugin
 

--- a/projects/vdk-core/plugins/vdk-trino/README.md
+++ b/projects/vdk-core/plugins/vdk-trino/README.md
@@ -44,3 +44,12 @@ They need to provide LineageLogger implementation and hook this way:
 # Configuration
 
 Run vdk config-help - search for those prefixed with "TRINO_" to see what configuration options are available.
+
+# Testing
+
+Testing this plugin locally requires installing the dependencies listed in plugins/vdk-trino/requirements.txt
+
+Run
+```bash
+pip install -r requirements.txt
+```

--- a/projects/vdk-core/plugins/vdk-trino/requirements.txt
+++ b/projects/vdk-core/plugins/vdk-trino/requirements.txt
@@ -1,4 +1,8 @@
 vdk-core
-click
 trino
+
+# testing requirements
+click
 vdk-test-utils
+pytest-docker
+docker-compose

--- a/projects/vdk-core/plugins/vdk-trino/tests/conftest.py
+++ b/projects/vdk-core/plugins/vdk-trino/tests/conftest.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import os
+import time
+from unittest import mock
+
+import pytest
+from taurus.vdk import trino_plugin
+from taurus.vdk.test_utils.util_funcs import CliEntryBasedTestRunner
+
+VDK_TRINO_HOST = "VDK_TRINO_HOST"
+VDK_DB_DEFAULT_TYPE = "VDK_DB_DEFAULT_TYPE"
+VDK_TRINO_PORT = "VDK_TRINO_PORT"
+VDK_TRINO_USE_SSL = "VDK_TRINO_USE_SSL"
+
+
+def is_responsive(runner):
+    try:
+        result = runner.invoke(["trino-query", "--query", "SELECT 1"])
+        if result.exit_code == 0:
+            return True
+    except:
+        return False
+
+
+@pytest.fixture(scope="session")
+def docker_compose_file(pytestconfig):
+    return os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "docker-compose.yml"
+    )
+
+
+@pytest.fixture(scope="session")
+@mock.patch.dict(
+    os.environ,
+    {
+        VDK_TRINO_HOST: "localhost",
+        VDK_DB_DEFAULT_TYPE: "TRINO",
+        VDK_TRINO_PORT: "8080",
+        VDK_TRINO_USE_SSL: "False",
+    },
+)
+def trino_service(docker_ip, docker_services):
+    """Ensure that Trino service is up and responsive."""
+    os.system("echo Check open ports:")
+    os.system("ss -lntu")
+    runner = CliEntryBasedTestRunner(trino_plugin)
+
+    # give the server some time to start before checking if it is ready
+    # before adding this sleep there were intermittent fails of the CI/CD with error:
+    # requests.exceptions.ConnectionError:
+    #   ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
+    # More info: https://stackoverflow.com/questions/383738/104-connection-reset-by-peer-socket-error-or-when-does-closing-a-socket-resu
+    time.sleep(3)
+
+    docker_services.wait_until_responsive(
+        timeout=30.0, pause=0.3, check=lambda: is_responsive(runner)
+    )

--- a/projects/vdk-core/plugins/vdk-trino/tests/docker-compose.yml
+++ b/projects/vdk-core/plugins/vdk-trino/tests/docker-compose.yml
@@ -1,0 +1,8 @@
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+services:
+  trino:
+    image: "trinodb/trino"
+    ports:
+      - "8080:8080"

--- a/projects/vdk-core/plugins/vdk-trino/tests/test_vdk_templates.py
+++ b/projects/vdk-core/plugins/vdk-trino/tests/test_vdk_templates.py
@@ -6,6 +6,7 @@ import pathlib
 import unittest
 from unittest import mock
 
+import pytest
 from click.testing import Result
 from taurus.vdk import trino_plugin
 from taurus.vdk.test_utils.util_funcs import cli_assert_equal
@@ -44,6 +45,7 @@ def trino_move_data_to_table_break_tmp_to_target_and_restore(
     return org_move_data_to_table(obj, from_db, from_table_name, to_db, to_table_name)
 
 
+@pytest.mark.usefixtures("trino_service")
 @mock.patch.dict(
     os.environ,
     {

--- a/projects/vdk-core/plugins/vdk-trino/tests/test_vdk_trino_lineage.py
+++ b/projects/vdk-core/plugins/vdk-trino/tests/test_vdk_trino_lineage.py
@@ -4,6 +4,7 @@ import os
 import re
 from unittest import mock
 
+import pytest
 from click.testing import Result
 from taurus.api.plugin.hook_markers import hookimpl
 from taurus.vdk import trino_plugin
@@ -16,6 +17,7 @@ VDK_TRINO_PORT = "VDK_TRINO_PORT"
 VDK_TRINO_USE_SSL = "VDK_TRINO_USE_SSL"
 
 
+@pytest.mark.usefixtures("trino_service")
 @mock.patch.dict(
     os.environ,
     {

--- a/projects/vdk-core/plugins/vdk-trino/tests/test_vdk_trino_utils.py
+++ b/projects/vdk-core/plugins/vdk-trino/tests/test_vdk_trino_utils.py
@@ -19,6 +19,7 @@ VDK_TRINO_PORT = "VDK_TRINO_PORT"
 VDK_TRINO_USE_SSL = "VDK_TRINO_USE_SSL"
 
 
+@pytest.mark.usefixtures("trino_service")
 @mock.patch.dict(
     os.environ,
     {


### PR DESCRIPTION
Trino templates require a running Trino server. Until now,
a server had to be manually started, so that they could pass locally.

A plugin is used for starting the server automatically - pytest-docker.
Fixtures are implemented in conftest.py and template tests use them.
trino_service fixture waits for the server to be fully up and running
by checking if a query can be run against it.

Unit tests and PR CICD.

Signed-off-by: Yana Zhivkova <yzhivkova@vmware.com>