### PR TITLE
vdk-core: show default values in vdk config-help

### DIFF
--- a/projects/vdk-core/src/vdk/internal/core/config.py
+++ b/projects/vdk-core/src/vdk/internal/core/config.py
@@ -145,7 +145,7 @@ class ConfigurationBuilder:
         self,
         key: ConfigKey,
         default_value: ConfigValue,
-        show_default_value=False,
+        show_default_value=True,
         description=None,
     ) -> ConfigurationBuilder:
         """


### PR DESCRIPTION
We were defaulting to not showing default values. But that seems
a mistake. Default values enable users to more quickly understand the
configuration (as they are an example) and also to see how the vdk would
behave if left unset.

Testing Done: vdk config-help locally and saw they are populated. unit
tests

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>