### PR TITLE
vdk-heartbeat: add flag to disable manual execution test

### DIFF
--- a/projects/vdk-heartbeat/src/taurus/vdk/heartbeat/config.py
+++ b/projects/vdk-heartbeat/src/taurus/vdk/heartbeat/config.py
@@ -100,6 +100,15 @@ class Config:
         self.clean_up_on_failure = self._string_to_bool(
             self.get_value("CLEAN_UP_ON_FAILURE", "true", False)
         )
+        """
+        Flag is used to check if manual execution needs to be run as part of the heartbeat test.
+        In manual execution - it will disable the scheduled execution and start manually execution
+        and wait it to finish successfully. It will not verify the logic (e.g it will not run run_test for a second time).
+        It defaults to True.
+        """
+        self.check_manual_job_execution = self._string_to_bool(
+            self.get_value("CHECK_MANUAL_JOB_EXECUTION", "true", False)
+        )
 
         """
         Set file path to the JUNIT XML Test report file. If left empty , the file will not be generated.

--- a/projects/vdk-heartbeat/src/taurus/vdk/heartbeat/hearbeat.py
+++ b/projects/vdk-heartbeat/src/taurus/vdk/heartbeat/hearbeat.py
@@ -49,9 +49,10 @@ class Heartbeat:
 
             job_controller.disable_deployment()
 
-            job_controller.check_job_execution_finished()
-            job_controller.start_job_execution()
-            job_controller.check_job_execution_finished()
+            if self._config.check_manual_job_execution:
+                job_controller.check_job_execution_finished()
+                job_controller.start_job_execution()
+                job_controller.check_job_execution_finished()
 
             self.clean(run_test, job_controller)
             log.info("Heartbeat has finished successfully.")


### PR DESCRIPTION
We should make vdk-heartbeat very configurable since we do want to
be able to use it in very different deployments and setups of Versatile
Data Kit. It is possible that in some setups manual execution is not
important and testing for it is not necessary or it is too expensive (if
the job under test is very slow). I also would use it to skip this check
until we fix a bug in execution API with too long names in short term.

Testing Done: ran vdk-heartbeat with export
check_manual_job_execution=True and verified in logs that manual
execution was skipped

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>