### PR TITLE
control-service: fix a bug when updating the notification status

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMonitor.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMonitor.java
@@ -197,12 +197,17 @@ public class DataJobMonitor {
 
 
     private boolean shouldUpdateTerminationStatus(DataJob dataJob, String executionId, ExecutionTerminationStatus terminationStatus) {
-        if (terminationStatus == ExecutionTerminationStatus.SKIPPED) {
-            log.debug("The termination status of data job {} will not be updated. New status is: {}", dataJob.getName(), terminationStatus);
+        // Do not update the status when either:
+        //   * the status is SKIPPED
+        //   * the status and executionId have not changed
+        if (terminationStatus == ExecutionTerminationStatus.SKIPPED ||
+                dataJob.getLatestJobTerminationStatus() == terminationStatus &&
+                        StringUtils.equals(dataJob.getLatestJobExecutionId(), executionId)) {
+            log.debug("The termination status of data job {} will not be updated. Old status is: {}, New status is: {}; Old execution id: {}, New execution id: {}",
+                    dataJob.getName(), dataJob.getLatestJobTerminationStatus(), terminationStatus, dataJob.getLatestJobExecutionId(), executionId);
             return false;
         }
-        return dataJob.getLatestJobTerminationStatus() != terminationStatus ||
-                StringUtils.equals(dataJob.getLatestJobExecutionId(), executionId);
+        return true;
     }
 
     /**


### PR DESCRIPTION
There is a bug when checking whether to update the termination status of
a data job. Rather than checking if the executions are different, we
are checking that they are the same.

This commit fixes the bug and also adds more logging when an update is skipped.

Testing done: new unit tests are added

Signed-off-by: Tsvetomir Palashki <tpalashki@vmware.com>