### PR TITLE
vdk-control-cli: fix warning message not to crash

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/create.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/create.py
@@ -84,7 +84,7 @@ class JobCreate:
                     why=f"Error is: {e}",
                     consequence="Local execution of the job might fail since the job may not have permissions to some resources",
                     countermeasure="Try to manually download the data job keytab with vdk",
-                )
+                ).message
             )
 
     def validate_job_path(self, path: str, name: str) -> None:

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli_impl.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli_impl.py
@@ -116,7 +116,7 @@ class JobDeploy:
                     why=f"VDK CLI did not clean up after deploying: {e}",
                     consequence="There is a leftover archive file next to the folder containing the data job",
                     countermeasure="Clean up the archive file manually or leave it",
-                )
+                ).message
             )
 
     def __update_data_job_deploy_configuration(

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/download_job.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/download_job.py
@@ -70,7 +70,7 @@ class JobDownloadSource:
                     why=f"VDK CLI did not clean up after deploying: {e}",
                     consequence="There is a leftover archive file next to the folder containing the data job",
                     countermeasure="Clean up the archive file manually or leave it",
-                )
+                ).message
             )
 
 


### PR DESCRIPTION
Some warning messages were causing issues sinc we use VDKEXception to
format the log message and the type is not string.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>