### PR TITLE
vdk-test-utils, vdk-plugin-control-cli: fix version of vdk-core

### DIFF
--- a/projects/vdk-core/plugins/vdk-plugin-control-cli/setup.py
+++ b/projects/vdk-core/plugins/vdk-plugin-control-cli/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     description="Versatile Data Kit SDK plugin exposing CLI commands for managing the lifecycle of a Data Jobs.",
     long_description=pathlib.Path("README.md").read_text(),
     long_description_content_type="text/markdown",
-    install_requires=["vdk-core", "vdk-control-cli", "requests"],
+    install_requires=["vdk-core==0.0.381839719", "vdk-control-cli", "requests"],
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),
     entry_points={

--- a/projects/vdk-core/plugins/vdk-test-utils/setup.py
+++ b/projects/vdk-core/plugins/vdk-test-utils/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     description="Provides utilities for testing Versatile Data Kit SDK plugins.",
     long_description=pathlib.Path("README.md").read_text(),
     long_description_content_type="text/markdown",
-    install_requires=["vdk-core"],
+    install_requires=["vdk-core==0.0.381839719"],
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),
     classifiers=[


### PR DESCRIPTION
We are fixing the version of vdk-core since we are planning a breaking change in IPropertiesServiceClient in a next version. We would adopt it in subsequent PR and un-fix the version. 

Testing Done: existing automated tests

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>