### PR TITLE
vdk-core: Fix ingesting NULL values

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_utils.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_utils.py
@@ -92,9 +92,8 @@ def convert_table(table: iter, column_names: iter) -> List[dict]:
     for row in table:
         cdf_row = dict()
         for index, value in enumerate(row):
-            if value is not None:
-                value = _handle_special_types(value)
-                cdf_row[column_names[index]] = value
+            value = _handle_special_types(value)
+            cdf_row[column_names[index]] = value
         converted_rows.append(cdf_row)
 
     return converted_rows

--- a/projects/vdk-core/tests/taurus/vdk/builtin_plugins/ingestion/test_ingester_base.py
+++ b/projects/vdk-core/tests/taurus/vdk/builtin_plugins/ingestion/test_ingester_base.py
@@ -71,15 +71,10 @@ def test_send_object_for_ingestion(mocked_send):
 
 
 def test_send_tabular_data_for_ingestion():
-    test_rows = iter([["testrow0testcol0", 42]])
-    test_columns = ["testcol0", "testcol1"]
+    test_rows = iter([["testrow0testcol0", 42, None]])
+    test_columns = ["testcol0", "testcol1", "testcol2"]
     destination_table = "a_destination_table"
-    converted_row = [
-        {
-            "testcol0": "testrow0testcol0",
-            "testcol1": 42,
-        }
-    ]
+    converted_row = [{"testcol0": "testrow0testcol0", "testcol1": 42, "testcol2": None}]
     method = "test_method"
     target = "some_target"
     collection_id = "test_job|42a420"


### PR DESCRIPTION
Until now, None values wouldn't be ingested and would just be
skipped. This is not preferred, as it's possible for a database
to have NULL values within it.
This change fixed that by removing the skipping of None values.

Testing done:  amended send_tabular_data_for_ingestion unit
test to include None value

Signed-off-by: gageorgiev <gageorgiev@vmware.com>