### PR TITLE
vdk-control-cli: improve execute error handling

### DIFF
--- a/projects/vdk-control-cli/src/taurus/vdk/control/command_groups/job/execute.py
+++ b/projects/vdk-control-cli/src/taurus/vdk/control/command_groups/job/execute.py
@@ -10,6 +10,7 @@ import click
 from tabulate import tabulate
 from taurus.vdk.control.configuration.defaults_config import load_default_team_name
 from taurus.vdk.control.rest_lib.factory import ApiClientFactory
+from taurus.vdk.control.rest_lib.rest_client_errors import ApiClientErrorDecorator
 from taurus.vdk.control.utils import cli_utils
 from taurus.vdk.control.utils.cli_utils import get_or_prompt
 from taurus.vdk.control.utils.cli_utils import OutputFormat
@@ -51,6 +52,7 @@ class JobExecute:
         elif output == OutputFormat.JSON.value:
             return cli_utils.json_format(list(executions))
 
+    @ApiClientErrorDecorator()
     def start(self, name: str, team: str, output: OutputFormat):
         execution_request = DataJobExecutionRequest(
             started_by=f"vdk-control-cli", args={}
@@ -80,12 +82,14 @@ class JobExecute:
             }
             click.echo(json.dumps(result))
 
+    @ApiClientErrorDecorator()
     def show(self, name: str, team: str, execution_id: str, output: OutputFormat):
         execution: DataJobExecution = self.execution_api.data_job_execution_read(
             team_name=team, job_name=name, execution_id=execution_id
         )
         click.echo(self.__model_executions([execution], output))
 
+    @ApiClientErrorDecorator()
     def list(self, name: str, team: str, output: OutputFormat):
         executions: list[DataJobExecution] = self.execution_api.data_job_execution_list(
             team_name=team, job_name=name

--- a/projects/vdk-control-cli/tests/taurus/vdk/control/command_groups/job/test_execute.py
+++ b/projects/vdk-control-cli/tests/taurus/vdk/control/command_groups/job/test_execute.py
@@ -114,3 +114,12 @@ def test_execute_start_output_json(httpserver: PluginHTTPServer, tmpdir: LocalPa
 
     assert job_name == json_output.get("job_name")
     assert team_name == json_output.get("team")
+    
+def test_execute_with_exception(httpserver: PluginHTTPServer, tmpdir:LocalPath):
+    runner = CliRunner()
+    result = runner.invoke(execute, ["--start", "-n", "job_name", "-t", "team_name", "-u", "localhost"])
+    
+    assert (
+        result.exit_code == 2
+    ), f"result exit code is not 2, result output: {result.output}, exc: {result.exc_info}"
+    assert "what" in result.output and "why" in result.output


### PR DESCRIPTION
When an exception occurs while the `vdkcli execute`
command is used, we print the whole stack trace in the
terminal, which is not user-friendly, and could cause
confusion.

This change adds error handling to the execute command
that provides more manageable error message, and avoids
printing the whole stack trace of the exception.

Testing Done: Existing unit tests and added a new
test

Signed-off-by: Andon Andonov <andonova@vmware.com>