### PR TITLE
vdk-logging-json: Escape double quotes in message

### DIFF
--- a/projects/vdk-core/plugins/vdk-logging-json/src/vdk/plugin/logging_json/logging_json.py
+++ b/projects/vdk-core/plugins/vdk-logging-json/src/vdk/plugin/logging_json/logging_json.py
@@ -19,14 +19,14 @@ format_template = (
 # this class serves to escape newline characters in the log message
 # as according to https://stackoverflow.com/questions/42068/how-do-i-handle-newlines-in-json
 # it is currently experimental and might be removed
-class RemoveNewlinesFormatter(logging.Formatter):
+class EscapeNewlinesAndQuotesFormatter(logging.Formatter):
     def __init__(self, fmt):
         super().__init__(fmt=fmt)
         self.default_time_format = "%Y-%m-%dT%H:%M:%S"
         self.default_msec_format = "%s.%03dZ"
 
     def format(self, record):
-        record.msg = record.msg.replace("\n", "\\n")
+        record.msg = record.msg.replace("\n", "\\n").replace('"', '\\"')
         return super().format(record)
 
 
@@ -36,7 +36,7 @@ def vdk_start(plugin_registry: IPluginRegistry, command_line_args: List):
         "{" + format_template.format(job_name="", attempt_id="") + "}"
     )  # appending the braces
     for handler in logging.getLogger().handlers:
-        formatter = RemoveNewlinesFormatter(fmt=format_copy)
+        formatter = EscapeNewlinesAndQuotesFormatter(fmt=format_copy)
 
         handler.setFormatter(formatter)
 
@@ -51,6 +51,6 @@ def initialize_job(context: JobContext) -> None:
     )  # appending the braces
 
     for handler in logging.getLogger().handlers:
-        formatter = RemoveNewlinesFormatter(fmt=detailed_format)
+        formatter = EscapeNewlinesAndQuotesFormatter(fmt=detailed_format)
 
         handler.setFormatter(formatter)

--- a/projects/vdk-core/plugins/vdk-logging-json/tests/test_logging_json.py
+++ b/projects/vdk-core/plugins/vdk-logging-json/tests/test_logging_json.py
@@ -2,9 +2,32 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 
+from vdk.plugin.logging_json.logging_json import EscapeNewlinesAndQuotesFormatter
 from vdk.plugin.logging_json.logging_json import format_template
 
 
 def test_json_logging():
     for handler in logging.getLogger(__name__).handlers:
         assert handler.formatter._fmt == format_template
+
+
+def test_formatter():
+    formatter = EscapeNewlinesAndQuotesFormatter(fmt="")
+
+    log_record = logging.LogRecord(
+        name="",
+        level=1,
+        pathname="",
+        lineno=1,
+        msg="test-string",
+        args=(),
+        exc_info=None,
+    )
+
+    assert formatter.format(log_record) == "test-string"
+
+    log_record.msg = "test\nstring\nwith\nnewlines"
+    assert formatter.format(log_record) == "test\\nstring\\nwith\\nnewlines"
+
+    log_record.msg = 'test"string"with"double"quotes'
+    assert formatter.format(log_record) == 'test\\"string\\"with\\"double\\"quotes'


### PR DESCRIPTION
Double quotes in the log message would mess up the parsing, as
JSON separates fields and values based on double quote pairs.
This change escapes the double quotes in the message string.

Testing done: verified that the formatted log with double quotes
in the message is valid JSON
Logs before:
```
{"@timestamp":"2021-10-05T14:15:00.959Z","created":"1633432500.959478","jobname":"gg-job2","level":"INFO","modulename":"vdk.internal.builtin_plugins.run.cli_run","filename":"cli_run.py","lineno":"66","funcname":"run_job","attemptid":"1633432500-7b4ee0-db01f0","message":"Data Job execution summary: {\n  "data_job_name": "gg-job2",\n  "execution_id": "1633432500-7b4ee0",\n  "start_time": "2021-10-05T11:15:00.958685",\n  "end_time": "2021-10-05T11:15:00.959378",\n  "status": "success",\n  "steps_list": [\n    {\n      "name": "10.py",\n      "type": "python",\n      "start_time": "2021-10-05T11:15:00.958709",\n      "end_time": "2021-10-05T11:15:00.959355",\n      "status": "success",\n      "details": null,\n      "exception": null\n    }\n  ],\n  "exception": null\n}"}
```
This causes a JSON parsing error.

Logs after:
```
{"@timestamp":"2021-10-05T14:18:15.617Z","created":"1633432695.617323","jobname":"gg-job2","level":"INFO","modulename":"vdk.internal.builtin_plugins.run.cli_run","filename":"cli_run.py","lineno":"66","funcname":"run_job","attemptid":"1633432695-a89cbb-d5a5c7","message":"Data Job execution summary: {\n  \"data_job_name\": \"gg-job2\",\n  \"execution_id\": \"1633432695-a89cbb\",\n  \"start_time\": \"2021-10-05T11:18:15.616559\",\n  \"end_time\": \"2021-10-05T11:18:15.617217\",\n  \"status\": \"success\",\n  \"steps_list\": [\n    {\n      \"name\": \"10.py\",\n      \"type\": \"python\",\n      \"start_time\": \"2021-10-05T11:18:15.616584\",\n      \"end_time\": \"2021-10-05T11:18:15.617192\",\n      \"status\": \"success\",\n      \"details\": null,\n      \"exception\": null\n    }\n  ],\n  \"exception\": null\n}"}
```

Signed-off-by: gageorgiev <gageorgiev@vmware.com>