### PR TITLE
vdk-control-cli: add command to set vdk version

### DIFF
--- a/projects/vdk-control-cli/requirements.txt
+++ b/projects/vdk-control-cli/requirements.txt
@@ -6,7 +6,7 @@ pluggy~=0.13
 tabulate
 click-spinner
 
-vdk-control-service-api==1.0.4
+vdk-control-service-api==1.0.5
 requests_oauthlib
 
 # Dependencies for creating HTTP calls against the OAuth2 provider. We can potentially remove those

--- a/projects/vdk-control-cli/setup.cfg
+++ b/projects/vdk-control-cli/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     requests>=2.25
     setuptools>=47.0
     pluggy==0.*
-    vdk-control-service-api==1.0.4
+    vdk-control-service-api==1.0.5
     tabulate
     requests_oauthlib>=1.0
     urllib3>=1.26.5

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli.py
@@ -140,8 +140,8 @@ vdk deploy --update --job-version <job-version-here> -n example-job -t job-team
     type=click.STRING,
     hidden=True,
     help="The vdk version to be used in a cloud run."
-    " It must be the same vdk python distribution that is installed by Control Service operators. "
-    " To check for possible versions see vdk distribution docker image tags. "
+    "It must be the same vdk python distribution that is installed by Control Service operators. "
+    "To check for possible versions see vdk distribution docker image tags. "
     "Assuming each released python distribution has a corresponding image "
     "check with pip index versions vdk-distribution-name. "
     "The option is valid only when used alongside --update otherwise it's ignored."

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli.py
@@ -57,6 +57,10 @@ while ! vdk deploy --show -o json -n example-job -t job-team | grep $new_version
 echo "Job1
 job2
 job3" | xargs -I {JOB} vdk deploy  -t job-team  -n {JOB} –p <PARENT_DIR_TO_JOBS>/{JOB}
