### PR TITLE
control-service: fix NPE when non-datajob cron job exists

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -1355,7 +1355,7 @@ public abstract class KubernetesService implements InitializingBean {
                 deployment.setImageName(image); // TODO do we really need to return image_name?
             }
             var initContainers = cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getInitContainers();
-            if (!initContainers.isEmpty()) {
+            if (!CollectionUtils.isEmpty(initContainers)) {
                 String vdkImage = initContainers.get(0).getImage();
                 deployment.setVdkImageName(vdkImage);
                 deployment.setVdkVersion(DockerImageName.getTag(vdkImage));


### PR DESCRIPTION
When there's cronjob in teh kubernetes namespace that is not a data job
deployment, we fail with NPE

We should likely filter them better so data job specific logic is not
applied to non-datajob cronjobs

Testing Done: integration test (created cron job in the namespace where
integration test runs)

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>