### PR TITLE
[DRAFT] control-service: do not start build job in privilege

### DIFF
--- a/projects/control-service/CHANGELOG.md
+++ b/projects/control-service/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 * **New feature**
 
 * **Improvement**
+  * Switch Job Builder image to use kaniko
+    This will enable Control Servie to run in more secure kubernetes (pod security - no privilege run, seccomp/apparmor profiles enabled)
+    It will enable to use local docker registry (without ssl) for easier deployment for prototype purposes
 
 * **Bug Fixes**
 

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -118,7 +118,7 @@ control_service_publish_vdk_job_builder_image:
   script:
     - apk add --no-cache bash
     - docker login --username "${VDK_DOCKER_REGISTRY_USERNAME}" --password "${VDK_DOCKER_REGISTRY_PASSWORD}" "${VDK_DOCKER_REGISTRY_URL}"
-    - cd projects/control-service/projects/vdk_job_builder
+    - cd projects/control-service/projects/job-builder
     - bash -ex ./publish-vdk-job-builder.sh
   retry: !reference [.control_service_retry, retry_options]
   only:

--- a/projects/control-service/projects/job-builder/Dockerfile
+++ b/projects/control-service/projects/job-builder/Dockerfile
@@ -1,0 +1,32 @@
+# Used to trigger a build for a data job image.
+
+FROM gcr.io/kaniko-project/executor
+
+FROM alpine
+
+COPY --from=0 /kaniko /kaniko
+
+
+ENV PATH $PATH:/kaniko
+ENV SSL_CERT_DIR=/kaniko/ssl/certs
+ENV DOCKER_CONFIG /kaniko/.docker/
+
+WORKDIR /workspace
+
+COPY Dockerfile.python.vdk /workspace/Dockerfile
+COPY build_image.sh /build_image.sh
+RUN chmod +x /build_image.sh
+
+
+# Setup Python and Git
+## Update & Install dependencies
+RUN apk add --no-cache --update \
+    git \
+    bash
+
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.10/main python3=3.7.10-r0 py3-pip \
+    && pip3 install awscli  \
+    && apk --purge -v del py3-pip \
+    && rm -rf /var/cache/apk/*
+
+ENTRYPOINT ["/build_image.sh"]

--- a/projects/control-service/projects/job-builder/Dockerfile.python.vdk
+++ b/projects/control-service/projects/job-builder/Dockerfile.python.vdk
@@ -1,0 +1,24 @@
+# https://docs.docker.com/develop/develop-images/dockerfile_best-practices
+
+ARG base_image=python:3.9-slim
+
+FROM $base_image
+
+# Set the working directory
+WORKDIR /job
+
+# Make sure base image is python based
+RUN python -V
+
+# Copy the actual job that has to be executed
+ARG job_name
+COPY $job_name $job_name/
+
+# TODO: this would trigger for any change in job even if requirements.txt does not change
+# but there's no COPY_IF_EXISTS command in docker to try copy it.
+ARG requirements_file=requirements.txt
+RUN if [ -f "$job_name/$requirements_file" ]; then pip3 install --disable-pip-version-check -q -r "$job_name/$requirements_file" || ( echo ">requirements_failed<" && exit 1 ) ; fi
+
+ARG job_githash
+ENV JOB_NAME $job_name
+ENV VDK_JOB_GITHASH $job_githash

--- a/projects/control-service/projects/job-builder/README.md
+++ b/projects/control-service/projects/job-builder/README.md
@@ -1,0 +1,2 @@
+# Job Builder
+This package provides a way to configure and build your own Data Job images.

--- a/projects/control-service/projects/job-builder/build_image.sh
+++ b/projects/control-service/projects/job-builder/build_image.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -ex
+
+# TODO: replace those as env variables
+aws_access_key_id=$1
+aws_secret_access_key=$2
+aws_region=$3
+docker_registry=$4
+git_username=$5
+git_password=$6
+git_repository=$7
+registry_type=$8
+registry_username=$9
+registry_password=${10}
+
+
+# We default to generic repo.
+# We have special support for ECR because
+# even though Kaniko supports building and pushing images to ECR
+# it doesn't create repository nor do they think they should support it -
+# https://github.com/GoogleContainerTools/kaniko/pull/1537
+# And ECR requires for each image to create separate repository
+# And ECR will not create new image repository on docker push
+# So we need to do it manually.
+if [ "$registry_type" = "ecr" ] || [ "$registry_type" = "ECR" ] ; then
+    # Setup credentials to connect to AWS - same creds will be used by kaniko as well.
+    aws configure set aws_access_key_id $aws_access_key_id
+    aws configure set aws_secret_access_key $aws_secret_access_key
+
+    # https://stackoverflow.com/questions/1199613/extract-filename-and-path-from-url-in-bash-script
+    repository_prefix=${docker_registry#*/}
+    # Create docker repository if it does not exist
+    aws ecr describe-repositories --region $aws_region --repository-names $repository_prefix/${DATA_JOB_NAME} ||
+        aws ecr create-repository --region $aws_region --repository-name $repository_prefix/${DATA_JOB_NAME}
+
+    echo '{ "credsStore": "ecr-login" }' > /kaniko/.docker/config.json
+
+elif [ "$registry_type" = "generic" ] || [ "$registry_type" = "GENERIC" ]; then
+    export auth=$(echo -n $registry_username:$registry_password | base64 -w 0)
+cat > /kaniko/.docker/config.json <<- EOM
+{
+  "auths": {
+    "$IMAGE_REGISTRY_PATH": {
+      "username":"$registry_username",
+      "password":"$registry_password",
+      "auth": "$auth"
+    }
+  }
+}
+EOM
+#cat /kaniko/.docker/config.json
+fi
+
+
+# Clone repo into /data-jobs dir to get job's source
+git clone https://$git_username:$git_password@$git_repository ./data-jobs
+cd ./data-jobs
+git reset --hard $GIT_COMMIT || ( echo ">data-job-not-found<" && exit 1 )
+if [ ! -d ${DATA_JOB_NAME} ]; then
+  echo ">data-job-not-found<"
+  exit 1
+fi
+cd ..
+
+# kaniko supports building directly from git repository but as we've cloned it here anyhow
+# (to check if job directory exists) there's no need to.
+/kaniko/executor \
+        --dockerfile=/workspace/Dockerfile \
+        --destination="${IMAGE_REGISTRY_PATH}/${DATA_JOB_NAME}:${GIT_COMMIT}"       \
+        --build-arg=job_githash="$JOB_GITHASH"            \
+        --build-arg=base_image="$BASE_IMAGE" \
+        --build-arg=job_name="$JOB_NAME"     \
+        --context=./data-jobs $EXTRA_ARGUMENTS

