### PR TITLE
vdk-server: expose port 443 on the Kind cluster

### DIFF
--- a/projects/vdk-core/plugins/vdk-server/src/vdk/internal/installer.py
+++ b/projects/vdk-core/plugins/vdk-server/src/vdk/internal/installer.py
@@ -338,7 +338,7 @@ class Installer:
                 attempt += 1
                 time.sleep(back_off_time_secs)
         if successful:
-            log.debug("Git server configured successfully")
+            log.info("Git server configured successfully")
         else:
             log.error(f"Failed to configure Git server. {ex_as_string}")
             sys.exit(1)
@@ -647,6 +647,8 @@ class Installer:
                     stderr_as_str = result.stderr.decode("utf-8")
                     log.error(f"Stderr output: {stderr_as_str}")
                     exit(result.returncode)
+                else:
+                    log.info("Control Service installed successfully")
         except Exception as ex:
             log.error(
                 f"Failed to install Helm chart. Make sure you have Helm installed. {str(ex)}"

--- a/projects/vdk-core/plugins/vdk-server/src/vdk/internal/kind-cluster-config-template.yaml
+++ b/projects/vdk-core/plugins/vdk-server/src/vdk/internal/kind-cluster-config-template.yaml
@@ -12,6 +12,9 @@ nodes:
       - containerPort: 80
         hostPort: 8092
         protocol: TCP
+      - containerPort: 443
+        hostPort: 443
+        protocol: TCP
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:{docker_registry_port}"]


### PR DESCRIPTION
This commit attempts to fix a failing installation of the
Control Service on some environments due to ingress
validate webhook failure. This was part of the original
Kind example anyway which we decided to remove earlier.

Signed-off-by: Tsvetomir Palashki <tpalashki@vmware.com>