### PR TITLE
vdk-control-cli: add vdk execute --logs

### DIFF
--- a/projects/vdk-control-cli/requirements.txt
+++ b/projects/vdk-control-cli/requirements.txt
@@ -6,7 +6,7 @@ pluggy~=0.13
 tabulate
 click-spinner
 
-vdk-control-service-api==1.0.1
+vdk-control-service-api==1.0.4
 requests_oauthlib
 
 # Dependencies for creating HTTP calls against the OAuth2 provider. We can potentially remove those

--- a/projects/vdk-control-cli/setup.cfg
+++ b/projects/vdk-control-cli/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     requests>=2.25
     setuptools>=47.0
     pluggy==0.*
-    vdk-control-service-api==1.0.1
+    vdk-control-service-api==1.0.4
     tabulate
     requests_oauthlib>=1.0
     urllib3>=1.26.5

--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_execute.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_execute.py
@@ -2,17 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 import json
 import os
+from unittest.mock import patch
 
 from click.testing import CliRunner
 from py._path.local import LocalPath
 from pytest_httpserver.pytest_plugin import PluginHTTPServer
+from taurus_datajob_api import DataJobDeployment
+from taurus_datajob_api import DataJobExecution
 from vdk.internal import test_utils
 from vdk.internal.control.command_groups.job.execute import execute
 from werkzeug import Response
 
 test_utils.disable_vdk_authentication()
-
-os.environ["VDK_ACKNOWLEDGE_USE_OF_EXPERIMENTAL_EXECUTE_API"] = "yes"
 
 
 def test_execute(httpserver: PluginHTTPServer, tmpdir: LocalPath):
@@ -160,3 +161,105 @@ def test_execute_with_exception(httpserver: PluginHTTPServer, tmpdir: LocalPath)
         result.exit_code == 2
     ), f"result exit code is not 2, result output: {result.output}, exc: {result.exc_info}"
     assert "what" in result.output and "why" in result.output
+
+
+def test_execute_no_execution_id(httpserver: PluginHTTPServer, tmpdir: LocalPath):
+    rest_api_url = httpserver.url_for("")
+    team_name = "test-team"
+    job_name = "test-job"
+
+    execution: DataJobExecution = DataJobExecution(
+        id="1",
+        job_name=job_name,
+        logs_url="",
+        deployment=DataJobDeployment(),
+        start_time="2021-09-24T14:14:03.922Z",
+    )
+    older_execution = DataJobExecution(
+        id="2",
+        job_name=job_name,
+        logs_url="",
+        deployment=DataJobDeployment(),
+        start_time="2020-09-24T14:14:03.922Z",
+    )
+
+    httpserver.expect_request(
+        uri=f"/data-jobs/for-team/{team_name}/jobs/{job_name}/executions",
+        method="GET",
+    ).respond_with_json(
+        [older_execution.to_dict(), execution.to_dict(), older_execution.to_dict()]
+    )
+
+    httpserver.expect_request(
+        uri=f"/data-jobs/for-team/{team_name}/jobs/{job_name}/executions/1/logs",
+        method="GET",
+    ).respond_with_json({"logs": "We are the logs! We are awesome!"})
+
+    runner = CliRunner()
+    result = runner.invoke(
+        execute,
+        ["-n", job_name, "-t", team_name, "--logs", "-u", rest_api_url],
+    )
+    test_utils.assert_click_status(result, 0)
+    assert result.output.strip() == "We are the logs! We are awesome!".strip()
+
+
+def test_execute_logs_using_api(httpserver: PluginHTTPServer, tmpdir: LocalPath):
+    rest_api_url = httpserver.url_for("")
+    team_name = "test-team"
+    job_name = "test-job"
+    id = "1"
+
+    execution: DataJobExecution = DataJobExecution(
+        id=id, job_name=job_name, logs_url="", deployment=DataJobDeployment()
+    )
+
+    httpserver.expect_request(
+        uri=f"/data-jobs/for-team/{team_name}/jobs/{job_name}/executions/1",
+        method="GET",
+    ).respond_with_json(execution.to_dict())
+
+    httpserver.expect_request(
+        uri=f"/data-jobs/for-team/{team_name}/jobs/{job_name}/executions/1/logs",
+        method="GET",
+    ).respond_with_json({"logs": "We are the logs! We are awesome!"})
+
+    runner = CliRunner()
+    result = runner.invoke(
+        execute,
+        ["-n", job_name, "-t", team_name, "-i", id, "--logs", "-u", rest_api_url],
+    )
+    test_utils.assert_click_status(result, 0)
+    assert result.output.strip() == "We are the logs! We are awesome!".strip()
+
+
+def test_execute_logs_with_external_log_url(
+    httpserver: PluginHTTPServer, tmpdir: LocalPath
+):
+    rest_api_url = httpserver.url_for("")
+    team_name = "test-team"
+    job_name = "test-job"
+    id = "1"
+
+    execution: DataJobExecution = DataJobExecution(
+        id=id,
+        job_name=job_name,
+        logs_url="http://external-service-job-logs",
+        deployment=DataJobDeployment(),
+    )
+
+    httpserver.expect_request(
+        uri=f"/data-jobs/for-team/{team_name}/jobs/{job_name}/executions/1",
+        method="GET",
+    ).respond_with_json(execution.to_dict())
+
+    with patch("webbrowser.open") as mock_browser_open:
+        mock_browser_open.return_value = False
+
+        runner = CliRunner()
+        result = runner.invoke(
+            execute,
+            ["-n", job_name, "-t", team_name, "-i", id, "--logs", "-u", rest_api_url],
+        )
+        test_utils.assert_click_status(result, 0)
+        mock_browser_open.assert_called_once_with("http://external-service-job-logs")


### PR DESCRIPTION
After engineers have started manually their data job it will be good for
them to be able to see their logs in order to track the progress of the
job and if the job fails to troubleshoot and so on. In other words, Logs
are invaluable.

Testing Done: unit tests added.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>