### PR TITLE
control-service: add unit test for jobs repository

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobsRepositoryIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobsRepositoryIT.java
@@ -57,4 +57,17 @@ public class JobsRepositoryIT {
 
       Assertions.assertEquals(entity.getLatestJobDeploymentStatus(), DeploymentStatus.NONE);
    }
+
+   @Test
+   void testUpdateDataJobEnabledByName() {
+      var entity = new DataJob("hello", new JobConfig(), DeploymentStatus.NONE);
+      entity.setEnabled(true);
+      repository.save(entity);
+
+      repository.updateDataJobEnabledByName("hello", false);
+
+      var persistedEntity = repository.findById("hello");
+      Assertions.assertTrue(persistedEntity.isPresent());
+      Assertions.assertFalse(persistedEntity.get().getEnabled());
+   }
 }


### PR DESCRIPTION
A recently added functionality (`JobsRepository.updateDataJobEnabledByName`)
did not have tests.

This commit aims to remedy that.

Signed-off-by: Tsvetomir Palashki <tpalashki@vmware.com>