### PR TITLE
vdk-ingest-http: Fix wrong namespace

### DIFF
--- a/projects/vdk-core/plugins/vdk-ingest-http/setup.py
+++ b/projects/vdk-core/plugins/vdk-ingest-http/setup.py
@@ -18,7 +18,9 @@ setuptools.setup(
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),
     entry_points={
-        "vdk.plugin.run": ["vdk-ingest-http = vdk.plugin.ingest_http_plugin"]
+        "vdk.plugin.run": [
+            "vdk-ingest-http = vdk.plugin.ingest_http.ingest_http_plugin"
+        ]
     },
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
The setup entry point was left wrong. This change fixes that.

Signed-off-by: gageorgiev <gageorgiev@vmware.com>