### PR TITLE
vdk-core: Remove misleading ingester docs

### DIFF
--- a/projects/vdk-core/src/vdk/api/job_input.py
+++ b/projects/vdk-core/src/vdk/api/job_input.py
@@ -164,15 +164,14 @@ class IIngester:
                 specify which plugin is to be used by default for ingestion.
 
             target: Optional[str]
-                target identifies where the data should be ingested into. Specifies
-                a data source and its destination database.
+                target identifies where the data should be ingested into.
 
-                The values for this parameter can be in the format
-                `<some-data-source_and-db-table>`, or as a URL.
-                Example: http://example.com/<some-api>/<data-source_and-db-table>
+                The value for this parameter depends on the ingest method chosen.
+                For "http" method, it would require an HTTP URL.
+                    Example: http://example.com/<some>/<api>/<endpoint>
+                For "file" method, it would require a file name or path.
 
-                The `__STAGING/__PRODUCTION` can be added at the end of the target if
-                separation of dev/test from production data is required.
+                See chosen ingest method (ingestion plugin) documentation for more details on the expected target format.
 
                 This parameter does not need to be used, in case the
                 `INGEST_TARGET_DEFAULT` environment variable is set. This can be
@@ -246,16 +245,18 @@ class IIngester:
                 See plugin_input for how to develop a new plugin with new ingest method.
 
             target: Optional[str]
-                target identifies where the data should be ingested into. Specifies
-                a data source and its destination database.
+                target identifies where the data should be ingested into.
 
-                The values for this parameter can be in the format
-                `<some-data-source_and-db-table>`, or as a URL.
-                Example: http://example.com/<some-api>/<data-source_and-db-table>
+                The value for this parameter depends on the ingest method chosen.
+                For "http" method, it would require an HTTP URL.
+                    Example: http://example.com/<some>/<api>/<endpoint>
+                For "file" method, it would require a file name or path.
+
+                See chosen ingest method (ingestion plugin) documentation for more details on the expected target format.
 
                 This parameter does not need to be used. In case the
                 `VDK_INGEST_TARGET_DEFAULT` environment variable is set it will be used.
-                 If not plugins  may set default value.
+                 If not, plugins may set a default value.
 
             collection_id: Optional[str]
                 Optional. An identifier to indicate that data from different method

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_base.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_base.py
@@ -113,18 +113,19 @@ class IngesterBase(IIngester):
             specify which plugin is to be used by default for ingestion.
         :param target: Optional[string]
             (Optional) Used to identify where the data should be ingested into.
-                Specifies a data source and its destination database.
-                The values for this parameter can be in the format
-                `<some-data-source_and-db-table>`, or as a URL.
-                Example: http://example.com/<some-api>/<data-source_and-db-table>
+                The value for this parameter depends on the ingest method chosen.
+                For "http" method, it would require an HTTP URL.
+                    Example: http://example.com/<some>/<api>/<endpoint>
+                For "file" method, it would require a file name or path.
+
+                See chosen ingest method (ingestion plugin) documentation for more details on the expected target format.
             This parameter does not need to be used, in case the
             `INGEST_TARGET_DEFAULT` environment variable is set. This can be made by
             plugins, which may set default value, or it can be overwritten by users.
         :param collection_id: Optional[string]
             (Optional) An identifier to indicate that data from different method
             invocations belong to same collection. Defaults to "data_job_name|OpID",
-            meaning all method invocations from a data job run will belong to the
-            same collection.
+            meaning all method invocations from a data job run will belong to the same collection.
         """
         self.__verify_payload_format(payload_dict=payload)
 
@@ -185,18 +186,19 @@ class IngesterBase(IIngester):
             specify which plugin is to be used by default for ingestion.
         :param target: Optional[string]
             (Optional) Used to identify where the data should be ingested into.
-                Specifies a data source and its destination database.
-                The values for this parameter can be in the format
-                `<some-data-source_and-db-table>`, or as a URL.
-                Example: http://example.com/<some-api>/<data-source_and-db-table>
+                The value for this parameter depends on the ingest method chosen.
+                For "http" method, it would require an HTTP URL.
+                    Example: http://example.com/<some>/<api>/<endpoint>
+                For "file" method, it would require a file name or path.
+
+                See chosen ingest method (ingestion plugin) documentation for more details on the expected target format.
             This parameter does not need to be used, in case the
             `INGEST_TARGET_DEFAULT` environment variable is set. This can be made by
             plugins, which may set default value, or it can be overwritten by users.
         :param collection_id: Optional[string]
             (Optional) An identifier to indicate that data from different method
             invocations belong to same collection. Defaults to "data_job_name|OpID",
-            meaning all method invocations from a data job run will belong to the
-            same collection.
+            meaning all method invocations from a data job run will belong to the same collection.
         """
         if len(column_names) == 0 and destination_table is None:
             errors.log_and_throw(
@@ -280,16 +282,17 @@ class IngesterBase(IIngester):
                     method="http" -> ingest using HTTP POST requests
                     method="kafka" -> ingest to kafka endpoint
         :param target: string
-            Used to identify where the data should be ingested into. Specifies
-                a data source and its destination database.
-                The values for this parameter can be in the format
-                `<some-data-source_and-db-table>`, or as a URL.
-                Example: http://example.com/<some-api>/<data-source_and-db-table>
+            Used to identify where the data should be ingested into.
+                The value for this parameter depends on the ingest method chosen.
+                For "http" method, it would require an HTTP URL.
+                    Example: http://example.com/<some>/<api>/<endpoint>
+                For "file" method, it would require a file name or path.
+
+                See chosen ingest method (ingestion plugin) documentation for more details on the expected target format.
         :param collection_id: string
             (Optional) An identifier to indicate that data from different method
             invocations belong to same collection. Defaults to "data_job_name|OpID",
-            meaning all method invocations from a data job run will belong to the
-            same collection.
+            meaning all method invocations from a data job run will belong to the same collection.
         """
         self._objects_queue.put(
             (payload_dict, destination_table, method, target, collection_id)
@@ -420,11 +423,13 @@ class IngesterBase(IIngester):
             meaning all method invocations from a data job run will belong to the
             same collection.
         :param target: string
-            Used to identify where the data should be ingested into. Specifies
-                a data source and its destination database.
-                The values for this parameter can be in the format
-                `<some-data-source_and-db-table>`, or as a URL.
-                Example: http://example.com/<some-api>/<data-source_and-db-table>
+            Used to identify where the data should be ingested into.
+                The value for this parameter depends on the ingest method chosen.
+                For "http" method, it would require an HTTP URL.
+                    Example: http://example.com/<some>/<api>/<endpoint>
+                For "file" method, it would require a file name or path.
+
+                See chosen ingest method (ingestion plugin) documentation for more details on the expected target format.
         """
         if aggregated_payload:
             try:


### PR DESCRIPTION
Currently, the docstrings of the Versatile Data Kit's
Ingestion API make misleading claims as to how the target
parameter is treated, and how it can be used by data engineers.

This change refactors the docstrings, and removes the misleading
parts.

Testing Done: Documentation change, no testing required

Signed-off-by: Andon Andonov <andonova@vmware.com>