### PR TITLE
control-service: Classify OOM as User Errors

### DIFF
--- a/projects/control-service/CHANGELOG.md
+++ b/projects/control-service/CHANGELOG.md
@@ -12,6 +12,13 @@ MAJOR.MINOR - dd.MM.yyyy
 * **Breaking Changes**
 
 =======
+1.3 - 09.11.2021
+----
+* **Bug fixes**
+  * Classify K8s pod OOM errors as UserError.
+
+
+=======
 1.3 - 03.11.2021
 ----
 * **Bug fixes**

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -140,7 +140,7 @@ public abstract class KubernetesService implements InitializingBean {
         String executionType;
         String jobName;
         String terminationMessage;
-        String terminationReason;
+        String jobTerminationReason;
         Boolean succeeded;
         String opId;
         OffsetDateTime startTime;
@@ -153,6 +153,7 @@ public abstract class KubernetesService implements InitializingBean {
         Integer resourcesMemoryLimit;
         OffsetDateTime deployedDate;
         String deployedBy;
+        String containerTerminationReason;
     }
 
     @AllArgsConstructor
@@ -799,8 +800,14 @@ public abstract class KubernetesService implements InitializingBean {
             lastTerminatedPodState
                   .map(v1ContainerStateTerminated -> StringUtils.trim(v1ContainerStateTerminated.getMessage()))
                   .ifPresent(s -> jobExecutionStatusBuilder.terminationMessage(s));
-            jobExecutionStatusBuilder.terminationReason(jobStatusCondition.getReason());
+            jobExecutionStatusBuilder.jobTerminationReason(jobStatusCondition.getReason());
+
+            // Termination Reason of the data job pod container
+            lastTerminatedPodState
+                    .map(v1ContainerStateTerminated -> StringUtils.trim(v1ContainerStateTerminated.getReason()))
+                    .ifPresent(s -> jobExecutionStatusBuilder.containerTerminationReason(s));
         }
+
         // Job resources
         Optional<V1Container> containerOptional = Optional.ofNullable(job.getSpec())
               .map(V1JobSpec::getTemplate)

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionResultManager.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionResultManager.java
@@ -30,6 +30,7 @@ public class JobExecutionResultManager {
    static final String TERMINATION_MESSAGE_ATTRIBUTE_STATUS = "status";
    static final String TERMINATION_MESSAGE_ATTRIBUTE_VDK_VERSION = "vdk_version";
    static final String TERMINATION_REASON_DEADLINE_EXCEEDED = "DeadlineExceeded";
+   static final String TERMINATION_REASON_OUT_OF_MEMORY = "OOMKilled";
 
    @Data
    @Builder
@@ -51,7 +52,7 @@ public class JobExecutionResultManager {
       ExecutionTerminationStatus terminationStatus = getTerminationStatus(terminationMessage.getTerminationStatus());
 
       terminationStatus = updateTerminationStatusBasedOnExecutionStatus(
-              terminationStatus, executionStatus, terminationMessage.getTerminationStatus(), jobExecution.getTerminationReason());
+              terminationStatus, executionStatus, terminationMessage.getTerminationStatus(), jobExecution.getJobTerminationReason(), jobExecution.getContainerTerminationReason());
       executionStatus = updateExecutionStatusBasedOnTerminationStatus(executionStatus, terminationStatus);
 
       return ExecutionResult.builder()
@@ -109,7 +110,8 @@ public class JobExecutionResultManager {
     * @param terminationStatus termination status based on the K8S Pod termination status
     * @param executionStatus execution status based on K8S Job status
     * @param terminationStatusString termination status returned from K8S Pod (e.g. "Success", "User error", etc.)
-    * @param terminationReason condition reason as reported by K8s Job (e.g. "DeadlineExceeded", "BackoffLimitExceeded", etc.)
+    * @param jobTerminationReason condition reason as reported by K8s Job (e.g. "DeadlineExceeded", "BackoffLimitExceeded", etc.)
+    * @param containerTerminationReason termination reason for pod container as reported by K8s Job (e.g., "OOMKilled", etc.)
     * @return if there is no termination message due to the missing K8S Pod
     * returns termination status based on execution status otherwise returns
     * termination status based on the K8S Pod termination status
@@ -118,12 +120,14 @@ public class JobExecutionResultManager {
          ExecutionTerminationStatus terminationStatus,
          ExecutionStatus executionStatus,
          String terminationStatusString,
-         String terminationReason) {
+         String jobTerminationReason,
+         String containerTerminationReason) {
 
       if (StringUtils.isEmpty(terminationStatusString) && ExecutionStatus.FINISHED.equals(executionStatus)) {
          terminationStatus = ExecutionTerminationStatus.SUCCESS;
       } else if (StringUtils.isEmpty(terminationStatusString) && ExecutionStatus.FAILED.equals(executionStatus)) {
-         if (StringUtils.equalsIgnoreCase(terminationReason, TERMINATION_REASON_DEADLINE_EXCEEDED)) {
+         if (StringUtils.equalsIgnoreCase(jobTerminationReason, TERMINATION_REASON_DEADLINE_EXCEEDED) ||
+                 StringUtils.equalsIgnoreCase(containerTerminationReason, TERMINATION_REASON_OUT_OF_MEMORY)) {
             terminationStatus = ExecutionTerminationStatus.USER_ERROR;
          } else {
             terminationStatus = ExecutionTerminationStatus.PLATFORM_ERROR;

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionResultManagerTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionResultManagerTest.java
@@ -176,7 +176,7 @@ public class JobExecutionResultManagerTest {
               KubernetesService.JobExecution.builder()
                       .terminationMessage(null)
                       .succeeded(false)
-                      .terminationReason(JobExecutionResultManager.TERMINATION_REASON_DEADLINE_EXCEEDED)
+                      .jobTerminationReason(JobExecutionResultManager.TERMINATION_REASON_DEADLINE_EXCEEDED)
                       .build();
 
       ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
@@ -189,10 +189,24 @@ public class JobExecutionResultManagerTest {
               KubernetesService.JobExecution.builder()
                       .terminationMessage(null)
                       .succeeded(false)
-                      .terminationReason("SomeReason")
+                      .jobTerminationReason("SomeReason")
                       .build();
 
       ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
       Assertions.assertEquals(ExecutionTerminationStatus.PLATFORM_ERROR, actualResult.getTerminationStatus());
+   }
+
+   @Test
+   void testGetResult_terminationMessageNullAndExecutionStatusFailedAndTerminationReasonOutOfMemory_shouldReturnTerminationStatusUserError() {
+      KubernetesService.JobExecution jobExecution =
+              KubernetesService.JobExecution.builder()
+                      .terminationMessage(null)
+                      .succeeded(false)
+                      .jobTerminationReason("Some Reason")
+                      .containerTerminationReason(JobExecutionResultManager.TERMINATION_REASON_OUT_OF_MEMORY)
+                      .build();
+
+      ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
+      Assertions.assertEquals(ExecutionTerminationStatus.USER_ERROR, actualResult.getTerminationStatus());
    }
 }


### PR DESCRIPTION
Currently, if a data job execution exceeds the allowed memory
quota, the pod of the execution is immediately killed by
Kubernetes and restarted. Which in turn usually results in a
similar failure. This causes a Platform Error to be raised, whereas
it should be classified as a User Error.

This change re-classifies such errors as User Errors.

Testing Done: Added unit test.

Signed-off-by: Andon Andonov <andonova@vmware.com>