### PR TITLE
control-service: synchronize job execution statuses

### DIFF
--- a/projects/control-service/CHANGELOG.md
+++ b/projects/control-service/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog
 * **Bug Fixes**
   * Data job execution status fix
     In case of failed data job execution due to the User Error the execution status will be marked as Failed instead of Finished.
+  * Data Job Execution statuses synchronization
+    This will keep in sync all job executions in the database in case of Control Service downtime or missed Kubernetes Job Event.
 * **Breaking Changes**
 
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobExecutionRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobExecutionRepository.java
@@ -10,6 +10,7 @@ import com.vmware.taurus.service.model.DataJobExecutionIdAndEndTime;
 import com.vmware.taurus.service.model.ExecutionStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 /**
@@ -33,4 +34,5 @@ public interface JobExecutionRepository extends JpaRepository<DataJobExecution, 
 
    List<DataJobExecutionIdAndEndTime> findByDataJobNameAndStatusNotInOrderByEndTime(String jobName, List<ExecutionStatus> statuses);
 
+   List<DataJobExecution> findDataJobExecutionsByStatusInAndStartTimeBefore(List<ExecutionStatus> statuses, OffsetDateTime startTime);
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -934,9 +934,13 @@ public abstract class KubernetesService implements InitializingBean {
      * @throws ApiException
      * @throws IOException
      */
