### PR TITLE
vdk-core: Remove click.echo calls, print calls

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/vdk_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/vdk_config.py
@@ -150,7 +150,7 @@ Only the following options can be set with config.ini: {[e.value for e in JobCon
             and self.__job_path.is_dir()
             and self.__job_path.joinpath("config.ini").exists()
         ):
-            print("Detected config.ini. Will try to read config.ini.")
+            log.info("Detected config.ini. Will try to read config.ini.")
 
             job_config = JobConfig(self.__job_path)
             config_builder.set_value(JobConfigKeys.TEAM, job_config.get_team())

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/cli_run.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/cli_run.py
@@ -108,11 +108,9 @@ def run(ctx: click.Context, data_job_directory: str, arguments: str) -> None:
     """
     Entry point of the CLI run. It start a run (execution) of a data job.
     """
-    click.echo(
-        f"Versatile Data Kit (VDK){os.linesep}{version.get_version_info()}",
-        err=True,
+    log.info(
+        f"Versatile Data Kit (VDK){os.linesep}{version.get_version_info()}{os.linesep + '-' * 80}"
     )
-    click.echo("-" * 80, err=True)
     context: CoreContext = cast(CoreContext, ctx.obj)
     run_impl = CliRunImpl()
     run_impl.run_job(context, pathlib.Path(data_job_directory), arguments)

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/version/version.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/version/version.py
@@ -79,6 +79,7 @@ def get_version_info():
 @click.pass_context
 def version(ctx: click.Context):
     # all necessary info is printed by LogVersionInfoPlugin
-    click.echo(f"Versatile Data Kit (VDK){os.linesep}{get_version_info()}", err=True)
-    click.echo("-" * 80, err=True)
+    log.info(
+        f"Versatile Data Kit (VDK){os.linesep}{get_version_info()}{os.linesep + '-' * 80}"
+    )
     pass


### PR DESCRIPTION
Using click.echo inside a remote job execution is not ideal, as
click.echo does not inherit the logging config. This means that
job logs cannot be formatted appropriately for forwarding.
This change fixed this by changing click.echo calls to log.info
calls. Additionally it combines pairs of calls into one call, so
that they do not get parsed separately.

Testing done: ran job locally, verified logs get formatted by
vdk-logging-json

Signed-off-by: gageorgiev <gageorgiev@vmware.com>