### PR TITLE
vdk-snowflake: Uncomment release step

### DIFF
--- a/projects/vdk-core/plugins/vdk-snowflake/.plugin-ci.yml
+++ b/projects/vdk-core/plugins/vdk-snowflake/.plugin-ci.yml
@@ -19,8 +19,7 @@ build-py39-vdk-snowflake:
   extends: .build-vdk-snowflake
   image: "python:3.9"
 
-# TODO: Uncomment below lines and Fix CI/CD when the plugin is ready
-# release-vdk-snowflake:
-#   variables:
-#     PLUGIN_NAME: vdk-snowflake
-#   extends: .release-plugin
+release-vdk-snowflake:
+  variables:
+    PLUGIN_NAME: vdk-snowflake
+  extends: .release-plugin

--- a/projects/vdk-core/plugins/vdk-snowflake/setup.py
+++ b/projects/vdk-core/plugins/vdk-snowflake/setup.py
@@ -5,7 +5,7 @@ import pathlib
 import setuptools
 
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 setuptools.setup(
     name="vdk-snowflake",


### PR DESCRIPTION
As part of the initial development of the plugin,
the release step in the CI/CD script was commented
out to prevent the release of an unfinished package.

This change removes the comments, and allows the final
package to be released.

Testing Done: CI/CD passes

Signed-off-by: Andon Andonov <andonova@vmware.com>