### PR TITLE
vdk-control-cli: `deploy --show` shouldn't print help if JSON

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli_impl.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli_impl.py
@@ -218,11 +218,11 @@ class JobDeploy:
                 ),
                 deployments,
             )
-            click.echo(
-                "You can compare the version seen here to the one seen when "
-                "deploying to verify your deployment was successful."
-            )
             if output == OutputFormat.TEXT.value:
+                click.echo(
+                    "You can compare the version seen here to the one seen when "
+                    "deploying to verify your deployment was successful."
+                )
                 click.echo("")
                 click.echo(tabulate(deployments, headers="keys"))
             else:

--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_deploy.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_deploy.py
@@ -288,10 +288,7 @@ def test_deploy_show_with_json_output(httpserver: PluginHTTPServer, tmpdir: Loca
     ), f"result exit code is not 0, result output: {result.output}, exc: {result.exc_info}"
 
     try:
-        json_result = json.loads(
-            result.output[110:]
-        )  # the slice is because of a help message printed at the start
-        # which cannot be decoded as json
+        json_result = json.loads(result.output)
     except JSONDecodeError as error:
         assert False, f"failed to parse the response as a JSON object, error: {error}"
     assert isinstance(json_result, list)


### PR DESCRIPTION
`vdk deploy --show` shouldn't print the help message describing
how to verify correct job deployment if the output of the command
is a JSON dump.

Testing done: fixed unit test, pipelines passed

Signed-off-by: gageorgiev <gageorgiev@vmware.com>