### PR TITLE
vdk-core: fix unit tests

### DIFF
--- a/projects/vdk-core/tests/functional/cli/test_set_cli_defaults.py
+++ b/projects/vdk-core/tests/functional/cli/test_set_cli_defaults.py
@@ -4,8 +4,8 @@ import click
 from vdk.api.plugin.hook_markers import hookimpl
 from vdk.api.plugin.plugin_utils import set_defaults_for_all_commands
 from vdk.api.plugin.plugin_utils import set_defaults_for_specific_command
-from vdk.internal.test_utils.util_funcs import cli_assert_equal
-from vdk.internal.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
 
 
 def test_set_defaults_for_specific_command():

--- a/projects/vdk-core/tests/functional/run/test_run_decorate_job_input.py
+++ b/projects/vdk-core/tests/functional/run/test_run_decorate_job_input.py
@@ -9,10 +9,10 @@ from functional.run.test_run_sql_queries import VDK_DB_DEFAULT_TYPE
 from functional.run.test_run_templates import AppendTemplatePlugin
 from vdk.api.plugin.hook_markers import hookimpl
 from vdk.internal.builtin_plugins.run.job_context import JobContext
-from vdk.internal.test_utils.util_funcs import cli_assert_equal
-from vdk.internal.test_utils.util_funcs import CliEntryBasedTestRunner
-from vdk.internal.test_utils.util_plugins import DB_TYPE_SQLITE_MEMORY
-from vdk.internal.test_utils.util_plugins import SqLite3MemoryDbPlugin
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_plugins import DB_TYPE_SQLITE_MEMORY
+from vdk.plugin.test_utils.util_plugins import SqLite3MemoryDbPlugin
 
 
 class DecoratorsPlugin:

--- a/projects/vdk-core/tests/functional/run/test_run_ingest.py
+++ b/projects/vdk-core/tests/functional/run/test_run_ingest.py
@@ -5,9 +5,9 @@ from typing import Optional
 
 from click.testing import Result
 from functional.run import util
-from vdk.internal.test_utils.util_funcs import cli_assert_equal
-from vdk.internal.test_utils.util_funcs import CliEntryBasedTestRunner
-from vdk.internal.test_utils.util_plugins import IngestIntoMemoryPlugin
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_plugins import IngestIntoMemoryPlugin
 
 
 class FailingIngestIntoMemoryPlugin(IngestIntoMemoryPlugin):

--- a/projects/vdk-core/tests/functional/run/test_run_notifications.py
+++ b/projects/vdk-core/tests/functional/run/test_run_notifications.py
@@ -8,10 +8,10 @@ from click.testing import Result
 from functional.run import util
 from smtpdfix import SMTPDFix
 from vdk.internal.core import errors
-from vdk.internal.test_utils.util_funcs import cli_assert_equal
-from vdk.internal.test_utils.util_funcs import CliEntryBasedTestRunner
-from vdk.internal.test_utils.util_plugins import DB_TYPE_SQLITE_MEMORY
-from vdk.internal.test_utils.util_plugins import DecoratedSqLite3MemoryDbPlugin
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_plugins import DB_TYPE_SQLITE_MEMORY
+from vdk.plugin.test_utils.util_plugins import DecoratedSqLite3MemoryDbPlugin
 
 os.environ["SMTPD_SSL_CERTS_PATH"] = "."
 

--- a/projects/vdk-core/tests/functional/run/test_run_properties.py
+++ b/projects/vdk-core/tests/functional/run/test_run_properties.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 from click.testing import Result
 from functional.run import util
-from vdk.internal.test_utils.util_funcs import cli_assert_equal
-from vdk.internal.test_utils.util_funcs import CliEntryBasedTestRunner
-from vdk.internal.test_utils.util_plugins import TestPropertiesPlugin
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_plugins import TestPropertiesPlugin
 
 
 def test_run_properties():

--- a/projects/vdk-core/tests/functional/run/test_run_simple.py
+++ b/projects/vdk-core/tests/functional/run/test_run_simple.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from click.testing import Result
 from functional.run import util
-from vdk.internal.test_utils.util_funcs import cli_assert_equal
-from vdk.internal.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
 
 
 def test_run():

--- a/projects/vdk-core/tests/functional/run/test_run_sql_queries.py
+++ b/projects/vdk-core/tests/functional/run/test_run_sql_queries.py
@@ -8,12 +8,12 @@ from unittest import mock
 from click.testing import Result
 from functional.run import util
 from vdk.internal.core.errors import VdkConfigurationError
