### PR TITLE
control-service: install trino flavor of vdk-heartbeat

### DIFF
--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -208,7 +208,7 @@ control_service_post_deployment_test:
   script:
     - set -x
     - pip install quickstart-vdk
-    - pip install vdk-heartbeat
+    - pip install vdk-heartbeat[trino]
     - vdk version
     - export VDKCLI_OAUTH2_REFRESH_TOKEN=$VDK_API_TOKEN
     - vdk-heartbeat -f projects/control-service/cicd/post_deploy_test_heartbeat_config.ini


### PR DESCRIPTION
We removed trino from quickstart-vdk but that breaks the test because we
vdk-heartbeat needs trino . So we install trino using
vdk-heartbeat[trino] which allow us to install extra requirements when
installing vdk-heartbeat.

Testing Done: install locally vdk-heartbeat[trino] and saw trino was
installed.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>