-    public void watchJobs(Map<String, String> labelsToWatch, Consumer<JobExecution> watcher, long lastWatchTime)
-            throws IOException, ApiException {
-        watchJobs(labelsToWatch, watcher, lastWatchTime, WATCH_JOBS_TIMEOUT_SECONDS);
+    public void watchJobs(
+          Map<String, String> labelsToWatch,
+          Consumer<JobExecution> watcher,
+          Consumer<List<String>> runningJobExecutionsConsumer,
+          long lastWatchTime) throws IOException, ApiException {
+
+        watchJobs(labelsToWatch, watcher, runningJobExecutionsConsumer, lastWatchTime, WATCH_JOBS_TIMEOUT_SECONDS);
     }
 
     /**
@@ -956,11 +960,14 @@ public abstract class KubernetesService implements InitializingBean {
      * @throws ApiException
      * @throws IOException
      */
-    public void watchJobs(Map<String, String> labelsToWatch, Consumer<JobExecution> watcher,
-                          long lastWatchTime, Integer timeoutSeconds)
-            throws ApiException, IOException {
-        Objects.requireNonNull(watcher, "The watcher cannot be null");
+    public void watchJobs(
+          Map<String, String> labelsToWatch,
+          Consumer<JobExecution> watcher,
+          Consumer<List<String>> runningJobExecutionsConsumer,
+          long lastWatchTime,
+          Integer timeoutSeconds) throws ApiException, IOException {
 
+        Objects.requireNonNull(watcher, "The watcher cannot be null");
         log.info("Start watching jobs with labels: {}", labelsToWatch);
 
         // Job change detection implementation:
@@ -968,14 +975,23 @@ public abstract class KubernetesService implements InitializingBean {
         String labelSelector = buildLabelSelector(labelsToWatch);
         String resourceVersion;
         try {
-            var jobList = new BatchV1Api(client).listNamespacedJob(
-                    namespace, "false", null, null, labelSelector, null, null, null, null);
+            var jobList = new BatchV1Api(client)
+                  .listNamespacedJob(namespace, "false", null, null, labelSelector, null, null, null, null);
+            List<String> runningExecutionIds = new ArrayList<>();
+
             jobList.getItems().forEach(job -> {
                 var condition = getJobCondition(job);
-                if (condition != null && condition.getCompletionTime() > lastWatchTime) {
+
+                if (condition == null) {
+                    Optional.ofNullable(job.getMetadata())
+                          .map(V1ObjectMeta::getName)
+                          .ifPresent(executionId -> runningExecutionIds.add(executionId));
+                } else if (condition.getCompletionTime() > lastWatchTime) {
                     getJobExecutionStatus(job, condition).ifPresent(watcher);
                 }
             });
+
+            runningJobExecutionsConsumer.accept(runningExecutionIds);
             resourceVersion = jobList.getMetadata().getResourceVersion();
         } catch (ApiException ex) {
             log.info("Failed to list jobs for watching. Error was: {}", ex.getMessage());

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/RepositoryUtil.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/RepositoryUtil.java
@@ -40,12 +40,33 @@ public final class RepositoryUtil {
          String executionId,
          DataJob dataJob,
          ExecutionStatus executionStatus,
+         OffsetDateTime startTime) {
+
+      return createDataJobExecution(jobExecutionRepository, executionId, dataJob, executionStatus, "test_message", startTime);
+   }
+
+   public static DataJobExecution createDataJobExecution(
+         JobExecutionRepository jobExecutionRepository,
+         String executionId,
+         DataJob dataJob,
+         ExecutionStatus executionStatus,
          String message) {
+
+      return createDataJobExecution(jobExecutionRepository, executionId, dataJob, executionStatus, message, OffsetDateTime.now());
+   }
+
+   public static DataJobExecution createDataJobExecution(
+         JobExecutionRepository jobExecutionRepository,
+         String executionId,
+         DataJob dataJob,
+         ExecutionStatus executionStatus,
+         String message,
+         OffsetDateTime startTime) {
 
       var expectedJobExecution = DataJobExecution.builder()
             .id(executionId)
             .dataJob(dataJob)
-            .startTime(OffsetDateTime.now())
+            .startTime(startTime)
             .type(ExecutionType.MANUAL)
             .status(executionStatus)
             .resourcesCpuRequest(1F)

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionCleanupServiceIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionCleanupServiceIT.java
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.vmware.taurus.service;
+package com.vmware.taurus.service.execution;
 
 import com.vmware.taurus.ControlplaneApplication;
 import com.vmware.taurus.RepositoryUtil;
-import com.vmware.taurus.service.execution.JobExecutionCleanupService;
+import com.vmware.taurus.service.JobExecutionRepository;
+import com.vmware.taurus.service.JobsRepository;
 import com.vmware.taurus.service.model.DataJob;
 import com.vmware.taurus.service.model.ExecutionStatus;
 import com.vmware.taurus.service.model.JobConfig;

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceCancelExecutionIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceCancelExecutionIT.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.vmware.taurus.execution;
+package com.vmware.taurus.service.execution;
 
 import com.vmware.taurus.ControlplaneApplication;
 import com.vmware.taurus.RepositoryUtil;
@@ -11,7 +11,6 @@ import com.vmware.taurus.exception.DataJobExecutionCannotBeCancelledException;
 import com.vmware.taurus.exception.KubernetesException;
 import com.vmware.taurus.service.JobExecutionRepository;
 import com.vmware.taurus.service.JobsRepository;
-import com.vmware.taurus.service.execution.JobExecutionService;
 import com.vmware.taurus.service.kubernetes.DataJobsKubernetesService;
 import com.vmware.taurus.service.model.DataJob;
 import com.vmware.taurus.service.model.ExecutionStatus;

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceListExecutionsIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceListExecutionsIT.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.vmware.taurus.execution;
+package com.vmware.taurus.service.execution;
 
 import com.vmware.taurus.ControlplaneApplication;
 import com.vmware.taurus.RepositoryUtil;
@@ -25,8 +25,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 
-import static com.vmware.taurus.execution.JobExecutionServiceUtil.assertDataJobExecutionListValid;
-import static com.vmware.taurus.execution.JobExecutionServiceUtil.assertDataJobExecutionValid;
+import static com.vmware.taurus.service.execution.JobExecutionServiceUtil.assertDataJobExecutionListValid;
+import static com.vmware.taurus.service.execution.JobExecutionServiceUtil.assertDataJobExecutionValid;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = ControlplaneApplication.class)

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceReadExecutionIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceReadExecutionIT.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.vmware.taurus.execution;
+package com.vmware.taurus.service.execution;
 
 import com.vmware.taurus.ControlplaneApplication;
 import com.vmware.taurus.RepositoryUtil;
@@ -11,7 +11,6 @@ import com.vmware.taurus.exception.DataJobExecutionNotFoundException;
 import com.vmware.taurus.exception.DataJobNotFoundException;
 import com.vmware.taurus.service.JobExecutionRepository;
 import com.vmware.taurus.service.JobsRepository;
-import com.vmware.taurus.service.execution.JobExecutionService;
 import com.vmware.taurus.service.model.DataJob;
 import com.vmware.taurus.service.model.ExecutionStatus;
 import org.junit.jupiter.api.Assertions;

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceStartExecutionIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceStartExecutionIT.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.vmware.taurus.execution;
+package com.vmware.taurus.service.execution;
 
 import com.vmware.taurus.ControlplaneApplication;
 import com.vmware.taurus.RepositoryUtil;
@@ -15,7 +15,6 @@ import com.vmware.taurus.service.JobExecutionRepository;
 import com.vmware.taurus.service.JobsRepository;
 import com.vmware.taurus.service.deploy.DeploymentService;
 import com.vmware.taurus.service.diag.OperationContext;
-import com.vmware.taurus.service.execution.JobExecutionService;
 import com.vmware.taurus.service.kubernetes.DataJobsKubernetesService;
 import com.vmware.taurus.service.model.*;
 import io.kubernetes.client.ApiException;
@@ -30,7 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.vmware.taurus.execution.JobExecutionServiceUtil.buildStartedBy;
+import static com.vmware.taurus.service.execution.JobExecutionServiceUtil.buildStartedBy;
 
 @SpringBootTest(classes = ControlplaneApplication.class)
 public class JobExecutionServiceStartExecutionIT {

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceSyncExecutionIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceSyncExecutionIT.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.execution;
+
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.vmware.taurus.ControlplaneApplication;
+import com.vmware.taurus.RepositoryUtil;
+import com.vmware.taurus.service.JobExecutionRepository;
+import com.vmware.taurus.service.JobsRepository;
+import com.vmware.taurus.service.model.DataJob;
+import com.vmware.taurus.service.model.ExecutionStatus;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = ControlplaneApplication.class)
+public class JobExecutionServiceSyncExecutionIT {
+
+   @Autowired
+   private JobsRepository jobsRepository;
+
+   @Autowired
+   private JobExecutionRepository jobExecutionRepository;
+
+   @Autowired
+   private JobExecutionService jobExecutionService;
+
+   @AfterEach
+   public void cleanUp() {
+      jobsRepository.deleteAll();
+   }
+
+   @Test
+   public void testSyncJobExecutionStatuses_fourRunningExecutionsWithStartTimeBefore5min_shouldSyncTwoExecutions() {
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+
+      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution1 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
+      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution3 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
+
+      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsBeforeSync =
+            jobExecutionRepository.findDataJobExecutionsByDataJobNameAndStatusIn(actualDataJob.getName(), List.of(ExecutionStatus.RUNNING));
+
+      Assert.assertEquals(4, dataJobExecutionsBeforeSync.size());
+      jobExecutionService.syncJobExecutionStatuses(List.of(expectedJobExecution1.getId(), expectedJobExecution3.getId()));
+
+      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsAfterSync =
+            jobExecutionRepository.findDataJobExecutionsByDataJobNameAndStatusIn(actualDataJob.getName(), List.of(ExecutionStatus.RUNNING));
+
+      Assert.assertEquals(2, dataJobExecutionsAfterSync.size());
+      Assert.assertEquals(expectedJobExecution1.getId(), dataJobExecutionsAfterSync.get(0).getId());
+      Assert.assertEquals(expectedJobExecution3.getId(), dataJobExecutionsAfterSync.get(1).getId());
+   }
+
+   @Test
+   public void testSyncJobExecutionStatuses_twoRunningExecutionsWithStartTimeBefore2minAndTwoWithStartTimeBefore5min_shouldSyncOneExecutions() {
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+
+      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution1 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
+      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution2 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(2));
+      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution3 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(2));
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
+
+      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsBeforeSync =
+            jobExecutionRepository.findDataJobExecutionsByDataJobNameAndStatusIn(actualDataJob.getName(), List.of(ExecutionStatus.RUNNING));
+
+      Assert.assertEquals(4, dataJobExecutionsBeforeSync.size());
+      jobExecutionService.syncJobExecutionStatuses(List.of(expectedJobExecution1.getId(), expectedJobExecution3.getId()));
+
+      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsAfterSync =
+            jobExecutionRepository.findDataJobExecutionsByDataJobNameAndStatusIn(actualDataJob.getName(), List.of(ExecutionStatus.RUNNING));
+
+      Assert.assertEquals(3, dataJobExecutionsAfterSync.size());
+      Assert.assertEquals(expectedJobExecution1.getId(), dataJobExecutionsAfterSync.get(0).getId());
+      Assert.assertEquals(expectedJobExecution2.getId(), dataJobExecutionsAfterSync.get(1).getId());
+      Assert.assertEquals(expectedJobExecution3.getId(), dataJobExecutionsAfterSync.get(2).getId());
+   }
+
+   @Test
+   public void testSyncJobExecutionStatuses_fourRunningExecutionsWithStartTimeBefore5min_shouldSyncFourExecutions() {
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+
+      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution1 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
+      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution3 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
+
+      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsBeforeSync =
+            jobExecutionRepository.findDataJobExecutionsByDataJobNameAndStatusIn(actualDataJob.getName(), List.of(ExecutionStatus.RUNNING));
+
+      Assert.assertEquals(4, dataJobExecutionsBeforeSync.size());
+      jobExecutionService.syncJobExecutionStatuses(Collections.emptyList());
+
+      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsAfterSync =
+            jobExecutionRepository.findDataJobExecutionsByDataJobNameAndStatusIn(actualDataJob.getName(), List.of(ExecutionStatus.RUNNING));
+
+      Assert.assertEquals(0, dataJobExecutionsAfterSync.size());
+   }
+
+   @Test
+   public void testSyncJobExecutionStatuses_fourRunningExecutionsWithStartTimeBefore5min_shouldNotSyncAnyExecutions() {
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+
+      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution1 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
+      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution2 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
+      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution3 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
+      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution4 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
+
+      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsBeforeSync =
+            jobExecutionRepository.findDataJobExecutionsByDataJobNameAndStatusIn(actualDataJob.getName(), List.of(ExecutionStatus.RUNNING));
+
+      Assert.assertEquals(4, dataJobExecutionsBeforeSync.size());
+      jobExecutionService.syncJobExecutionStatuses(List.of(
+            expectedJobExecution1.getId(),
+            expectedJobExecution2.getId(),
+            expectedJobExecution3.getId(),
+            expectedJobExecution4.getId()));
+
+      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsAfterSync =
+            jobExecutionRepository.findDataJobExecutionsByDataJobNameAndStatusIn(actualDataJob.getName(), List.of(ExecutionStatus.RUNNING));
+
+      Assert.assertEquals(4, dataJobExecutionsAfterSync.size());
+   }
+
+   @Test
+   public void testSyncJobExecutionStatuses_fourRunningExecutionsWithStartTimeBefore5minAndNullRunningExecutionsIds_shouldNotSyncAnyExecutions() {
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
+
+      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsBeforeSync =
+            jobExecutionRepository.findDataJobExecutionsByDataJobNameAndStatusIn(actualDataJob.getName(), List.of(ExecutionStatus.RUNNING));
+
+      Assert.assertEquals(4, dataJobExecutionsBeforeSync.size());
+      jobExecutionService.syncJobExecutionStatuses(null);
+
+      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsAfterSync =
+            jobExecutionRepository.findDataJobExecutionsByDataJobNameAndStatusIn(actualDataJob.getName(), List.of(ExecutionStatus.RUNNING));
+
+      Assert.assertEquals(4, dataJobExecutionsAfterSync.size());
+   }
+
+   @Test
+   public void testSyncJobExecutionStatuses_twoRunningExecutionsWithStartTimeBefore5minAndTwoFinishedExecutionsWithStartTimeBefore5min_shouldSyncOneExecutions() {
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+
+      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution1 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.FINISHED, OffsetDateTime.now().minusMinutes(5));
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.FINISHED, OffsetDateTime.now().minusMinutes(5));
+      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution3 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
+      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution4 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
+
+      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsBeforeSync =
+            jobExecutionRepository.findDataJobExecutionsByDataJobNameAndStatusIn(actualDataJob.getName(), List.of(ExecutionStatus.RUNNING));
+
+      Assert.assertEquals(2, dataJobExecutionsBeforeSync.size());
+      Assert.assertEquals(expectedJobExecution3.getId(), dataJobExecutionsBeforeSync.get(0).getId());
+      Assert.assertEquals(expectedJobExecution4.getId(), dataJobExecutionsBeforeSync.get(1).getId());
+
+      jobExecutionService.syncJobExecutionStatuses(List.of(expectedJobExecution1.getId(), expectedJobExecution3.getId()));
+      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsAfterSync =
+            jobExecutionRepository.findDataJobExecutionsByDataJobNameAndStatusIn(actualDataJob.getName(), List.of(ExecutionStatus.RUNNING));
+
+      Assert.assertEquals(1, dataJobExecutionsAfterSync.size());
+      Assert.assertEquals(expectedJobExecution3.getId(), dataJobExecutionsAfterSync.get(0).getId());
+   }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceUpdateExecutionIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceUpdateExecutionIT.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.vmware.taurus.execution;
+package com.vmware.taurus.service.execution;
 
 import com.vmware.taurus.ControlplaneApplication;
 import com.vmware.taurus.RepositoryUtil;
@@ -11,9 +11,9 @@ import com.vmware.taurus.controlplane.model.data.DataJobExecution;
 import com.vmware.taurus.service.JobExecutionRepository;
 import com.vmware.taurus.service.JobsRepository;
 import com.vmware.taurus.service.KubernetesService;
-import com.vmware.taurus.service.execution.JobExecutionService;
 import com.vmware.taurus.service.model.DataJob;
 import com.vmware.taurus.service.model.ExecutionStatus;
+
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceUtil.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceUtil.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.vmware.taurus.execution;
+package com.vmware.taurus.service.execution;
 
 import com.vmware.taurus.controlplane.model.data.DataJobDeployment;
 import com.vmware.taurus.controlplane.model.data.DataJobExecution;

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DataJobStatusMonitorTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DataJobStatusMonitorTest.java
@@ -144,7 +144,7 @@ public class DataJobStatusMonitorTest {
         doAnswer(inv -> {
             jobStatuses.forEach(inv.getArgument(1));
             return null;
-        }).when(dataJobsKubernetesService).watchJobs(anyMap(), any(), anyLong());
+        }).when(dataJobsKubernetesService).watchJobs(anyMap(), any(), any(), anyLong());
         jobStatuses.forEach(s -> jobsRepository.save(new DataJob(s.getJobName(), new JobConfig())));
 
         dataJobStatusMonitor.watchJobs();
@@ -170,7 +170,7 @@ public class DataJobStatusMonitorTest {
         doAnswer(inv -> {
             jobStatuses.forEach(inv.getArgument(1));
             return null;
-        }).when(dataJobsKubernetesService).watchJobs(anyMap(), any(), anyLong());
+        }).when(dataJobsKubernetesService).watchJobs(anyMap(), any(), any(), anyLong());
 
         dataJobStatusMonitor.watchJobs();
 
@@ -188,7 +188,7 @@ public class DataJobStatusMonitorTest {
         doAnswer(inv -> {
             jobStatuses.forEach(inv.getArgument(1));
             return null;
-        }).when(dataJobsKubernetesService).watchJobs(anyMap(), any(), anyLong());
+        }).when(dataJobsKubernetesService).watchJobs(anyMap(), any(), any(), anyLong());
 
         dataJobStatusMonitor.watchJobs();
 
