### PR TITLE
vdk-core: make sure ingest failure causes data job failure

### DIFF
--- a/projects/vdk-core/src/taurus/vdk/builtin_plugins/ingestion/ingester_base.py
+++ b/projects/vdk-core/src/taurus/vdk/builtin_plugins/ingestion/ingester_base.py
@@ -5,6 +5,7 @@ import logging
 import queue
 import sys
 import threading
+from collections import defaultdict
 from typing import Iterable
 from typing import Optional
 
@@ -16,7 +17,10 @@ from taurus.vdk.builtin_plugins.ingestion.ingester_configuration import (
 )
 from taurus.vdk.builtin_plugins.ingestion.ingester_utils import AtomicCounter
 from taurus.vdk.core import errors
+from taurus.vdk.core.errors import PlatformServiceError
 from taurus.vdk.core.errors import ResolvableBy
+from taurus.vdk.core.errors import UserCodeError
+from taurus.vdk.core.errors import VdkConfigurationError
 
 log = logging.getLogger(__name__)
 
@@ -64,6 +68,9 @@ class IngesterBase(IIngester):
         )
 
         self._fail_count = AtomicCounter()
+        self._plugin_errors = defaultdict(
+            AtomicCounter
+        )  # something like {UserCodeError: 10, VdkConfigurationError: 2}
         self._success_count = AtomicCounter()
         self._closed = AtomicCounter()
         self._objects_queue: queue.Queue = queue.Queue(
@@ -72,6 +79,10 @@ class IngesterBase(IIngester):
         self._payloads_queue: queue.Queue = queue.Queue(
             ingest_config.get_payloads_queue_size()
         )
+        self._exception_on_failure = (
+            ingest_config.get_should_raise_exception_on_failure()
+        )
+
         self._start_workers()
 
     def send_object_for_ingestion(
@@ -262,7 +273,7 @@ class IngesterBase(IIngester):
         :param payload_dict: dict
             Payload to be send to the _objects_queue.
         :param destination_table: string
-            The name of the table, where the data sould be ingested into.
+            The name of the table, where the data should be ingested into.
         :param method: string
             Indicates the ingestion method to be used. E.g.:
                     method="file" -> ingest to file
@@ -296,7 +307,7 @@ class IngesterBase(IIngester):
         current_collection_id = None
         current_destination_table = None
         method = None
-        while True:
+        while self._closed.value == 0:
             try:
                 (
                     payload_dict,
@@ -397,7 +408,7 @@ class IngesterBase(IIngester):
         :param number_of_payloads: int,
             Number of payloads to be dequeued from the _objects_queue.
         :param destination_table: string
-            The name of the table, where the data sould be ingested into.
+            The name of the table, where the data should be ingested into.
         :param method: string
             Indicates the ingestion method to be used. E.g.:
                     method="file" -> ingest to file
@@ -453,7 +464,7 @@ class IngesterBase(IIngester):
         Thread doing final data preparation (adding additional metadata, telemetry
         data, etc.) and ingesting the data.
         """
-        while True:
+        while self._closed.value == 0:
             try:
                 payload = self._payloads_queue.get()
                 payload_dict, destination_table, method, target, collection_id = payload
@@ -467,9 +478,24 @@ class IngesterBase(IIngester):
                     )
 
                     self._success_count.increment()
-                except Exception as e:
+
+                except VdkConfigurationError as e:
+                    self._plugin_errors[VdkConfigurationError].increment()
                     log.warning(
-                        "An error occured while ingesting data. " f"The error was: {e}"
+                        "A configuration error occurred while ingesting data. "
+                        f"The error was: {e}"
+                    )
+                except UserCodeError as e:
+                    self._plugin_errors[UserCodeError].increment()
+                    log.warning(
+                        "An user error occurred while ingesting data. "
+                        f"The error was: {e}"
+                    )
+                except Exception as e:
+                    self._plugin_errors[PlatformServiceError].increment()
+                    log.warning(
+                        "A platform error occurred while ingesting data. "
+                        f"The error was: {e}"
                     )
 
             except Exception as e:
@@ -506,6 +532,62 @@ class IngesterBase(IIngester):
         """
         ingester_utils.wait_completion(
             objects_queue=self._objects_queue, payloads_queue=self._payloads_queue
+        )
+        self.close_now()
+
+    def close_now(self):
+        """
+        Close immediately. The method will not wait for the active queue items to get processed.
+        """
+        if self._closed.get_and_increment() == 0:
+
+            if self._exception_on_failure:
+                self._handle_results()
+
+            log.info(
+                "Ingester statistics: \n\t\t"
+                f"Successful uploads:{self._success_count}\n\t\t"
+                f"Failed uploads:{self._fail_count}\n\t\t"
+                f"ingesting plugin errors:{self._plugin_errors}\n\t\t"
+            )
+
+    def _handle_results(self):
+        if self._plugin_errors.get(UserCodeError, 0).value > 0:
+            self._log_and_throw(
+                to_be_fixed_by=ResolvableBy.USER_ERROR,
+                countermeasures="Ensure data you are sending is aligned with the requirements",
+                why_it_happened="User error occurred. See warning logs for more details. ",
+            )
+        if self._plugin_errors.get(VdkConfigurationError, 0).value > 0:
+            self._log_and_throw(
+                to_be_fixed_by=ResolvableBy.CONFIG_ERROR,
+                countermeasures="Ensure job is properly configured. "
+                "For example make sure that target and method specified are correct",
+            )
+        if (
+            self._plugin_errors.get(PlatformServiceError, 0).value > 0
+            or self._fail_count.value > 0
+        ):
+            self._log_and_throw(
+                to_be_fixed_by=ResolvableBy.PLATFORM_ERROR,
+                countermeasures="There has been temporary failure. "
+                "You can retry the data job again. "
+                "If error persist inspect logs and check ingest plugin documentation.",
+            )
+
+    def _log_and_throw(
+        self,
+        to_be_fixed_by,
+        countermeasures,
+        why_it_happened="Payloads failed to get posted for ingestion",
+    ):
+        errors.log_and_throw(
+            to_be_fixed_by=to_be_fixed_by,
+            log=log,
+            what_happened="Failed to post all data for ingestion successfully.",
+            why_it_happened=why_it_happened,
+            consequences="Some data will not be ingested into Super Collider.",
+            countermeasures=countermeasures,
         )
 
     @staticmethod

--- a/projects/vdk-core/src/taurus/vdk/builtin_plugins/ingestion/ingester_configuration.py
+++ b/projects/vdk-core/src/taurus/vdk/builtin_plugins/ingestion/ingester_configuration.py
@@ -11,6 +11,9 @@ INGESTER_LOG_UPLOAD_ERRORS = "INGESTER_LOG_UPLOAD_ERRORS"
 INGESTION_PAYLOAD_AGGREGATOR_TIMEOUT_SECONDS = (
     "INGESTION_PAYLOAD_AGGREGATOR_TIMEOUT_SECONDS"
 )
+INGESTER_SHOULD_RAISE_EXCEPTION_ON_FAILURE = (
+    "INGESTER_SHOULD_RAISE_EXCEPTION_ON_FAILURE"
+)
 
 
 class IngesterConfiguration:
@@ -31,6 +34,9 @@ class IngesterConfiguration:
 
     def get_should_log_upload_errors(self) -> bool:
         return bool(self.__config.get_value(INGESTER_LOG_UPLOAD_ERRORS))
+
+    def get_should_raise_exception_on_failure(self) -> bool:
+        return bool(self.__config.get_value(INGESTER_SHOULD_RAISE_EXCEPTION_ON_FAILURE))
 
     def get_payload_aggregator_timeout_seconds(self) -> int:
         return int(
@@ -75,6 +81,11 @@ def add_definitions(config_builder: ConfigurationBuilder):
         key=INGESTER_LOG_UPLOAD_ERRORS,
         default_value=True,
         description="Specifies if errors should be logged.",
+    )
+    config_builder.add(
+        key=INGESTER_SHOULD_RAISE_EXCEPTION_ON_FAILURE,
+        default_value=True,
+        description="If set to true, data job will fail with exception in case it a payload fail to ingest.",
     )
     config_builder.add(
         key=INGESTION_PAYLOAD_AGGREGATOR_TIMEOUT_SECONDS,

--- a/projects/vdk-core/src/taurus/vdk/builtin_plugins/ingestion/ingester_router.py
+++ b/projects/vdk-core/src/taurus/vdk/builtin_plugins/ingestion/ingester_router.py
@@ -244,10 +244,9 @@ class IngesterRouter(IIngesterRegistry):
             errors.log_and_throw(
                 to_be_fixed_by=errors.ResolvableBy.USER_ERROR,
                 log=self._log,
-                what_happened=f"Failed to clean some of the ingestion queues. Exceptions were: {errors_list}",
-                why_it_happened=f"There were errors while cleaning the queues for: {errors_list.keys()}.",
+                what_happened=f"Ingesting data failed. On close some ingest queues reported errors. Exceptions were: {errors_list}",
+                why_it_happened=f"There were errors while closing ingestion: {errors_list.keys()}.",
                 consequences="Some data was partially ingested or not ingested at all.",
-                countermeasures="""
-                Make sure all the data is ingested properly by re-running the job.
-                """,
+                countermeasures="Follow the instructions in the error messages and log warnings. Re-try the job if "
+                "necessary.",
             )


### PR DESCRIPTION
It's very very very important that data job fails if we fail to
upload/ingest/send all data to target destination. As it gives immediate
feedback to user (either directly when running locally or through VDK
monitoring and notifications when running on cloud) that something has
went wrong and make sure they know that not all data has been ingested.

If we swollow the errors or do not report the failure and the data job
report success, users will not find out (even if we log warnings and
errors). Job is sucessful and users would not have a reason to look more
carefully in the logs. And of course when running on cloud as mentioned
above , nor monitoring nor notifications will be triggered.

Testing Done: tests, locally ingested data using vdk ingest-csv

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>