### PR TITLE
vdk-core: add termination message writer plugin

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/builtin_hook_impl.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/builtin_hook_impl.py
@@ -23,6 +23,9 @@ from vdk.internal.builtin_plugins.job_properties.properties_api_plugin import (
     PropertiesApiPlugin,
 )
 from vdk.internal.builtin_plugins.notification.notification import NotificationPlugin
+from vdk.internal.builtin_plugins.termination_message.writer import (
+    TerminationMessageWriterPlugin,
+)
 from vdk.internal.builtin_plugins.version.new_version_check_plugin import (
     NewVersionCheckPlugin,
 )
@@ -100,6 +103,7 @@ def vdk_start(plugin_registry: PluginRegistry, command_line_args: List) -> None:
     # TODO: should be in run package only
     plugin_registry.add_hook_specs(JobRunHookSpecs)
     plugin_registry.load_plugin_with_hooks_impl(JobConfigIniPlugin())
+    plugin_registry.load_plugin_with_hooks_impl(TerminationMessageWriterPlugin())
 
 
 @hookimpl(tryfirst=True)

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/termination_message/action.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/termination_message/action.py
@@ -1,0 +1,73 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+from abc import ABC
+from abc import abstractmethod
+
+log = logging.getLogger(__name__)
+
+
+class ITerminationAction(ABC):
+    """
+    A base class representing an action that is performed upon data job completion, depending on the result.
+    """
+
+    @abstractmethod
+    def success(self):
+        """
+        Called when the job execution was successful.
+        """
+        pass
+
+    @abstractmethod
+    def user_error(self):
+        """
+        Called when the job execution failed with an user error.
+        """
+        pass
+
+    @abstractmethod
+    def platform_error(self):
+        """
+        Called when the job execution failed with a platform error.
+        """
+        pass
+
+
+class WriteToFileAction(ITerminationAction):
+    """
+    Writes a string message to a specified file upon completion of a data job execution.
+
+    This is intended to provide a termination status of a data job in a Kubernetes environment
+    (see https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/).
+    Keep in mind that there is a limit to the length of the termination message.
+    """
+
+    def __init__(self, filename, show_log_messages=True):
+        self.filename = filename
+        self.show_log_messages = show_log_messages
+
+    def _append_to_file(self, message):
+        if not self.filename:
+            return
+
+        try:
+            with open(self.filename, "a") as file:
+                file.write(message)
+        except OSError as e:
+            if self.show_log_messages:
+                log.debug(
+                    f'Unable to write termination message to file "{self.filename}". {e}'
+                )
+
+    def success(self):
+        self._append_to_file("Success\n")
+
+    def user_error(self):
+        self._append_to_file("User error\n")
+
+    def platform_error(self):
+        self._append_to_file("Platform error\n")
+
+    def skipped(self):
+        self._append_to_file("Skipped\n")

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/termination_message/writer.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/termination_message/writer.py
@@ -1,0 +1,75 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+from vdk.api.plugin.hook_markers import hookimpl
+from vdk.internal.builtin_plugins.config.vdk_config import LOG_CONFIG
+from vdk.internal.builtin_plugins.termination_message import action
+from vdk.internal.builtin_plugins.termination_message import (
+    writer_configuration,
+)
+from vdk.internal.builtin_plugins.termination_message.writer_configuration import (
+    WriterConfiguration,
+)
+from vdk.internal.core import errors
+from vdk.internal.core.config import ConfigurationBuilder
+from vdk.internal.core.context import CoreContext
+
+log = logging.getLogger(__name__)
+
+
+class TerminationMessageWriterPlugin:
+    @hookimpl(tryfirst=True)
+    def vdk_configure(self, config_builder: ConfigurationBuilder):
+        writer_configuration.add_definitions(config_builder)
+
+    @hookimpl
+    def vdk_exit(self, context: CoreContext, exit_code: int):
+        self._write_termination_message(
+            errors.get_blamee_overall(),  # TODO: get this from context
+            errors.get_blamee_overall_user_error(),  # TODO: get this from context
+            context.configuration,
+        )
+
+    def _write_termination_message(self, error_overall, user_error, configuration):
+        termination_message_writer_cfg = WriterConfiguration(configuration)
+
+        try:
+            termination_message_output_file = (
+                termination_message_writer_cfg.get_output_file()
+            )
+
+            if (
+                termination_message_writer_cfg.get_writer_enabled()
+                and termination_message_output_file
+            ):
+                # Hide termination messages when running locally
+                show_termination_log_messages = (
+                    configuration.get_value(LOG_CONFIG).lower() != "local"
+                )
+                termination_action = action.WriteToFileAction(
+                    termination_message_output_file, show_termination_log_messages
+                )
+
+                if show_termination_log_messages:
+                    log.debug(
+                        f'Writing termination message to file "{termination_message_output_file}"'
+                    )
+                self._execute_termination_action(
+                    termination_action, error_overall, user_error
+                )
+        except:
+            log.exception("Failed to write termination message.")
+
+    @staticmethod
+    def _execute_termination_action(
+        action, error_overall, user_error, execution_skipped=False
+    ):
+        if execution_skipped:
+            action.skipped()
+        elif not error_overall:
+            action.success()
+        elif user_error:
+            action.user_error()
+        else:
+            action.platform_error()

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/termination_message/writer_configuration.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/termination_message/writer_configuration.py
@@ -1,0 +1,32 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from vdk.internal.core.config import Configuration
+from vdk.internal.core.config import ConfigurationBuilder
+
+TERMINATION_MESSAGE_WRITER_ENABLED = "TERMINATION_MESSAGE_WRITER_ENABLED"
+TERMINATION_MESSAGE_WRITER_OUTPUT_FILE = "TERMINATION_MESSAGE_WRITER_OUTPUT_FILE"
+
+
+class WriterConfiguration:
+    def __init__(self, config: Configuration):
+        self.__config = config
+
+    def get_writer_enabled(self):
+        return bool(self.__config[TERMINATION_MESSAGE_WRITER_ENABLED])
+
+    def get_output_file(self):
+        return str(self.__config[TERMINATION_MESSAGE_WRITER_OUTPUT_FILE])
+
+
+def add_definitions(config_builder: ConfigurationBuilder):
+    config_builder.add(
+        key=TERMINATION_MESSAGE_WRITER_ENABLED,
+        default_value=True,
+        description="Set to false if you want to disable termination message writing.",
+    )
+    config_builder.add(
+        key=TERMINATION_MESSAGE_WRITER_OUTPUT_FILE,
+        default_value="/dev/termination-log",
+        show_default_value=True,
+        description="A file in which to write data job execution completion message.",
+    )

