### PR TITLE
vdk-control-cli: auto-create base config directory

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/configuration/vdk_config.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/configuration/vdk_config.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 import os
+import pathlib
 from configparser import ConfigParser
 from pathlib import Path
 
@@ -146,8 +147,10 @@ class VDKConfigFolder:
                 self.vdk_config_folder
             ):
                 try:
-                    os.mkdir(self.vdk_config_folder)
-                except OSError as e:
+                    pathlib.Path(self.vdk_config_folder).mkdir(
+                        parents=True, exist_ok=True
+                    )
+                except Exception as e:
                     raise VDKException(
                         what="Configuration folder was not created and user is not logged in",
                         why=f"Cannot create: {self.vdk_config_folder} configuration folder: {str(e)}",

--- a/projects/vdk-control-cli/tests/vdk/internal/control/configuration/test_vdk_config.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/configuration/test_vdk_config.py
@@ -47,6 +47,12 @@ def test_config_folder_named_file_exists_error():
                 VDKConfigFolder(dir_path)
 
 
+def test_config_folder_parent_paths_created():
+    with tempfile.TemporaryDirectory() as dir_path:
+        config_path = os.path.join(dir_path, "parent_dir", ".vdk_dir")
+        VDKConfigFolder(config_path)
+
+
 # TODO: Check why os.chmod(cred_file_mock, stat.S_IREAD) don't change permissions in the gitlab runner container
 # def test_credentials_file_bad_permissions_exists_error():
 #    with tempfile.TemporaryDirectory() as dir_path:


### PR DESCRIPTION
When someone configures VDK_BASE_CONFIG_FOLDER=~/.stg.vdk for example,
the directory must exist beforehand or vdk fails. This is a small
improvement that prevents it from falling so users do not have to
manually configure it every time.

Testing Done: the unit test (incl new ones)

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>