### PR TITLE
control-service: fix vdk-heartbeat

### DIFF
--- a/projects/control-service/cicd/vdk-options.ini
+++ b/projects/control-service/cicd/vdk-options.ini
@@ -8,11 +8,6 @@ VDK_TRINO_CATALOG=memory
 VDK_TRINO_USER=data-job-user
 VDK_DB_DEFAULT_TYPE=TRINO
 
-# TODO: this must not be set here.
-# we should use vdk-control-service-api client to
-VDK_PROPERTIES_API_URL=${CONTROL_SERVICE_URL}/data-jobs/for-team/{team_name}/jobs/{job_name}/deployments/foo/properties
-VDK_PROPERTIES_API_TOKEN_AUTHORIZATION_URL=https://console-stg.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize
-VDK_PROPERTIES_API_TOKEN=${VDK_API_TOKEN}
-VDK_TOKEN_AUTHORIZATION_SERVER_URL=https://console-stg.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize
+VDK_API_TOKEN_AUTHORIZATION_URL=https://console-stg.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize
 VDK_CONTROL_SERVICE_REST_API_URL=${CONTROL_SERVICE_URL}
 VDK_API_TOKEN=${VDK_API_TOKEN}


### PR DESCRIPTION
The post-deployment test(vdk-heartbeat) seems to be failing with
authorization errors. I guess it is because of misconfiguration.

I set the correct VDK_OPTIONS file in Gitlab CI (it can be overridden by Gitlab CI Variable).
I think it might be better to leave it and edit it directly in Gitlab CI ? 
And keep the one in source control for reference purposes. 

Testing Done: I set VDK_OPTIONS file in
https://gitlab.com/vmware-analytics/versatile-data-kit/-/settings/ci_cd
and ran manually to deploy control service with new options in pipeline https://gitlab.com/vmware-analytics/versatile-data-kit/-/pipelines/386027936

And then ran post-deployment test in same pipeline

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>