+
+\b
+# Experimental. Update job version (for example rollback quickly to latest stable version)
+vdk deploy --update --job-version <job-version-here> -n example-job -t job-team
                """
 )
 @click.option("-n", "--name", type=click.STRING, help="The Data Job name.")
@@ -95,7 +99,8 @@ job3" | xargs -I {JOB} vdk deploy  -t job-team  -n {JOB} –p <PARENT_DIR_TO_JOB
     help="Update specified deployment version of a Data Job for a cloud execution. "
     "It is used to revert to previous version. "
     "Deploy specific configuration will not be updated. "
-    "You need to specify --job-version as well.",
+    "You need to specify --job-version and/or --vdk-version. "
+    "The option is experimental",
 )
 @click.option(
     "--enable",
@@ -130,6 +135,19 @@ job3" | xargs -I {JOB} vdk deploy  -t job-team  -n {JOB} –p <PARENT_DIR_TO_JOB
     help="The job version (Git Commit) of the job. The job must have been deployed first (see --create).",
 )
 @click.option(
+    "-v",
+    "--vdk-version",
+    type=click.STRING,
+    hidden=True,
+    help="The vdk version to be used in a cloud run."
+    " It must be the same vdk python distribution that is installed by Control Service operators. "
+    " To check for possible versions see vdk distribution docker image tags. "
+    "Assuming each released python distribution has a corresponding image "
+    "check with pip index versions vdk-distribution-name. "
+    "The option is valid only when used alongside --update otherwise it's ignored."
+    "The option is experimental.",
+)
+@click.option(
     "-r",
     "--reason",
     help="Add a reason message for the job deploy. "
@@ -140,13 +158,24 @@ job3" | xargs -I {JOB} vdk deploy  -t job-team  -n {JOB} –p <PARENT_DIR_TO_JOB
 @cli_utils.rest_api_url_option()
 @cli_utils.output_option()
 @cli_utils.check_required_parameters
-def deploy(name, team, job_version, job_path, operation, reason, rest_api_url, output):
+def deploy(
+    name: str,
+    team: str,
+    job_version: str,
+    vdk_version: str,
+    job_path: str,
+    operation: str,
+    reason: str,
+    rest_api_url: str,
+    output: str,
+):
     cmd = JobDeploy(rest_api_url, output)
     if operation == DeployOperation.UPDATE:
         name = get_or_prompt("Job Name", name)
         team = get_or_prompt("Job Team", team)
-        job_version = get_or_prompt("Job Version", job_version)
-        return cmd.update(name, team, job_version, output)
+        if not vdk_version and not job_version:
+            job_version = get_or_prompt("Job Version", job_version)
+        return cmd.update(name, team, job_version, vdk_version, output)
     if operation == DeployOperation.ENABLE:
         name = get_or_prompt("Job Name", name)
         team = get_or_prompt("Job Team", team)

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli_impl.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli_impl.py
@@ -4,6 +4,7 @@ import glob
 import json
 import logging
 import os
+from typing import Optional
 
 import click
 import click_spinner
@@ -14,7 +15,6 @@ from taurus_datajob_api import DataJobConfig
 from taurus_datajob_api import DataJobContacts
 from taurus_datajob_api import DataJobDeployment
 from taurus_datajob_api import DataJobSchedule
-from taurus_datajob_api import Enable
 from vdk.internal.control.configuration.defaults_config import load_default_team_name
 from vdk.internal.control.exception.vdk_exception import VDKException
 from vdk.internal.control.job.job_archive import JobArchive
@@ -141,54 +141,78 @@ class JobDeploy:
         self.jobs_api.data_job_update(team_name=team, job_name=name, data_job=job)
 
     @ApiClientErrorDecorator()
-    def update(self, name: str, team: str, job_version: str, output: str) -> None:
-        deployment = DataJobDeployment(
-            job_version=job_version, mode="release", enabled=True
-        )
+    def update(
+        self,
+        name: str,
+        team: str,
+        job_version: Optional[str],
+        vdk_version: Optional[str],
+        output: str,
+    ) -> None:
+        deployment = DataJobDeployment(enabled=None)
+        if job_version:
+            deployment.job_version = job_version
+        if vdk_version:
+            deployment.vdk_version = vdk_version
+        if job_version:
+            self.__update_job_version(name, team, deployment, output)
+        elif vdk_version:
+            self.__update_deployment(name, team, deployment)
+            log.info(
+                f"Deployment of Data Job {name} updated to use vdk version {vdk_version}."
+            )
+        else:
+            log.warning(f"Nothing to update for deployment of job {name}.")
+
+    def __update_deployment(
+        self, name: str, team: str, deployment: DataJobDeployment
+    ) -> None:
         log.debug(f"Update Deployment of a job {name} of team {team} : {deployment}")
+        self.deploy_api.deployment_patch(
+            team_name=team,
+            job_name=name,
+            deployment_id=self.__deployment_id,
+            data_job_deployment=deployment,
+        )
+
+    def __update_job_version(
+        self, name: str, team: str, deployment: DataJobDeployment, output: str
+    ):
+        log.debug(
+            f"Update Deployment version of a job {name} of team {team} : {deployment}"
+        )
         self.deploy_api.deployment_update(
             team_name=team, job_name=name, data_job_deployment=deployment
         )
-
         if output == OutputFormat.TEXT.value:
             log.info(
-                f"Request to deploy Data Job {name} using version {job_version} finished successfully.\n"
+                f"Request to deploy Data Job {name} using version {deployment.job_version} finished successfully.\n"
                 f"It would take a few minutes for the Data Job to be deployed in the server.\n"
                 f"If notified_on_job_deploy option in config.ini is configured then "
                 f"notification will be sent on successful deploy or in case of an error.\n\n"
                 f"You can also execute `vdk deploy --show -t {team} -n {name}` and compare the printed version "
-                f"to the one of the newly deployed job - {job_version} - to verify that the deployment "
+                f"to the one of the newly deployed job - {deployment.job_version} - to verify that the deployment "
                 f"was successful."
             )
         else:
             result = {
                 "job_name": name,
-                "job_version": job_version,
+                "job_version": deployment.job_version,
             }
             click.echo(json.dumps(result))
 
     @ApiClientErrorDecorator()
     def disable(self, name: str, team: str) -> None:
-        enable = Enable(enabled=False)
+        deployment = DataJobDeployment(enabled=False)
         log.debug(f"Disable Deployment of a job {name} of team {team}")
-        self.deploy_api.deployment_enable(
-            team_name=team,
-            job_name=name,
-            deployment_id=self.__deployment_id,
-            enable=enable,
-        )
+        self.__update_deployment(name, team, deployment)
         log.info(f"Deployment of Data Job {name} disabled.")
 
     @ApiClientErrorDecorator()
     def enable(self, name: str, team: str) -> None:
-        enable = Enable(enabled=True)
+        deployment = DataJobDeployment(enabled=True)
         log.debug(f"Enable Deployment of a job {name} of team {team}")
-        self.deploy_api.deployment_enable(
-            team_name=team,
-            job_name=name,
-            deployment_id=self.__deployment_id,
-            enable=enable,
-        )
+        self.__update_deployment(name, team, deployment)
         log.info(f"Deployment of Data Job {name} enabled.")
 
     @ApiClientErrorDecorator()
@@ -281,6 +305,6 @@ class JobDeploy:
                 )
 
             self.__update_data_job_deploy_configuration(job_path, name, team)
-            self.update(name, team, data_job_version.version_sha, output)
+            self.update(name, team, data_job_version.version_sha, None, output)
         finally:
             self.__cleanup_archive(archive_path=archive_path)

--- a/projects/vdk-control-cli/src/vdk/internal/control/rest_lib/rest_client_errors.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/rest_lib/rest_client_errors.py
@@ -52,6 +52,7 @@ class ApiClientErrorDecorator:
         @functools.wraps(fn)
         def decorated(*args, **kwargs):
             try:
+                log.debug(f"Call function {fn.__module__}.{fn.__name__}")
                 result = fn(*args, **kwargs)
                 return result
             except ApiException as ex:


### PR DESCRIPTION
Setting vdk version is someitmes necessary to enable canary releases and
A/B Testing. See https://github.com/vmware/versatile-data-kit/issues/377

Adding command to set vdk version. It is hidden for now as it's
experimental

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>