### PR TITLE
control-service: Fix authentication when pulling images

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/_helpers.tpl
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/_helpers.tpl
@@ -192,3 +192,10 @@ JDBC secret name
 {{- define "pipelines-control-service.jdbcSecretName" -}}
 {{ include "common.names.fullname" . }}-jdbc
 {{- end -}}
+
+{{/*
+Image Pull Secret in json format
+*/}}
+{{- define "imagePullSecretJson" }}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.deploymentDockerRepository (printf "%s:%s" .Values.deploymentDockerRegistryUsernameReadOnly .Values.deploymentDockerRegistryPasswordReadOnly | b64enc) | b64enc }}
+{{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -80,6 +80,10 @@ spec:
               value: "{{ .Values.deploymentDockerRegistryUsername }}"
             - name: DOCKER_REGISTRY_PASSWORD
               value: "{{ .Values.deploymentDockerRegistryPassword }}"
+            {{- if and (eq .Values.deploymentDockerRegistryType "generic") .Values.deploymentDockerRegistryUsernameReadOnly .Values.deploymentDockerRegistryPasswordReadOnly }}
+            - name: DOCKER_REGISTRY_SECRET
+              value: {{ template "pipelines-control-service.fullname" . }}-docker-repo-creds
+            {{- end }}
             - name: DOCKER_REPOSITORY_URL
               value: "{{ .Values.deploymentDockerRepository }}"
             - name: DOCKER_VDK_BASE_IMAGE

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_img.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_img.yaml
@@ -1,0 +1,11 @@
+{{- if and (eq .Values.deploymentDockerRegistryType "generic") .Values.deploymentDockerRegistryUsernameReadOnly .Values.deploymentDockerRegistryPasswordReadOnly }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "pipelines-control-service.fullname" . }}-docker-repo-creds
+  namespace: {{ .Values.deploymentK8sNamespace }}
+  labels: {{- include "pipelines-control-service.labels" . | nindent 4 }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "imagePullSecretJson" . }}
+{{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -174,6 +174,13 @@ deploymentEcrAwsAccessKeySecret: ""
 deploymentDockerRegistryUsername: ""
 deploymentDockerRegistryPassword: ""
 
+## [Required if deploymentDockerRegistryType=generic and registry requires authentication]
+## Username and Password credentials in case the deploymentDockerRegistryType is generic.
+## Container registry credentials used for authenticating when pulling Data Job images.
+## The account with those credentials needs to have pull permissions over the registry.
+deploymentDockerRegistryUsernameReadOnly: ""
+deploymentDockerRegistryPasswordReadOnly: ""
+
 ## Image name of VDK which will be used to run the data jobs.
 ## It is recommended to use image with same tag (e.g release or latest)
 ## As it will be pulled before any execution thus making sure all jobs use the same and latest version of VDK.

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-test.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-test.properties
@@ -24,6 +24,7 @@ datajobs.docker.registryType=generic
 # Credentials for generic registry type like Harbor or Dockerhub.
 datajobs.docker.registryUsername=${DOCKER_REGISTRY_USERNAME}
 datajobs.docker.registryPassword=${DOCKER_REGISTRY_PASSWORD}
+datajobs.docker.registrySecret=${DOCKER_REGISTRY_SECRET:}
 
 #WebHook settings for the integration tests
 integrationTest.mockedWebHookServerHost=localhost

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -537,7 +537,7 @@ public abstract class KubernetesService implements InitializingBean {
                               List<V1Volume> volumes, Map<String, String> jobDeploymentAnnotations)
             throws ApiException {
         createCronJob(name, image, envs, schedule, enable, args, request, limit, jobContainer, initContainer,
-                volumes, jobDeploymentAnnotations, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+                volumes, jobDeploymentAnnotations, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), "");
     }
 
     // TODO:  container/volume args are breaking a bit abstraction of KubernetesService by leaking impl. details
@@ -545,11 +545,12 @@ public abstract class KubernetesService implements InitializingBean {
                               boolean enable, List<String> args, Resources request, Resources limit,
                               V1Container jobContainer, V1Container initContainer,
                               List<V1Volume> volumes, Map<String, String> jobDeploymentAnnotations,
-                              Map<String, String> jobPodLabels, Map<String, String> jobAnnotations, Map<String, String> jobLabels)
+                              Map<String, String> jobPodLabels, Map<String, String> jobAnnotations, Map<String, String> jobLabels,
+                              String imagePullSecret)
             throws ApiException {
         log.debug("Creating k8s cron job name:{}, image:{}", name, image);
         var cronJob = cronJobFromTemplate(name, schedule, !enable, jobContainer, initContainer,
-                volumes, jobDeploymentAnnotations, jobPodLabels, jobAnnotations, jobLabels);
+                volumes, jobDeploymentAnnotations, jobPodLabels, jobAnnotations, jobLabels, imagePullSecret);
         V1beta1CronJob nsJob = new BatchV1beta1Api(client).createNamespacedCronJob(namespace, cronJob, null, null, null);
         log.debug("Created k8s cron job: {}", nsJob);
         log.debug("Created k8s cron job name: {}, uid:{}, link:{}", nsJob.getMetadata().getName(), nsJob.getMetadata().getUid(), nsJob.getMetadata().getSelfLink());
