### PR TITLE
vdk-core: improve config help documentation

### DIFF
--- a/projects/vdk-core/src/taurus/vdk/builtin_plugins/builtin_hook_impl.py
+++ b/projects/vdk-core/src/taurus/vdk/builtin_plugins/builtin_hook_impl.py
@@ -10,6 +10,7 @@ import click
 from taurus.api.plugin.core_hook_spec import JobRunHookSpecs
 from taurus.api.plugin.hook_markers import hookimpl
 from taurus.vdk import vdk_build_info
+from taurus.vdk.builtin_plugins.config.config_help import ConfigHelpPlugin
 from taurus.vdk.builtin_plugins.config.log_config import LoggingPlugin
 from taurus.vdk.builtin_plugins.config.vdk_config import CoreConfigDefinitionPlugin
 from taurus.vdk.builtin_plugins.config.vdk_config import EnvironmentVarsConfigPlugin
@@ -88,6 +89,7 @@ def vdk_start(plugin_registry: PluginRegistry, command_line_args: List) -> None:
     log.info("Load default (builtin) vdk plugins.")
     plugin_registry.load_plugin_with_hooks_impl(DebugPlugins())
     plugin_registry.load_plugin_with_hooks_impl(LoggingPlugin())
+    plugin_registry.load_plugin_with_hooks_impl(ConfigHelpPlugin())
     plugin_registry.load_plugin_with_hooks_impl(CoreConfigDefinitionPlugin())
     plugin_registry.load_plugin_with_hooks_impl(EnvironmentVarsConfigPlugin())
     plugin_registry.load_plugin_with_hooks_impl(RuntimeStateInitializePlugin())

--- a/projects/vdk-core/src/taurus/vdk/builtin_plugins/config/config_help.py
+++ b/projects/vdk-core/src/taurus/vdk/builtin_plugins/config/config_help.py
@@ -32,6 +32,7 @@ def description_line_wrapping(description, description_start=40, description_len
             break_on_hyphens=False,
         )
     indent = " " * description_start
+    # we do not need to wrap the first line (it's already padded to the config key)
     for index, line in enumerate(wrapped_text_list[1:], start=1):
         wrapped_text_list[index] = indent + wrapped_text_list[index]
     return "\n".join(wrapped_text_list)
@@ -64,11 +65,32 @@ def generate_config_list_help(variable_to_description_map):
 
 
 @click.command(
-    help="Configuration help. Prints details on all possible configuration options of vdk"
+    help="Configuration help."
+    "Prints details on all possible configuration options of vdk ."
+    "It includes all configuration options added by plugins"
+    """
+
+Examples:
+
+\b
+# if we call config-help we get similar output to one below.
+# first we provide details on how those configuration can be set (e.g environment varibales, files, etc)
+# Next list of all possible configuration variables supported.
+vdk config-help
+
+\b
+Configuring VDK is done via:
+environment variables                   Attempts to load all defined configurations using
+                                        environment variables by adding prefix "VDK_".
+                                        ...
+-----
+List of configuration variables:
+DB_DEFAULT_TYPE                         Default DB connection provided by VDK when ..
+EXECUTION_ID                            An identifier to be associated with the current VDK run ...
+    """
 )
 @click.pass_context
 def config_help(ctx: click.Context) -> None:
-    """ """
     configuration = cast(CoreContext, ctx.obj).configuration
 
     vars_to_descriptions = {}
@@ -94,7 +116,10 @@ def config_help(ctx: click.Context) -> None:
 
 class ConfigHelpPlugin:
     """
-    Plugin which adds some debug functionalities
+    The following plugins add a new command (vdk conflig-help) which would enable
+    users to query for possible configurations. Each plugin declare their possible configuration
+    in vdk_configure hook (using config_builder.add) providng descriptions and other attributes,
+    Those then can be queried by end users. See vdk_configure doc for more information.
     """
 
     @hookimpl