@@ -206,7 +206,7 @@ public class DataJobStatusMonitorTest {
         doAnswer(inv -> {
             jobStatuses.forEach(inv.getArgument(1));
             return null;
-        }).when(dataJobsKubernetesService).watchJobs(anyMap(), any(), anyLong());
+        }).when(dataJobsKubernetesService).watchJobs(anyMap(), any(), any(), anyLong());
         jobStatuses.forEach(s -> jobsRepository.save(
                 new DataJob(s.getJobName(), new JobConfig(), DeploymentStatus.NONE, getTerminationStatus(s), null)));
 
@@ -230,7 +230,7 @@ public class DataJobStatusMonitorTest {
         doAnswer(inv -> {
             jobStatuses.forEach(inv.getArgument(1));
             return null;
-        }).when(dataJobsKubernetesService).watchJobs(anyMap(), any(), anyLong());
+        }).when(dataJobsKubernetesService).watchJobs(anyMap(), any(), any(), anyLong());
         jobStatuses.forEach(s -> jobsRepository.save(
                 new DataJob(s.getJobName(), new JobConfig(), DeploymentStatus.NONE, getTerminationStatus(s), null)));
 
@@ -260,7 +260,7 @@ public class DataJobStatusMonitorTest {
     @Test
     @Order(12)
     public void testWatchJobsWhenExceptionIsThrown() throws IOException, ApiException {
-        doThrow(new ApiException()).when(dataJobsKubernetesService).watchJobs(anyMap(), any(), anyLong());
+        doThrow(new ApiException()).when(dataJobsKubernetesService).watchJobs(anyMap(), any(), any(), anyLong());
 
         Assertions.assertDoesNotThrow(() -> dataJobStatusMonitor.watchJobs());
     }


### PR DESCRIPTION
We need to keep in sync all job executions in the database
in case of Control Service downtime or missed Kubernetes Job Event.

This change aims to synchronize Data Job Execution statuses in the database
with the actual running jobs in Kubernetes.

It takes into account the executions that are started concurrently
during the synchronization or delayed Kubernetes Job Events
by synchronizing only executions that are started before now() - 3 minutes.

Testing done: unit tests

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com