### PR TITLE
vdk-core: allow iterable for send_tabular_data_for_ingestion

### DIFF
--- a/projects/vdk-core/setup.cfg
+++ b/projects/vdk-core/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     # click 8 has some breaking changes that break vdk-control-cli
     # https://github.com/pallets/click/issues/1960
     click==7.*
-    pluggy
+    pluggy==0.*
     click_log
     click-plugins
     tenacity

--- a/projects/vdk-core/src/taurus/vdk/builtin_plugins/ingestion/ingester_router.py
+++ b/projects/vdk-core/src/taurus/vdk/builtin_plugins/ingestion/ingester_router.py
@@ -14,6 +14,7 @@ from taurus.vdk.builtin_plugins.ingestion.ingester_configuration import (
 from taurus.vdk.builtin_plugins.run.execution_state import ExecutionStateStoreKeys
 from taurus.vdk.core import errors
 from taurus.vdk.core.config import Configuration
+from taurus.vdk.core.errors import ResolvableBy
 from taurus.vdk.core.statestore import CommonStoreKeys
 from taurus.vdk.core.statestore import StateStore
 
@@ -182,6 +183,16 @@ class IngesterRouter(IIngesterRegistry):
         except Exception as e:
             self._log.error(
                 "Failed to send tabular data for ingestion." f"Exception was: {e}"
+            )
+            errors.log_and_rethrow(
+                ResolvableBy.USER_ERROR,
+                self._log,
+                what_happened="Failed to send tabular data for ingestion",
+                why_it_happened=f"Exception was: {e}",
+                consequences="Data is not ingested and the method will raise an exception",
+                countermeasures="Please look the error message and try to fix the error and re-try.",
+                exception=e,
+                wrap_in_vdk_error=True,
             )
 
     def __initialize_ingester(self, method) -> IngesterBase:

--- a/projects/vdk-core/src/taurus/vdk/builtin_plugins/ingestion/ingester_utils.py
+++ b/projects/vdk-core/src/taurus/vdk/builtin_plugins/ingestion/ingester_utils.py
@@ -124,3 +124,17 @@ def _handle_special_types(value: Any) -> Any:
 def wait_completion(objects_queue: queue.Queue, payloads_queue: queue.Queue):
     objects_queue.join()
     payloads_queue.join()
+
+
+def is_iterable(obj: Any) -> bool:
+    """
+    According to Python doc this is the most reliable way to determine if object is iterable.
+    See https://docs.python.org/3/library/collections.abc.html#collections.abc.Iterable
+    :param obj: the object to check
+    :return: true or false :)
+    """
+    try:
+        _ = iter(obj)
+        return True
+    except TypeError:
+        return False


### PR DESCRIPTION
We currently check if rows object in send_tabular_data_for_ingestion is
iterator. But that is unnecessarily restrictive.

Iterable is a parent class of Iterator and enables traversing the
collection in for cycle.
See https://docs.python.org/3/library/collections.abc.html


Also, there could be a plugin that could infer the column names from their order so requiring column names always is not necessary. That's often seen in practice so we probably should allow it.


Testing Done: existing unit tests

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>