### PR TITLE
versatile-data-kit: Fix Ingestion from CSV Example

### DIFF
--- a/examples/ingest-from-csv-example/ingest-from-csv-example-job/20_create_table.sql
+++ b/examples/ingest-from-csv-example/ingest-from-csv-example-job/20_create_table.sql
@@ -3,7 +3,6 @@ CREATE TABLE noaa_ghcn_data_1763 (
     Date         NVARCHAR,
     Element      NVARCHAR,
     ElementValue NVARCHAR,
-    DataValue    NVARCHAR,
     MFlag        NVARCHAR,
     QFlag        NVARCHAR,
     SFlag        NVARCHAR,


### PR DESCRIPTION
Remove extra field DataValue in create table step.

Executed steps from the example locally.

Signed-off-by: yzhivkova@vmware.com