### PR TITLE
control-service: pass builder extra arguments

### DIFF
--- a/projects/control-service/projects/job-builder/build_image.sh
+++ b/projects/control-service/projects/job-builder/build_image.sh
@@ -74,4 +74,4 @@ cd ..
         --build-arg=job_githash="$JOB_GITHASH"            \
         --build-arg=base_image="$BASE_IMAGE" \
         --build-arg=job_name="$JOB_NAME"     \
-        --context=./data-jobs
+        --context=./data-jobs $EXTRA_ARGUMENTS

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
@@ -58,6 +58,8 @@ public class JobImageBuilder {
    private String registryPassword;
    @Value("${datajobs.deployment.dataJobBaseImage:python:3.9-slim}")
    private String deploymentDataJobBaseImage;
+   @Value("${datajobs.deployment.builder.extraArgs:}")
+   private String extraArgs;
 
    private final ControlKubernetesService controlKubernetesService;
    private final DockerRegistryService dockerRegistryService;
@@ -212,7 +214,8 @@ public class JobImageBuilder {
             entry("GIT_COMMIT", jobVersion),
             entry("JOB_GITHASH", jobVersion),
             entry("IMAGE_REGISTRY_PATH", dockerRepositoryUrl),
-            entry("BASE_IMAGE", deploymentDataJobBaseImage)
+            entry("BASE_IMAGE", deploymentDataJobBaseImage),
+            entry("EXTRA_ARGUMENTS", extraArgs)
       );
    }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application-prod.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application-prod.properties
@@ -87,3 +87,8 @@ datajobs.monitoring.sync.interval=${DEFAULT_MONITORING_SYNC_INTERVAL}
 #
 # The value is a number in milliseconds
 datajobs.monitoring.sync.initial.delay=${DEFAULT_MONITORING_INITIAL_DELAY_SYNC_INTERVAL}
+
+# Set extra arguments to be passed on Data Job Builder Kubernetes Job
+# Builder is based on kaniko so any arguments accepted by kaniko/executor will be accepted
+# For example if working with non-SSL registry you can pass --insecure
+#datajobs.deployment.builder.extraArgs=${DATAJOBS_DEPLOYMENT_BUILDER_EXTRAARGS}


### PR DESCRIPTION
To enable to customize builder job we need to be able to pass extra
arguments. For example we will use it in implementation of local (single
click) installation of our helm chart with local docker registry and
pass "--insecure" flag.

We will provide property using it to pass extra arguments to builder.
Argumetns are same as those that can be passed to kaniko executor :
https://github.com/GoogleContainerTools/kaniko/blob/master/README.md#additional-flags

From helm install they can be passed using

`helm install ... --set
extraEnvVars.DATAJOBS_DEPLOYMENT_BUILDER_EXTRAARGS="--insecure"`

Testing Done: started locally control service depoy integration test
with env variable DATAJOBS_DEPLOYMENT_BUILDER_EXTRAARGS="--insecure" and
saw in the logs it was passed

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>