### PR TITLE
control-service: Update Builder Job Version in helm

### DIFF
--- a/projects/control-service/CHANGELOG.md
+++ b/projects/control-service/CHANGELOG.md
@@ -11,6 +11,11 @@ MAJOR.MINOR - dd.MM.yyyy
 
 * **Breaking Changes**
 
+1.3 - 02.11.2021
+
+* **Bug fixes**
+  * Remove logging of credentials in builder jobs.
+
 1.3 - 22.10.2021
 
 * **Bug fixes**

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -25,7 +25,7 @@ image:
 deploymentBuilderImage:
   registry: registry.hub.docker.com/versatiledatakit
   repository: job-builder
-  tag: "1.2"
+  tag: "1.2.1"
 
 
 ## String to partially override pipelines-control-service.fullname template (will maintain the release name)


### PR DESCRIPTION
This change updates the version of the builder job image used
by the Control Service when deploying data jobs.

Testing Done: CI/CD Pipelines. Artefact in docker hub:
https://hub.docker.com/layers/175175600/versatiledatakit/job-builder/1.2.1/images/sha256-bb41b45fd10d109ccdd50f728c1d36413f91fdce94b9b02b203aa6c0049ceedd?context=repo

Signed-off-by: Andon Andonov <andonova@vmware.com>