### PR TITLE
vdk-trino: Escape identifiers in templates

### DIFF
--- a/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/dimension/scd1/00-test-if-view-matches-target.sql
+++ b/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/dimension/scd1/00-test-if-view-matches-target.sql
@@ -1,3 +1,3 @@
-(SELECT * FROM {source_schema}.{source_view} LIMIT 0)
+(SELECT * FROM "{source_schema}"."{source_view}" LIMIT 0)
 UNION ALL
-(SELECT * FROM {target_schema}.{target_table} LIMIT 0)
+(SELECT * FROM "{target_schema}"."{target_table}" LIMIT 0)

--- a/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/dimension/scd1/01-drop-target.sql
+++ b/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/dimension/scd1/01-drop-target.sql
@@ -1,1 +1,1 @@
-DROP TABLE {target_schema}.{target_table}
+DROP TABLE "{target_schema}"."{target_table}"

--- a/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/dimension/scd1/02-create-target.sql
+++ b/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/dimension/scd1/02-create-target.sql
@@ -1,3 +1,3 @@
-CREATE TABLE {target_schema}.{target_table}(
-    LIKE {source_schema}.{source_view}
+CREATE TABLE "{target_schema}"."{target_table}"(
+    LIKE "{source_schema}"."{source_view}"
 )

--- a/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/dimension/scd1/03-insert-into-target.sql
+++ b/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/dimension/scd1/03-insert-into-target.sql
@@ -1,2 +1,2 @@
-INSERT INTO {target_schema}.{target_table}
-    SELECT * FROM {source_schema}.{source_view}
+INSERT INTO "{target_schema}"."{target_table}"
+    SELECT * FROM "{source_schema}"."{source_view}"

--- a/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/dimension/scd2/01-add-props-for-args.py
+++ b/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/dimension/scd2/01-add-props-for-args.py
@@ -7,11 +7,13 @@ def run(job_input: IJobInput):
     args = job_input.get_arguments()
     props = job_input.get_all_properties()
     props["value_columns_str"] = ", ".join(
-        [f"{column}" for column in args["value_columns"]]
+        [f'"{column}"' for column in args["value_columns"]]
     )
     props["hash_expr_str"] = ",\n".join(
         [
-            f"            COALESCE(CAST({column} AS VARCHAR), '#')"
+            f"""
+                        COALESCE(CAST("{column}" AS VARCHAR), '#')
+            """
             for column in args["tracked_columns"]
         ]
     ).lstrip()

--- a/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/dimension/scd2/02-test-if-view-matches-target.sql
+++ b/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/dimension/scd2/02-test-if-view-matches-target.sql
@@ -1,12 +1,12 @@
 (
   SELECT
-    NULL as {sk_column},
-    NULL as {active_from_column},
-    NULL as {active_to_column},
-    {id_column},
+    NULL as "{sk_column}",
+    NULL as "{active_from_column}",
+    NULL as "{active_to_column}",
+    "{id_column}",
     {value_columns_str}
   FROM
-    {source_schema}.{source_view}
+    "{source_schema}"."{source_view}"
   LIMIT 0
 )
 UNION ALL
@@ -14,6 +14,6 @@ UNION ALL
   SELECT
     *
   FROM
-    {target_schema}.{target_table}
+    "{target_schema}"."{target_table}"
   LIMIT 0
 )

--- a/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/dimension/scd2/03-drop-tmp-target.sql
+++ b/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/dimension/scd2/03-drop-tmp-target.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS {target_schema}.tmp_{target_table}
+DROP TABLE IF EXISTS "{target_schema}"."tmp_{target_table}"

--- a/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/dimension/scd2/04-drop-backup-target.sql
+++ b/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/dimension/scd2/04-drop-backup-target.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS {target_schema}.backup_{target_table}
+DROP TABLE IF EXISTS "{target_schema}"."backup_{target_table}"

