### PR TITLE
control-service: add last execution info to the data_job table

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/db/migration/V20213110120000__add_last_execution_info_data_job.sql
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/db/migration/V20213110120000__add_last_execution_info_data_job.sql
@@ -1,4 +1,6 @@
 alter table if exists data_job
-    add column if not exists last_execution_status smallint,
-    add column if not exists last_execution_end_time timestamp,
+    add column if not exists last_execution_status smallint;
+alter table if exists data_job
+    add column if not exists last_execution_end_time timestamp;
+alter table if exists data_job
     add column if not exists last_execution_duration int;

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/db/migration/V20213110120000__add_last_execution_info_data_job.sql
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/db/migration/V20213110120000__add_last_execution_info_data_job.sql
@@ -1,4 +1,4 @@
-alter table data_job
-    add last_execution_status smallint,
-    add last_execution_end_time timestamp,
-    add last_execution_duration int;
+alter table if exists data_job
+    add column if not exists last_execution_status smallint,
+    add column if not exists last_execution_end_time timestamp,
+    add column if not exists last_execution_duration int;

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/db/migration/V20213110120000__add_last_execution_info_data_job.sql
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/db/migration/V20213110120000__add_last_execution_info_data_job.sql
@@ -1,0 +1,4 @@
+alter table data_job
+    add last_execution_status smallint,
+    add last_execution_end_time timestamp,
+    add last_execution_duration int;


### PR DESCRIPTION
As part of preparation for the implementation of the ability to filter
and sort data jobs by their last execution status, time, and duration,
add the respective columns to the data_job table.

Testing done: Start the service and verify that the columns are created
in the data_job table.

Signed-off-by: Tsvetomir Palashki <tpalashki@vmware.com>