### PR TITLE
control-service: GraphQL executions query

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/build.gradle
+++ b/projects/control-service/projects/pipelines_control_service/build.gradle
@@ -67,6 +67,7 @@ dependencies { // Implementation dependencies are found on compile classpath of 
     implementation versions.'net.javacrumbs.shedlock:shedlock-spring'
     implementation versions.'net.javacrumbs.shedlock:shedlock-provider-jdbc-template'
 
+    implementation versions.'com.graphql-java:graphql-java-extended-scalars'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLProvider.java
@@ -8,6 +8,7 @@ package com.vmware.taurus.service.graphql;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import graphql.GraphQL;
+import graphql.scalars.ExtendedScalars;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.idl.RuntimeWiring;
 import graphql.schema.idl.SchemaGenerator;
@@ -54,6 +55,7 @@ public class GraphQLProvider {
 
    private RuntimeWiring buildWiring() {
       return RuntimeWiring.newRuntimeWiring()
+            .scalar(ExtendedScalars.DateTime)
             .type(newTypeWiring("Query")
                   .dataFetcher("jobs", graphQLDataFetchers.findAllAndBuildDataJobPage()))
             .build();

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionFilter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionFilter.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.graphql.model;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import com.vmware.taurus.controlplane.model.data.DataJobExecution;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class DataJobExecutionFilter {
+   private OffsetDateTime startTimeGte;
+   private OffsetDateTime endTimeGte;
+   private List<DataJobExecution.StatusEnum> statusIn;
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionOrder.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionOrder.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.graphql.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.data.domain.Sort;
+
+@Data
+@AllArgsConstructor
+public class DataJobExecutionOrder {
+   private String property;
+   private Sort.Direction sort;
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionQueryVariables.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionQueryVariables.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Copyright (c) 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.graphql.model;
+
+import lombok.Data;
+
+@Data
+public class DataJobExecutionQueryVariables {
+   private Integer pageSize;
+   private Integer pageNumber;
+   private DataJobExecutionFilter filter;
+   private DataJobExecutionOrder order;
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/schema.graphqls
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/schema.graphqls
@@ -1,9 +1,12 @@
+scalar DateTime
+
 schema {
     query: Query
 }
 
 type Query {
     jobs(pageNumber: Int = 0, pageSize: Int = 20, filter: [Predicate], search: String): DataJobPage
+    executions(pageNumber: Int, pageSize: Int, filter: DataJobExecutionFilter, order: DataJobExecutionOrder): DataJobExecutionResponse
 }
 
 input Predicate {
@@ -17,9 +20,26 @@ enum Direction {
     DESC
 }
 
+input DataJobExecutionFilter {
+    startTimeGte: DateTime,
+    endTimeGte: DateTime,
+    statusIn: [DataJobExecutionStatus]
+}
+
+input DataJobExecutionOrder {
+    property: String,
+    direction: Direction
+}
+
 # TODO use auto-generation [TAUR-1376]
 type DataJobPage {
     content: [DataJob]
+    totalPages: Int
+    totalItems: Int
+}
+
+type DataJobExecutionResponse {
+    content: [DataJobExecution]
     totalPages: Int
     totalItems: Int
 }

--- a/projects/control-service/projects/versions-of-external-dependencies.gradle
+++ b/projects/control-service/projects/versions-of-external-dependencies.gradle
@@ -40,6 +40,7 @@ project.ext {
             'org.tuckey:urlrewritefilter'                                        : 'org.tuckey:urlrewritefilter:4.0.4',
             'org.apache.commons:commons-lang3'                                   : 'org.apache.commons:commons-lang3:3.12.0',
             'com.github.tomakehurst:wiremock'                                    : 'com.github.tomakehurst:wiremock:2.27.2',
+            'com.graphql-java:graphql-java-extended-scalars'                     : 'com.graphql-java:graphql-java-extended-scalars:15.0.0',
 
             // transitive dependencies version force (freeze)
             // on next upgrade, revise if those still need to be set explicitly


### PR DESCRIPTION
Extended the GraphQL schema (resources/schema.graphqls) by adding
an additional query called _executions_. It will allow us to filter
and sort executions by the following fields: status, startTime, endTime.

Sample request:
```
{{ baseUrl }}/data-jobs/for-team/no-team-specified/jobs?query={
  executions(filter: {
		endTime_gte: "2021-10-19T10:14:47Z",
		status_in: ["failed", "cancelled"]
             },
	     order: {property: "endTime", sort: DESC}) {
    content {
          id
          startTime
          endTime
          status
          jobName
    }
  }
}
```

Еvaluated an advanced filtering approach, but it seems to be out of scope
of this issue. It will take more implementation time since we should
introduce a new query engine.

```
{{ baseUrl }}/data-jobs/for-team/no-team-specified/jobs?query={
  executions(filter: [
		{op: gte, property: "endTime", value: "2021-10-19T10:14:47Z"},
		{op: in, property: "status", values: ["failed", "cancelled"]}
	     ],
             order: {property: "status", sort: DESC}) {
    content {
          id
          startTime
          endTime
          status
          jobName
    }
  }
}
```

Testing: unit tests

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com