### PR TITLE
control-service: fix control service cicd deployment configuration

### DIFF
--- a/projects/control-service/cicd/deploy-testing-pipelines-service.sh
+++ b/projects/control-service/cicd/deploy-testing-pipelines-service.sh
@@ -78,6 +78,7 @@ helm upgrade --install --wait --timeout 10m0s $RELEASE_NAME . \
       --set proxyRepositoryURL="$CICD_CONTAINER_REGISTRY_URI/cicd-data-jobs/$RELEASE_NAME" \
       --set security.enabled=true \
       --set security.oauth2.jwtJwkSetUri=https://console-stg.cloud.vmware.com/csp/gateway/am/api/auth/token-public-key?format=jwks \
+      --set security.oauth2.jwtIssuerUrl=https://gaz-preview.csp-vidm-prod.com \
       --set security.authorizationEnabled=true \
       --set security.authorization.webhookUri=https://httpbin.org/post \
       --set extraEnvVars.LOGGING_LEVEL_COM_VMWARE_TAURUS=DEBUG \


### PR DESCRIPTION
With the most recent changes to the authorization, the jwtIssuerUrl
configuration must now be set when security is enabled.
This commit changes the cicd deployment of the control service to
now set this property.

Signed-off-by: Tsvetomir Palashki <tpalashki@vmware.com>