@@ -561,17 +562,18 @@ public abstract class KubernetesService implements InitializingBean {
                               List<V1Volume> volumes, Map<String, String> jobDeploymentAnnotations)
             throws ApiException {
         updateCronJob(name, image, envs, schedule, enable, args, request, limit, jobContainer,
-                initContainer, volumes, jobDeploymentAnnotations, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+                initContainer, volumes, jobDeploymentAnnotations, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), "");
     }
 
     public void updateCronJob(String name, String image,  Map<String, String> envs, String schedule,
                               boolean enable, List<String> args, Resources request, Resources limit,
                               V1Container jobContainer, V1Container initContainer,
                               List<V1Volume> volumes, Map<String, String> jobDeploymentAnnotations,
-                              Map<String, String> jobPodLabels, Map<String, String> jobAnnotations, Map<String, String> jobLabels)
+                              Map<String, String> jobPodLabels, Map<String, String> jobAnnotations, Map<String, String> jobLabels,
+                              String imagePullSecret)
             throws ApiException {
         var cronJob = cronJobFromTemplate(name, schedule, !enable, jobContainer, initContainer,
-                volumes, jobDeploymentAnnotations, jobPodLabels, jobAnnotations, jobLabels);
+                volumes, jobDeploymentAnnotations, jobPodLabels, jobAnnotations, jobLabels, imagePullSecret);
         V1beta1CronJob nsJob = new BatchV1beta1Api(client).replaceNamespacedCronJob(name, namespace, cronJob, null, null, null);
         log.debug("Updated k8s cron job status for name:{}, image:{}, uid:{}, link:{}", name, image, nsJob.getMetadata().getUid(), nsJob.getMetadata().getSelfLink());
     }
