### PR TITLE
control-service: Add username to executions

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobTerminationStatusIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobTerminationStatusIT.java
@@ -396,7 +396,7 @@ public class DataJobTerminationStatusIT extends BaseIT {
         assertEquals(SIMPLE_JOB_NAME, dataJobExecution.getJobName());
         assertEquals(executionStatus, dataJobExecution.getStatus());
         assertEquals(DataJobExecution.TypeEnum.MANUAL, dataJobExecution.getType());
-        assertEquals("manual/" + USER_NAME, dataJobExecution.getStartedBy());
+        assertEquals("manual/" + USER_NAME + "/" + "user", dataJobExecution.getStartedBy());
         assertEquals(opId, dataJobExecution.getOpId());
     }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
@@ -83,7 +83,7 @@ public class JobExecutionService {
          annotations.put(JobAnnotation.OP_ID.getValue(), opId);
 
          String startedBy = StringUtils.isNotBlank(jobExecutionRequest.getStartedBy()) ?
-               jobExecutionRequest.getStartedBy() :
+               jobExecutionRequest.getStartedBy() + "/" + operationContext.getUser() :
                operationContext.getUser();
          String startedByBuilt = buildStartedByAnnotationValue(ExecutionType.MANUAL, startedBy);
          annotations.put(JobAnnotation.STARTED_BY.getValue(), startedByBuilt);

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/execution/JobExecutionServiceStartExecutionIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/execution/JobExecutionServiceStartExecutionIT.java
@@ -94,7 +94,7 @@ public class JobExecutionServiceStartExecutionIT {
    @Test
    public void testStartDataJobExecution_correctDataJobDeployment_shouldStartDataJobExecution() throws ApiException {
       String opId = "test-op-id";
-      String startedBy = "startedBy";
+      String startedBy = "startedBy" + "/" + operationContext.getUser();
       String cronJobName = "test-cron-job";
 
       DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);


### PR DESCRIPTION
As part of improving the user experience when
doing manual job executions, and troubleshooting
failed executions, we need to be able to tell by
whom was an execution started.

This change adds the username of the user, who has
initiated an execution, to the startedBy annotation.

Testing Done: Updated existing unit test to reflect the
change.

Signed-off-by: Andon Andonov <andonova@vmware.com>