### PR TITLE
vdk-sqlite: Fix sqlite-query bug caused by no cursor description

### DIFF
--- a/projects/vdk-core/plugins/vdk-sqlite/src/vdk/plugin/sqlite/sqlite_plugin.py
+++ b/projects/vdk-core/plugins/vdk-sqlite/src/vdk/plugin/sqlite/sqlite_plugin.py
@@ -39,7 +39,7 @@ def initialize_job(context: JobContext) -> None:
 
 
 @click.command(
-    name="sqlite-query", help="Execute a SQL query against a local SQlite database."
+    name="sqlite-query", help="Execute a SQL query against a local SQLite database."
 )
 @click.option("-q", "--query", type=click.STRING, required=True)
 @click.pass_context
@@ -49,7 +49,11 @@ def sqlite_query(ctx: click.Context, query):
 
     with closing_noexcept_on_close(conn.new_connection().cursor()) as cursor:
         cursor.execute(query)
-        column_names = [column_info[0] for column_info in cursor.description]
+        column_names = (
+            [column_info[0] for column_info in cursor.description]
+            if cursor.description
+            else ()  # same as the default value for the headers parameter of the tabulate function
+        )
         res = cursor.fetchall()
         click.echo(tabulate(res, headers=column_names))
 


### PR DESCRIPTION
Sometimes, the result of a SQL query has no description for the
cursor, for example when executing a `DROP TABLE` query. This
causes a `NoneType isn't iterable` error, since we still try
to iterate over the description to get the column names. Note
that this issue was merely a cosmetic one, as the query would
still be executed successfully.
This change fixes this by nesting the printing statements inside
an if-block which checks if the cursor description exists.

Testing done: ran DROP TABLE and observed no errors were caused

Signed-off-by: gageorgiev <gageorgiev@vmware.com>