--- a/projects/vdk-core/tests/taurus/vdk/builtin_plugins/termination_message/test_action.py
+++ b/projects/vdk-core/tests/taurus/vdk/builtin_plugins/termination_message/test_action.py
@@ -1,0 +1,55 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import unittest
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from vdk.internal.builtin_plugins.termination_message.action import WriteToFileAction
+
+
+class TerminationActionTest(unittest.TestCase):
+    @patch("builtins.open")
+    def test_write_to_file_action_with_empty_file(self, mock_open):
+        action = WriteToFileAction("")
+        action.success()
+        mock_open.assert_not_called()
+
+    @patch("builtins.open")
+    def test_write_to_file_action_with_success(self, mock_open):
+        mock_file = MagicMock()
+        mock_open.return_value = mock_file
+        action = WriteToFileAction("somefile")
+        action.success()
+        # Assert that the write() method of the file returned by the open() mocked method is called once
+        mock_file.__enter__.return_value.write.assert_called_once_with("Success\n")
+
+    @patch("builtins.open")
+    def test_write_to_file_action_with_user_error(self, mock_open):
+        mock_file = MagicMock()
+        mock_open.return_value = mock_file
+        action = WriteToFileAction("somefile")
+        action.user_error()
+        # Assert that the write() method of the file returned by the open() mocked method is called once
+        mock_file.__enter__.return_value.write.assert_called_once_with("User error\n")
+
+    @patch("builtins.open")
+    def test_write_to_file_action_with_platform_error(self, mock_open):
+        mock_file = MagicMock()
+        mock_open.return_value = mock_file
+        action = WriteToFileAction("somefile")
+        action.platform_error()
+        # Assert that the write() method of the file returned by the open() mocked method is called once
+        mock_file.__enter__.return_value.write.assert_called_once_with(
+            "Platform error\n"
+        )
+
+    @patch("builtins.open")
+    @patch("logging.Logger.debug")
+    def test_write_to_file_when_error_happens(self, mock_logger_debug, mock_open):
+        mock_file = MagicMock()
+        mock_file.__enter__.return_value.write.side_effect = OSError()
+        mock_open.return_value = mock_file
+        action = WriteToFileAction("somefile")
+        action.platform_error()
+        # Assert that the mocked logger method is called once
+        mock_logger_debug.expect_to_be_called_once()