--- a/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/dimension/scd2/05-create-tmp-target.sql
+++ b/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/dimension/scd2/05-create-tmp-target.sql
@@ -1,3 +1,3 @@
-CREATE TABLE {target_schema}.tmp_{target_table}(
-    LIKE {target_schema}.{target_table}
+CREATE TABLE "{target_schema}"."tmp_{target_table}"(
+    LIKE "{target_schema}"."{target_table}"
 )

--- a/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/dimension/scd2/06-insert-into-tmp-target.sql
+++ b/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/dimension/scd2/06-insert-into-tmp-target.sql
@@ -1,10 +1,10 @@
-INSERT INTO {target_schema}.tmp_{target_table}
+INSERT INTO "{target_schema}"."tmp_{target_table}"
   -- Compute the union of the source and target tables and augment each side with the following columns:
   -- _values_hash:
   --     A hash of the tracked values.
   -- _lineage:
   --     Tag the record source (either "source" or "target").
- WITH {target_table}_union AS (
+ WITH "{target_table}_union" AS (
     (
       SELECT
         'source' AS _lineage,
@@ -14,13 +14,13 @@ INSERT INTO {target_schema}.tmp_{target_table}
             {hash_expr_str}
           ) AS VARBINARY
         )) AS _values_hash,
-        CAST(UUID() AS VARCHAR) AS {sk_column},
-        {updated_at_column} AS {active_from_column},
-        CAST('9999-12-31' AS TIMESTAMP) AS {active_to_column},
-        {id_column},
+        CAST(UUID() AS VARCHAR) AS "{sk_column}",
+        "{updated_at_column}" AS "{active_from_column}",
+        CAST('9999-12-31' AS TIMESTAMP) AS "{active_to_column}",
+        "{id_column}",
         {value_columns_str}
       FROM
-        {source_schema}.{source_view}
+        "{source_schema}"."{source_view}"
     )
     UNION ALL
     (
@@ -32,13 +32,13 @@ INSERT INTO {target_schema}.tmp_{target_table}
             {hash_expr_str}
           ) AS VARBINARY
         )) AS _values_hash,
-        {sk_column},
-        {active_from_column},
-        {active_to_column},
-        {id_column},
+        "{sk_column}",
+        "{active_from_column}",
+        "{active_to_column}",
+        "{id_column}",
         {value_columns_str}
       FROM
-        {target_schema}.{target_table}
+        "{target_schema}"."{target_table}"
     )
   ),
   -- Extend {target_table}_union with the following expressions:
@@ -49,27 +49,27 @@ INSERT INTO {target_schema}.tmp_{target_table}
   --     The first value of that column from the partition of records sharing the same primary key and start time,
   --     where "target" records are listed before "source".
   -- The result set is ready for elimination of overridden records.
