### PR TITLE
vdk-core: Raise exception if Data Job has no steps

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/data_job.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/data_job.py
@@ -119,7 +119,7 @@ class DataJobDefaultHookImplPlugin:
                 what_happened="Data Job execution has failed.",
                 why_it_happened="Data Job has no steps.",
                 consequences="Data job execution will not continue.",
-                countermeasures="Please include at least 1 step in your Data Job.",
+                countermeasures="Please include at least 1 valid step in your Data Job. Also make sure you are passing the correct data job directory.",
             )
 
         try:


### PR DESCRIPTION
Currently, an empty Data Job, i.e. one with no steps, will succeed.
This is suboptimal as in certain cases a user might believe they
are executing a Data Job while in fact they are not.
There is no apparent use case for an empty Data Job.

This change fixes the aformentioned problem by making VDK raise an
exception if there are no steps in the target Data Job.

Testing done: executed an empty Data Job and verified an exception
is raised:
```
...
  File "/Users/gageorgiev/vdk-tuts/venv/lib/python3.7/site-packages/vdk/internal/core/errors.py", line 271, in log_and_throw
    raise UserCodeError(msg)
vdk.internal.core.errors.UserCodeError: An error in data job code  occurred. The error should be resolved by User Error. Here are the details:
  WHAT HAPPENED : Data Job execution has failed.
WHY IT HAPPENED : Data Job has no steps.
   CONSEQUENCES : Data job execution will not continue.
COUNTERMEASURES : Please include at least 1 step in your Data Job.
```

Signed-off-by: gageorgiev <gageorgiev@vmware.com>