### PR TITLE
vdk-server: configure default rest url during Control Service installation

### DIFF
--- a/projects/vdk-control-cli/src/taurus/vdk/control/command_groups/common_group/default.py
+++ b/projects/vdk-control-cli/src/taurus/vdk/control/command_groups/common_group/default.py
@@ -1,7 +1,9 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 import click
+from taurus.vdk.control.configuration.defaults_config import reset_default_rest_api_url
 from taurus.vdk.control.configuration.defaults_config import reset_default_team_name
+from taurus.vdk.control.configuration.defaults_config import write_default_rest_api_url
 from taurus.vdk.control.configuration.defaults_config import write_default_team_name
 
 # Default command implies parity for set-default and reset-default sections bellow.
@@ -18,10 +20,18 @@ from taurus.vdk.control.configuration.defaults_config import write_default_team_
     type=click.STRING,
     help="Set the default team name that will be used in all the commands that require a team.",
 )
+@click.option(
+    "-u",
+    "--rest-api-url",
+    type=click.STRING,
+    help="Set the default REST API url that will be used in all the commands that require it.",
+)
 @click.pass_context
-def set_default_command(ctx, team: str):
+def set_default_command(ctx, team: str, rest_api_url: str):
     if team is not None:
         write_default_team_name(team)
+    if rest_api_url is not None:
+        write_default_rest_api_url(rest_api_url)
 
 
 @click.command(
@@ -37,7 +47,17 @@ def set_default_command(ctx, team: str):
     default=False,
     help="Reset the default team name.",
 )
+@click.option(
+    "-u",
+    "--rest-api-url",
+    is_flag=True,
+    flag_value=True,
+    default=False,
+    help="Reset the default REST API url.",
+)
 @click.pass_context
-def reset_default_command(ctx, team: bool):
+def reset_default_command(ctx, team: bool, rest_api_url: bool):
     if team:
         reset_default_team_name()
+    if rest_api_url:
+        reset_default_rest_api_url()

--- a/projects/vdk-control-cli/src/taurus/vdk/control/configuration/defaults_config.py
+++ b/projects/vdk-control-cli/src/taurus/vdk/control/configuration/defaults_config.py
@@ -3,6 +3,7 @@
 from taurus.vdk.control.configuration.vdk_config import VDKConfigFolder
 
 TEAM_OPTION = "team-name"
+REST_API_URL_OPTION = "rest-api-url"
 
 DEFAULTS_SECTION = "defaults"
 
@@ -21,3 +22,21 @@ def write_default_team_name(default_team_name):
 
 def reset_default_team_name():
     VDKConfigFolder().reset_configuration(section=DEFAULTS_SECTION, option=TEAM_OPTION)
+
+
+def load_default_rest_api_url():
+    return VDKConfigFolder().read_configuration(
+        section=DEFAULTS_SECTION, option=REST_API_URL_OPTION
+    )
+
+
+def write_default_rest_api_url(default_rest_api_url):
+    VDKConfigFolder().write_configuration(
+        section=DEFAULTS_SECTION, option=REST_API_URL_OPTION, value=default_rest_api_url
+    )
+
+
+def reset_default_rest_api_url():
+    VDKConfigFolder().reset_configuration(
+        section=DEFAULTS_SECTION, option=REST_API_URL_OPTION
+    )

--- a/projects/vdk-control-cli/src/taurus/vdk/control/utils/cli_utils.py
+++ b/projects/vdk-control-cli/src/taurus/vdk/control/utils/cli_utils.py
@@ -12,8 +12,10 @@ from enum import Enum
 from enum import unique
 
 import click
+from taurus.vdk.control.configuration.defaults_config import load_default_rest_api_url
 from taurus.vdk.control.configuration.vdk_config import VDKConfig
 from taurus.vdk.control.exception.vdk_exception import VDKException
+
 
 log = logging.getLogger(__name__)
 
@@ -59,7 +61,8 @@ def rest_api_url_option(*names, **kwargs):
             type=click.STRING,
             cls=extended_option(hide_if_default=True),
             help="The base REST API URL. It looks like http://server (without path e.g. /data-jobs)",
-            default=VDKConfig().control_service_rest_api_url,
+            default=VDKConfig().control_service_rest_api_url
+            or load_default_rest_api_url(),
             **kwargs,
         )(f)
 


### PR DESCRIPTION
As part of the local installation of the Control Service, we want the
Control Service to be immediately useable with vdk cli commands without
the need for the user to specify the REST endpoint for each command.

Extended the set-default command to also support rest-api-url in addition
to team. Changed the vdk server command to use the set-default option in
order to configure the default REST API url.

Testing done: Manually performed a Control Service installation by using
`vdk server -i` then verified that all vdk cli commands work without the
need to specify the --rest-api-url option.

Signed-off-by: Tsvetomir Palashki <tpalashki@vmware.com>