-from vdk.internal.test_utils.util_funcs import cli_assert_equal
-from vdk.internal.test_utils.util_funcs import CliEntryBasedTestRunner
-from vdk.internal.test_utils.util_funcs import get_test_job_path
-from vdk.internal.test_utils.util_plugins import DB_TYPE_SQLITE_MEMORY
-from vdk.internal.test_utils.util_plugins import DecoratedSqLite3MemoryDbPlugin
-from vdk.internal.test_utils.util_plugins import SqLite3MemoryDbPlugin
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_funcs import get_test_job_path
+from vdk.plugin.test_utils.util_plugins import DB_TYPE_SQLITE_MEMORY
+from vdk.plugin.test_utils.util_plugins import DecoratedSqLite3MemoryDbPlugin
+from vdk.plugin.test_utils.util_plugins import SqLite3MemoryDbPlugin
 
 VDK_DB_DEFAULT_TYPE = "VDK_DB_DEFAULT_TYPE"
 

--- a/projects/vdk-core/tests/functional/run/test_run_templates.py
+++ b/projects/vdk-core/tests/functional/run/test_run_templates.py
@@ -9,11 +9,11 @@ from functional.run import util
 from functional.run.test_run_sql_queries import VDK_DB_DEFAULT_TYPE
 from vdk.api.plugin.hook_markers import hookimpl
 from vdk.internal.builtin_plugins.run.job_context import JobContext
-from vdk.internal.test_utils.util_funcs import cli_assert_equal
-from vdk.internal.test_utils.util_funcs import CliEntryBasedTestRunner
-from vdk.internal.test_utils.util_funcs import get_test_job_path
-from vdk.internal.test_utils.util_plugins import DB_TYPE_SQLITE_MEMORY
-from vdk.internal.test_utils.util_plugins import SqLite3MemoryDbPlugin
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_funcs import get_test_job_path
+from vdk.plugin.test_utils.util_plugins import DB_TYPE_SQLITE_MEMORY
+from vdk.plugin.test_utils.util_plugins import SqLite3MemoryDbPlugin
 
 
 class AppendTemplatePlugin:

--- a/projects/vdk-core/tests/functional/run/util.py
+++ b/projects/vdk-core/tests/functional/run/util.py
@@ -3,7 +3,7 @@
 import os
 import pathlib
 
-from vdk.internal.test_utils.util_funcs import get_test_job_path
+from vdk.plugin.test_utils.util_funcs import get_test_job_path
 
 
 def job_path(job_name: str):

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_config_help.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_config_help.py
@@ -3,8 +3,8 @@
 from vdk.api.plugin.hook_markers import hookimpl
 from vdk.internal.builtin_plugins.config.config_help import ConfigHelpPlugin
 from vdk.internal.core.config import ConfigurationBuilder
-from vdk.internal.test_utils.util_funcs import cli_assert_equal
-from vdk.internal.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
 
 
 class TestConfigPlugin:

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/run/test_data_job.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/run/test_data_job.py
@@ -8,7 +8,7 @@ from vdk.api.plugin.plugin_registry import HookCallResult
 from vdk.internal.builtin_plugins.run.execution_results import ExecutionResult
 from vdk.internal.builtin_plugins.run.job_context import JobContext
 from vdk.internal.builtin_plugins.run.step import Step
-from vdk.internal.test_utils.util_funcs import DataJobBuilder
+from vdk.plugin.test_utils.util_funcs import DataJobBuilder
 
 
 def failing_runner_func(step: Step, job_input: IJobInput) -> bool:

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/version/test_version.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/version/test_version.py
@@ -1,7 +1,7 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
-from vdk.internal.test_utils.util_funcs import cli_assert_equal
-from vdk.internal.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
 
 
 def test_version():

--- a/projects/vdk-core/tests/vdk/internal/test_cli_entry.py
+++ b/projects/vdk-core/tests/vdk/internal/test_cli_entry.py
@@ -4,8 +4,8 @@ import click
 from click.testing import CliRunner
 from vdk.api.plugin.hook_markers import hookimpl
 from vdk.internal.cli_entry import cli
-from vdk.internal.test_utils.util_funcs import cli_assert_equal
-from vdk.internal.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
 
 
 def test_cli():


### PR DESCRIPTION
The unit test of vdk-core are not executing at all. And also are broken
due to changes in vdk-test-utils.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>