--- a/projects/vdk-core/src/taurus/vdk/builtin_plugins/config/vdk_config.py
+++ b/projects/vdk-core/src/taurus/vdk/builtin_plugins/config/vdk_config.py
@@ -40,7 +40,7 @@ class CoreConfigDefinitionPlugin:
     def vdk_configure(self, config_builder: ConfigurationBuilder) -> None:
         """Set common configuration necessary for vdk
 
-        We are setting it as tryfirst to make sure any config provider afterwards would see the defintions.
+        We are setting it as tryfirst to make sure any config provider afterwards would see the definitions.
         """
 
         # TODO: Get currently supported db types
@@ -63,7 +63,7 @@ class CoreConfigDefinitionPlugin:
         config_builder.add(
             LOG_LEVEL_VDK,
             "DEBUG",
-            "Logging verbosity of VDK code can be cotrolled from here. "
+            "Logging verbosity of VDK code can be controlled from here. "
             "Allowed values: CRITICAL, ERROR, WARNING, INFO, DEBUG",
         )
         config_builder.add(JOB_GITHASH, "unknown")
@@ -133,6 +133,11 @@ class JobConfigIniPlugin:
 
     @hookimpl(tryfirst=True)
     def vdk_configure(self, config_builder: ConfigurationBuilder) -> None:
+        description = f"""Used only during vdk run only - load configuration specified in
+config.ini file in the data job's root directory. It can be overridden by environment variables configuration.
+config.ini loads only specific configuration and is used for legacy reasons.
+The following options are set with config.ini: {[e.value for e in JobConfigKeys]}
+         """
         if (
             self.__job_path
             and self.__job_path.exists()
@@ -140,10 +145,6 @@ class JobConfigIniPlugin:
             and self.__job_path.joinpath("config.ini").exists()
         ):
             print("Detected config.ini. Will try to read config.ini.")
-            description = f"""Attempts configuration specified in config.ini file in the data job's root directory.
-config.ini loads only specific configuration and is used for legacy reasons.
-The following options are set with config.ini: {[e.value for e in JobConfigKeys]}
-         """
             config_builder.add(
                 key="__config_provider__job config ini",
                 default_value="always_enabled",

--- a/projects/vdk-core/src/taurus/vdk/core/config.py
+++ b/projects/vdk-core/src/taurus/vdk/core/config.py
@@ -137,7 +137,7 @@ class ConfigurationBuilder:
         :param description: Set description if you want config variable to appear in command line help .
         It is strongly recommended to set description. If no description is set the config key will be hidden.
         TODO: in the future we should require description always and have separate hidden=True/False instead
-        :return: self so it can be chained
+        :return: self so it can be chained like builder.add(..).set_value(...)...
         """
         self.set_value(key, default_value)
         if description and show_default_value:
@@ -153,7 +153,7 @@ class ConfigurationBuilder:
         It will try to cast it to the specified default type inferred from default value (set with #add method)
         :param key: the configuration key
         :param value: the configuration value.
-        :return: self so it can be chained
+        :return: self so it can be chained like builder.set_value(..).add(...)...
         """
         default_value = (
             self.__config_key_to_value.get(key)


### PR DESCRIPTION
Make sure the CLI adhere to 12 factor principles
https://medium.com/@jdxcode/12-factor-cli-apps-dd3c227a0e46 in this case
means help should provide examples.
Address other documentation review comments from previous review.

Testing Done: Example help vdk config-help --help

```
Usage: vdk config-help [OPTIONS]

Configuration help.Prints details on all possible configuration
options of
  vdk .It includes all configuration options added by plugins

Examples:

environment varibales, files, etc)
  # Next list of all possible configuration variables supported.
  vdk config-help

Configuring VDK is done via:
environment variables                   Attempts to load all defined
configurations using
environment variables by
adding prefix "VDK_".
                                          ...
  -----
  List of configuration variables:
DB_DEFAULT_TYPE                         Default DB connection provided
by VDK when ..
EXECUTION_ID                            An identifier to be associated
with the current VDK run ...

```

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>