### PR TITLE
control-service: set job execution end time during the sync

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
@@ -298,6 +298,7 @@ public class JobExecutionService {
                   .map(dataJobExecution -> {
                      dataJobExecution.setStatus(ExecutionStatus.FINISHED);
                      dataJobExecution.setMessage("Status is set by VDK Control Service");
+                     dataJobExecution.setEndTime(OffsetDateTime.now());
                      return dataJobExecution;
                   })
                   .collect(Collectors.toList());

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceSyncExecutionIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceSyncExecutionIT.java
@@ -8,6 +8,7 @@ package com.vmware.taurus.service.execution;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
@@ -22,6 +23,7 @@ import com.vmware.taurus.RepositoryUtil;
 import com.vmware.taurus.service.JobExecutionRepository;
 import com.vmware.taurus.service.JobsRepository;
 import com.vmware.taurus.service.model.DataJob;
+import com.vmware.taurus.service.model.DataJobExecution;
 import com.vmware.taurus.service.model.ExecutionStatus;
 
 @ExtendWith(SpringExtension.class)
@@ -192,5 +194,9 @@ public class JobExecutionServiceSyncExecutionIT {
 
       Assert.assertEquals(1, dataJobExecutionsAfterSync.size());
       Assert.assertEquals(expectedJobExecution3.getId(), dataJobExecutionsAfterSync.get(0).getId());
+
+      DataJobExecution actualFinishedExecution = jobExecutionRepository.findById(expectedJobExecution4.getId()).get();
+      Assert.assertEquals("Status is set by VDK Control Service", actualFinishedExecution.getMessage());
+      Assert.assertNotNull(actualFinishedExecution.getEndTime());
    }
 }


### PR DESCRIPTION
Along with status and message we must set the job execution end time
during the synchronization.

Testing: Local run of unit tests.

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com