### PR TITLE
vdk-sqlite: auto-create table if it does not exists

### DIFF
--- a/projects/vdk-core/plugins/vdk-sqlite/src/vdk/plugin/sqlite/sqlite_configuration.py
+++ b/projects/vdk-core/plugins/vdk-sqlite/src/vdk/plugin/sqlite/sqlite_configuration.py
@@ -1,0 +1,37 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import pathlib
+import tempfile
+
+from vdk.internal.core.config import Configuration
+from vdk.internal.core.config import ConfigurationBuilder
+
+SQLITE_FILE = "SQLITE_FILE"
+SQLITE_INGEST_AUTO_CREATE_TABLE_ENABLED = "SQLITE_INGEST_AUTO_CREATE_TABLE_ENABLED"
+
+
+class SQLiteConfiguration:
+    def __init__(self, configuration: Configuration):
+        self.__config = configuration
+
+    def get_auto_create_table_enabled(self) -> bool:
+        return self.__config.get_value(SQLITE_INGEST_AUTO_CREATE_TABLE_ENABLED)
+
+    def get_sqlite_file(self) -> pathlib.Path:
+        return pathlib.Path(self.__config.get_value(SQLITE_FILE))
+
+
+def add_definitions(config_builder: ConfigurationBuilder):
+    config_builder.add(
+        key=SQLITE_FILE,
+        default_value=str(
+            pathlib.Path(tempfile.gettempdir()).joinpath("vdk-sqlite.db")
+        ),
+        description="The file of the sqlite database.",
+    )
+    config_builder.add(
+        key=SQLITE_INGEST_AUTO_CREATE_TABLE_ENABLED,
+        default_value=True,
+        description="If set to true, auto create table if it does not exists during ingestion."
+        "This is only applicable when ingesting data into sqlite (ingest method is sqlite).",
+    )

--- a/projects/vdk-core/plugins/vdk-sqlite/src/vdk/plugin/sqlite/sqlite_connection.py
+++ b/projects/vdk-core/plugins/vdk-sqlite/src/vdk/plugin/sqlite/sqlite_connection.py
@@ -5,23 +5,9 @@ import pathlib
 import tempfile
 from typing import List
 
-from vdk.internal.core.config import Configuration
 from vdk.internal.util.decorators import closing_noexcept_on_close
 
-SQLITE_FILE = "SQLITE_FILE"
-
 log = logging.getLogger(__name__)
-
-
-class SQLiteConfiguration:
-    def __init__(self, configuration: Configuration):
-        self.__config = configuration
-
-    def get_default_ingest_target(self) -> pathlib.Path:
-        return pathlib.Path(self.__config.get_value("INGEST_TARGET_DEFAULT"))
-
-    def get_sqlite_file(self) -> pathlib.Path:
-        return pathlib.Path(self.__config.get_value(SQLITE_FILE))
 
 
 class SQLiteConnection:

--- a/projects/vdk-core/plugins/vdk-sqlite/src/vdk/plugin/sqlite/sqlite_plugin.py
+++ b/projects/vdk-core/plugins/vdk-sqlite/src/vdk/plugin/sqlite/sqlite_plugin.py
@@ -1,31 +1,20 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 import logging
-import os
 import pathlib
-import tempfile
 
 import click
 from tabulate import tabulate
 from vdk.api.plugin.hook_markers import hookimpl
 from vdk.internal.builtin_plugins.run.job_context import JobContext
 from vdk.internal.core.config import ConfigurationBuilder
+from vdk.internal.util.decorators import closing_noexcept_on_close
+from vdk.plugin.sqlite import sqlite_configuration
 from vdk.plugin.sqlite.ingest_to_sqlite import IngestToSQLite
-from vdk.plugin.sqlite.sqlite_connection import SQLITE_FILE
-from vdk.plugin.sqlite.sqlite_connection import SQLiteConfiguration
+from vdk.plugin.sqlite.sqlite_configuration import SQLiteConfiguration
 from vdk.plugin.sqlite.sqlite_connection import SQLiteConnection
 
 log = logging.getLogger(__name__)
-
-
-def add_definitions(config_builder: ConfigurationBuilder):
-    config_builder.add(
-        key=SQLITE_FILE,
-        default_value=str(
-            pathlib.Path(tempfile.gettempdir()).joinpath("vdk-sqlite.db")
-        ),
-        description="The file of the sqlite database.",
-    )
 
 
 @hookimpl
@@ -33,7 +22,7 @@ def vdk_configure(config_builder: ConfigurationBuilder) -> None:
     """
     Here we define what configuration settings are needed for sqlite with reasonable defaults
     """
-    add_definitions(config_builder)
+    sqlite_configuration.add_definitions(config_builder)
 
 
 @hookimpl
@@ -57,8 +46,12 @@ def initialize_job(context: JobContext) -> None:
 def sqlite_query(ctx: click.Context, query):
     conf = SQLiteConfiguration(ctx.obj.configuration)
     conn = SQLiteConnection(conf.get_sqlite_file())
-    res = conn.execute_query(query)
-    click.echo(tabulate(res))
+
+    with closing_noexcept_on_close(conn.new_connection().cursor()) as cursor:
+        cursor.execute(query)
+        column_names = [column_info[0] for column_info in cursor.description]
+        res = cursor.fetchall()
+        click.echo(tabulate(res, headers=column_names))
 
 
 @hookimpl


### PR DESCRIPTION
I was experimenting with vdk ingest-csv and user may want to ingest
locally new data into local database to do some quick analysis on it.

I also saw this use-case while going through data engineering
forums and saw it a few times.

Concrete examples was user want to create some kind of transformations
which is very hard to do with excel only.
Now users can do
```
vdk ingest-csv -f excel.csv
vdk export-csv -q "select count(1), name from excel group by name"
```

Though currently export-csv is missing
(https://github.com/vmware/versatile-data-kit/issues/370) but they can
at least do
vdk sqlite-query -q "query" which will printed it to stdout as ascii
table.

In case users want more strict behaviour it can be disabled with flag
SQLITE_INGEST_AUTO_CREATE_TABLE_ENABLED

Testing Done: locally the above scenario + the modified tests

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>