### PR TITLE
control-service: Change dep additional labels to be set using YML

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "pipelines-control-service.labels" . | nindent 4 }}
   {{- if .Values.deploymentAdditionalLabels }}
-  {{- .Values.deploymentAdditionalLabels | nindent 4 }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.deploymentAdditionalLabels "context" $) | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.replicas }}
@@ -21,7 +21,7 @@ spec:
     metadata:
       labels: {{- include "pipelines-control-service.labels" . | nindent 8 }}
       {{- if .Values.deploymentAdditionalLabels }}
-      {{- .Values.deploymentAdditionalLabels | nindent 8 }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.deploymentAdditionalLabels "context" $) | nindent 8 }}
       {{- end }}
       annotations:
         # https://helm.sh/docs/howto/charts_tips_and_tricks Automatically Roll Deployments


### PR DESCRIPTION
Previously, the additional labels used by the CS Deployment and
the pods it manages were set as a multiline string in Values.yml.
After this change, they are set as YML instead.

Testing done: set additional labels in Values.yml and ran `helm
install --dry-run`, observed labels in correct place

Signed-off-by: gageorgiev <gageorgiev@vmware.com>