### PR TITLE
vdk-control-cli: Team in execute start output

### DIFF
--- a/projects/vdk-control-cli/src/taurus/vdk/control/command_groups/job/execute.py
+++ b/projects/vdk-control-cli/src/taurus/vdk/control/command_groups/job/execute.py
@@ -67,14 +67,15 @@ class JobExecute:
         location = headers["Location"]
         execution_id = os.path.basename(location)
         if output == OutputFormat.TEXT.value:
-            log.info(
+            click.echo(
                 f"Execution of Data Job {name} started. "
                 f"See execution status using: \n\n"
-                f"vdkcli execute --show --execution-id {execution_id} -n {name}"
+                f"vdkcli execute --show --execution-id {execution_id} -n {name} -t {team}"
             )
         elif output == OutputFormat.JSON.value:
             result = {
                 "job_name": name,
+                "team": team,
                 "execution_id": execution_id,
             }
             click.echo(json.dumps(result))

--- a/projects/vdk-control-cli/tests/taurus/vdk/control/command_groups/job/test_execute.py
+++ b/projects/vdk-control-cli/tests/taurus/vdk/control/command_groups/job/test_execute.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 import os
+import json
 
 from click.testing import CliRunner
 from py._path.local import LocalPath
@@ -60,3 +61,56 @@ def test_execute_with_empty_url(httpserver: PluginHTTPServer, tmpdir: LocalPath)
         result.exit_code == 2
     ), f"result exit code is not 2, result output: {result.output}, exc: {result.exc_info}"
     assert "what" in result.output and "why" in result.output
+
+
+def test_execute_start_output_text(httpserver: PluginHTTPServer, tmpdir: LocalPath):
+    rest_api_url = httpserver.url_for("")
+    team_name = "test-team"
+    job_name = "test-job"
+
+    httpserver.expect_request(
+        uri=f"/data-jobs/for-team/{team_name}/jobs/{job_name}/deployments/production/executions",
+        method="POST",
+    ).respond_with_response(
+        Response(
+            status=200,
+            headers=dict(
+                Location=f"/data-jobs/for-team/{team_name}/jobs/{job_name}/executions/foo"
+            ),
+        )
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        execute, ["-n", job_name, "-t", team_name, "--start", "-u", rest_api_url]
+    )
+
+    assert f"-n {job_name}" in result.output
+    assert f"-t {team_name}" in result.output
+
+
+def test_execute_start_output_json(httpserver: PluginHTTPServer, tmpdir: LocalPath):
+    rest_api_url = httpserver.url_for("")
+    team_name = "test-team"
+    job_name = "test-job"
+
+    httpserver.expect_request(
+        uri=f"/data-jobs/for-team/{team_name}/jobs/{job_name}/deployments/production/executions",
+        method="POST",
+    ).respond_with_response(
+        Response(
+            status=200,
+            headers=dict(
+                Location=f"/data-jobs/for-team/{team_name}/jobs/{job_name}/executions/foo"
+            ),
+        )
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        execute, ["-n", job_name, "-t", team_name, "--start", "-u", rest_api_url, "-o", "json"]
+    )
+    json_output = json.loads(result.output)
+
+    assert job_name == json_output.get("job_name")
+    assert team_name == json_output.get("team")


### PR DESCRIPTION
When a data job is manually executed using the Execution
API, a message is outputted with an `execute --show`
command that the client can use to see the status of the
execution. The command in the message, however, was not
complete, as it did not show the team name.

This change fixes that by adding the team name to the
show command in the output message.

Testing Done: Manually tested to see if the team name
appears in the output message of `vdkcli execute --start`.
It does.

Signed-off-by: Andon Andonov <andonova@vmware.com>