### PR TITLE
vdk-control-cli: Shorten length of heartbeat job

### DIFF
--- a/projects/vdk-control-cli/.gitlab-ci.yml
+++ b/projects/vdk-control-cli/.gitlab-ci.yml
@@ -48,7 +48,7 @@ vdk-control-cli-release-acceptance-test:
     - pip install vdk-heartbeat --extra-index-url $PIP_EXTRA_INDEX_URL
     - vdkcli version
     - export VDKCLI_OAUTH2_REFRESH_TOKEN=$VDK_API_TOKEN
-    - export JOB_NAME=vdk-control-cli-release-test-job-$(date +%s)
+    - export JOB_NAME=vdkcli-release-job-$(date +%s)
     - vdk-heartbeat -f cicd/release_test_heartbeat_config.ini
   artifacts:
     when: always


### PR DESCRIPTION
Currently, the vdkcli heartbeat job is failing due to its name
being too long. This change fixes that by shortening its name
from `vdk-control-cli-release-test-job-*suffix*` to
`vdkcli-release-job-*suffix*`.

Testing done: pipelines passed

Signed-off-by: gageorgiev <gageorgiev@vmware.com>