### PR TITLE
control-service: mark job executions as failed in case of user error

### DIFF
--- a/projects/control-service/CHANGELOG.md
+++ b/projects/control-service/CHANGELOG.md
@@ -6,6 +6,8 @@ Changelog
 * **New feature**
 * **Improvement**
 * **Bug Fixes**
+  * Data job execution status fix
+    In case of failed data job execution due to the User Error the execution status will be marked as Failed instead of Finished.
 * **Breaking Changes**
 
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
@@ -275,6 +275,8 @@ public class JobExecutionService {
 
       if (isJobExecutionSkipped(jobExecution)) {
          return ExecutionStatus.SKIPPED;
+      } else if (isJobExecutionFailed(jobExecution)) {
+         return ExecutionStatus.FAILED;
       }
 
       var jobStatus = jobExecution.getStatus();
@@ -302,7 +304,21 @@ public class JobExecutionService {
     * @return
     */
    private static boolean isJobExecutionSkipped(KubernetesService.JobExecution jobExecution) {
-      return KubernetesService.PodTerminationMessage.SKIPPED.getValue().equals(StringUtils.trim(jobExecution.getTerminationMessage()));
+      return jobExecutionEquals(jobExecution, KubernetesService.PodTerminationMessage.SKIPPED);
    }
 
+   /**
+    * This is a helper method used to determine if a data job execution's status should be changed to FAILED.
+    *
+    * @param jobExecution
+    * @return
+    */
+   private static boolean isJobExecutionFailed(KubernetesService.JobExecution jobExecution) {
+      return jobExecutionEquals(jobExecution, KubernetesService.PodTerminationMessage.USER_ERROR) ||
+            jobExecutionEquals(jobExecution, KubernetesService.PodTerminationMessage.PLATFORM_ERROR);
+   }
+
+   private static boolean jobExecutionEquals(KubernetesService.JobExecution jobExecution, KubernetesService.PodTerminationMessage podTerminationMessage) {
+      return podTerminationMessage.getValue().equals(StringUtils.trim(jobExecution.getTerminationMessage()));
+   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/RepositoryUtil.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/RepositoryUtil.java
@@ -11,6 +11,7 @@ import com.vmware.taurus.service.model.*;
 import org.junit.jupiter.api.Assertions;
 
 import java.time.OffsetDateTime;
+import java.util.Random;
 
 public final class RepositoryUtil {
 
@@ -31,6 +32,16 @@ public final class RepositoryUtil {
          DataJob dataJob,
          ExecutionStatus executionStatus) {
 
+      return createDataJobExecution(jobExecutionRepository, executionId, dataJob, executionStatus, "test_message");
+   }
+
+   public static DataJobExecution createDataJobExecution(
+         JobExecutionRepository jobExecutionRepository,
+         String executionId,
+         DataJob dataJob,
+         ExecutionStatus executionStatus,
+         String message) {
+
       var expectedJobExecution = DataJobExecution.builder()
             .id(executionId)
             .dataJob(dataJob)
@@ -41,7 +52,7 @@ public final class RepositoryUtil {
             .resourcesCpuLimit(2F)
             .resourcesMemoryRequest(500)
             .resourcesMemoryLimit(1000)
-            .message("test_message")
+            .message(message)
             .lastDeployedBy("test_user")
             .lastDeployedDate(OffsetDateTime.now())
             .jobVersion("test_version")

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/execution/JobExecutionServiceUpdateExecutionIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/execution/JobExecutionServiceUpdateExecutionIT.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.execution;
+
+import java.time.OffsetDateTime;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.vmware.taurus.ControlplaneApplication;
+import com.vmware.taurus.RepositoryUtil;
+import com.vmware.taurus.controlplane.model.data.DataJobExecution;
+import com.vmware.taurus.service.JobsRepository;
+import com.vmware.taurus.service.KubernetesService;
+import com.vmware.taurus.service.execution.JobExecutionService;
+import com.vmware.taurus.service.model.DataJob;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = ControlplaneApplication.class)
+public class JobExecutionServiceUpdateExecutionIT {
+
+   @Autowired
+   private JobsRepository jobsRepository;
+
+   @Autowired
+   private JobExecutionService jobExecutionService;
+
+   @AfterEach
+   public void cleanUp() {
+      jobsRepository.deleteAll();
+   }
+
+   @Test
+   public void testUpdateJobExecution_statusFinishedAndTerminationMessageUserError_shouldRecordExecutionStatusFailed() {
+      testUpdateJobExecution(
+            KubernetesService.JobExecution.Status.FINISHED,
+            KubernetesService.PodTerminationMessage.USER_ERROR,
+            DataJobExecution.StatusEnum.FAILED);
+   }
+
+   @Test
+   public void testUpdateJobExecution_statusFinishedAndTerminationMessagePlatformError_shouldRecordExecutionStatusFailed() {
+      testUpdateJobExecution(
+            KubernetesService.JobExecution.Status.FINISHED,
+            KubernetesService.PodTerminationMessage.PLATFORM_ERROR,
+            DataJobExecution.StatusEnum.FAILED);
+   }
+
+   @Test
+   public void testUpdateJobExecution_statusFinishedAndTerminationMessageSkipped_shouldRecordExecutionStatusSkipped() {
+      testUpdateJobExecution(
+            KubernetesService.JobExecution.Status.FINISHED,
+            KubernetesService.PodTerminationMessage.SKIPPED,
+            DataJobExecution.StatusEnum.SKIPPED,
+            "Skipping job execution due to another parallel running execution.");
+   }
+
+   @Test
+   public void testUpdateJobExecution_statusFinishedAndTerminationMessageSuccess_shouldRecordExecutionStatusFinish() {
+      testUpdateJobExecution(
+            KubernetesService.JobExecution.Status.FINISHED,
+            KubernetesService.PodTerminationMessage.SUCCESS,
+            DataJobExecution.StatusEnum.FINISHED);
+   }
+
+   private void testUpdateJobExecution(
+         KubernetesService.JobExecution.Status actualExecutionStatus,
+         KubernetesService.PodTerminationMessage actualTerminationMessage,
+         DataJobExecution.StatusEnum expectedJobExecutionStatus) {
+
+      testUpdateJobExecution(actualExecutionStatus, actualTerminationMessage, expectedJobExecutionStatus, null);
+   }
+
+   private void testUpdateJobExecution(
+         KubernetesService.JobExecution.Status actualExecutionStatus,
+         KubernetesService.PodTerminationMessage actualTerminationMessage,
+         DataJobExecution.StatusEnum expectedJobExecutionStatus,
+         String expectedJobExecutionMessage) {
+
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+      KubernetesService.JobExecution expectedJobExecution = KubernetesService.JobExecution.builder()
+            .status(actualExecutionStatus)
+            .opId("test_op_id")
+            .executionId("test_execution_id")
+            .executionType("manual")
+            .jobName(actualDataJob.getName())
+            .jobVersion("test_job_version")
+            .jobSchedule("test_job_schedule")
+            .startTime(OffsetDateTime.now())
+            .endTime(OffsetDateTime.now())
+            .resourcesCpuLimit(1f)
+            .resourcesCpuRequest(1f)
+            .resourcesMemoryLimit(1)
+            .resourcesMemoryRequest(1)
+            .deployedBy("test_deployed_by")
+            .deployedDate(OffsetDateTime.now())
+            .terminationMessage(actualTerminationMessage.getValue()).build();
+      jobExecutionService.updateJobExecution(actualDataJob, expectedJobExecution);
+
+      DataJobExecution actualJobExecution = jobExecutionService.readJobExecution(
+            actualDataJob.getJobConfig().getTeam(),
+            actualDataJob.getName(),
+            expectedJobExecution.getExecutionId());
+
+      expectedJobExecutionMessage = expectedJobExecutionMessage != null ? expectedJobExecutionMessage : expectedJobExecution.getTerminationMessage();
+      assertDataJobExecutionValid(expectedJobExecution, expectedJobExecutionStatus, expectedJobExecutionMessage, actualJobExecution);
+   }
+
+   private void assertDataJobExecutionValid(
+         KubernetesService.JobExecution expectedJobExecution,
+         DataJobExecution.StatusEnum expectedJobStatus,
+         String expectedMessage,
+         DataJobExecution actualJobExecution) {
+
+      Assert.assertEquals(expectedJobExecution.getExecutionId(), actualJobExecution.getId());
+      Assert.assertEquals(expectedJobExecution.getExecutionType(), actualJobExecution.getType().toString());
+      Assert.assertEquals(expectedJobExecution.getJobName(), actualJobExecution.getJobName());
+      Assert.assertEquals(expectedJobExecution.getJobVersion(), actualJobExecution.getDeployment().getJobVersion());
+      Assert.assertEquals(expectedMessage, actualJobExecution.getMessage());
+      Assert.assertEquals(expectedJobStatus, actualJobExecution.getStatus());
+      Assert.assertEquals(expectedJobExecution.getOpId(), actualJobExecution.getOpId());
+      Assert.assertEquals(expectedJobExecution.getStartTime(), actualJobExecution.getStartTime());
+      Assert.assertEquals(expectedJobExecution.getEndTime(), actualJobExecution.getEndTime());
+      Assert.assertEquals(expectedJobExecution.getJobSchedule(), actualJobExecution.getDeployment().getSchedule().getScheduleCron());
+      Assert.assertEquals(expectedJobExecution.getResourcesCpuLimit(), actualJobExecution.getDeployment().getResources().getCpuLimit());
+      Assert.assertEquals(expectedJobExecution.getResourcesCpuRequest(), actualJobExecution.getDeployment().getResources().getCpuRequest());
+      Assert.assertEquals(expectedJobExecution.getResourcesMemoryLimit(), actualJobExecution.getDeployment().getResources().getMemoryLimit());
+      Assert.assertEquals(expectedJobExecution.getResourcesMemoryRequest(), actualJobExecution.getDeployment().getResources().getMemoryRequest());
+      Assert.assertEquals(expectedJobExecution.getDeployedDate(), actualJobExecution.getDeployment().getDeployedDate());
+      Assert.assertEquals(expectedJobExecution.getDeployedBy(), actualJobExecution.getDeployment().getDeployedBy());
+   }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobExecutionRepositoryIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobExecutionRepositoryIT.java
@@ -113,4 +113,15 @@ public class JobExecutionRepositoryIT {
       Assertions.assertNotNull(actualJobExecutions);
       Assertions.assertTrue(actualJobExecutions.isEmpty());
    }
+
+   @Test
+   public void testFindDataJobExecutionsByDataJobName_existingDataJobExecution_shouldReturnResult2() {
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+
+      String executionId = "test-execution-id";
+      ExecutionStatus executionStatus = ExecutionStatus.RUNNING;
+      DataJobExecution expectedJobExecution =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, executionId, actualDataJob, executionStatus);
+
+   }
 }


### PR DESCRIPTION
In case of failed data job execution due to the User Error the execution status will be marked as Failed instead of Finished.

Testing done: unit tests

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com