### PR TITLE
control-service: Include additional labels for service template

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/service.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/service.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels: {{- include "pipelines-control-service.labels" . | nindent 4 }}
+  {{- if .Values.service.additionalLabels }}
+  {{- .Values.service.additionalLabels | nindent 4 }}
+  {{- end }}
   name: {{ .Release.Name }}-svc
   namespace: {{ .Release.Namespace }}
 spec:

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -45,6 +45,7 @@ service:
    # loadBalancerSourceRanges:
    # loadBalancerIP:
    # clusterIP
+   # additionalLabels:
 
 ### Ingress resource parameters
 ingress:


### PR DESCRIPTION
Currently, there is no way for a control-service deployment to
add additional labels for their service instance. This change
allows the addition of such through Values.yml.

Testing done: generated template locally using helm install
--dry-run and verified the additional labels are added correctly
and are formatted appropriately

Signed-off-by: gageorgiev <gageorgiev@vmware.com>