### PR TITLE
vdk-core: vdk run logging levels

### DIFF
--- a/projects/vdk-core/cicd/example-job/30_check_orders_table.py
+++ b/projects/vdk-core/cicd/example-job/30_check_orders_table.py
@@ -5,6 +5,8 @@ Detailed documentation of VDK provided functionalities in job_input object can b
 """
 import logging
 
+log = logging.getLogger(__name__)
+
 
 def run(job_input):
     """
@@ -12,12 +14,13 @@ def run(job_input):
        Arguments:
           job_input: object automatically passed to run() method by VDK on execution.
     """
+    log.debug(f"Start data job step {__name__}.")
     result = job_input.execute_query(
         """
       select count(1) from orders
    """
     )
     if result and result[0][0] > 0:
-        logging.getLogger(__name__).info("Job has completed successfully")
+        log.info("Job has completed successfully")
     else:
         raise Exception("Job has failed. Could not get correct number of rows.")

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/log_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/log_config.py
@@ -48,14 +48,13 @@ def configure_loggers(
         "requests_kerberos": {"level": "INFO"},
         "requests_oauthlib": {"level": "INFO"},
         "urllib3": {"level": "INFO"},
-        "taurus": {"level": vdk_logging_level},
+        "vdk": {"level": vdk_logging_level},
     }
 
     _FORMATTERS = {"detailedFormatter": {"format": DETAILED_FORMAT}}
 
     _CONSOLE_HANDLER = {
         "class": "logging.StreamHandler",
-        "level": "DEBUG",
         "formatter": "detailedFormatter",
         "stream": "ext://sys.stderr",
     }
@@ -65,7 +64,7 @@ def configure_loggers(
             "version": 1,
             "handlers": {"consoleHandler": _CONSOLE_HANDLER},
             "formatters": _FORMATTERS,
-            "root": {"handlers": ["consoleHandler"], "level": "INFO"},
+            "root": {"handlers": ["consoleHandler"]},
             "loggers": _LOGGERS,
             "disable_existing_loggers": False,
         }
@@ -77,7 +76,7 @@ def configure_loggers(
             "version": 1,
             "handlers": {"consoleHandler": _CONSOLE_HANDLER},
             "formatters": _FORMATTERS,
-            "root": {"handlers": ("consoleHandler",), "level": "DEBUG"},
+            "root": {"handlers": ("consoleHandler",)},
             "loggers": _LOGGERS,
             "disable_existing_loggers": False,
         }

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/vdk_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/vdk_config.py
@@ -62,9 +62,10 @@ class CoreConfigDefinitionPlugin:
         )  # {LOCAL, CLOUD, NONE} To be overridden when executing in cloud
         config_builder.add(
             LOG_LEVEL_VDK,
-            "DEBUG",
+            None,
             "Logging verbosity of VDK code can be controlled from here. "
-            "Allowed values: CRITICAL, ERROR, WARNING, INFO, DEBUG",
+            "Allowed values: CRITICAL, ERROR, WARNING, INFO, DEBUG. "
+            "If not set python default or one set by vdk -v LEVEL is used. ",
         )
         config_builder.add(JOB_GITHASH, "unknown")
         config_builder.add(


### PR DESCRIPTION
`vdk -v LEVEL` can be used to set logging level. But during vdk run this
was overriden by default levels set when configuring loggers. So `vdk -v
LEVEL` was not really working. This fixes that.

Logs of the vdk namespaces can also be controled by separate configu
LOG_LEVEL_VDK. It is set to INFO by default. It was being set to wrong
package though.

Also it's made optional. If not set, default log level (e.g provdied by
vdk -v LEVEL) is used.

Testing Done: ran `vdk -v DEBUG run example-job` and `vdk run
example-job` and saw expected logs

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>