### PR TITLE
control-service: Allow for additional labels in deployment pod

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -20,6 +20,9 @@ spec:
   template:
     metadata:
       labels: {{- include "pipelines-control-service.labels" . | nindent 8 }}
+      {{- if .Values.deploymentAdditionalLabels }}
+      {{- .Values.deploymentAdditionalLabels | nindent 8 }}
+      {{- end }}
       annotations:
         # https://helm.sh/docs/howto/charts_tips_and_tricks Automatically Roll Deployments
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}


### PR DESCRIPTION
A previous change allowed for the deployment to have additional
labels specified in the values.yml file, but those labels did
not transfer over to pods managed by the deployment.
This change allows for that.

Signed-off-by: gageorgiev <gageorgiev@vmware.com>