### PR TITLE
vdk: team config definition being overriding team value

### DIFF
--- a/projects/vdk-core/src/taurus/vdk/builtin_plugins/notification/notification.py
+++ b/projects/vdk-core/src/taurus/vdk/builtin_plugins/notification/notification.py
@@ -103,7 +103,7 @@ def _notify(error_overall, user_error, configuration, state):
 
 
 class NotificationPlugin:
-    @hookimpl
+    @hookimpl(tryfirst=True)
     def vdk_configure(self, config_builder: ConfigurationBuilder):
         notification_configuration.add_definitions(config_builder)
 

--- a/projects/vdk-core/src/taurus/vdk/builtin_plugins/notification/notification_configuration.py
+++ b/projects/vdk-core/src/taurus/vdk/builtin_plugins/notification/notification_configuration.py
@@ -65,13 +65,6 @@ class SmtpConfiguration:
 
 def __add_job_notified_configuration_definitions(config_builder: ConfigurationBuilder):
     config_builder.add(
-        key=JobConfigKeys.TEAM,
-        default_value="",
-        description="Specified which is the team that owns the data job. "
-        "Value is case-sensitive and must be an actual team name as specified during job creation."
-        "",
-    )
-    config_builder.add(
         key=JobConfigKeys.NOTIFIED_ON_JOB_FAILURE_USER_ERROR,
         default_value="",
         description="Semicolon-separated list of email addresses to be notified on job execution "
@@ -137,13 +130,6 @@ def __add_smtp_configuration_definitions(config_builder):
 
 
 def __add_job_notified_configuration_definitions(config_builder: ConfigurationBuilder):
-    config_builder.add(
-        key=JobConfigKeys.TEAM,
-        default_value="",
-        description="Specified which is the team that owns the data job. "
-        "Value is case-sensitive and must be an actual team name as specified during job creation."
-        "",
-    )
     config_builder.add(
         key=JobConfigKeys.NOTIFIED_ON_JOB_FAILURE_USER_ERROR,
         default_value="",


### PR DESCRIPTION
Since the Notification configuration plugin was executed after
vdk_config JobConfigIniPlugin  which populates the configuration we had
an issue where the notification config plugin was overriwrting the team
value already set by JobConfigIniPlugin :

1st. JobConfigIniPlugin.vdk_configure is called which populates team
using `config_builder.set_value("team", x)`
2nd. Then NotificationPlugin.vdk_configure is called which defines team
config using config_builder.add("team", default_value="") and the
default value override the previously set value

As a quick fix I am simply removing team definition from notification
configuraiton (it does not belong there anyhow).

A long term fix is to not allow default_value to ovrride set value.

Testing Done: ran vdk run properties-job and saw that properteis are not
fetched correctly.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>