### PR TITLE
control-service: do not log stracktrace in debug log

### DIFF
--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/methodintercept/MetricsHelper.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/methodintercept/MetricsHelper.java
@@ -18,6 +18,8 @@ import java.util.*;
 @Slf4j
 public class MetricsHelper {
 
+    private final static ObjectMapper mapper = new ObjectMapper();
+
     public void signatureToMetricsAboutJavaMethod(MethodSignature signature, Map<Metrics, Object> metrics) {
         String classNameCanonical = signature.getDeclaringType().getCanonicalName();
         String classNameSimple = signature.getDeclaringType().getSimpleName();
@@ -69,11 +71,10 @@ public class MetricsHelper {
         }
         String result = "";
         try {
-            ObjectMapper mapper = new ObjectMapper();
             mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
             result = mapper.writeValueAsString(obj);
         } catch (JsonProcessingException e) {
-            log.debug("Failed to convert object to json: {}: {}", obj.getClass(), e);
+            log.debug("Failed to convert object to json: {}: {}", obj.getClass(), e.getMessage());
             result = "" + obj;
         }
         return result;


### PR DESCRIPTION
When MetricsHelper failed to serialize (for telemetry) some object we
log strack trace , which is distracting when troubleshooting issues. As
telemetry is informational it's possible that some object cannot be
serialized to json in which case we just send its string representation
which is ok.

Testing Done: run Control service locally and no longer saw stack trace
with the debug message

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>