### PR TITLE
vdk-snowflake: Add plugin configurations

### DIFF
--- a/projects/vdk-core/plugins/vdk-snowflake/.plugin-ci.yml
+++ b/projects/vdk-core/plugins/vdk-snowflake/.plugin-ci.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 VMware, Inc.
+# Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 image: "python:3.7"
 

--- a/projects/vdk-core/plugins/vdk-snowflake/src/taurus/vdk/snowflake_plugin.py
+++ b/projects/vdk-core/plugins/vdk-snowflake/src/taurus/vdk/snowflake_plugin.py
@@ -1,9 +1,93 @@
-# Copyright (c) 2021 VMware, Inc.
+# Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import pluggy
+import click
 import logging
+from typing import Callable
+from snowflake.connector.errors import ProgrammingError
 from taurus.api.plugin.hook_markers import hookimpl
+from taurus.vdk.builtin_plugins.connection.pep249.interfaces import PEP249Connection
+from taurus.vdk.builtin_plugins.run.job_context import JobContext
+from taurus.vdk.core.config import ConfigurationBuilder
+from taurus.vdk.core.context import CoreContext
+from taurus.vdk.core.statestore import ImmutableStoreKey
+from taurus.vdk.snowflake_connection import SnowflakeConnection
+from taurus.vdk.builtin_plugins.run.step import Step
+from taurus.vdk.core.errors import UserCodeError
 
 """
 VDK-Snowflake Plugin
 """
 log = logging.getLogger(__name__)
+
+
+@hookimpl(tryfirst=True)
+def vdk_configure(config_builder: ConfigurationBuilder) -> None:
+    """
+    Here we define what configuration settings are needed for snowflake with reasonable defaults
+    """
+    config_builder.add(
+        key="SNOWFLAKE_ACCOUNT",
+        default_value="localhost",
+        description="The Snowflake account identifier as described in https://docs.snowflake.com/en/user-guide/admin-account-identifier.html It is required to connect to a Snowflake instance.",
+    )
+    config_builder.add(
+        key="SNOWFLAKE_SCHEMA", default_value=None, description="The database schema"
+    )
+    config_builder.add(
+        key="SNOWFLAKE_WAREHOUSE", default_value=None, description="The warehouse to be used."
+    )
+    config_builder.add(
+        key="SNOWFLAKE_DATABASE", default_value=None, description="The snowflake database to be used."
+    )
+    config_builder.add(
+        key="SNOWFLAKE_USER", default_value="unknown", description="User name"
+    )
+    config_builder.add(
+        key="SNOWFLAKE_PASSWORD", default_value=None, description="User password"
+    )
+
+
+SnowflakeConnectionFunc = Callable[[], PEP249Connection]
+CONNECTION_FUNC_KEY = ImmutableStoreKey[SnowflakeConnectionFunc]("snowflake-connection-method")
+
+
+@hookimpl
+def vdk_initialize(context: CoreContext) -> None:
+    configuration = context.configuration
+
+    def new_connection() -> PEP249Connection:
+        connection = SnowflakeConnection(
+            account=configuration.get_required_value("SNOWFLAKE_ACCOUNT"),
+            schema=configuration.get_value("SNOWFLAKE_SCHEMA"),
+            warehouse=configuration.get_value("SNOWFLAKE_WAREHOUSE"),
+            database=configuration.get_value("SNOWFLAKE_DATABASE"),
+            user=configuration.get_required_value("SNOWFLAKE_USER"),
+            password=configuration.get_required_value("SNOWFLAKE_PASSWORD"),
+        )
+        return connection
+
+    context.state.set(CONNECTION_FUNC_KEY, new_connection)
+
+
+@hookimpl
+def initialize_job(context: JobContext) -> None:
+    context.connections.add_open_connection_factory_method(
+        "SNOWFLAKE", context.core_context.state.get(CONNECTION_FUNC_KEY)
+    )
+
+
+@click.command(name="snowflake-query", help="executes SQL query against Snowflake")
+@click.option("-q", "--query", type=click.STRING, required=True)
+@click.pass_context
+def snowflake_query(ctx: click.Context, query):
+    with ctx.obj.state.get(CONNECTION_FUNC_KEY)() as conn:
+        res = conn.execute_query(query)
+        import json
+
+        click.echo(json.dumps(res, indent=2))
+
+
+@hookimpl
+def vdk_command_line(root_command: click.Group):
+    root_command.add_command(snowflake_query)


### PR DESCRIPTION
As part of the Versatile Data Kit's support for
Snowflake, we need to make a fully functioning sql
plugin that interacts with a Snowflake instance.

This change introduces configurations and hook
implementations, required for the vdk-snowflake plugin
to be a fully-functioning plugin.

Testing Done: Ran a data job using sql queries against
a Snowflake instance, and verified that the results from
the executions were as expected.

The steps executed were as follows:
1) Create a Snowflake account.
2) Export the following environment variables:
          VDK_DB_DEFAULT_TYPE=SNOWFLAKE
          VDK_SNOWFLAKE_USER=<username>
          VDK_SNOWFLAKE_PASSWORD=<user_password>
          VDK_SNOWFLAKE_ACCOUNT=<account_name_provided_by_snowflake>
3) Create a data job with sql queries to
'use warehouse'
`USE WAREHOUSE COMPUTE_WH`
'create database'
`CREATE DATABASE IF NOT EXISTS aatestdb`
'use database'
`USE DATABASE aatestdb`
'create schema'
`CREATE SCHEMA IF NOT EXISTS aatestschema`
'use schema'
`USE SCHEMA aatestdb.aatestschema`
'create table'
`CREATE OR REPLACE TABLE aatesttable(col1 integer, col2 string)`
'insert data into the table'
`INSERT INTO aatesttable(col1, col2) VALUES (123, 'test string1'),(456, 'test string2')`

3) execute `vdk run <job_name>`

Signed-off-by: Andon Andonov <andonova@vmware.com>