-  {target_table}_union_extended_v1 AS (
+  "{target_table}_union_extended_v1" AS (
     SELECT
       _lineage,
       _values_hash,
       LEAD(TRUE, 1, FALSE) OVER(
-        PARTITION BY {id_column}, {active_from_column}
+        PARTITION BY "{id_column}", "{active_from_column}"
         ORDER BY _lineage DESC
       ) AS _is_overridden,
-      FIRST_VALUE({sk_column}) OVER(
-        PARTITION BY {id_column}, {active_from_column}
+      FIRST_VALUE("{sk_column}") OVER(
+        PARTITION BY "{id_column}", "{active_from_column}"
         ORDER BY _lineage DESC
-      ) AS {sk_column},
-      {active_from_column},
-      FIRST_VALUE({active_to_column}) OVER(
-        PARTITION BY {id_column}, {active_from_column}
+      ) AS "{sk_column}",
+      "{active_from_column}",
+      FIRST_VALUE("{active_to_column}") OVER(
+        PARTITION BY "{id_column}", "{active_from_column}"
         ORDER BY _lineage DESC
-      ) AS {active_to_column},
-      {id_column},
+      ) AS "{active_to_column}",
+      "{id_column}",
       {value_columns_str}
     FROM
-      {target_table}_union
+      "{target_table}_union"
   ),
   -- Exclude overridden records from {target_table}_union_extended_v1 and
   -- extend the result with the following expressions:
@@ -77,33 +77,33 @@ INSERT INTO {target_schema}.tmp_{target_table}
   --     A boolean flag indicating whether the record will be merged with the previous record within a partition of
   --     records that share the same primary key and values hash and are ordered by their "active from" timestamp.
   -- The result set is ready for merging of adjacent records with the same values hash.
-  {target_table}_union_extended_v2 AS (
+  "{target_table}_union_extended_v2" AS (
     SELECT
       LAG(_values_hash, 1, to_big_endian_32(0)) OVER(
-        PARTITION BY {id_column}
-        ORDER BY {active_from_column}
+        PARTITION BY "{id_column}"
+        ORDER BY "{active_from_column}"
       ) = _values_hash AS _merge_with_previous,
-      {sk_column},
-      {active_from_column},
-      {active_to_column},
-      {id_column},
+      "{sk_column}",
+      "{active_from_column}",
+      "{active_to_column}",
+      "{id_column}",
       {value_columns_str}
     FROM
-      {target_table}_union_extended_v1
+      "{target_table}_union_extended_v1"
     WHERE
       _is_overridden = FALSE
   )
   -- Exclude records that are merged with the preceding record and fix the "active to" timestamp.
   SELECT
-    {sk_column},
-    {active_from_column},
-    LEAD({active_from_column}, 1, TIMESTAMP '9999-12-31') OVER(
-      PARTITION BY {id_column}
-      ORDER BY {active_from_column}
-    ) AS {active_to_column},
-    {id_column},
+    "{sk_column}",
+    "{active_from_column}",
+    LEAD("{active_from_column}", 1, TIMESTAMP '9999-12-31') OVER(
+      PARTITION BY "{id_column}"
+      ORDER BY "{active_from_column}"
+    ) AS "{active_to_column}",
+    "{id_column}",
     {value_columns_str}
   FROM
-    {target_table}_union_extended_v2
+    "{target_table}_union_extended_v2"
   WHERE
     _merge_with_previous = FALSE

--- a/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/fact/periodic_snapshot/01-test-if-view-matches-target.sql
+++ b/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/fact/periodic_snapshot/01-test-if-view-matches-target.sql
@@ -1,3 +1,3 @@
-(SELECT * FROM {source_schema}.{source_view} LIMIT 0)
+(SELECT * FROM "{source_schema}"."{source_view}" LIMIT 0)
 UNION ALL
-(SELECT * FROM {target_schema}.{target_table} LIMIT 0)
+(SELECT * FROM "{target_schema}"."{target_table}" LIMIT 0)

--- a/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/fact/periodic_snapshot/02-drop-tmp-target.sql
+++ b/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/fact/periodic_snapshot/02-drop-tmp-target.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS {target_schema}.tmp_{target_table}
+DROP TABLE IF EXISTS "{target_schema}"."tmp_{target_table}"

--- a/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/fact/periodic_snapshot/03-drop-backup-target.sql
+++ b/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/fact/periodic_snapshot/03-drop-backup-target.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS {target_schema}.backup_{target_table}
+DROP TABLE IF EXISTS "{target_schema}"."backup_{target_table}"

--- a/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/fact/periodic_snapshot/04-create-tmp-target.sql
+++ b/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/fact/periodic_snapshot/04-create-tmp-target.sql
@@ -1,3 +1,3 @@
-CREATE TABLE {target_schema}.tmp_{target_table}(
-    LIKE {target_schema}.{target_table}
+CREATE TABLE "{target_schema}"."tmp_{target_table}"(
+    LIKE "{target_schema}"."{target_table}"
 )

--- a/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/fact/periodic_snapshot/05-insert-into-tmp-target.sql
+++ b/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/templates/load/fact/periodic_snapshot/05-insert-into-tmp-target.sql
@@ -1,11 +1,11 @@
-INSERT INTO {target_schema}.tmp_{target_table}
+INSERT INTO "{target_schema}"."tmp_{target_table}"
 (
   SELECT *
-  FROM   {target_schema}.{target_table}
-  WHERE  {last_arrival_ts} < (SELECT MIN({last_arrival_ts}) FROM {source_schema}.{source_view})
+  FROM   "{target_schema}"."{target_table}"
+  WHERE  "{last_arrival_ts}" < (SELECT MIN("{last_arrival_ts}") FROM "{source_schema}"."{source_view}")
 )
 UNION ALL
 (
   SELECT *
-  FROM   {source_schema}.{source_view}
+  FROM   "{source_schema}"."{source_view}"
 )

--- a/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/trino_utils.py
+++ b/projects/vdk-core/plugins/vdk-trino/src/taurus/vdk/trino_utils.py
@@ -28,7 +28,11 @@ class TrinoTemplateQueries:
         """
         result = True
         try:
-            self.__job_input.execute_query(f"DESCRIBE {db}.{table_name}")
+            self.__job_input.execute_query(
+                f"""
+                DESCRIBE "{db}"."{table_name}"
+                """
+            )
         except Exception as e:
             if self.__is_table_not_found_error(e):
                 result = False
@@ -57,23 +61,23 @@ class TrinoTemplateQueries:
         if strategy == "RENAME":
             return self.__job_input.execute_query(
                 f"""
-                ALTER TABLE {from_db}.{from_table_name} RENAME TO {to_db}.{to_table_name}
+                ALTER TABLE "{from_db}"."{from_table_name}" RENAME TO "{to_db}"."{to_table_name}"
                 """
             )
         elif strategy == "INSERT_SELECT":
             self.__job_input.execute_query(
                 f"""
-                CREATE TABLE {to_db}.{to_table_name} (LIKE {from_db}.{from_table_name})
+                CREATE TABLE "{to_db}"."{to_table_name}" (LIKE "{from_db}"."{from_table_name}")
                 """
             )
             self.__job_input.execute_query(
                 f"""
-                INSERT INTO {to_db}.{to_table_name} SELECT * FROM {from_db}.{from_table_name}
+                INSERT INTO "{to_db}"."{to_table_name}" SELECT * FROM "{from_db}"."{from_table_name}"
                 """
             )
             return self.__job_input.execute_query(
                 f"""
-                DROP TABLE {from_db}.{from_table_name}
+                DROP TABLE "{from_db}"."{from_table_name}"
                 """
             )
         else:
@@ -95,7 +99,7 @@ class TrinoTemplateQueries:
         """
         return self.__job_input.execute_query(
             f"""
-            DROP TABLE IF EXISTS {db}.{table_name}
+            DROP TABLE IF EXISTS "{db}"."{table_name}"
             """
         )
 

--- a/projects/vdk-core/plugins/vdk-trino/tests/jobs/load_dimension_scd1_template_job/01_prepare_input_data.py
+++ b/projects/vdk-core/plugins/vdk-trino/tests/jobs/load_dimension_scd1_template_job/01_prepare_input_data.py
@@ -15,12 +15,12 @@ def run(job_input: IJobInput) -> None:
     # Step 1: create a new table that represents the current state
     job_input.execute_query(
         f"""
-            DROP TABLE IF EXISTS {target_schema}.{target_table}
+            DROP TABLE IF EXISTS "{target_schema}"."{target_table}"
         """
     )
     job_input.execute_query(
         f"""
-            CREATE TABLE IF NOT EXISTS {target_schema}.{target_table} (
+            CREATE TABLE IF NOT EXISTS "{target_schema}"."{target_table}" (
               org_id INT,
               org_name VARCHAR,
               org_type VARCHAR,
@@ -32,7 +32,7 @@ def run(job_input: IJobInput) -> None:
     )
     job_input.execute_query(
         f"""
-            INSERT INTO {target_schema}.{target_table} VALUES
+            INSERT INTO "{target_schema}"."{target_table}" VALUES
               (2, 'johnlocke@vmware.com'     , 'CUSTOMER_POC'       , 'VMware'           , 1, 6 ),
               (3, 'lilly.johnsonn@goofys.com', 'CUSTOMER'           , 'Goofy''s'          , 2, 16),
               (4, 'jilliandoe@uncanny.ca'    , 'PARTNER_SISO'       , 'Uncanny Company'  , 2, 16),
@@ -46,12 +46,12 @@ def run(job_input: IJobInput) -> None:
     # Step 2: create a new table that represents the next state
     job_input.execute_query(
         f"""
-               DROP TABLE IF EXISTS {source_schema}.{source_view}
+               DROP TABLE IF EXISTS "{source_schema}"."{source_view}"
            """
     )
     job_input.execute_query(
         f"""
-            CREATE TABLE IF NOT EXISTS {source_schema}.{source_view} (
+            CREATE TABLE IF NOT EXISTS "{source_schema}"."{source_view}" (
               org_id INT,
               org_name VARCHAR,
               org_type VARCHAR,
@@ -63,7 +63,7 @@ def run(job_input: IJobInput) -> None:
     )
     job_input.execute_query(
         f"""
-            INSERT INTO {source_schema}.{source_view} VALUES
+            INSERT INTO "{source_schema}"."{source_view}" VALUES
               (1, 'mullen@actual.com'        , 'CUSTOMER_MSP_TENANT', 'actual Master Org', 2, 32),
               (2, 'johnlocke@vmware.com'     , 'CUSTOMER_POC'       , 'VMware'           , 1, 6 ),
               (3, 'lilly.johnsonn@goofys.com', 'CUSTOMER'           , 'Goofy''s'          , 2, 32),

--- a/projects/vdk-core/plugins/vdk-trino/tests/jobs/load_dimension_scd2_template_job/01_prepare_input_data.py
+++ b/projects/vdk-core/plugins/vdk-trino/tests/jobs/load_dimension_scd2_template_job/01_prepare_input_data.py
@@ -12,16 +12,16 @@ def run(job_input: IJobInput) -> None:
 
     job_input.execute_query(
         """
-        DROP TABLE IF EXISTS {target_schema}.{target_table}
+        DROP TABLE IF EXISTS "{target_schema}"."{target_table}"
     """
     )
     job_input.execute_query(
         """
-           CREATE TABLE IF NOT EXISTS {target_schema}.{target_table} (
-             {sk_column} VARCHAR,
+           CREATE TABLE IF NOT EXISTS "{target_schema}"."{target_table}" (
+             "{sk_column}" VARCHAR,
              {active_from_column} TIMESTAMP,
              {active_to_column} TIMESTAMP,
-             {id_column} INT,
+             "{id_column}" INT,
              updated_by_user_id INT,
              state VARCHAR,
              is_next BOOLEAN,
@@ -32,7 +32,7 @@ def run(job_input: IJobInput) -> None:
     )
     job_input.execute_query(
         """
-           INSERT INTO {target_schema}.{target_table} VALUES
+           INSERT INTO "{target_schema}"."{target_table}" VALUES
              ('sddc01-v01', TIMESTAMP '2019-01-01', TIMESTAMP '9999-12-31', 1, 7, 'RUNNING'     , false, 'Azure', 498),
              ('sddc02-v01', TIMESTAMP '2019-02-01', TIMESTAMP '9999-12-31', 2, 9, 'STOPPED'     , false, 'AWS'  , 500),
              ('sddc03-v01', TIMESTAMP '2019-03-01', TIMESTAMP '9999-12-31', 3, 3, 'PROVISIONING', false, 'Azure', 497),
@@ -47,14 +47,14 @@ def run(job_input: IJobInput) -> None:
 
     job_input.execute_query(
         """
-        DROP TABLE IF EXISTS {source_schema}.{source_view}
+        DROP TABLE IF EXISTS "{source_schema}"."{source_view}"
     """
     )
     job_input.execute_query(
         """
-           CREATE TABLE IF NOT EXISTS {source_schema}.{source_view} (
+           CREATE TABLE IF NOT EXISTS "{source_schema}"."{source_view}" (
              {updated_at_column} TIMESTAMP,
-             {id_column} INT,
+             "{id_column}" INT,
              updated_by_user_id INT,
              state VARCHAR,
              is_next BOOLEAN,
@@ -65,7 +65,7 @@ def run(job_input: IJobInput) -> None:
     )
     job_input.execute_query(
         """
-           INSERT INTO {source_schema}.{source_view} VALUES
+           INSERT INTO "{source_schema}"."{source_view}" VALUES
              (TIMESTAMP '2019-02-02', 2, 1, 'STARTING'    , false, 'AWS'  , 500), -- Update (1) - new  time, new  values
              (TIMESTAMP '2019-03-01', 3, 4, 'RUNNING'     , false, 'Azure', 497), -- Update (2) - same time, new  values
              (TIMESTAMP '2019-04-02', 4, 5, 'PROVISIONING', true , 'Azure', 498), -- Update (3) - new  time, same values
@@ -80,16 +80,16 @@ def run(job_input: IJobInput) -> None:
 
     job_input.execute_query(
         """
-        DROP TABLE IF EXISTS {expect_schema}.{expect_table}
+        DROP TABLE IF EXISTS "{expect_schema}"."{expect_table}"
     """
     )
     job_input.execute_query(
         """
-           CREATE TABLE IF NOT EXISTS {expect_schema}.{expect_table} (
-             {sk_column} VARCHAR,
+           CREATE TABLE IF NOT EXISTS "{expect_schema}"."{expect_table}" (
+             "{sk_column}" VARCHAR,
              {active_from_column} TIMESTAMP,
              {active_to_column} TIMESTAMP,
-             {id_column} INT,
+             "{id_column}" INT,
              updated_by_user_id INT,
              state VARCHAR,
              is_next BOOLEAN,
@@ -100,7 +100,7 @@ def run(job_input: IJobInput) -> None:
     )
     job_input.execute_query(
         """
-           INSERT INTO {expect_schema}.{expect_table} VALUES
+           INSERT INTO "{expect_schema}"."{expect_table}" VALUES
              ('sddc01-v01', TIMESTAMP '2019-01-01', TIMESTAMP '9999-12-31', 1, 7, 'RUNNING'     , false, 'Azure', 498),
 
              ('sddc02-v01', TIMESTAMP '2019-02-01', TIMESTAMP '2019-02-02', 2, 9, 'STOPPED'     , false, 'AWS'  , 500),
@@ -124,7 +124,7 @@ def run(job_input: IJobInput) -> None:
     if args.get("test_restore_from_backup") == "True":
         job_input.execute_query(
             """
-               DROP TABLE IF EXISTS {target_schema}.backup_{target_table}
+               DROP TABLE IF EXISTS "{target_schema}"."backup_{target_table}"
            """
         )
 

--- a/projects/vdk-core/plugins/vdk-trino/tests/jobs/load_fact_periodic_snapshot_template_job/01_prepare_input_data.py
+++ b/projects/vdk-core/plugins/vdk-trino/tests/jobs/load_fact_periodic_snapshot_template_job/01_prepare_input_data.py
@@ -12,24 +12,24 @@ def run(job_input: IJobInput) -> None:
 
     job_input.execute_query(
         """
-        DROP TABLE IF EXISTS {target_schema}.{target_table}
+        DROP TABLE IF EXISTS "{target_schema}"."{target_table}"
     """
     )
     job_input.execute_query(
         """
-        CREATE TABLE IF NOT EXISTS {target_schema}.{target_table} (
+        CREATE TABLE IF NOT EXISTS "{target_schema}"."{target_table}" (
           dim_sddc_sk VARCHAR,
           dim_org_id INT,
           dim_date_id TIMESTAMP,
           host_count BIGINT,
           cluster_count BIGINT,
-          {last_arrival_ts} TIMESTAMP
+          "{last_arrival_ts}" TIMESTAMP
         )
     """
     )
     job_input.execute_query(
         """
-        INSERT INTO {target_schema}.{target_table} VALUES
+        INSERT INTO "{target_schema}"."{target_table}" VALUES
           -- 2019-11-18
           ('sddc01-r01', 1, TIMESTAMP '2019-11-18', 5 , 1, TIMESTAMP '2019-11-18 09:00:00'),
           ('sddc02-r01', 2, TIMESTAMP '2019-11-18', 4 , 1, TIMESTAMP '2019-11-18 09:00:00'),
@@ -48,24 +48,24 @@ def run(job_input: IJobInput) -> None:
 
     job_input.execute_query(
         """
-        DROP TABLE IF EXISTS {source_schema}.{source_view}
+        DROP TABLE IF EXISTS "{source_schema}"."{source_view}"
     """
     )
     job_input.execute_query(
         """
-        CREATE TABLE IF NOT EXISTS {source_schema}.{source_view} (
+        CREATE TABLE IF NOT EXISTS "{source_schema}"."{source_view}" (
           dim_sddc_sk VARCHAR,
           dim_org_id INT,
           dim_date_id TIMESTAMP,
           host_count BIGINT,
           cluster_count BIGINT,
-          {last_arrival_ts} TIMESTAMP
+          "{last_arrival_ts}" TIMESTAMP
         )
     """
     )
     job_input.execute_query(
         """
-        INSERT INTO {source_schema}.{source_view} VALUES
+        INSERT INTO "{source_schema}"."{source_view}" VALUES
           -- 2019-11-18
           ('sddc05-r01', 5, TIMESTAMP '2019-11-18', 18, 4, TIMESTAMP '2019-11-18 09:30:00'), -- late arrival
           -- 2019-11-19 (duplicated)
@@ -88,24 +88,24 @@ def run(job_input: IJobInput) -> None:
 
     job_input.execute_query(
         """
-        DROP TABLE IF EXISTS {expect_schema}.{expect_table}
+        DROP TABLE IF EXISTS "{expect_schema}"."{expect_table}"
     """
     )
     job_input.execute_query(
         """
-        CREATE TABLE IF NOT EXISTS {expect_schema}.{expect_table} (
+        CREATE TABLE IF NOT EXISTS "{expect_schema}"."{expect_table}" (
           dim_sddc_sk VARCHAR,
           dim_org_id INT,
           dim_date_id TIMESTAMP,
           host_count BIGINT,
           cluster_count BIGINT,
-          {last_arrival_ts} TIMESTAMP
+          "{last_arrival_ts}" TIMESTAMP
         )
     """
     )
     job_input.execute_query(
         """
-        INSERT INTO {expect_schema}.{expect_table} VALUES
+        INSERT INTO "{expect_schema}"."{expect_table}" VALUES
           -- 2019-11-18
           ('sddc01-r01', 1, TIMESTAMP '2019-11-18', 5 , 1, TIMESTAMP '2019-11-18 09:00:00'),
           ('sddc02-r01', 2, TIMESTAMP '2019-11-18', 4 , 1, TIMESTAMP '2019-11-18 09:00:00'),
@@ -134,7 +134,7 @@ def run(job_input: IJobInput) -> None:
     if args.get("test_restore_from_backup") == "True":
         job_input.execute_query(
             """
-               DROP TABLE IF EXISTS {target_schema}.backup_{target_table}
+               DROP TABLE IF EXISTS "{target_schema}"."backup_{target_table}"
            """
         )
 

--- a/projects/vdk-core/plugins/vdk-trino/tests/jobs/load_fact_periodic_snapshot_template_job_empty_source/01_prepare_input_data.py
+++ b/projects/vdk-core/plugins/vdk-trino/tests/jobs/load_fact_periodic_snapshot_template_job_empty_source/01_prepare_input_data.py
@@ -11,24 +11,24 @@ def run(job_input: IJobInput) -> None:
 
     job_input.execute_query(
         """
-        DROP TABLE IF EXISTS {target_schema}.{target_table}
+        DROP TABLE IF EXISTS "{target_schema}"."{target_table}"
     """
     )
     job_input.execute_query(
         """
-        CREATE TABLE IF NOT EXISTS {target_schema}.{target_table} (
+        CREATE TABLE IF NOT EXISTS "{target_schema}"."{target_table}" (
           dim_sddc_sk VARCHAR,
           dim_org_id INT,
           dim_date_id TIMESTAMP,
           host_count BIGINT,
           cluster_count BIGINT,
-          {last_arrival_ts} TIMESTAMP
+          "{last_arrival_ts}" TIMESTAMP
         )
     """
     )
     job_input.execute_query(
         """
-        INSERT INTO {target_schema}.{target_table} VALUES
+        INSERT INTO "{target_schema}"."{target_table}" VALUES
           -- 2019-11-18
           ('sddc01-r01', 1, TIMESTAMP '2019-11-18', 5 , 1, TIMESTAMP '2019-11-18 09:00:00'),
           ('sddc02-r01', 2, TIMESTAMP '2019-11-18', 4 , 1, TIMESTAMP '2019-11-18 09:00:00'),
@@ -47,18 +47,18 @@ def run(job_input: IJobInput) -> None:
 
     job_input.execute_query(
         """
-        DROP TABLE IF EXISTS {source_schema}.{source_view}
+        DROP TABLE IF EXISTS "{source_schema}"."{source_view}"
     """
     )
     job_input.execute_query(
         """
-        CREATE TABLE IF NOT EXISTS {source_schema}.{source_view} (
+        CREATE TABLE IF NOT EXISTS "{source_schema}"."{source_view}" (
           dim_sddc_sk VARCHAR,
           dim_org_id INT,
           dim_date_id TIMESTAMP,
           host_count BIGINT,
           cluster_count BIGINT,
-          {last_arrival_ts} TIMESTAMP
+          "{last_arrival_ts}" TIMESTAMP
         )
     """
     )
@@ -67,24 +67,24 @@ def run(job_input: IJobInput) -> None:
 
     job_input.execute_query(
         """
-        DROP TABLE IF EXISTS {expect_schema}.{expect_table}
+        DROP TABLE IF EXISTS "{expect_schema}"."{expect_table}"
     """
     )
     job_input.execute_query(
         """
-        CREATE TABLE IF NOT EXISTS {expect_schema}.{expect_table} (
+        CREATE TABLE IF NOT EXISTS "{expect_schema}"."{expect_table}" (
           dim_sddc_sk VARCHAR,
           dim_org_id INT,
           dim_date_id TIMESTAMP,
           host_count BIGINT,
           cluster_count BIGINT,
-          {last_arrival_ts} TIMESTAMP
+          "{last_arrival_ts}" TIMESTAMP
         )
     """
     )
     job_input.execute_query(
         """
-        INSERT INTO {expect_schema}.{expect_table} VALUES
+        INSERT INTO "{expect_schema}"."{expect_table}" VALUES
           -- 2019-11-18
           ('sddc01-r01', 1, TIMESTAMP '2019-11-18', 5 , 1, TIMESTAMP '2019-11-18 09:00:00'),
           ('sddc02-r01', 2, TIMESTAMP '2019-11-18', 4 , 1, TIMESTAMP '2019-11-18 09:00:00'),

--- a/projects/vdk-core/plugins/vdk-trino/tests/test_vdk_templates.py
+++ b/projects/vdk-core/plugins/vdk-trino/tests/test_vdk_templates.py
@@ -85,11 +85,23 @@ class TemplateRegressionTests(unittest.TestCase):
         cli_assert_equal(0, result)
 
         actual_rs: Result = self.__runner.invoke(
-            ["trino-query", "--query", f"SELECT * FROM {target_schema}.{target_table}"]
+            [
+                "trino-query",
+                "--query",
+                f"""
+                SELECT * FROM "{target_schema}"."{target_table}"
+                """,
+            ]
         )
 
         expected_rs: Result = self.__runner.invoke(
-            ["trino-query", "--query", f"SELECT * FROM {source_schema}.{source_view}"]
+            [
+                "trino-query",
+                "--query",
+                f"""
+                SELECT * FROM "{source_schema}"."{source_view}"
+                """,
+            ]
         )
 
         cli_assert_equal(0, actual_rs)
@@ -330,7 +342,9 @@ class TemplateRegressionTests(unittest.TestCase):
             [
                 "trino-query",
                 "--query",
-                f"SELECT * FROM {test_schema}.{target_table} ORDER BY dim_date_id, dim_sddc_sk",
+                f"""
+                SELECT * FROM "{test_schema}"."{target_table}" ORDER BY dim_date_id, dim_sddc_sk
+                """,
             ]
         )
 
@@ -338,7 +352,9 @@ class TemplateRegressionTests(unittest.TestCase):
             [
                 "trino-query",
                 "--query",
-                f"SELECT * FROM {test_schema}.{expect_table} ORDER BY dim_date_id, dim_sddc_sk",
+                f"""
+                SELECT * FROM "{test_schema}"."{expect_table}" ORDER BY dim_date_id, dim_sddc_sk
+                """,
             ]
         )
 
@@ -412,7 +428,7 @@ class TemplateRegressionTests(unittest.TestCase):
                 "trino-query",
                 "--query",
                 f"""SELECT active_from, active_to, sddc_id, updated_by_user_id, state, is_next, cloud_vendor, version
-                FROM {test_schema}.{target_table}
+                FROM "{test_schema}"."{target_table}"
                 ORDER BY sddc_id, active_to""",
             ]
         )
@@ -422,7 +438,7 @@ class TemplateRegressionTests(unittest.TestCase):
                 "trino-query",
                 "--query",
                 f"""SELECT active_from, active_to, sddc_id, updated_by_user_id, state, is_next, cloud_vendor, version
-                FROM {test_schema}.{expect_table}
+                FROM "{test_schema}"."{expect_table}"
                 ORDER BY sddc_id, active_to""",
             ]
         )


### PR DESCRIPTION
Templates work with identifiers provided by users and we
need to make sure that if they use a reserved Trino keyword
as an identifier, this will not break the template.

Double quotes are added for all identifier params -
https://trino.io/docs/current/language/reserved.html

Tested by unit tests.

Signed-off-by: Yana Zhivkova <yzhivkova@vmware.com>