### PR TITLE
control-service: improve list executions api correctness

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobTerminationStatusIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobTerminationStatusIT.java
@@ -230,8 +230,7 @@ public class DataJobTerminationStatusIT extends BaseIT {
 
         // Validate that the metrics has a value of 0.0 (i.e. Success)
         System.out.println(match.get().trim());
-        // TODO: Temporary disabled since the К8S POD termination message is always null and respectively the termination status is 1.0
-        // assertTrue("The value of the taurus_datajob_termination_status metrics does not match", match.get().trim().endsWith("0.0"));
+        assertTrue(match.get().trim().endsWith("0.0"), "The value of the taurus_datajob_termination_status metrics does not match");
 
         // Check the data job execution status
         checkDataJobExecutionStatus(executionId, DataJobExecution.StatusEnum.FINISHED, opId);


### PR DESCRIPTION
The VDK Skip plugin relies heavily on running execution status.
In some cases, the execution status in the database may be
outdated due to delay. As a result the next job execution will be skipped.

In order to avoid such cases we must return only running jobs
in Kubernetes when a filter (status=RUNNING) is passed to the API.

Testing: unit tests

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com