### PR TITLE
vdk-heartbeat: Test Trino templates execution

### DIFF
--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/config.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/config.py
@@ -147,6 +147,15 @@ class Config:
         )
 
         """
+        Flag is used to check if Trino template execution needs to be run as part of the heartbeat test.
+        If set to true, the vdk_heartbeat_data_job/trino job will perform a step which will execute a template.
+        It defaults to True.
+        """
+        self.check_template_execution = self._string_to_bool(
+            self.get_value("CHECK_TEMPLATE_EXECUTION", "true", False)
+        )
+
+        """
         Set file path to the JUNIT XML Test report file. If left empty , the file will not be generated.
         The file does not need to exists but all parent directories must exist.
         """

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
@@ -385,6 +385,7 @@ def run(job_input):
     props['table_destination'] = "{self.config.DATABASE_TEST_TABLE_DESTINATION}"
     props['table_load_destination'] = "{self.config.DATABASE_TEST_TABLE_LOAD_DESTINATION}"
     props['job_name'] = "{self.config.job_name}"
+    props['execute_template'] = "{self.config.check_template_execution}"
     job_input.set_all_properties(props)
         """
 

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/vdk_heartbeat_data_job/trino/25_execute_template.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/vdk_heartbeat_data_job/trino/25_execute_template.py
@@ -1,0 +1,84 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+import uuid
+
+
+log = logging.getLogger(__name__)
+
+
+def run(job_input):
+    # This step is prefixed with '25_' because it is important that it is executed before the last step.
+    # vdk-heartbeat currently finishes successfully after wait_for_results_and_verify verifies that the expected
+    # data was successfully moved in step 30_move_data_using_sql.sql - this is why execute_template step
+    # must be placed before that.
+
+    if job_input.get_property("execute_template") == "False":
+        log.info(f"Skipping Trino template execution test.")
+        return
+
+    ts = uuid.uuid4().hex
+
+    # If db property includes catalog name, get only the schema name ('default' from 'memory.default').
+    # This is done because the templates' implementation escapes db, table and column names passed as arguments, so that
+    # reserved words could be used for their values
+    db_name = job_input.get_property("db").split(".")[-1]
+
+    target_table = f"vdk_heartbeat_template_dim_users_{ts}"
+    source_table = f"vdk_heartbeat_template_vw_dim_users_{ts}"
+
+    try:
+        run_template_test(job_input, db_name, target_table, source_table)
+    finally:
+        job_input.execute_query(f"DROP TABLE IF EXISTS {db_name}.{target_table}")
+        job_input.execute_query(f"DROP TABLE IF EXISTS {db_name}.{source_table}")
+
+
+def run_template_test(job_input, db_name, target_table, source_table):
+    # prepare source data
+    job_input.execute_query(
+        f"""
+        CREATE TABLE IF NOT EXISTS {db_name}.{source_table}
+        (
+            id varchar,
+            name varchar,
+            username varchar,
+            email varchar
+        )
+        """
+    )
+    job_input.execute_query(
+        f"""
+        INSERT INTO {db_name}.{source_table} VALUES
+            ('id', 'A. Userov',  'auserov', 'auserov@example.com')
+        """
+    )
+
+    # prepare target table
+    job_input.execute_query(
+        f"""
+        DROP TABLE IF EXISTS {db_name}.{target_table}
+        """
+    )
+    job_input.execute_query(
+        f"""
+        CREATE TABLE {db_name}.{target_table} (
+            LIKE {db_name}.{source_table}
+        )
+        """
+    )
+
+    # execute template which will copy data from source to target
+    template_args = {
+        "target_schema": db_name,
+        "target_table": target_table,
+        "source_schema": db_name,
+        "source_view": source_table,
+    }
+    job_input.execute_template(template_name="scd1", template_args=template_args)
+
+    # check if target was correctly populated (only 1 entry from source should be inserted there)
+    result = job_input.execute_query(f"SELECT COUNT (1) FROM {db_name}.{target_table}")
+
+    if result and result[0][0] != 1:
+        raise Exception("scd1 template did not work correctly.")


### PR DESCRIPTION
Trino template execution is currently not automatically tested
in vdk-heartbeat. This opens a door for releasing a version with
broken templates.

Add a step which executes a template in vdk-heartbeat Trino
Data Job. Add a config for turning template execution testing
on/off - CHECK_TEMPLATE_EXECUTION.

Tested by manually running locally built vdk-heartbeat against
TMS Production and checking that the 'execute template' step passes
successfully for both on and off values of
CHECK_TEMPLATE_EXECUTION.

Signed-off-by: Yana Zhivkova <yzhivkova@vmware.com>