### PR TITLE
vdk-server: clean up the default configuration during uninstall

### DIFF
--- a/projects/vdk-core/plugins/vdk-server/src/vdk/internal/installer.py
+++ b/projects/vdk-core/plugins/vdk-server/src/vdk/internal/installer.py
@@ -15,6 +15,8 @@ from kubernetes import client
 from kubernetes import config
 from kubernetes import utils
 from kubernetes import watch
+from taurus.vdk.control.configuration.defaults_config import reset_default_rest_api_url
+from taurus.vdk.control.configuration.defaults_config import write_default_rest_api_url
 from vdk.internal.core.errors import BaseVdkError
 from vdk.internal.core.errors import ErrorMessage
 
@@ -460,7 +462,7 @@ class Installer:
                         f'Failed to create Kind cluster "{self.kind_cluster_name}". '
                         "If you have a previous installation, remove it by running `vdk server -u` and try again."
                     )
-                    log.info(stderr_as_str)
+                    log.info(f"Stderr output: {stderr_as_str}")
                     sys.exit(0)
             except Exception as ex:
                 log.error(
@@ -481,7 +483,7 @@ class Installer:
             )
             if result.returncode != 0:
                 stderr_as_str = result.stderr.decode("utf-8")
-                log.error(stderr_as_str)
+                log.error(f"Stderr output: {stderr_as_str}")
         except Exception as ex:
             log.error(
                 f'Failed to delete Kind cluster "{self.kind_cluster_name}". Make sure you have Kind installed. {str(ex)}'
@@ -546,12 +548,12 @@ class Installer:
                 )
                 if result.returncode != 0:
                     stderr_as_str = result.stderr.decode("utf-8")
-                    log.error(stderr_as_str)
+                    log.error(f"Stderr output: {stderr_as_str}")
                     exit(result.returncode)
                 result = subprocess.run(["helm", "repo", "update"], capture_output=True)
                 if result.returncode != 0:
                     stderr_as_str = result.stderr.decode("utf-8")
-                    log.error(stderr_as_str)
+                    log.error(f"Stderr output: {stderr_as_str}")
                     exit(result.returncode)
                 result = subprocess.run(
                     [
@@ -597,7 +599,7 @@ class Installer:
                 )
                 if result.returncode != 0:
                     stderr_as_str = result.stderr.decode("utf-8")
-                    log.error(stderr_as_str)
+                    log.error(f"Stderr output: {stderr_as_str}")
                     exit(result.returncode)
         except Exception as ex:
             log.error(
@@ -613,7 +615,7 @@ class Installer:
             )
             if result.returncode != 0:
                 stderr_as_str = result.stderr.decode("utf-8")
-                log.error(stderr_as_str)
+                log.error(f"Stderr output: {stderr_as_str}")
             else:
                 log.info("Control Service uninstalled successfully")
         except Exception as ex:
@@ -679,20 +681,7 @@ class Installer:
     def __finalize_configuration():
         log.info("Finalizing installation...")
         try:
-            result = subprocess.run(
-                [
-                    "vdk",
-                    "set-default",
-                    "-u",
-                    "http://localhost:8092",
-                ],
-                capture_output=True,
-            )
-            if result.returncode != 0:
-                stderr_as_str = result.stderr.decode("utf-8")
-                log.error("Failed to finalize installation")
-                log.error(stderr_as_str)
-                exit(result.returncode)
+            write_default_rest_api_url("http://localhost:8092")
         except Exception as ex:
             log.error(f"Failed to finalize installation. {str(ex)}")
             exit(1)
@@ -702,19 +691,7 @@ class Installer:
     def __cleanup_configuration():
         log.info("Cleaning up...")
         try:
-            result = subprocess.run(
-                [
-                    "vdk",
-                    "reset-default",
-                    "-u",
-                ],
-                capture_output=True,
-            )
-            if result.returncode != 0:
-                stderr_as_str = result.stderr.decode("utf-8")
-                log.error("Failed to clean up")
-                log.error(stderr_as_str)
-                exit(result.returncode)
+            reset_default_rest_api_url()
         except Exception as ex:
             log.error(f"Failed to clean up. {str(ex)}")
             exit(1)


### PR DESCRIPTION
The default REST API url was not cleaned up when the Control
Service is uninstalled. This was fixed as part of this commit.

Testing done: Manually uninstalled the service and verified
that the default REST url configuration has been cleaned up.

Signed-off-by: Tsvetomir Palashki <tpalashki@vmware.com>