### PR TITLE
vdk-logging-json: Remove newline escaping

### DIFF
--- a/projects/vdk-core/plugins/vdk-logging-json/src/vdk/plugin/logging_json/logging_json.py
+++ b/projects/vdk-core/plugins/vdk-logging-json/src/vdk/plugin/logging_json/logging_json.py
@@ -26,7 +26,7 @@ class RemoveNewlinesFormatter(logging.Formatter):
         self.default_msec_format = "%s.%03dZ"
 
     def format(self, record):
-        record.msg = record.msg.replace("\n", "\\n")
+        # record.msg = record.msg.replace("\n", "\\n")
         return super().format(record)
 
 


### PR DESCRIPTION
Keeping the newlines as they are wasn't tested after the label
issue was resolved, so this PR aims to de-escape newlines from
JSON-formatted logs to see how Kibana responds to it.

Signed-off-by: gageorgiev <gageorgiev@vmware.com>