### PR TITLE
vdk-core: expose job config in config-help

### DIFF
--- a/projects/vdk-core/src/taurus/vdk/builtin_plugins/config/vdk_config.py
+++ b/projects/vdk-core/src/taurus/vdk/builtin_plugins/config/vdk_config.py
@@ -133,11 +133,18 @@ class JobConfigIniPlugin:
 
     @hookimpl(tryfirst=True)
     def vdk_configure(self, config_builder: ConfigurationBuilder) -> None:
-        description = f"""Used only during vdk run only - load configuration specified in
-config.ini file in the data job's root directory. It can be overridden by environment variables configuration.
+        description = f"""Used only during vdk run  - load configuration specified in
+config.ini file in the data job's root directory.
+It can be overridden by environment variables configuration (set by operators in Cloud deployment or by users locally).
 config.ini loads only specific configuration and is used for legacy reasons.
-The following options are set with config.ini: {[e.value for e in JobConfigKeys]}
+Only the following options can be set with config.ini: {[e.value for e in JobConfigKeys]}
          """
+
+        config_builder.add(
+            key="__config_provider__job config ini",
+            default_value="always_enabled",
+            description=description,
+        )
         if (
             self.__job_path
             and self.__job_path.exists()
@@ -145,11 +152,6 @@ The following options are set with config.ini: {[e.value for e in JobConfigKeys]
             and self.__job_path.joinpath("config.ini").exists()
         ):
             print("Detected config.ini. Will try to read config.ini.")
-            config_builder.add(
-                key="__config_provider__job config ini",
-                default_value="always_enabled",
-                description=description,
-            )
 
             job_config = JobConfig(self.__job_path)
             config_builder.set_value(JobConfigKeys.TEAM, job_config.get_team())

--- a/projects/vdk-core/src/taurus/vdk/builtin_plugins/notification/notification_configuration.py
+++ b/projects/vdk-core/src/taurus/vdk/builtin_plugins/notification/notification_configuration.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import List
 
+from taurus.vdk.builtin_plugins.config.job_config import JobConfigKeys
 from taurus.vdk.core.config import Configuration
 from taurus.vdk.core.config import ConfigurationBuilder
 
@@ -33,6 +34,45 @@ class NotificationConfiguration:
         return str(self.__config[NOTIFICATION_SMTP_HOST])
 
 
+def __add_job_notified_configuration_definitions(config_builder: ConfigurationBuilder):
+    config_builder.add(
+        key=JobConfigKeys.TEAM,
+        default_value="",
+        description="Specified which is the team that owns the data job. "
+        "Value is case-sensitive and must be an actual team name as specified during job creation."
+        "",
+    )
+    config_builder.add(
+        key=JobConfigKeys.NOTIFIED_ON_JOB_FAILURE_USER_ERROR,
+        default_value="",
+        description="Semicolon-separated list of email addresses to be notified on job execution "
+        "failure caused by user code or user configuration problem. "
+        " For example: if the job contains an SQL script with syntax error.",
+    )
+    config_builder.add(
+        key=JobConfigKeys.NOTIFIED_ON_JOB_FAILURE_PLATFORM_ERROR,
+        default_value="",
+        description="Semicolon-separated list of email addresses to be notified on job execution failure "
+        "caused by a platform problem, including job execution delays.",
+    )
+    config_builder.add(
+        key=JobConfigKeys.NOTIFIED_ON_JOB_SUCCESS,
+        default_value="",
+        description="Semicolon-separated list of email addresses to be notified on job execution success.",
+    )
+    config_builder.add(
+        key=JobConfigKeys.NOTIFIED_ON_JOB_DEPLOY,
+        default_value="",
+        description="Semicolon-separated list of email addresses to be notified of job deployment outcome",
+    )
+    config_builder.add(
+        key=JobConfigKeys.ENABLE_ATTEMPT_NOTIFICATIONS,
+        default_value=False,
+        description="Flag to enable or disable the email notifications sent to the recipients listed above "
+        "for each data job run attempt.",
+    )
+
+
 def add_definitions(config_builder: ConfigurationBuilder):
     config_builder.add(
         key=NOTIFICATION_JOB_LOG_URL_PATTERN,
@@ -61,3 +101,4 @@ def add_definitions(config_builder: ConfigurationBuilder):
         default_value="smtp.vmware.com",
         description="The SMTP host used for to send the notification email.",
     )
+    __add_job_notified_configuration_definitions(config_builder)


### PR DESCRIPTION
If you wreite vdk config-help job config.ini did not show up as possible
provider which is going to be confusing to users that try to configure
vdk. As it is necessary to properly configure job for remote/cloud
executions.

Testing Done: ran vdk config-help and saw that the documenation shows
job config.ini as provider:
```
Configuring VDK is done via:
environment variables                   Attempts to load all defined...

job config ini                          Used only during vdk run  - load
 					configuration specified in
                                        config.ini file ...
```
Signed-off-by: Antoni Ivanov <aivanov@vmware.com>