### PR TITLE
vdk-heartbeat: fix encoding when reading job execution logs

### DIFF
--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
@@ -142,7 +142,7 @@ class JobController:
                 self.config.job_team,
             ]
         )
-        logs = res.decode("string_escape") if res else res
+        logs = res.decode("unicode_escape") if res else res
         log.info(
             f"Team {self.config.job_team}, Job: {self.config.job_name} Logs:\n {logs}"
         )


### PR DESCRIPTION
The current encoding "string_escape" does not seem to be valid
in all enviorments (particularly in the CI/CD one) and is causing
the heartbeat to fail. Change the encoding to one that is recognized.

Signed-off-by: Tsvetomir Palashki <tpalashki@vmware.com>