### PR TITLE
[control-service]:fix memoryToMB conversion overflow in KubernetesService

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -1488,7 +1488,15 @@ public abstract class KubernetesService implements InitializingBean {
       return Optional.ofNullable(deployment);
    }
 
-    private static int convertMemoryToMBs(Quantity quantity) {
+    /**
+     * Default for testing purposes.
+     * This method returns the megabytes amount contained in a
+     * quantity.
+     *
+     * @param quantity the quantity to convert.
+     * @return integer MB's in the quantity
+     */
+    static int convertMemoryToMBs(Quantity quantity) {
         var divider = BigInteger.valueOf(1024);
         if (quantity.getFormat().getBase() == 10) {
             divider = BigInteger.valueOf(1000);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -44,6 +44,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
 import java.io.*;
+import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Instant;
@@ -1488,12 +1489,12 @@ public abstract class KubernetesService implements InitializingBean {
    }
 
     private static int convertMemoryToMBs(Quantity quantity) {
-        long divider = 1024;
-
+        var divider = BigInteger.valueOf(1024);
         if (quantity.getFormat().getBase() == 10) {
-            divider = 1000;
+            divider = BigInteger.valueOf(1000);
         }
-
-        return (int) (quantity.getNumber().intValue() / (divider * divider));
+        return quantity.getNumber().toBigInteger()
+                       .divide(divider.multiply(divider))
+                       .intValue();
     }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -218,4 +218,47 @@ public class KubernetesServiceTest {
         }
     }
 
+    @Test
+    public void testQuantityToMbConversionMegabytes() throws Exception {
+        var hundredMb = "100M";
+        testQuantityToMbConversion(100, hundredMb);
+
+        var thousandMb = "1000M";
+        testQuantityToMbConversion(1000, thousandMb);
+        // this should be enough for overflow errors on the method to manifest.
+        var tenThousandMb = "10000M";
+        testQuantityToMbConversion(10000, tenThousandMb);
+
+        var hundredThousandMb = "100000M";
+        testQuantityToMbConversion(100000, hundredThousandMb);
+
+    }
+
+    @Test
+    public void testQuantityConversionGigabytes() throws Exception {
+        var oneG = "1G";
+        testQuantityToMbConversion(1000, oneG);
+
+        var twoG = "2G";
+        testQuantityToMbConversion(2000, twoG);
+        // this should be enough for overflow errors on the method to manifest.
+        var threeG = "3G";
+        testQuantityToMbConversion(3000, threeG);
+
+        var fourG = "4G";
+        testQuantityToMbConversion(4000, fourG);
+
+        var sixtyFourG = "64G";
+        testQuantityToMbConversion(64000, sixtyFourG);
+    }
+
+    public void testQuantityToMbConversion(int expectedMb, String providedResources) throws Exception {
+        Method convertMemoryToMBs = KubernetesService.class.getDeclaredMethod("convertMemoryToMBs", Quantity.class);
+        convertMemoryToMBs.setAccessible(true);
+        var q = Quantity.fromString(providedResources);
+        var actual = (int) convertMemoryToMBs.invoke(convertMemoryToMBs, q);
+
+        Assertions.assertEquals(expectedMb, actual);
+    }
+
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -253,11 +253,9 @@ public class KubernetesServiceTest {
     }
 
     public void testQuantityToMbConversion(int expectedMb, String providedResources) throws Exception {
-        Method convertMemoryToMBs = KubernetesService.class.getDeclaredMethod("convertMemoryToMBs", Quantity.class);
-        convertMemoryToMBs.setAccessible(true);
+        KubernetesService service = new DataJobsKubernetesService("default", "someConfig");
         var q = Quantity.fromString(providedResources);
-        var actual = (int) convertMemoryToMBs.invoke(convertMemoryToMBs, q);
-
+        var actual = service.convertMemoryToMBs(q);
         Assertions.assertEquals(expectedMb, actual);
     }
 

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -253,9 +253,8 @@ public class KubernetesServiceTest {
     }
 
     public void testQuantityToMbConversion(int expectedMb, String providedResources) throws Exception {
-        KubernetesService service = new DataJobsKubernetesService("default", "someConfig");
         var q = Quantity.fromString(providedResources);
-        var actual = service.convertMemoryToMBs(q);
+        var actual = KubernetesService.convertMemoryToMBs(q);
         Assertions.assertEquals(expectedMb, actual);
     }
 


### PR DESCRIPTION
why: We noticed in the logs that a running control service 
would update a data job execution with a negative value for 
memory allocation. As a user I want to know for certain the 
allocated memory resources for a data job and a negative
value is an obvious bug.

what: Changed culprit function's implementation to use BigInteger instead
of int as the calculations it was performing would easily overflow the int
value at around 2gb or more.

testing: Added unit tests that verify function is working as intended
on small and large conversion numbers.

Signed-off-by: Momchil Zhivkov <mzhivkov@vmware.com>