### PR TITLE
control-service: reduce the k8s job deadline to 12 hours

### DIFF
--- a/projects/control-service/CHANGELOG.md
+++ b/projects/control-service/CHANGELOG.md
@@ -11,10 +11,18 @@ MAJOR.MINOR - dd.MM.yyyy
 
 * **Breaking Changes**
 
-1.3 - 22.10.2021
 
+1.3 - 2.11.2021
+----
+* **Improvement**
+  * Reduce the maximum duration of a data job execution to 12 hours
+
+
+1.3 - 22.10.2021
+----
 * **Bug fixes**
   * Proper classification of data job requirements.txt errors
+
 
 1.3 - 26.10.2021
 ----

--- a/projects/control-service/CHANGELOG.md
+++ b/projects/control-service/CHANGELOG.md
@@ -21,7 +21,7 @@ MAJOR.MINOR - dd.MM.yyyy
 1.3 - 2.11.2021
 ----
 * **Improvement**
-  * Reduce the maximum duration of a data job execution to 12 hours
+  * Reduce the default maximum duration of a data job execution to 12 hours
 
 
 1.3 - 22.10.2021

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -744,7 +744,7 @@ datajobTemplate:
       suspend: false                 # overridden by TPCS
       jobTemplate:
         spec:
-          activeDeadlineSeconds: 129600
+          activeDeadlineSeconds: 43200
           backoffLimit: 3
           template:
             metadata:

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/k8s-data-job-template.yaml
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/k8s-data-job-template.yaml
@@ -18,7 +18,7 @@ spec:
       annotations: # merged with additional annotations from TPCS
       labels: # merged with additional labels from TPCS
     spec:
-      activeDeadlineSeconds: 129600
+      activeDeadlineSeconds: 43200
       backoffLimit: 3
       template:
         metadata:


### PR DESCRIPTION
Currently, Kubernetes jobs used for data job executions are configured by default
to run for up to 36 hours before being terminated.
This is a long time for single job execution. After examining the potential
impact of reducing this value on existing adoptions of the Versatile Data Kit,
I have decided to modify the deadline to use a more meaningful default of 12 hours.

Testing done: deployed a new data job and verified that its activeDeadlineSeconds is
now 12 hours.

Signed-off-by: Tsvetomir Palashki <tpalashki@vmware.com>