### PR TITLE
control-service: set correct properties api url for cicd

### DIFF
--- a/projects/control-service/cicd/vdk-options.ini
+++ b/projects/control-service/cicd/vdk-options.ini
@@ -8,7 +8,9 @@ VDK_TRINO_CATALOG=memory
 VDK_TRINO_USER=data-job-user
 VDK_DB_DEFAULT_TYPE=TRINO
 
-VDK_PROPERTIES_API_URL=${CONTROL_SERVICE_URL}/data-jobs/for-team/{team_name}/name/{job_name}/deployments/foo/properties
+# TODO: this must not be set here.
+# we should use vdk-control-service-api client to
+VDK_PROPERTIES_API_URL=${CONTROL_SERVICE_URL}/data-jobs/for-team/{team_name}/jobs/{job_name}/deployments/foo/properties
 VDK_PROPERTIES_API_TOKEN_AUTHORIZATION_URL=https://console-stg.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize
 VDK_PROPERTIES_API_TOKEN=${VDK_API_TOKEN}
 VDK_TOKEN_AUTHORIZATION_SERVER_URL=https://console-stg.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize


### PR DESCRIPTION
We currently hard-code the properteis api url (there's issue to fix
that). So we have not change it when we removed deprecated endpoints so
I am changig it.

Testing Done: execute vdk-heartbeat locally and proeprties were working

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>