### PR TITLE
control-service: Bump builder job version in helm

### DIFF
--- a/projects/control-service/CHANGELOG.md
+++ b/projects/control-service/CHANGELOG.md
@@ -12,6 +12,12 @@ MAJOR.MINOR - dd.MM.yyyy
 * **Breaking Changes**
 
 =======
+1.3 - 03.11.2021
+----
+* **Bug fixes**
+  * Remove debug mode for data job build and release script.
+
+
 1.3 - 02.11.2021
 ----
 * **Bug fixes**

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -25,7 +25,7 @@ image:
 deploymentBuilderImage:
   registry: registry.hub.docker.com/versatiledatakit
   repository: job-builder
-  tag: "1.2.1"
+  tag: "1.2.2"
 
 
 ## String to partially override pipelines-control-service.fullname template (will maintain the release name)


### PR DESCRIPTION
As part of the process of adopting the new builder image that
is to be used when deploying data jobs, we need to update the
version of the builder used by the Control Service.

This change updates the builder job image in the helm chart's
values.yml file.

Testing Done: Builder job image that is to be used is available
at https://hub.docker.com/layers/versatiledatakit/job-builder/1.2.2/images/sha256-8dd0d55bd9120621b557d5b36282084b453ca4cd0acb578999a34c8dc32fc5bd?context=repo

Signed-off-by: Andon Andonov <andonova@vmware.com>