### PR TITLE
control-service: Update the GraphQL model with the last execution

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/ToApiModelConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/ToApiModelConverter.java
@@ -21,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 public class ToApiModelConverter {
@@ -137,7 +138,10 @@ public class ToApiModelConverter {
       return dataJobQueryResponse;
    }
 
-   public static V2DataJobDeployment toV2DataJobDeployment(JobDeploymentStatus jobDeploymentStatus) {
+   public static V2DataJobDeployment toV2DataJobDeployment(JobDeploymentStatus jobDeploymentStatus, DataJob sourceDataJob) {
+      Objects.requireNonNull(jobDeploymentStatus);
+      Objects.requireNonNull(sourceDataJob);
+
       var v2DataJobDeployment = new V2DataJobDeployment();
 
       v2DataJobDeployment.setId(jobDeploymentStatus.getCronJobName());
@@ -145,6 +149,10 @@ public class ToApiModelConverter {
       v2DataJobDeployment.setJobVersion(jobDeploymentStatus.getGitCommitSha());
       v2DataJobDeployment.setMode(DataJobMode.fromValue(jobDeploymentStatus.getMode()));
       v2DataJobDeployment.setResources(jobDeploymentStatus.getResources());
+      // TODO: Get these from the job deployment when they are available there
+      v2DataJobDeployment.setLastExecutionStatus(convertStatusEnum(sourceDataJob.getLastExecutionStatus()));
+      v2DataJobDeployment.setLastExecutionTime(sourceDataJob.getLastExecutionEndTime());
+      v2DataJobDeployment.setLastExecutionDuration(sourceDataJob.getLastExecutionDuration());
 
       // TODO finish mapping implementation in TAUR-1535
       v2DataJobDeployment.setContacts(new DataJobContacts());

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/ToApiModelConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/ToApiModelConverter.java
@@ -203,6 +203,9 @@ public class ToApiModelConverter {
 
    // Public for testing purposes
    public static DataJobExecution.StatusEnum convertStatusEnum(ExecutionStatus status) {
+      if (status == null) {
+         return null;
+      }
       switch (status) {
          case SUBMITTED:
             return DataJobExecution.StatusEnum.SUBMITTED;

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/V2DataJobDeployment.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/V2DataJobDeployment.java
@@ -11,6 +11,7 @@ import com.vmware.taurus.controlplane.model.data.DataJobMode;
 import com.vmware.taurus.controlplane.model.data.DataJobResources;
 import lombok.Data;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @Data
@@ -24,4 +25,7 @@ public class V2DataJobDeployment {
    private V2DataJobSchedule schedule;
    private DataJobResources resources;
    private List<DataJobExecution> executions;
+   private DataJobExecution.StatusEnum lastExecutionStatus;
+   private OffsetDateTime lastExecutionTime;
+   private Integer lastExecutionDuration;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DataJob.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DataJob.java
@@ -8,6 +8,7 @@ package com.vmware.taurus.service.model;
 import lombok.*;
 
 import javax.persistence.*;
+import java.time.OffsetDateTime;
 import java.util.Set;
 
 @Getter
@@ -45,6 +46,15 @@ public class DataJob {
 
    private Boolean enabled;
 
+   @Column(name = "last_execution_status")
+   private ExecutionStatus lastExecutionStatus;
+
+   @Column(name = "last_execution_end_time")
+   private OffsetDateTime lastExecutionEndTime;
+
+   @Column(name = "last_execution_duration")
+   private Integer lastExecutionDuration;
+
    public DataJob(String name, JobConfig jobConfig) {
       this.name = name;
       this.jobConfig = jobConfig;
@@ -53,10 +63,10 @@ public class DataJob {
    }
 
    public DataJob(String name, JobConfig jobConfig, DeploymentStatus deploymentStatus) {
-      this(name, jobConfig, deploymentStatus, ExecutionTerminationStatus.NONE, null, null, true);
+      this(name, jobConfig, deploymentStatus, ExecutionTerminationStatus.NONE, null, null, true, null, null, null);
    }
 
    public DataJob(String name, JobConfig jobConfig, DeploymentStatus deploymentStatus, ExecutionTerminationStatus terminationStatus, String latestJobExecutionId) {
-      this(name, jobConfig, deploymentStatus, terminationStatus, latestJobExecutionId, null, true);
+      this(name, jobConfig, deploymentStatus, terminationStatus, latestJobExecutionId, null, true, null, null, null);
    }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/schema.graphqls
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/schema.graphqls
@@ -82,6 +82,9 @@ type DataJobDeployment {
     vdkVersion: String
     executions(pageNumber: Int, pageSize: Int, filter: [Predicate]): [DataJobExecution]
     status: DataJobDeploymentStatus
+    lastExecutionStatus: DataJobExecutionStatus
+    lastExecutionTime: String
+    lastExecutionDuration: Int
 }
 
 type DataJobConfig {


### PR DESCRIPTION
Extended the GraphQL and service models to reflect the properties that were added
as part of the implementation of the ability to sort and filter data jobs by their
last execution status, time, and duration.

Wire the two models so that the newly added properties can be queried via GraphQL.

Testing done: Run the service locally and verified that the new properties are
returned when requested.

Signed-off-by: Tsvetomir Palashki <tpalashki@vmware.com>