### PR TITLE
control-service: return and udpate vdkVersion in Deployment

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudIT.java
@@ -176,6 +176,7 @@ public class DataJobDeploymentCrudIT extends BaseIT {
       Assertions.assertEquals(true, jobDeployment.getEnabled());
       Assertions.assertEquals(DataJobMode.RELEASE, jobDeployment.getMode());
       Assertions.assertEquals(true, jobDeployment.getEnabled());
+      Assertions.assertEquals("release", jobDeployment.getVdkVersion());
       Assertions.assertEquals("user", jobDeployment.getLastDeployedBy());
       // just check some valid date is returned. It would be too error-prone/brittle to verify exact time.
       DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(jobDeployment.getLastDeployedDate());

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/ToApiModelConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/ToApiModelConverter.java
@@ -104,6 +104,7 @@ public class ToApiModelConverter {
       deployment.setJobVersion(jobDeploymentStatus.getGitCommitSha());
       deployment.setLastDeployedBy(jobDeploymentStatus.getLastDeployedBy());
       deployment.setLastDeployedDate(jobDeploymentStatus.getLastDeployedDate());
+      deployment.setVdkVersion(jobDeploymentStatus.getVdkVersion());
 
       return deployment;
    }
@@ -148,7 +149,7 @@ public class ToApiModelConverter {
       // TODO finish mapping implementation in TAUR-1535
       v2DataJobDeployment.setContacts(new DataJobContacts());
       v2DataJobDeployment.setSchedule(new V2DataJobSchedule());
-      v2DataJobDeployment.setVdkVersion("");
+      v2DataJobDeployment.setVdkVersion(jobDeploymentStatus.getVdkVersion());
       v2DataJobDeployment.setExecutions(new ArrayList<>());
 
       return v2DataJobDeployment;

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/ToModelApiConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/ToModelApiConverter.java
@@ -25,6 +25,7 @@ public class ToModelApiConverter {
          jobDeployment.setMode(dataJobDeployment.getMode().toString());
       }
       jobDeployment.setGitCommitSha(dataJobDeployment.getJobVersion());
+      jobDeployment.setVdkVersion(dataJobDeployment.getVdkVersion());
 
       return jobDeployment;
    }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DockerImageName.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DockerImageName.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.deploy;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DockerImageName {
+
+    private static final Pattern tagPattern = Pattern.compile("^(.+?)(?::([^:/]+))?$");
+
+    @NotNull
+    private static Matcher matchImageName(String imageName) {
+        if(imageName.contains("@sha256")) {
+            String[] digestParts = imageName.split("@");
+            imageName = digestParts[0];
+            // digest = digestParts[1];
+        }
+
+        var matcher = tagPattern.matcher(imageName);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Parsing image name failed. It was not properly formatted image name: " + imageName
+            + " Image name format is usually [registryAddress/]name:tag. See docker or OCI standard documentation for more details.");
+        } return matcher;
+    }
+
+
+    /**
+     * See https://github.com/distribution/distribution/blob/main/reference/regexp.go#L72
+     * and https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier
+     * @param imageName the full image name.
+     * @return the tag
+     */
+    public static String getTag(String imageName) {
+        var tag = matchImageName(imageName).group(2);
+        return tag != null ? tag : "latest";
+    }
+
+    /**
+     * Updates the image name with the new tag
+     * @param imageName the update name to update
+     * @param newTag the new tag to set
+     * @return the updated image name
+     */
+    public static String updateImageWithTag(String imageName, String newTag) {
+        var matcher = matchImageName(imageName);
+        return matcher.group(1) + ":" + newTag;
+    }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/JobDeployment.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/JobDeployment.java
@@ -19,6 +19,8 @@ public class JobDeployment {
 
    private String gitCommitSha;
 
+   private String vdkVersion;
+
    private String imageName;
 
    private String cronJobName;

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/JobDeploymentStatus.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/JobDeploymentStatus.java
@@ -18,6 +18,10 @@ public class JobDeploymentStatus {
 
     private String gitCommitSha;
 
+    private String vdkImageName;
+
+    private String vdkVersion;
+
     private String imageName;
 
     private String cronJobName;

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DockerImageNameTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DockerImageNameTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.deploy;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DockerImageNameTest {
+
+    @Test
+    void testGetTag() {
+        Assertions.assertEquals("tag", DockerImageName.getTag("domain:5000/name:tag"));
+        Assertions.assertEquals("v1.0.1", DockerImageName.getTag("name:v1.0.1"));
+        Assertions.assertEquals("v1.0.2", DockerImageName.getTag("foo.bar/name:v1.0.2"));
+        Assertions.assertEquals("latest", DockerImageName.getTag("foo.bar/name"));
+        Assertions.assertEquals("latest", DockerImageName.getTag("domain:5000/name"));
+    }
+
+    @Test
+    void testUpdateImageWithTag() {
+        Assertions.assertEquals("domain:5000/name:tag2",
+                DockerImageName.updateImageWithTag("domain:5000/name:tag", "tag2"));
+        Assertions.assertEquals("name:v5",
+                DockerImageName.updateImageWithTag("name:v1.0.1", "v5"));
+        Assertions.assertEquals("foo.bar/name:v6",
+                DockerImageName.updateImageWithTag("foo.bar/name:v1.0.2", "v6"));
+
+        Assertions.assertEquals("name:tag",
+                DockerImageName.updateImageWithTag("name", "tag"));
+        Assertions.assertEquals("domain:5000/name:tag",
+                DockerImageName.updateImageWithTag("domain:5000/name", "tag"));
+    }
+
+}


### PR DESCRIPTION
VDK version is the version of the VDK library with which the data job
run. We need it to return it when querying for deployment informatin in
order to know with which version of vdk the data job is configured to
run in cloud(kubernetes) deployment. 
See details on the analysis of how we update the vdk version in https://github.com/vmware/versatile-data-kit/issues/377

GET deployment (or list of deployments) returns the configured vdk
version

Testing Done: integration tests, unit tests.
Issue: https://github.com/vmware/versatile-data-kit/issues/377


Signed-off-by: Antoni Ivanov <aivanov@vmware.com>
