### PR TITLE
control-service: Convert debug logs to info

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -650,7 +650,7 @@ public abstract class KubernetesService implements InitializingBean {
     }
 
     public String getPodLogs(String podName) throws IOException, ApiException {
-        log.debug("Get logs for pod {}", podName);
+        log.info("Get logs for pod {}", podName);
         Optional<V1Pod> pod = getPod(podName);
 
         String logs = "";
@@ -659,6 +659,7 @@ public abstract class KubernetesService implements InitializingBean {
 
             try (BufferedReader br = new BufferedReader(new InputStreamReader(podLogs.streamNamespacedPodLog(pod.get()), Charsets.UTF_8))) {
                 // The builder logs are relatively small so we can afford to load it all in memory for easier processing.
+                log.info("Retrieving logs for Pod with name: {}", podName);
                 logs = br.lines().peek(s -> log.debug("[{}] {}", podName, s)).collect(Collectors.joining(System.lineSeparator()));
             }
         }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
@@ -162,11 +162,11 @@ public class JobImageBuilder {
       log.debug("Finished watching builder job {}. Condition is: {}", builderJobName, condition);
       String logs = null;
       try {
-         log.debug("Get logs of builder job {}", builderJobName);
+         log.info("Get logs of builder job {}", builderJobName);
          logs = controlKubernetesService.getPodLogs(builderJobName);
       } catch (Exception e) {
          // wrap in Kubernetes exception in case it's ApiException - in order to log more details.
-         String message = new KubernetesException("Could not get pod" + builderJobName + " logs", e).getMessage();
+         String message = new KubernetesException("Could not get pod " + builderJobName + " logs", e).getMessage();
          log.warn("Could not find logs from builder job {}; reason: {}", builderJobName, message);
       }
       if (!condition.isSuccess()) {


### PR DESCRIPTION
When a requirements.txt file of a data job is broken,
a platform error is raised, because the Control Service
is not able to get the logs from the builder k8s pod.

Currently, we cannot properly investigate what are the
reasons for that, as we don't log enough data in the control
service's log stream.

This change converts some of the debug log messages to info messages
to allow for a better view over the possible reason for the service
not being able to get the logs from the builder pods.

Testing Done: New log message appear alongside the
regular logs.

Signed-off-by: Andon Andonov <andonova@vmware.com>