### PR TITLE
vdk-control-cli: fix vdk create help

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/create.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/create.py
@@ -174,7 +174,7 @@ Examples:
 \b
 # Simplest form which will prompt for necessary info:
 # It will create it locally and created in cloud
-# only if there is control service configured.
+# only if there is a Control Service configured.
 vdk create
 
 \b


### PR DESCRIPTION
Fix help to address teh new changes in vdk create introduced in
https://github.com/vmware/versatile-data-kit/pull/211

Testing Done: vdk create --help
```
Usage: vdk create [OPTIONS]

  Creates a new data job in cloud and locally.

  Examples:

  # Simplest form and will prompt for necessary info:
  vdkcli create

  # Create data job in cloud runtime registering it in the Control Service.
  # This will make it possible to use Control Service functionalities (like Properties)
  vdkcli create --cloud

  # Create local data job folder (from a sample).
  vdkcli create --local

  # Create job without prompts by specifying all necessary fields
  # This will create job with name "example" that belongs to team 'super-team'
  # and create sample template of the job in /home/user/data-jobs/example-job
  vdkcli create -n example-job -t super-team -p /home/user/data-jobs

Options:
  -n, --name TEXT                 The data job name. It must be between 6 and
                                  45 characters: lowercase or dash.

  -t, --team TEXT                 The team name to which the job should belong
                                  to.

  -p, --path PATH                 The path to the parent directory of the Data
                                  Job. If none specified it will use the
                                  current working directory. New directory
                                  using job name will be created inside that
                                  path with sample job (unless --no-sample is
                                  used). Otherwise the keytab for the job will
                                  be placed into the directory.

  --cloud, --no-sample, --no-template
                                  Will not create sample job on local file
                                  system (--path parameter is ignored in this
                                  case). Will only register it in the cloud
                                  Control service.--no-sample and --no-
                                  template are deprecated. Perfer to use
                                  --cloud.

  --local                         Create sample job on local file system
                                  (--path parameter is required in this case).

  -u, --rest-api-url TEXT         The base REST API URL. It looks like
                                  http://server (without path e.g. /data-jobs)

  --help                          Show this message and exit.
```

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>