### PR TITLE
control-service: bump python model version

### DIFF
--- a/projects/control-service/projects/model/apidefs/datajob-api/config-python.json
+++ b/projects/control-service/projects/model/apidefs/datajob-api/config-python.json
@@ -2,5 +2,5 @@
   "packageName": "taurus_datajob_api",
   "projectName": "vdk-control-service-api",
   "verbose": true,
-  "packageVersion": "1.0.2"
+  "packageVersion": "1.0.3"
 }


### PR DESCRIPTION
In order to adopt changes in API in VDK CLI we need a new version of the
python library of the control service

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>