### PR TITLE
control-service: Fix JsonSyntaxException when cancelling execution

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -475,16 +475,25 @@ public abstract class KubernetesService implements InitializingBean {
 
     public void cancelRunningCronJob(String teamName, String jobName, String executionId) throws ApiException {
         log.info("K8S deleting job for team: {} data job name: {} execution: {}", teamName, jobName, executionId);
-        var operationResponse = new BatchV1Api(client).deleteNamespacedJob(executionId, namespace, null,
-                null, null,
-                null,
-                null,
-                "Foreground");
+        try {
+            var operationResponse = new BatchV1Api(client).deleteNamespacedJob(executionId, namespace, null,
+                    null, null,
+                    null,
+                    null,
+                    "Foreground");
+            //Status of the operation. One of: "Success" or "Failure"
+            if (operationResponse.getStatus().equals("Failure")) {
+                log.warn("Failed to delete K8S job. Reason: {} Details: {}", operationResponse.getReason(), operationResponse.getDetails().toString());
+                throw new ApiException(operationResponse.getCode(), operationResponse.getMessage());
+            }
 
-        //Status of the operation. One of: "Success" or "Failure"
-        if (operationResponse.getStatus().equals("Failure")) {
-            log.warn("Failed to delete K8S job. Reason: {} Details: {}", operationResponse.getReason(), operationResponse.getDetails().toString());
-            throw new ApiException(operationResponse.getCode(), operationResponse.getMessage());
+        } catch (JsonSyntaxException e) {
+            if (e.getCause() instanceof IllegalStateException) {
+                IllegalStateException ise = (IllegalStateException) e.getCause();
+                if (ise.getMessage() != null && ise.getMessage().contains("Expected a string but was BEGIN_OBJECT"))
+                    log.debug("Catching exception because of issue https://github.com/kubernetes-client/java/issues/86", e);
+                else throw e;
+            } else throw e;
         }
     }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
@@ -5,6 +5,7 @@
 
 package com.vmware.taurus.service.execution;
 
+import com.google.gson.JsonSyntaxException;
 import com.vmware.taurus.controlplane.model.data.DataJobExecution;
 import com.vmware.taurus.controlplane.model.data.DataJobExecutionRequest;
 import com.vmware.taurus.datajobs.ToApiModelConverter;
@@ -138,7 +139,7 @@ public class JobExecutionService {
          jobExecutionRepository.save(jobExecution);
          log.info("Cancelled data job execution {} successfully.", executionId);
 
-      } catch (ApiException e) {
+      } catch (ApiException | JsonSyntaxException e) {
          throw new KubernetesException(String.format("Cannot cancel a Data Job '%s' execution with execution id '%s'", jobName, executionId), e);
       }
    }


### PR DESCRIPTION
Why: During testing of the new feature - cancelling a running or submitted
data job execution I stumbled upon an error in the K8S api. A sucessfull
call would throw a JsonSyntaxException. This is a known issue on the K8S
API - https://github.com/kubernetes-client/java/issues/86 . We already handle
this in other methods.

What: Mimicked the way we handle this exception in our codebase and
modified the cancelRunningCronJob method to handle JsonSyntaxExceptions.

Type: Bug fix.

Testing: ci/cd and ran tests concerning Execution cancellation locally.

Signed-off-by: Momchil Zhivkov <mzhivkov@vmware.com>