--- a/projects/vdk-core/tests/taurus/vdk/builtin_plugins/termination_message/test_configuration.py
+++ b/projects/vdk-core/tests/taurus/vdk/builtin_plugins/termination_message/test_configuration.py
@@ -1,0 +1,26 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from typing import cast
+
+from vdk.internal.builtin_plugins.termination_message.writer_configuration import (
+    WriterConfiguration,
+)
+from vdk.internal.core.config import Configuration
+
+
+def test_termination_message_writer_configuration():
+    expected_output_file = "/dev/file.out"
+    expected_writer_enabled = False
+
+    writer_cfg = WriterConfiguration(
+        cast(
+            Configuration,
+            dict(
+                TERMINATION_MESSAGE_WRITER_ENABLED=expected_writer_enabled,
+                TERMINATION_MESSAGE_WRITER_OUTPUT_FILE=expected_output_file,
+            ),
+        )
+    )
+
+    assert expected_output_file == writer_cfg.get_output_file()
+    assert expected_writer_enabled == writer_cfg.get_writer_enabled()

--- a/projects/vdk-core/tests/taurus/vdk/builtin_plugins/termination_message/test_writer.py
+++ b/projects/vdk-core/tests/taurus/vdk/builtin_plugins/termination_message/test_writer.py
@@ -1,0 +1,51 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import unittest
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from vdk.api.plugin.plugin_registry import IPluginRegistry
+from vdk.internal.builtin_plugins.config import vdk_config
+from vdk.internal.builtin_plugins.termination_message.writer import (
+    TerminationMessageWriterPlugin,
+)
+from vdk.internal.core.config import ConfigurationBuilder
+from vdk.internal.core.context import CoreContext
+from vdk.internal.core.errors import get_blamee_overall
+from vdk.internal.core.statestore import StateStore
+
+
+class WriterTest(unittest.TestCase):
+    @patch("builtins.open")
+    @patch(f"{get_blamee_overall.__module__}.{get_blamee_overall.__name__}")
+    def test_writer(self, get_blamee_overall, mock_open):
+        get_blamee_overall.return_value = None
+        mock_file = MagicMock()
+        mock_open.return_value = mock_file
+        vdk = TerminationMessageWriterPlugin()
+
+        configuration_builder = ConfigurationBuilder()
+        vdk.vdk_configure(configuration_builder)
+
+        configuration = (
+            configuration_builder.add(
+                key="TERMINATION_MESSAGE_WRITER_OUTPUT_FILE",
+                default_value="filename.txt",
+            )
+            .add(
+                key=vdk_config.LOG_CONFIG,
+                default_value="local",
+            )
+            .build()
+        )
+
+        context = CoreContext(
+            MagicMock(spec=IPluginRegistry),
+            configuration,
+            MagicMock(spec=StateStore),
+        )
+
+        vdk.vdk_exit(context, 0)
+
+        # Assert that the write() method of the file returned by the open() mocked method is called once
+        mock_file.__enter__.return_value.write.assert_called_once_with("Success\n")


### PR DESCRIPTION
In order to complete the alerting and Execution API integrations we need
to export the job execution status. The status will be exported through
the K8S Pod termination message. Control Service monitors it and records it
into the database.

This plugin writes the job execution status to a specific file (default: "/dev/termination-log").
https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/#writing-and-reading-a-termination-message

Testing Done: added unit tests

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com