### PR TITLE
vdk-server: disable authentication during server installation

### DIFF
--- a/projects/vdk-core/plugins/vdk-server/src/vdk/internal/installer.py
+++ b/projects/vdk-core/plugins/vdk-server/src/vdk/internal/installer.py
@@ -16,7 +16,13 @@ from kubernetes import config
 from kubernetes import utils
 from kubernetes import watch
 from vdk.internal.control.configuration.defaults_config import (
+    reset_default_authentication_disable,
+)
+from vdk.internal.control.configuration.defaults_config import (
     reset_default_rest_api_url,
+)
+from vdk.internal.control.configuration.defaults_config import (
+    write_default_authentication_disable,
 )
 from vdk.internal.control.configuration.defaults_config import (
     write_default_rest_api_url,
@@ -686,6 +692,7 @@ class Installer:
         log.info("Finalizing installation...")
         try:
             write_default_rest_api_url("http://localhost:8092")
+            write_default_authentication_disable("true")
         except Exception as ex:
             log.error(f"Failed to finalize installation. {str(ex)}")
             exit(1)
@@ -696,6 +703,7 @@ class Installer:
         log.info("Cleaning up...")
         try:
             reset_default_rest_api_url()
+            reset_default_authentication_disable()
         except Exception as ex:
             log.error(f"Failed to clean up. {str(ex)}")
             exit(1)


### PR DESCRIPTION
We don't want to require users to authenticate when installing
local Control Service (in which case authentication is disabled
on the server-side anyway). This commit turns off authentication
in the vdk client during local Control Service installation so
that the cli is useable immediately without the necessity for
further configurations.

Testing done: Installed the Control Service locally and
verified that the vdk is useable against it without
authentication problems.

Signed-off-by: Tsvetomir Palashki <tpalashki@vmware.com>