@@ -1294,7 +1296,7 @@ public abstract class KubernetesService implements InitializingBean {
                                    Map<String, String> jobDeploymentAnnotations,
                                    Map<String, String> jobPodLabels,
                                    Map<String, String> jobAnnotations,
-                                   Map<String, String> jobLabels) {
+                                   Map<String, String> jobLabels, String imagePullSecret) {
         V1beta1CronJob cronjob = loadCronjobTemplate();
         checkForMissingEntries(cronjob);
         cronjob.getMetadata().setName(name);
@@ -1309,6 +1311,14 @@ public abstract class KubernetesService implements InitializingBean {
 
         cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations().putAll(jobAnnotations);
         cronjob.getSpec().getJobTemplate().getMetadata().getLabels().putAll(jobLabels);
+
+        if(!StringUtils.isEmpty(imagePullSecret)) {
+            var imagePullSecretObj = new V1LocalObjectReferenceBuilder()
+                    .withName(imagePullSecret)
+                    .build();
+            cronjob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().setImagePullSecrets(List.of(imagePullSecretObj));
+        }
+
 
         return cronjob;
     }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
@@ -13,6 +13,7 @@ import com.vmware.taurus.service.kubernetes.DataJobsKubernetesService;
 import com.vmware.taurus.service.model.*;
 import com.vmware.taurus.service.notification.NotificationContent;
 import io.kubernetes.client.ApiException;
+import io.kubernetes.client.models.V1LocalObjectReferenceBuilder;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,6 +39,9 @@ public class JobImageDeployer {
    // It may make sense to just pass the module name as argument instead of an image ???
    @Value("${datajobs.vdk.image}")
    private String vdkImage;
+
+   @Value("${datajobs.docker.registrySecret:}")
+   private String dockerRegistrySecret = "";
 
    private static final String VOLUME_NAME = "vdk";
    private static final String VOLUME_MOUNT_PATH = "/vdk";
@@ -212,12 +216,14 @@ public class JobImageDeployer {
          dataJobsKubernetesService.updateCronJob(cronJobName, jobDeployment.getImageName(), jobContainerEnvVars, schedule,
                  jobDeployment.getEnabled(), List.of(), defaultConfigurations.dataJobRequests(),
                  defaultConfigurations.dataJobLimits(), jobContainer,
-                 jobInitContainer, Arrays.asList(volume, secretVolume), jobDeploymentAnnotations, Collections.emptyMap(), jobAnnotations, jobLabels);
+                 jobInitContainer, Arrays.asList(volume, secretVolume), jobDeploymentAnnotations, Collections.emptyMap(),
+                 jobAnnotations, jobLabels, dockerRegistrySecret);
       } else {
          dataJobsKubernetesService.createCronJob(cronJobName, jobDeployment.getImageName(), jobContainerEnvVars, schedule,
                  jobDeployment.getEnabled(), List.of(), defaultConfigurations.dataJobRequests(),
                  defaultConfigurations.dataJobLimits(), jobContainer,
-                 jobInitContainer, Arrays.asList(volume, secretVolume), jobDeploymentAnnotations, Collections.emptyMap(), jobAnnotations, jobLabels);
+                 jobInitContainer, Arrays.asList(volume, secretVolume), jobDeploymentAnnotations, Collections.emptyMap(),
+                 jobAnnotations, jobLabels, dockerRegistrySecret);
       }
    }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -66,6 +66,7 @@ datajobs.docker.registryType=generic
 
 # Docker repository used to store Versatile Data Kit images
 datajobs.docker.repositoryUrl=ghcr.io/versatile-data-kit-dev/dp