--- a/projects/control-service/projects/job-builder/publish-vdk-job-builder.sh
+++ b/projects/control-service/projects/job-builder/publish-vdk-job-builder.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+VERSION_TAG=$(cat "$SCRIPT_DIR/version.txt")
+VDK_DOCKER_REGISTRY_URL=${VDK_DOCKER_REGISTRY_URL:-"registry.hub.docker.com/versatiledatakit"}
+
+function build_and_push_image() {
+    name="$1"
+    docker_file="$2"
+    arguments="$3"
+
+    image_repo="$VDK_DOCKER_REGISTRY_URL/$name"
+    image_tag="$image_repo:$VERSION_TAG"
+
+    docker build -t $image_tag -t $image_repo:latest -f "$SCRIPT_DIR/$docker_file" $arguments "$SCRIPT_DIR"
+    docker push $image_tag
+    #docker push $image_repo:latest
+}
+
+build_and_push_image "job-builder" Dockerfile

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
@@ -42,19 +42,19 @@ public class JobImageBuilder {
    private String gitUsername;
    @Value("${datajobs.git.password}")
    private String gitPassword;
-   @Value("${datajobs.aws.region}")
+   @Value("${datajobs.aws.region:}")
    private String awsRegion;
-   @Value("${datajobs.aws.accessKeyId}")
+   @Value("${datajobs.aws.accessKeyId:}")
    private String awsAccessKeyId;
-   @Value("${datajobs.aws.secretAccessKey}")
+   @Value("${datajobs.aws.secretAccessKey:}")
    private String awsSecretAccessKey;
    @Value("${datajobs.docker.repositoryUrl}")
    private String dockerRepositoryUrl;
    @Value("${datajobs.docker.registryType}")
    private String registryType;
-   @Value("${datajobs.docker.registryUsername}")
+   @Value("${datajobs.docker.registryUsername:}")
    private String registryUsername;
-   @Value("${datajobs.docker.registryPassword}")
+   @Value("${datajobs.docker.registryPassword:}")
    private String registryPassword;
    @Value("${datajobs.deployment.dataJobBaseImage:python:3.9-slim}")
    private String deploymentDataJobBaseImage;
@@ -77,7 +77,7 @@ public class JobImageBuilder {
 
    /**
     * Builds and pushes a docker image for a data job.
-    * Runs a docker-in-docker job on k8s which is responsible for building and pushing the data job image.
+    * Runs a  job on k8s which is responsible for building and pushing the data job image.
     * This call will block until the builder job has finished.
     * Notifies the users on failure.
     *
@@ -142,7 +142,7 @@ public class JobImageBuilder {
       controlKubernetesService.createJob(
             builderJobName,
             dockerRegistryService.builderImage(),
-            true,
+            false,
             envs,
             args,
             null,


### PR DESCRIPTION
The  control service builder runs in a privileged context which is not
permitted on many K8s environments for security reasons.

Our builder job uses https://github.com/genuinetools/img so we do not
need priveleged context to run builder jobs

Testing Done: this CI - integration test  deploys job in kubernetes and
will catch if there is an issue in changing the flag.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>