### PR TITLE
vdk-logging-json: Revert to escaping newline chars

### DIFF
--- a/projects/vdk-core/plugins/vdk-logging-json/src/vdk/internal/logging_json.py
+++ b/projects/vdk-core/plugins/vdk-logging-json/src/vdk/internal/logging_json.py
@@ -13,11 +13,12 @@ format_template = (
     '"lineno":"%(lineno)s","funcname":"%(funcName)s","attemptid":"{attempt_id}","message":"%(message)s"'
 )
 
-# this class serves to convert newline characters to tabs
+# this class serves to escape newline characters in the log message
+# as according to https://stackoverflow.com/questions/42068/how-do-i-handle-newlines-in-json
 # it is currently experimental and might be removed
 class RemoveNewlinesFormatter(logging.Formatter):
     def format(self, record):
-        record.msg = record.msg.replace("\n", "\t")
+        record.msg = record.msg.replace("\n", "\\n")
         return super().format(record)
 
 


### PR DESCRIPTION
Newline characters were previously escaped, but later this
functionality was replaced by substituting newlines to tabs.
This change is being reverted as the previous was tested and
works better.

Testing done: used previous version of vdk-logging-json and
verified forwarded logs are being formatted correctly

Signed-off-by: gageorgiev <gageorgiev@vmware.com>