### PR TITLE
vdk-ingest-http: add functional test

### DIFF
--- a/projects/vdk-core/plugins/vdk-ingest-http/README.md
+++ b/projects/vdk-core/plugins/vdk-ingest-http/README.md
@@ -35,3 +35,15 @@ The payload needs to be a json object, and should contain the `destination_table
 The `method` attribute needs to be provided for the time being.
 <br>
 The `target` attribute should specify the url endpoint, where the data will be ingested.
+
+### Testing
+
+To develop or test locally (from the current directory)
+```bash
+# install dev and test dependencies
+pip install -r requirements
+# install the plugin in editable mode
+pip install -e .
+# run the tests
+pytest
+```

--- a/projects/vdk-core/plugins/vdk-ingest-http/requirements.txt
+++ b/projects/vdk-core/plugins/vdk-ingest-http/requirements.txt
@@ -1,2 +1,7 @@
 requests
 vdk-core
+
+# testing dependencies
+pytest
+pytest-httpserver
+vdk-test-utils

--- a/projects/vdk-core/plugins/vdk-ingest-http/tests/functional/jobs/ingest-job/ingest_test_data.py
+++ b/projects/vdk-core/plugins/vdk-ingest-http/tests/functional/jobs/ingest-job/ingest_test_data.py
@@ -1,0 +1,10 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from taurus.api.job_input import IJobInput
+
+
+def run(job_input: IJobInput):
+    rows = [[i, i + 1, "hi"] for i in range(100)]
+    job_input.send_tabular_data_for_ingestion(
+        rows, column_names=["index", "next", "word"], destination_table="test"
+    )

--- a/projects/vdk-core/plugins/vdk-ingest-http/tests/functional/test_http_ingest.py
+++ b/projects/vdk-core/plugins/vdk-ingest-http/tests/functional/test_http_ingest.py
@@ -1,0 +1,38 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import os
+import pathlib
+from unittest import mock
+
+from click.testing import Result
+from pytest_httpserver.pytest_plugin import PluginHTTPServer
+from taurus.vdk import ingest_http_plugin
+from taurus.vdk.test_utils.util_funcs import cli_assert_equal
+from taurus.vdk.test_utils.util_funcs import CliEntryBasedTestRunner
+from taurus.vdk.test_utils.util_funcs import get_test_job_path
+from werkzeug import Response
+
+
+def job_path(job_name: str):
+    return get_test_job_path(
+        pathlib.Path(os.path.dirname(os.path.abspath(__file__))), job_name
+    )
+
+
+def test_http_ingestion(httpserver: PluginHTTPServer):
+    httpserver.expect_request(uri="/ingest").respond_with_response(Response(status=200))
+
+    with mock.patch.dict(
+        os.environ,
+        {
+            "VDK_INGEST_METHOD_DEFAULT": "http",
+            "VDK_INGEST_TARGET_DEFAULT": httpserver.url_for("/ingest"),
+        },
+    ):
+        # create table first, as the ingestion fails otherwise
+        runner = CliEntryBasedTestRunner(ingest_http_plugin)
+
+        result: Result = runner.invoke(["run", job_path("ingest-job")])
+        cli_assert_equal(0, result)
+
+        assert len(httpserver.log) == 100


### PR DESCRIPTION
In order to make sure that the plugin work as expected in user
environment having a functional type of test where the plugin is used in
realistic scenario would make it much less likely to have regressions.

Testign Done: tests including new one passed

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>