### PR TITLE
control-service: make image registry configurable

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/_helpers.tpl
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/_helpers.tpl
@@ -67,9 +67,10 @@ Create the name of the service account to use
 
 
 {{/*
-Return the proper Pipelines Control Service image name
+Return the proper Control Service image name
 */}}
 {{- define "pipelines-control-service.image" -}}
+{{- $globalRegistryOverrideName := .Values.image.globalRegistryOverride -}}
 {{- $registryName := .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
 {{- $tag := .Values.image.tag | toString -}}
@@ -78,12 +79,59 @@ Helm 2.11 supports the assignment of a value to a variable defined in a differen
 but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
 Also, we can't use a single if because lazy evaluation is not an option
 */}}
-{{- if .Values.global.imageRegistry }}
+{{- if $globalRegistryOverrideName }}
+    {{- printf "%s/%s:%s" $globalRegistryOverrideName $repositoryName $tag -}}
+{{- else if .Values.global.imageRegistry }}
     {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
 {{- else -}}
     {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the proper Control Service deployment builder image name
+*/}}
+{{- define "pipelines-control-service.deploymentBuilderImage" -}}
+{{- $globalRegistryOverrideName := .Values.deploymentBuilderImage.globalRegistryOverride -}}
+{{- $registryName := .Values.deploymentBuilderImage.registry -}}
+{{- $repositoryName := .Values.deploymentBuilderImage.repository -}}
+{{- $tag := .Values.deploymentBuilderImage.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if $globalRegistryOverrideName }}
+    {{- printf "%s/%s:%s" $globalRegistryOverrideName $repositoryName $tag -}}
+{{- else if .Values.global.imageRegistry }}
+    {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Control Service vdk image used to run deployed data jobs
+*/}}
+{{- define "pipelines-control-service.deploymentVdkDistributionImage" -}}
+{{- $globalRegistryOverrideName := .Values.deploymentVdkDistributionImage.globalRegistryOverride -}}
+{{- $registryName := .Values.deploymentVdkDistributionImage.registry -}}
+{{- $repositoryName := .Values.deploymentVdkDistributionImage.repository -}}
+{{- $tag := .Values.deploymentVdkDistributionImage.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if $globalRegistryOverrideName }}
+    {{- printf "%s/%s:%s" $globalRegistryOverrideName $repositoryName $tag -}}
+{{- else if .Values.global.imageRegistry }}
+    {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
 
 {{/*
 Create the name of the deployment Kubernetes namespace used by Data Jobs

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -103,7 +103,9 @@ spec:
             - name: DOCKER_REPOSITORY_URL
               value: "{{ .Values.deploymentDockerRepository }}"
             - name: DOCKER_VDK_BASE_IMAGE
-              value: "{{ .Values.deploymentDockerVdkBaseImage }}"
+              value: {{ template "pipelines-control-service.deploymentVdkDistributionImage" . }}
+            - name: DATAJOBS_BUILDER_IMAGE
+              value: {{ template "pipelines-control-service.deploymentBuilderImage" . }}
             - name: SERVER_MAX_HTTP_HEADER_SIZE
               value: "{{ .Values.server.maxHttpHeaderSize }}"
             - name: DB_JDBC_URL

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -1,6 +1,7 @@
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
 ## Current available global Docker image parameters: imageRegistry and imagePullSecrets
+## Set global.imageRegistry if you use docker proxy to the proxy prefix for versatiledataki.
 ##
 global: {}
 #   imageRegistry: myRegistryName
@@ -18,6 +19,14 @@ image:
    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
    ##
    pullPolicy: Always
+
+# The image configuration for builder jobs used during deployment of data jobs.
+# Generally those should be left as it is.
+deploymentBuilderImage:
+  registry: registry.hub.docker.com/versatiledatakit
+  repository: job-builder
+  tag: "1.0.5"
+
 
 ## String to partially override pipelines-control-service.fullname template (will maintain the release name)
 ##
@@ -168,13 +177,16 @@ deploymentDockerRegistryUsername: ""
 deploymentDockerRegistryPassword: ""
 
 ## Image name of VDK which will be used to run the data jobs.
-## It will use image with tag latest and will be pulled before any execution thus making sure jobs use the same and latest version of VDK.
+## It is recommended to use image with same tag (e.g release or latest)
+## As it will be pulled before any execution thus making sure all jobs use the same and latest version of VDK.
 ## The image should contain installation of VDK (vdk) which will be used to run the data jobs (vdk run command)
 ## Only the installed python modules (vdk and its dependencies) will be used from the image.
 ## Everything else is effectively discarded since another image is used as base during execution.
 ## Override if you build VDK SDK yourself instead of using one provided by default.
-## (without https:// scheme)
-deploymentDockerVdkBaseImage: "registry.hub.docker.com/versatiledatakit/quickstart-vdk:release"
+deploymentVdkDistributionImage:
+  registry: registry.hub.docker.com/versatiledatakit
+  repository: quickstart-vdk
+  tag: "release"
 
 
 ## ini formatted options that provides default and per-job VDK options.


### PR DESCRIPTION
Our build images are currently in dockerhub. Dockerhub imposes limits on
number of pulls which can be hit very frequently. Often common solution
to this problem to use proxy cache server. From VMware popular one is
Harbor (https://goharbor.io/). AWS and Google Cloud offer their own
proxy solutions as well. So we should expect that customers would
frequently need to configure a proxy.

While we want customers to configure proxy we generally do not want them
to override the name of the repository and especially the version since
these are usually set during release so they match. And if user upgrades
the helm chart he'd need to manually bump the versions which is very
error prone (and easy to forget).

Hence common solution used in many charts (see
https://github.com/bitnami/charts/tree/master/bitnami) is to separate
registry, repository and tag.

Also global.imageRegistry enables users to specify the proxy registry
just once and not for every chart. That makes it forward-compatible (in
other words if we add new image it would automatically use the proxy
cache when users upgrade)

Testing Done: helm lint locally passed. Gitlab CI will test it fully.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>