### PR TITLE
control-service: fix NullPointerException when reading job deployment status

### DIFF
--- a/projects/control-service/CHANGELOG.md
+++ b/projects/control-service/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog
 * **Improvement**
 
 * **Bug Fixes**
+  * Fix an error which happens occasionally when listing data jobs or job deployment statuses
 
 * **Breaking Changes**
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -1480,7 +1480,10 @@ public abstract class KubernetesService implements InitializingBean {
                 deployment.setImageName(image); // TODO do we really need to return image_name?
             }
             var labels = cronJob.getSpec().getJobTemplate().getMetadata().getLabels();
-            if (labels.containsKey(JobLabel.VERSION.getValue())) {
+            if (labels == null) {
+                log.warn("The cronjob of data job '{}' does not have any labels defined.", deployment.getDataJobName());
+            }
+            if (labels != null && labels.containsKey(JobLabel.VERSION.getValue())) {
                 deployment.setGitCommitSha(labels.get(JobLabel.VERSION.getValue()));
             } else {
                 // Legacy approach to get version:


### PR DESCRIPTION
Testing done: Tested against a local control service, configured to run against
the environment where the bug initially appeared.

Signed-off-by: Tsvetomir Palashki <tpalashki@vmware.com>