### PR TITLE
vdk-control-cli: fix flaky unit tests

### DIFF
--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_create.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_create.py
@@ -190,7 +190,7 @@ def test_create_without_url_only_local_detected(
 
     runner = CliRunner()
     result = runner.invoke(
-        create, ["-n", "job-name", "-t", "team_name", "-p", jobs_dir]
+        create, ["-n", "job-name", "-t", "team_name", "-p", jobs_dir, "-u", ""]
     )
 
     assert_click_status(result, 0)

--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_execute.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_execute.py
@@ -79,7 +79,7 @@ def test_cancel(httpserver: PluginHTTPServer, tmpdir: LocalPath):
 
 def test_execute_without_url(httpserver: PluginHTTPServer, tmpdir: LocalPath):
     runner = CliRunner()
-    result = runner.invoke(execute, ["-n", "job_name", "-t", "team_name"])
+    result = runner.invoke(execute, ["-n", "job_name", "-t", "team_name", "-u", ""])
 
     assert (
         result.exit_code == 2


### PR DESCRIPTION
If you have a plugin install that sets rest api url the test is affected
and it fails. This fixes that by setting explcitly the rest api url to
be emtpy

Testing Done: unit tests

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>