### PR TITLE
control-service: remove data job name suffix

### DIFF
--- a/projects/control-service/CHANGELOG.md
+++ b/projects/control-service/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog
   * Data Job Execution statuses synchronization
     This will keep in sync all job executions in the database in case of Control Service downtime or missed Kubernetes Job Event.
 * **Breaking Changes**
+  * Removed '-latest' suffix from the К8S Cron Job name
 
 
 1.2.7 - 03.09.2021

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -471,7 +471,7 @@ alerting:
                       * on(data_job) group_left(email_notified_on_success)
                         avg by(data_job, email_notified_on_success) (taurus_datajob_info{email_notified_on_success!=""}) == bool 0)
                     * on(data_job) group_left(job_name)
-                      topk by(data_job) (1, label_replace(kube_job_status_completion_time, "data_job", "$1", "job_name", "(.*)-latest.*")) != 0,
+                      topk by(data_job) (1, label_replace(kube_job_status_completion_time, "data_job", "$1", "job_name", "(.*)-.*")) != 0,
                     "execution_id", "$1", "job_name", "(.*)")`}}
          JobDelay:
             enabled: true
@@ -506,7 +506,7 @@ alerting:
                {{`label_replace(
                   label_replace(
                     (kube_cronjob_next_schedule_time > 0) - time(),
-                    "data_job", "$1", "cronjob", "(.+)-latest")
+                    "data_job", "$1", "cronjob", "(.+)")
                   * on(data_job) group_left(email_notified_on_platform_error)
                     avg by(data_job, email_notified_on_platform_error) (taurus_datajob_info{email_notified_on_platform_error!=""})
                <
@@ -549,7 +549,7 @@ alerting:
                       * on(data_job) group_left(email_notified_on_platform_error)
                         avg by(data_job, email_notified_on_platform_error) (taurus_datajob_info{email_notified_on_platform_error!=""}) == bool 1)
                     * on(data_job) group_left(job_name)
