### PR TITLE
vdk-ingest-http: send all payloads as one http request

### DIFF
--- a/projects/vdk-core/plugins/vdk-ingest-http/src/taurus/vdk/ingest_over_http.py
+++ b/projects/vdk-core/plugins/vdk-ingest-http/src/taurus/vdk/ingest_over_http.py
@@ -30,7 +30,12 @@ class IngestOverHttp(IIngesterPlugin):
             f"collection_id: {collection_id}"
         )
 
-        # Check if target is passed
+        self.__verify_target(target)
+        self.__amend_payload(payload, destination_table)
+        self.__send_data(payload, target, header)
+
+    @staticmethod
+    def __verify_target(target):
         if not target:
             errors.log_and_throw(
                 errors.ResolvableBy.CONFIG_ERROR,
@@ -45,7 +50,8 @@ class IngestOverHttp(IIngesterPlugin):
                 "or passed target to send_**for_ingestion APIs",
             )
 
-        # TODO: do not make separate http requests for each payload but send them in single http request
+    @staticmethod
+    def __amend_payload(payload, destination_table):
         for obj in payload:
             # TODO: Move all ingestion formatting logic to a separate plugin.
             if not ("@table" in obj):
@@ -62,9 +68,8 @@ class IngestOverHttp(IIngesterPlugin):
                 else:
                     obj["@table"] = destination_table
 
-            self.__send_data(obj, target, header)
-
-    def __send_data(self, data, http_url, headers):
+    @staticmethod
+    def __send_data(data, http_url, headers):
         try:
             req = requests.post(
                 url=http_url,

--- a/projects/vdk-core/plugins/vdk-ingest-http/tests/functional/test_http_ingest.py
+++ b/projects/vdk-core/plugins/vdk-ingest-http/tests/functional/test_http_ingest.py
@@ -27,6 +27,7 @@ def test_http_ingestion(httpserver: PluginHTTPServer):
         {
             "VDK_INGEST_METHOD_DEFAULT": "http",
             "VDK_INGEST_TARGET_DEFAULT": httpserver.url_for("/ingest"),
+            "VDK_INGESTER_PAYLOAD_SIZE_BYTES_THRESHOLD": "1000",
         },
     ):
         # create table first, as the ingestion fails otherwise
@@ -35,4 +36,5 @@ def test_http_ingestion(httpserver: PluginHTTPServer):
         result: Result = runner.invoke(["run", job_path("ingest-job")])
         cli_assert_equal(0, result)
 
-        assert len(httpserver.log) == 100
+        # a single record/row is 100 bytes with 100 records would result is 10 batches of 1000 bytes
+        assert len(httpserver.log) == 10

--- a/projects/vdk-core/plugins/vdk-ingest-http/tests/test_ingest_over_http.py
+++ b/projects/vdk-core/plugins/vdk-ingest-http/tests/test_ingest_over_http.py
@@ -48,7 +48,7 @@ def test_ingest_over_http(mock_post):
 
     mock_post.assert_called_with(
         headers={"Content-Type": "application/octet-stream"},
-        json=payload,
+        json=[payload],
         url="http://example.com/data-source",
         verify=False,
     )


### PR DESCRIPTION
Sending each row/record as separate http request creates very high
overhead and also slow down data ingestion. Even sending 100 records
takes more than 1 minute which is way too much.

After the change now it takes less than 1 second.

Testing Done: edited tests. Also used vdk ingest-csv to ingest 100 rows
and verified they were properly ingested using http plugin.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>