### PR TITLE
versatile-data-kit: From DB to DB Ingestion Example

### DIFF
--- a/examples/ingest-from-db-example/README.md
+++ b/examples/ingest-from-db-example/README.md
@@ -1,0 +1,3 @@
+## Ingesting data from DB into Database (Data Lake)
+This directory contains the relevant files for the [Ingesting data from DB into Database (Data Lake)](https://github.com/vmware/versatile-data-kit/wiki/Ingesting-data-from-DB-into-Database-%28Data-Lake%29)
+example from the wiki.

--- a/examples/ingest-from-db-example/ingest-from-db-example-job/10_drop_table.sql
+++ b/examples/ingest-from-db-example/ingest-from-db-example-job/10_drop_table.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS backup_employees;

--- a/examples/ingest-from-db-example/ingest-from-db-example-job/20_create_table.sql
+++ b/examples/ingest-from-db-example/ingest-from-db-example-job/20_create_table.sql
@@ -1,0 +1,17 @@
+CREATE TABLE backup_employees (
+    EmployeeId INTEGER,
+    LastName   NVARCHAR,
+    FirstName  NVARCHAR,
+    Title      NVARCHAR,
+    ReportsTo  INTEGER,
+    BirthDate  NVARCHAR,
+    HireDate   NVARCHAR,
+    Address    NVARCHAR,
+    City       NVARCHAR,
+    State      NVARCHAR,
+    Country    NVARCHAR,
+    PostalCode NVARCHAR,
+    Phone      NVARCHAR,
+    Fax        NVARCHAR,
+    Email      NVARCHAR
+);

--- a/examples/ingest-from-db-example/ingest-from-db-example-job/30_ingest_to_table.py
+++ b/examples/ingest-from-db-example/ingest-from-db-example-job/30_ingest_to_table.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import sqlite3
+
+
+def run(job_input):
+    db_connection = sqlite3.connect(
+        "chinook.db"
+    )  # if chinook.db file is not in your current directory, replace "chinook.db" with the path to your chinook.db file
+    cursor = db_connection.cursor()
+    cursor.execute("SELECT * FROM employees")
+    job_input.send_tabular_data_for_ingestion(
+        cursor,
+        column_names=[column_info[0] for column_info in cursor.description],
+        destination_table="backup_employees",
+    )


### PR DESCRIPTION
Versatile Data Kit project needs examples
demonstrating basic functionality for new users.

This change includes an example demonstrating
how to ingest data from source database to
target database, and the required job to
do it. Source and target db are the same local
SQLite db, so that the example would be easy to
test.
The example job creates a backup of the
employees table.

Executed steps from the example locally.

Signed-off-by: Yana Zhivkova <yzhivkova@vmware.com>