### PR TITLE
vdk-core: configure correct attempt, execution and op id.

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/builtin_hook_impl.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/builtin_hook_impl.py
@@ -10,6 +10,7 @@ import click
 from vdk.api.plugin.core_hook_spec import JobRunHookSpecs
 from vdk.api.plugin.hook_markers import hookimpl
 from vdk.internal import vdk_build_info
+from vdk.internal.builtin_plugins.config import vdk_config
 from vdk.internal.builtin_plugins.config.config_help import ConfigHelpPlugin
 from vdk.internal.builtin_plugins.config.log_config import LoggingPlugin
 from vdk.internal.builtin_plugins.config.vdk_config import CoreConfigDefinitionPlugin
@@ -43,15 +44,6 @@ class RuntimeStateInitializePlugin:
     """
 
     @hookimpl(tryfirst=True)
-    def vdk_configure(self, config_builder: ConfigurationBuilder) -> None:
-        """
-        Some job attributes like op_id can be passed externally as configuration.
-        """
-        config_builder.add(CommonStoreKeys.OP_ID.key, None)
-        config_builder.add(CommonStoreKeys.EXECUTION_ID.key, None)
-        config_builder.add(CommonStoreKeys.ATTEMPT_ID.key, None)
-
-    @hookimpl(tryfirst=True)
     def vdk_initialize(self, context: CoreContext) -> None:
         """
         Setup common state attributes of the app (CommonStoreKeys).
@@ -63,9 +55,9 @@ class RuntimeStateInitializePlugin:
         * Execution id format is "op_id-random_suffix"
         * Op Id is random string.
         """
-        op_id = context.configuration.get_value(CommonStoreKeys.OP_ID.key)
-        execution_id = context.configuration.get_value(CommonStoreKeys.EXECUTION_ID.key)
-        attempt_id = context.configuration.get_value(CommonStoreKeys.ATTEMPT_ID.key)
+        op_id = context.configuration.get_value(vdk_config.OP_ID)
+        execution_id = context.configuration.get_value(vdk_config.EXECUTION_ID)
+        attempt_id = context.configuration.get_value(vdk_config.ATTEMPT_ID)
 
         if not op_id:
             op_id = str(int(time.time()))

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/vdk_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/vdk_config.py
@@ -18,6 +18,7 @@ JOB_GITHASH = "JOB_GITHASH"
 LOG_CONFIG = "LOG_CONFIG"
 LOG_LEVEL_VDK = "LOG_LEVEL_VDK"
 WORKING_DIR = "WORKING_DIR"
+ATTEMPT_ID = "ATTEMPT_ID"
 EXECUTION_ID = "EXECUTION_ID"
 OP_ID = "OP_ID"
 
@@ -70,20 +71,33 @@ class CoreConfigDefinitionPlugin:
             OP_ID,
             "",
             True,
-            "An identifier to be associated with the current VDK run, "
-            "or an empty string, to auto generate the identifier."
             "It identifies the trigger that initiated this job. "
-            "It is possible to have N jobs with same OpID (if Job1 started Job2 then Job1.opId = Job2.opId)."
+            "If left empty it will be auto-generated."
+            "OP ID is similar to trace ID in open tracing."
+            "It enable tracing multiple operations across difference services and datasets"
+            "For example, it is possible to have N jobs with same OpID (if Job1 started Job2 then Job1.opId = "
+            "Job2.opId). "
             "In HTTP requests it is passed as header 'X-OPID' by the Control Service.",
         )
         config_builder.add(
             EXECUTION_ID,
             "",
             True,
-            "An identifier to be associated with the current VDK execution, "
-            "or an empty string, to auto generate the identifier. "
+            "An identifier to be associated with the current VDK execution."
+            "If left empty it will be auto-generated. "
             "An instance of a running Data Job deployment is called an execution. "
-            "Data Job execution can run a Data Job one or more times. ",
+            "Data Job execution can run a Data Job one or more times. "
+            "It can be passed externally (in case of external re-tries are considered part of 1 execution).",
+        )
+        config_builder.add(
+            ATTEMPT_ID,
+            "",
+            True,
+            "An identifier to be associated with the current VDK execution attempt."
+            "If left empty it will be auto-generated. "
+            "An instance of a running Data Job deployment is called an execution. "
+            "Data Job execution can run a Data Job one or more times."
+            "Each distinct run would a single attempt.",
         )
 
 

--- a/projects/vdk-core/tests/functional/run/test_run_configuration.py
+++ b/projects/vdk-core/tests/functional/run/test_run_configuration.py
@@ -1,0 +1,45 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import os
+from typing import Optional
+from unittest import mock
+
+from click.testing import Result
+from functional.run import util
+from vdk.api.plugin.hook_markers import hookimpl
+from vdk.internal.builtin_plugins.run.execution_results import ExecutionResult
+from vdk.internal.builtin_plugins.run.job_context import JobContext
+from vdk.internal.core.statestore import CommonStoreKeys
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "VDK_OP_ID": "my-op-id",
+        "VDK_EXECUTION_ID": "my-execution-id",
+        "VDK_ATTEMPT_ID": "my-attempt-id",
+    },
+)
+def test_run_check_attempt_execution_op_id_are_set_correctly():
+    actual_ids = []
+
+    class PrintIdPlugin:
+        @hookimpl(tryfirst=True)
+        def run_job(self, context: JobContext) -> Optional[ExecutionResult]:
+            actual_ids.append(
+                context.core_context.state.get(CommonStoreKeys.ATTEMPT_ID)
+            )
+            actual_ids.append(
+                context.core_context.state.get(CommonStoreKeys.EXECUTION_ID)
+            )
+            actual_ids.append(context.core_context.state.get(CommonStoreKeys.OP_ID))
+            return None  # continue with next hook impl.
+
+    runner = CliEntryBasedTestRunner(PrintIdPlugin())
+
+    result: Result = runner.invoke(["run", util.job_path("simple-job")])
+
+    cli_assert_equal(0, result)
+    assert actual_ids == ["my-attempt-id", "my-execution-id", "my-op-id"]


### PR DESCRIPTION
For a configuration variable to be used it needs to be defined with
ConfigurationBuilder#add. If it is not defined the environment variables
configuration provider will likely not detect it.

In our case we define attempt id using:

config_builder.add(CommonStoreKeys.ATTEMPT_ID.key, None)
...

This is the configuration store key which as string look like this:

    ATTEMPT_ID: StoreKey[str] = StoreKey[str]("vdk.attempt_id")

So we basically defined it as `vdk.attempt_id` and the (environment
variables) configuration provider appends VDK_ (and replaces dot with an
underscore). So it searches for
the environment variable named "VDK_VDK_ATTEMPT_ID" in this example.

execution_id and op_id already had correct definitions. In this change
we adding one for op id. And removing redundant ones.
Also try to improve their description a bit.

Testing Done: add new test. I decide to use functional type of test
since the logic spans more than one vdk core component/class instead of
a unit test.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>