-                      topk by(data_job) (1, label_replace(kube_job_failed * on(job_name) group_left() kube_job_status_start_time, "data_job", "$1", "job_name", "(.*)-latest.*")) != 0,
+                      topk by(data_job) (1, label_replace(kube_job_failed * on(job_name) group_left() kube_job_status_start_time, "data_job", "$1", "job_name", "(.*)-.*")) != 0,
                     "execution_id", "$1", "job_name", "(.*)"),
                     "short_execution_id", "$1", "execution_id", "([a-zA-Z -_]{1,58}).*")`}}
          JobFailureUser:
@@ -587,7 +587,7 @@ alerting:
                       * on(data_job) group_left(email_notified_on_user_error)
                         avg by(data_job, email_notified_on_user_error) (taurus_datajob_info{email_notified_on_user_error!=""}) == bool 3)
                     * on(data_job) group_left(job_name)
-                      topk by(data_job) (1, label_replace(kube_job_status_start_time, "data_job", "$1", "job_name", "(.*)-latest.*")) != 0,
+                      topk by(data_job) (1, label_replace(kube_job_status_start_time, "data_job", "$1", "job_name", "(.*)-.*")) != 0,
                     "execution_id", "$1", "job_name", "(.*)"),
                     "short_execution_id", "$1", "execution_id", "([a-zA-Z -_]{1,58}).*")`}}
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -71,7 +71,6 @@ import static java.util.function.Predicate.not;
 public abstract class KubernetesService implements InitializingBean {
 
     public static final String LABEL_PREFIX = "com.vmware.taurus";
-    public static final String LATEST_VERSION_SUFFIX = "-latest";
     private static final int WATCH_JOBS_TIMEOUT_SECONDS = 300;
     private static final String K8S_DATA_JOB_TEMPLATE_RESOURCE ="k8s-data-job-template.yaml";
 
@@ -1413,7 +1412,7 @@ public abstract class KubernetesService implements InitializingBean {
       if (cronJob != null) {
          deployment = new JobDeploymentStatus();
          deployment.setEnabled(!cronJob.getSpec().isSuspend());
-         deployment.setDataJobName(StringUtils.removeEnd(cronJob.getMetadata().getName(), LATEST_VERSION_SUFFIX));
+         deployment.setDataJobName(cronJob.getMetadata().getName());
          deployment.setMode("release"); // TODO: Get from cron job config when we support testing environments
          deployment.setCronJobName(cronJobName == null ? cronJob.getMetadata().getName() : cronJobName);
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
@@ -296,6 +296,6 @@ public class JobImageDeployer {
 
    // Public for integration testing purposes
    public static String getCronJobName(String jobName) {
-      return jobName + KubernetesService.LATEST_VERSION_SUFFIX;
+      return jobName;
    }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
@@ -325,7 +325,7 @@ public class JobExecutionService {
    }
 
    private static String getExecutionId(String jobName) {
-      return String.format("%s-%s-%s", jobName, Instant.now().toEpochMilli(), UUID.randomUUID().toString().substring(0, 5));
+      return String.format("%s-%s", jobName, Instant.now().getEpochSecond());
    }
 
    private static String buildStartedByAnnotationValue(ExecutionType executionType, String startedBy) {

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
@@ -37,7 +37,7 @@ public class DeploymentServiceTest {
 
    private static final String OP_ID = "c00b40dcc9904ae6";
    private static final String TEST_JOB_NAME = "test-job-name";
-   private static final String TEST_CRONJOB_NAME = TEST_JOB_NAME + "-latest";
+   private static final String TEST_CRONJOB_NAME = TEST_JOB_NAME;
    private static final String TEST_JOB_IMAGE_NAME = "test-job-image-name";
    private static final String TEST_JOB_SCHEDULE = "*/5 * * * *";
    private static final String TEST_BUILDER_JOB_NAME = "builder-test-job-name";

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageDeployerTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageDeployerTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.*;
 public class JobImageDeployerTest {
 
    private static final String TEST_JOB_NAME = "test-job-name";
-   private static final String TEST_CRONJOB_NAME = TEST_JOB_NAME + "-latest";
+   private static final String TEST_CRONJOB_NAME = TEST_JOB_NAME;
    private static final String TEST_JOB_IMAGE_NAME = "test-job-image-name";
    private static final String TEST_JOB_SCHEDULE = "*/5 * * * *";
    private static final String TEST_BUILDER_JOB_NAME = "builder-test-job-name";
@@ -113,9 +113,9 @@ public class JobImageDeployerTest {
       when(kubernetesService.listCronJobs()).thenReturn(Set.of(TEST_CRONJOB_NAME));
       doThrow(new ApiException("foo", 422, Collections.emptyMap(), "{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{}," +
               "\"status\":\"Failure\",\"message\":\"CronJob.batch " +
-              "\\\"foo-latest\\\" is invalid: spec.schedule: Invalid value: \\\"a * * * *\\\": " +
+              "\\\"foo\\\" is invalid: spec.schedule: Invalid value: \\\"a * * * *\\\": " +
               "Failed to parse int from a: strconv.Atoi: parsing \\\"a\\\": invalid syntax\",\"reason\":" +
-              "\"Invalid\",\"details\":{\"name\":\"foo-latest\",\"group\":\"batch\",\"kind\":\"CronJob\",\"causes\":" +
+              "\"Invalid\",\"details\":{\"name\":\"foo\",\"group\":\"batch\",\"kind\":\"CronJob\",\"causes\":" +
               "[{\"reason\":\"FieldValueInvalid\",\"message\":\"Invalid value: \\\"a * * * *\\\": Failed to parse int from a:" +
               " strconv.Atoi: parsing \\\"a\\\": invalid syntax\",\"field\":\"spec.schedule\"}]},\"code\":422}"))
               .when(kubernetesService)


### PR DESCRIPTION
We have a K8S POD name lenght limitation of 63 characters.

POD name format: {data_job_name}-latest-{unix_timestamp}-{suffix}
Example: ccs-opportunity-lead-latest-1632067200-sz78m

data job name - up to 45 characters
-latest - 7 characters
timestamp - 11 characters
suffix - 6 characters
total - 69 characters

After the deletion of '-latest' the maximum POD name length will be up to 62 characters.

Testing done: unit tests

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com