+datajobs.docker.registrySecret=${DOCKER_REGISTRY_SECRET:}
 
 # open API generator is not generating example for parameters and causing noisy warnings
 logging.level.io.swagger.models.parameters.AbstractSerializableParameter=ERROR

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/MockKubernetes.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/MockKubernetes.java
@@ -83,7 +83,7 @@ public class MockKubernetes {
       doAnswer(inv -> crons.put(inv.getArgument(0), inv))
               .when(mock).createCronJob(anyString(), anyString(), any(), anyString(), anyBoolean(), any(), any(), any(), any(), any(), any(), any());
       doAnswer(inv -> crons.put(inv.getArgument(0), inv))
-              .when(mock).createCronJob(anyString(), anyString(), any(), anyString(), anyBoolean(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+              .when(mock).createCronJob(anyString(), anyString(), any(), anyString(), anyBoolean(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), anyString());
       doAnswer(inv -> crons.put(inv.getArgument(0), inv))
               .when(mock).updateCronJob(anyString(), anyString(), any(), anyString(), anyBoolean(), any(), any(), any(), any(), any(), any(), any());
       doAnswer(inv -> crons.keySet()).when(mock).listCronJobs();

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobImageDeployerTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobImageDeployerTest.java
@@ -84,7 +84,7 @@ public class JobImageDeployerTest {
                    .createCronJob(Mockito.anyString(), Mockito.anyString(), Mockito.anyMap(), Mockito.anyString(),
                                    Mockito.anyBoolean(), Mockito.anyList(), Mockito.any(), Mockito.any(), Mockito.any(),
                                    Mockito.any(), Mockito.anyList(), Mockito.anyMap(), Mockito.anyMap(),
-                                   annotationCaptor.capture(), labelCaptor.capture());
+                                   annotationCaptor.capture(), labelCaptor.capture(), Mockito.anyString());
             //execute public method.
             jobImageDeployer.scheduleJob(dataJob, jobDeployment, false, "lastDeployedBy");
             //verify we called the method only once.
@@ -92,7 +92,7 @@ public class JobImageDeployerTest {
                    .createCronJob(Mockito.anyString(), Mockito.anyString(), Mockito.anyMap(), Mockito.anyString(),
                                    Mockito.anyBoolean(), Mockito.anyList(), Mockito.any(), Mockito.any(), Mockito.any(),
                                    Mockito.any(), Mockito.anyList(), Mockito.anyMap(), Mockito.anyMap(), Mockito.anyMap(),
-                                   Mockito.anyMap());
+                                   Mockito.anyMap(), Mockito.anyString());
             //extract labels/annotations from call
             var labels = labelCaptor.getValue();
             var annotations = annotationCaptor.getValue();

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -205,7 +205,7 @@ public class KubernetesServiceTest {
                 Assertions.fail("The method 'cronJobFromTemplate' does not exist.");
             }
             method.get().setAccessible(true);
-            V1beta1CronJob cronjob = (V1beta1CronJob) method.get().invoke(service, "test-job-name", "test-job-schedule", true, null, null, null, Collections.EMPTY_MAP, Collections.EMPTY_MAP, Collections.EMPTY_MAP, Collections.EMPTY_MAP);
+            V1beta1CronJob cronjob = (V1beta1CronJob) method.get().invoke(service, "test-job-name", "test-job-schedule", true, null, null, null, Collections.EMPTY_MAP, Collections.EMPTY_MAP, Collections.EMPTY_MAP, Collections.EMPTY_MAP, "");
             Assertions.assertEquals("test-job-name", cronjob.getMetadata().getName());
             Assertions.assertEquals("test-job-schedule", cronjob.getSpec().getSchedule());
             Assertions.assertEquals(true, cronjob.getSpec().isSuspend());

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
@@ -146,7 +146,7 @@ public class DeploymentServiceTest {
       verify(kubernetesService).createCronJob(eq(TEST_CRONJOB_NAME), eq(TEST_JOB_IMAGE_NAME), any(),
             eq(TEST_JOB_SCHEDULE), eq(true), any(), any(), any(),
               any(),
-              any(), any(), any(), any(), any(), any());
+              any(), any(), any(), any(), any(), any(), anyString());
       verify(deploymentMonitor).recordDeploymentStatus(jobDeployment.getDataJobName(), DeploymentStatus.SUCCESS);
       verify(dataJobNotification).notifyJobDeploySuccess(testDataJob.getJobConfig());
 
@@ -172,7 +172,7 @@ public class DeploymentServiceTest {
       verify(dockerRegistryService).dataJobImage(TEST_JOB_NAME, "test-commit");
       verify(jobImageBuilder).buildImage(TEST_JOB_IMAGE_NAME, testDataJob, jobDeployment, true);
       verify(kubernetesService).updateCronJob(eq(TEST_CRONJOB_NAME), eq(TEST_JOB_IMAGE_NAME), any(),
-            eq(TEST_JOB_SCHEDULE), eq(true), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+            eq(TEST_JOB_SCHEDULE), eq(true), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), anyString());
       verify(deploymentMonitor).recordDeploymentStatus(jobDeployment.getDataJobName(), DeploymentStatus.SUCCESS);
       verify(dataJobNotification).notifyJobDeploySuccess(testDataJob.getJobConfig());
 
@@ -235,7 +235,7 @@ public class DeploymentServiceTest {
       deploymentService.enableDeployment(testDataJob, jobDeployment, true, TEST_PRINCIPAL_NAME);
 
       verify(kubernetesService).createCronJob(eq(TEST_CRONJOB_NAME), eq(TEST_JOB_IMAGE_NAME), any(),
-            eq(TEST_JOB_SCHEDULE), eq(true), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+            eq(TEST_JOB_SCHEDULE), eq(true), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), anyString());
 
       var dataJobCaptor = ArgumentCaptor.forClass(DataJob.class);
       verify(jobsRepository).save(dataJobCaptor.capture());
@@ -253,7 +253,7 @@ public class DeploymentServiceTest {
       deploymentService.enableDeployment(testDataJob, jobDeployment, false, TEST_PRINCIPAL_NAME);
 
       verify(kubernetesService).createCronJob(eq(TEST_CRONJOB_NAME), eq(TEST_JOB_IMAGE_NAME), any(),
-            eq(TEST_JOB_SCHEDULE), eq(false), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+            eq(TEST_JOB_SCHEDULE), eq(false), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), anyString());
 
       var dataJobCaptor = ArgumentCaptor.forClass(DataJob.class);
       verify(jobsRepository).save(dataJobCaptor.capture());

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageDeployerTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageDeployerTest.java
@@ -120,7 +120,7 @@ public class JobImageDeployerTest {
               " strconv.Atoi: parsing \\\"a\\\": invalid syntax\",\"field\":\"spec.schedule\"}]},\"code\":422}"))
               .when(kubernetesService)
               .updateCronJob(anyString(), anyString(), anyMap(), anyString(), anyBoolean(), anyList(), any(KubernetesService.Resources.class),
-                      any(KubernetesService.Resources.class), any(V1Container.class), any(V1Container.class), any(List.class), anyMap(), anyMap(), anyMap(), anyMap());
+                      any(KubernetesService.Resources.class), any(V1Container.class), any(V1Container.class), any(List.class), anyMap(), anyMap(), anyMap(), anyMap(), anyString());
 
       jobImageDeployer.scheduleJob(testDataJob, jobDeployment, true, TEST_PRINCIPAL_NAME);
       verify(deploymentProgress).failed(any(), any(), eq(DeploymentStatus.USER_ERROR), anyString(), anyBoolean());
@@ -142,7 +142,7 @@ public class JobImageDeployerTest {
       ArgumentCaptor<V1Container> containerCaptor = ArgumentCaptor.forClass(V1Container.class);
       verify(kubernetesService).createCronJob(anyString(), anyString(), anyMap(), anyString(), anyBoolean(),
               anyList(), any(KubernetesService.Resources.class), any(KubernetesService.Resources.class),
-              containerCaptor.capture(), any(V1Container.class), anyList(), anyMap(), anyMap(), anyMap(), anyMap());
+              containerCaptor.capture(), any(V1Container.class), anyList(), anyMap(), anyMap(), anyMap(), anyMap(), anyString());
       var jobContainer = containerCaptor.getValue();
       Assertions.assertEquals(testDataJob.getName(), jobContainer.getName());
    }

--- a/projects/control-service/projects/pipelines_control_service/src/test/resources/application-unittest.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/test/resources/application-unittest.properties
@@ -9,6 +9,7 @@ datajobs.kerberos.principal.suffix=
 
 datajobs.docker.registryUsername=
 datajobs.docker.registryPassword=
+datajobs.docker.registrySecret=
 datajobs.vdk_options_ini=
 
 datajobs.deployment.k8s.kubeconfig=


### PR DESCRIPTION
Some control-service instances need to store Data Job
images in a private container registry, so we need to
apply registry credentials when pulling Data Job images.

Add secret containing docker registry credentials to the
pipelines_control_service helm chart and set it in
cron jobs on deploy (imagePullSecrets).

Tested by created, deploying and executing a Data Job
against a control service instance configured to push/pull
images to/from a private container registry.

Signed-off-by: Yana Zhivkova <yzhivkova@vmware.com>