### PR TITLE
contro-service: revert some logic related to false-positive emails

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMonitor.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMonitor.java
@@ -197,9 +197,7 @@ public class DataJobMonitor {
 
 
     private boolean shouldUpdateTerminationStatus(DataJob dataJob, String executionId, ExecutionTerminationStatus terminationStatus) {
-        if (terminationStatus == null ||
-                terminationStatus == ExecutionTerminationStatus.NONE ||
-                terminationStatus == ExecutionTerminationStatus.SKIPPED) {
+        if (terminationStatus == ExecutionTerminationStatus.SKIPPED) {
             log.debug("The termination status of data job {} will not be updated. New status is: {}", dataJob.getName(), terminationStatus);
             return false;
         }


### PR DESCRIPTION
Last batch of changes to handle false-positive notifications introduced
a logic that skips updating the last_job_termination_status of a data job
if it is NONE or null.

This was incorrect because of how we find the execution_id inside rules: by
cross-referencing to the last kube_job_status_start_time metric. In this case, if
the last execution terminated with an error and a new execution starts, we will
cross-reference the last termination status (error) with the new job execution
and will send a notification.

This commit reverts the old logic that sents the last_job_termination_status
to NONE when a new execution starts.

Testing done: unit tests

Signed-off-by: Tsvetomir Palashki <tpalashki@vmware.com>