### PR TITLE
control-serivice: make smtp server configurable

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/build.gradle
+++ b/projects/control-service/projects/pipelines_control_service/build.gradle
@@ -78,6 +78,7 @@ dependencies { // Implementation dependencies are found on compile classpath of 
     testImplementation versions.'org.testcontainers:testcontainers'
     testImplementation versions.'org.springframework.security.kerberos:spring-security-kerberos-test'
     testImplementation versions.'org.awaitility:awaitility'
+    testImplementation 'com.github.kirviq:dumbster:1.7.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/notification/DataJobNotification.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/notification/DataJobNotification.java
@@ -40,7 +40,7 @@ public class DataJobNotification {
     @Value("${datajobs.notification.owner.email}")
     private String ownerEmail;
 
-    private EmailNotification notification = new EmailNotification();
+    private EmailNotification notification;
 
     public DataJobNotification() {}
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -103,3 +103,6 @@ datajobs.executions.cleanupJob.maximumExecutionsToStore=${DATAJOBS_EXECUTION_MAX
 #This variable exposes the total time to live of data job execution in seconds / default is 14 days
 #executions older than that will get deleted when the clean up job runs
 datajobs.executions.cleanupJob.executionsTtlSeconds=${DATAJOBS_EXECUTION_TTL_SECONDS:1209600}
+
+# https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html
+mail.smtp.host=smtp.vmware.com

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/notification/DataJobNotificationTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/notification/DataJobNotificationTest.java
@@ -5,30 +5,96 @@
 
 package com.vmware.taurus.service.notification;
 
+import com.dumbster.smtp.SimpleSmtpServer;
+import com.dumbster.smtp.SmtpMessage;
+import com.vmware.taurus.service.model.JobConfig;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.*;
 
 public class DataJobNotificationTest {
 
+    private SimpleSmtpServer smptServer;
+    private EmailNotification.SmtpProperties smtpProperties;
+    private JobConfig jobConfig;
+    private DataJobNotification dataJobNotification;
+    private String receiverMail;
+
+    @BeforeEach
+    public void setup() throws IOException {
+        this.smptServer = SimpleSmtpServer.start(SimpleSmtpServer.AUTO_SMTP_PORT);
+        this.smtpProperties = Mockito.mock(EmailNotification.SmtpProperties.class);
+        Mockito.when(smtpProperties.smtpWithPrefix()).thenReturn(getMailProperties(this.smptServer.getPort()));
+
+        this.dataJobNotification = new DataJobNotification(new EmailNotification(this.smtpProperties),
+                "Example Name","your_username@vmware.com");
+        this.receiverMail = "dummy@dummy.dummy";
+        this.jobConfig = getJobConfig();
+    }
+
+    @AfterEach
+    public void clean() {
+        this.smptServer.close();
+    }
+
     @Test
-    public void SendEmailsManualTest() {
-        /** Integration test with which you can send yourself some emails
-         *
-         * Uncomment and fill with your @vmware email
-         *
-         *
+    public void jobNotificationsMultiple() throws IOException {
+        dataJobNotification.notifyJobDeployError(jobConfig, "bad", "very bad");
+        dataJobNotification.notifyJobDeploySuccess(jobConfig);
+        dataJobNotification.notifyJobDeployError(jobConfig, "Some error", "Some error body");
 
-         JobConfig jobConfig = new JobConfig();
-         List receivers = new ArrayList();
-         receivers.add("your_username@vmware.com");
-         jobConfig.setNotifiedOnJobDeploy(receivers);
-         jobConfig.setJobName("test_job");
+        List<SmtpMessage> emails = this.smptServer.getReceivedEmails();
+        Assertions.assertEquals(3, emails.size());
+        Assertions.assertEquals("[deploy][data job failure] example_unittest_job", emails.get(0).getHeaderValue("Subject"));
+        Assertions.assertEquals("[deploy][data job success] example_unittest_job", emails.get(1).getHeaderValue("Subject"));
+    }
 
-         DataJobNotification dataJobNotification =
-                 new DataJobNotification(new EmailNotification(),"Example Name","your_username@vmware.com");
-         dataJobNotification.notifyJobDeployFailure(jobConfig);
-         dataJobNotification.notifyJobDeploySuccess(jobConfig);
-         dataJobNotification.notifyJobDeployError(jobConfig, "Some error", "Some error body");
+    @Test
+    public void jobNotificationsJobDeployError() throws IOException {
+        dataJobNotification.notifyJobDeployError(jobConfig, "Some error", "Some error body");
 
-         */
+        List<SmtpMessage> emails = this.smptServer.getReceivedEmails();
+        Assertions.assertEquals(1, emails.size());
+        var email = emails.get(0);
+        Assertions.assertEquals("[deploy][data job failure] example_unittest_job", email.getHeaderValue("Subject"));
+        Assertions.assertEquals(receiverMail, email.getHeaderValue("To"));
+    }
+
+    @Test
+    public void jobNotificationsJobDeploySuccess() throws IOException {
+        dataJobNotification.notifyJobDeploySuccess(jobConfig);
+
+        List<SmtpMessage> emails = this.smptServer.getReceivedEmails();
+        Assertions.assertEquals(1, emails.size());
+        var email = emails.get(0);
+        Assertions.assertEquals("[deploy][data job success] example_unittest_job", email.getHeaderValue("Subject"));
+        Assertions.assertEquals(receiverMail, email.getHeaderValue("To"));
+    }
+
+
+
+    @NotNull
+    private JobConfig getJobConfig() {
+        JobConfig jobConfig = new JobConfig();
+        List<String> receivers = new ArrayList<>();
+        receivers.add(receiverMail);
+        jobConfig.setNotifiedOnJobDeploy(receivers);
+        jobConfig.setJobName("example_unittest_job");
+        return jobConfig;
+    }
+
+    private Map<String, String> getMailProperties(int port) {
+        Map<String, String> mailProps = new HashMap<>();
+        mailProps.put("mail.smtp.host", "localhost");
+        mailProps.put("mail.smtp.port", "" + port);
+        mailProps.put("mail.smtp.sendpartial", "true");
+        return mailProps;
     }
 }


### PR DESCRIPTION
The smtp server used for deployment notifications was hard-coded which
means it would not have worked .

Testing Done: set datajobs.notifications.smtp.host in
application-properties and saw it is setting the correct value.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>