### PR TITLE
control-service: extend GraphQL execution data fetcher

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/build.gradle
+++ b/projects/control-service/projects/pipelines_control_service/build.gradle
@@ -69,6 +69,9 @@ dependencies { // Implementation dependencies are found on compile classpath of 
 
     implementation versions.'com.graphql-java:graphql-java-extended-scalars'
 
+    compileOnly versions.'org.hibernate:hibernate-jpamodelgen'
+    annotationProcessor versions.'org.hibernate:hibernate-jpamodelgen'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation versions.'com.mmnaseri.utils:spring-data-mock'

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/ToApiModelConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/ToApiModelConverter.java
@@ -9,6 +9,7 @@ import com.vmware.taurus.controlplane.model.data.DataJobExecution;
 import com.vmware.taurus.controlplane.model.data.DataJobPage;
 import com.vmware.taurus.controlplane.model.data.*;
 import com.vmware.taurus.service.Utilities;
+import com.vmware.taurus.service.graphql.GraphQLUtils;
 import com.vmware.taurus.service.graphql.model.V2DataJob;
 import com.vmware.taurus.service.graphql.model.V2DataJobConfig;
 import com.vmware.taurus.service.graphql.model.V2DataJobDeployment;
@@ -124,7 +125,12 @@ public class ToApiModelConverter {
          return dataJobQueryResponse;
       }
 
-      LinkedHashMap<String, Object> nestedExecutionResultData = executionResultData.get("jobs");
+      String executionResultDataKey = GraphQLUtils.QUERIES
+            .stream()
+            .filter(query -> executionResultData.containsKey(query))
+            .findFirst()
+            .orElse(null);
+      LinkedHashMap<String, Object> nestedExecutionResultData = executionResultData.get(executionResultDataKey);
       if (nestedExecutionResultData == null) {
          return dataJobQueryResponse;
       }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobExecutionFilterSpec.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobExecutionFilterSpec.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import org.apache.commons.collections.CollectionUtils;
+import org.springframework.data.jpa.domain.Specification;
+
+import com.vmware.taurus.service.graphql.model.DataJobExecutionFilter;
+import com.vmware.taurus.service.model.DataJobExecution;
+import com.vmware.taurus.service.model.DataJobExecution_;
+
+@AllArgsConstructor
+public class JobExecutionFilterSpec implements Specification<DataJobExecution> {
+
+   private DataJobExecutionFilter filter;
+
+   @Override
+   public Predicate toPredicate(Root<DataJobExecution> root, CriteriaQuery<?> query, CriteriaBuilder builder) {
+      List<Predicate> predicates = new ArrayList<>();
+
+      if (filter != null) {
+         if (filter.getStartTimeGte() != null) {
+            predicates.add(builder.greaterThanOrEqualTo(root.get(DataJobExecution_.START_TIME), filter.getStartTimeGte()));
+         }
+
+         if (filter.getEndTimeGte() != null) {
+            predicates.add(builder.greaterThanOrEqualTo(root.get(DataJobExecution_.END_TIME), filter.getEndTimeGte()));
+         }
+
+         if (CollectionUtils.isNotEmpty(filter.getStatusIn())) {
+            predicates.add(root.get(DataJobExecution_.STATUS).in(filter.getStatusIn()));
+         }
+      }
+
+      return builder.and(predicates.toArray(new Predicate[0]));
+   }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobExecutionRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobExecutionRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -27,7 +28,7 @@ import java.util.List;
  * <p>
  * JobExecutionRepositoryIT validates some aspects of the behavior
  */
-public interface JobExecutionRepository extends JpaRepository<DataJobExecution, String> {
+public interface JobExecutionRepository extends JpaRepository<DataJobExecution, String>, JpaSpecificationExecutor<DataJobExecution> {
 
    List<DataJobExecution> findDataJobExecutionsByDataJobName(String jobName);
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/ExecutionDataFetcher.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/ExecutionDataFetcher.java
@@ -10,21 +10,15 @@
 
 package com.vmware.taurus.service.graphql;
 
-import com.vmware.taurus.datajobs.ToApiModelConverter;
-import com.vmware.taurus.service.JobExecutionRepository;
-import com.vmware.taurus.service.graphql.model.V2DataJob;
-import com.vmware.taurus.service.graphql.strategy.datajob.JobFieldStrategyBy;
-import com.vmware.taurus.service.model.DataJobExecution;
-import com.vmware.taurus.service.graphql.model.Filter;
-import com.vmware.taurus.service.graphql.model.ExecutionQueryVariables;
-import graphql.GraphQLException;
-import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.SelectedField;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Component;
+import static com.vmware.taurus.service.graphql.model.DataJobExecutionOrder.AVAILABLE_PROPERTIES;
+import static com.vmware.taurus.service.graphql.model.DataJobExecutionOrder.DIRECTION_FIELD;
+import static com.vmware.taurus.service.graphql.model.DataJobExecutionOrder.PROPERTY_FIELD;
+import static com.vmware.taurus.service.graphql.model.DataJobExecutionQueryVariables.FILTER_FIELD;
+import static com.vmware.taurus.service.graphql.model.DataJobExecutionQueryVariables.ORDER_FIELD;
+import static com.vmware.taurus.service.graphql.model.DataJobExecutionQueryVariables.PAGE_NUMBER_FIELD;
+import static com.vmware.taurus.service.graphql.model.DataJobExecutionQueryVariables.PAGE_SIZE_FIELD;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -33,15 +27,40 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import graphql.GraphQLException;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.SelectedField;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
+
+import com.vmware.taurus.datajobs.ToApiModelConverter;
+import com.vmware.taurus.datajobs.ToModelApiConverter;
+import com.vmware.taurus.service.JobExecutionFilterSpec;
+import com.vmware.taurus.service.JobExecutionRepository;
+import com.vmware.taurus.service.graphql.model.DataJobExecutionFilter;
+import com.vmware.taurus.service.graphql.model.DataJobExecutionOrder;
+import com.vmware.taurus.service.graphql.model.DataJobExecutionQueryVariables;
+import com.vmware.taurus.service.graphql.model.ExecutionQueryVariables;
+import com.vmware.taurus.service.graphql.model.Filter;
+import com.vmware.taurus.service.graphql.model.DataJobPage;
+import com.vmware.taurus.service.graphql.model.V2DataJob;
+import com.vmware.taurus.service.graphql.strategy.datajob.JobFieldStrategyBy;
+import com.vmware.taurus.service.model.DataJobExecution;
+
 /**
  * Data fetcher class for Data Job Executions
- *
+ * <p>
  * Data fetchers are classes that provides to graphql api the needed data while it modify the source data:
  * By providing list of data jobs it alter each job and attach its execution while reading requested
  * information from graphql query to specify how many executions, are they sorted by specific field, etc.
- *
- * Currently, execution data fetcher does not provide filtering by specifying fields due
- * to its post-pagination loading - the execution data is attached after slicing of the requested page.
  */
 @Component
 public class ExecutionDataFetcher {
@@ -52,6 +71,10 @@ public class ExecutionDataFetcher {
       this.jobsExecutionRepository = jobsExecutionRepository;
    }
 
+   /**
+    * Currently, it does not provide filtering by specifying fields due
+    * to its post-pagination loading - the execution data is attached after slicing of the requested page.
+    */
    List<V2DataJob> populateExecutions(List<V2DataJob> allDataJob, DataFetchingEnvironment dataFetchingEnvironment) {
       final ExecutionQueryVariables queryVariables = fetchQueryVariables(dataFetchingEnvironment);
       final Pageable pageable = constructPageable(queryVariables);
@@ -76,24 +99,71 @@ public class ExecutionDataFetcher {
       SelectedField executionFields = dataFetchingEnvironment
             .getSelectionSet().getField(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath());
 
-      Map<String, Object> execArgs =  executionFields.getArguments();
-      if (execArgs.get("pageNumber") == null || execArgs.get("pageSize") == null) {
-         throw new GraphQLException("Executions field must contain pageSize and pageNumber");
-      }
-      queryVariables.setPageNumber((int) execArgs.get("pageNumber"));
-      queryVariables.setPageSize((int) execArgs.get("pageSize"));
-      GraphQLUtils.validatePageInput(queryVariables.getPageSize(), queryVariables.getPageNumber());
-      queryVariables.setFilters(GraphQLUtils.convertFilters((ArrayList<LinkedHashMap<String, String>>) execArgs.get("filter")));
+      Map<String, Object> execArgs = executionFields.getArguments();
+      Optional<ImmutablePair<Integer, Integer>> page = extractDataJobExecutionPage(
+            execArgs.get(PAGE_NUMBER_FIELD),
+            execArgs.get(PAGE_SIZE_FIELD));
+
+      page.ifPresent(pair -> {
+         queryVariables.setPageNumber(pair.getLeft());
+         queryVariables.setPageSize(pair.getRight());
+      });
+
+      queryVariables.setFilters(GraphQLUtils.convertFilters((ArrayList<LinkedHashMap<String, String>>)execArgs.get("filter")));
       validateFilterInputForExecutions(queryVariables.getFilters());
 
       return queryVariables;
+   }
+
+   public DataFetcher<Object> findAllAndBuildResponse() {
+      return environment -> {
+         DataJobExecutionQueryVariables dataJobExecutionQueryVariables = fetchDataJobExecutionQueryVariables(environment);
+
+         Page<DataJobExecution> dataJobExecutionsResult = findAllExecutions(dataJobExecutionQueryVariables);
+         List<com.vmware.taurus.controlplane.model.data.DataJobExecution> dataJobExecutions = dataJobExecutionsResult
+               .getContent()
+               .stream()
+               .map(dataJobExecution -> ToApiModelConverter.jobExecutionToConvert(dataJobExecution))
+               .collect(Collectors.toList());
+
+         return buildResponse(
+               dataJobExecutionsResult.getTotalPages(),
+               dataJobExecutionsResult.getNumberOfElements(),
+               dataJobExecutions);
+      };
+   }
+
+   private Page<DataJobExecution> findAllExecutions(DataJobExecutionQueryVariables dataJobExecutionQueryVariables) {
+      Specification<DataJobExecution> filterSpec = new JobExecutionFilterSpec(dataJobExecutionQueryVariables.getFilter());
+      Page<DataJobExecution> result;
+      DataJobExecutionOrder order = dataJobExecutionQueryVariables.getOrder();
+      Sort sort = order != null ? Sort.by(order.getDirection(), order.getProperty()) : null;
+
+      if (dataJobExecutionQueryVariables.getPageNumber() != null && dataJobExecutionQueryVariables.getPageSize() != null) {
+         PageRequest pageRequest = PageRequest.of(
+               dataJobExecutionQueryVariables.getPageNumber() - 1,
+               dataJobExecutionQueryVariables.getPageSize());
+         pageRequest = sort != null ? pageRequest.withSort(sort) : pageRequest;
+
+         result = jobsExecutionRepository.findAll(filterSpec, pageRequest);
+      } else {
+         List<DataJobExecution> elements = sort == null ?
+               jobsExecutionRepository.findAll(filterSpec) :
+               jobsExecutionRepository.findAll(filterSpec, sort);
+
+         result = new PageImpl(elements);
+      }
+
+      return result;
    }
 
    /**
     * As we receive filters as custom GraphQL object, this method translated it to Spring data Pageable element
     * By default if there isn't any fields specified we return only paginating details
     * If sorting is not provided we use the default (ASC), by design it take maximum 1 sorting
-    * @param queryVar Query variables which holds multiple Filter object
+    *
+    * @param queryVar
+    *       Query variables which holds multiple Filter object
     * @return Pageable element containing page and sort
     */
    private Pageable constructPageable(ExecutionQueryVariables queryVar) {
@@ -123,4 +193,116 @@ public class ExecutionDataFetcher {
       }
    }
 
+   private static DataJobExecutionQueryVariables fetchDataJobExecutionQueryVariables(DataFetchingEnvironment dataFetchingEnvironment) {
+      DataJobExecutionQueryVariables queryVariables = new DataJobExecutionQueryVariables();
+
+      Optional<ImmutablePair<Integer, Integer>> page = extractDataJobExecutionPage(
+            dataFetchingEnvironment.getArgument(PAGE_NUMBER_FIELD),
+            dataFetchingEnvironment.getArgument(PAGE_SIZE_FIELD));
+
+      page.ifPresent(pair -> {
+         queryVariables.setPageNumber(pair.getLeft());
+         queryVariables.setPageSize(pair.getRight());
+      });
+
+      extractDataJobExecutionFilter(dataFetchingEnvironment.getArgument(FILTER_FIELD))
+            .ifPresent(filter -> queryVariables.setFilter(filter));
+
+      extractDataJobExecutionOrder(dataFetchingEnvironment.getArgument(ORDER_FIELD))
+            .ifPresent(order -> queryVariables.setOrder(order));
+
+      return queryVariables;
+   }
+
+   private static Optional<ImmutablePair<Integer, Integer>> extractDataJobExecutionPage(Object pageNumberRaw, Object pageSizeRaw) {
+      Optional<ImmutablePair<Integer, Integer>> result = Optional.empty();
+
+      if (pageNumberRaw != null && pageSizeRaw == null) {
+         throw new GraphQLException(String.format("Executions field must contain %s", PAGE_SIZE_FIELD));
+      }
+
+      if (pageNumberRaw == null && pageSizeRaw != null) {
+         throw new GraphQLException(String.format("Executions field must contain %s", PAGE_NUMBER_FIELD));
+      }
+
+      if (pageNumberRaw != null && pageSizeRaw != null) {
+         Integer pageNumber = (Integer)pageNumberRaw;
+         Integer pageSize = (Integer)pageSizeRaw;
+         GraphQLUtils.validatePageInput(pageSize, pageNumber);
+         result = Optional.of(ImmutablePair.of(pageNumber, pageSize));
+      }
+
+      return result;
+   }
+
+   private static Optional<DataJobExecutionFilter> extractDataJobExecutionFilter(Map<String, Object> filterRaw) {
+      Optional<DataJobExecutionFilter> filter = Optional.empty();
+
+      if (filterRaw != null) {
+         DataJobExecutionFilter.DataJobExecutionFilterBuilder builder = DataJobExecutionFilter.builder();
+
+         builder.statusIn(
+               Optional.ofNullable(filterRaw.get(DataJobExecutionFilter.STATUS_IN_FIELD))
+                     .map(statusInRaw -> ((List<String>)statusInRaw))
+                     .stream()
+                     .flatMap(v1Jobs -> v1Jobs.stream())
+                     .filter(Objects::nonNull)
+                     .map(status -> com.vmware.taurus.controlplane.model.data.DataJobExecution.StatusEnum.fromValue(status.toLowerCase()))
+                     .map(statusEnum -> ToModelApiConverter.toExecutionStatus(statusEnum))
+                     .collect(Collectors.toList())
+         );
+
+         filter = Optional.of(
+               builder
+                     .startTimeGte((OffsetDateTime)filterRaw.get(DataJobExecutionFilter.START_TIME_GTE_FIELD))
+                     .endTimeGte((OffsetDateTime)filterRaw.get(DataJobExecutionFilter.END_TIME_GTE_FIELD))
+                     .build()
+         );
+      }
+
+      return filter;
+   }
+
+   private static Optional<DataJobExecutionOrder> extractDataJobExecutionOrder(Map<String, Object> orderRaw) {
+      Optional<DataJobExecutionOrder> order = Optional.empty();
+
+      if (orderRaw != null) {
+         DataJobExecutionOrder.DataJobExecutionOrderBuilder builder = DataJobExecutionOrder.builder();
+
+         builder.property(
+               Optional.ofNullable(orderRaw.get(PROPERTY_FIELD))
+                     .map(o -> (String)o)
+                     .filter(p -> AVAILABLE_PROPERTIES.contains(p))
+                     .orElseThrow(() -> new GraphQLException(String.format(
+                           "%s.%s must be in [%s]",
+                           ORDER_FIELD,
+                           PROPERTY_FIELD,
+                           StringUtils.join(AVAILABLE_PROPERTIES, ","))))
+         );
+
+         builder.direction(
+               Optional.ofNullable(orderRaw.get(DIRECTION_FIELD))
+                     .map(o -> Sort.Direction.fromString((String)o))
+                     .orElseThrow(() -> new GraphQLException(String.format(
+                           "Executions field must contain %s.%s",
+                           ORDER_FIELD,
+                           DIRECTION_FIELD)))
+         );
+
+         order = Optional.of(builder.build());
+      }
+
+      return order;
+   }
+
+   private static DataJobPage buildResponse(
+         int pageSize,
+         int count,
+         List pageList) {
+
+      return DataJobPage.builder()
+            .content(new ArrayList<>(pageList))
+            .totalPages(pageSize)
+            .totalItems(count).build();
+   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLDataFetchers.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLDataFetchers.java
@@ -11,12 +11,12 @@ import com.vmware.taurus.service.deploy.DeploymentService;
 import com.vmware.taurus.service.graphql.model.Criteria;
 import com.vmware.taurus.service.graphql.model.DataJobQueryVariables;
 import com.vmware.taurus.service.graphql.model.Filter;
+import com.vmware.taurus.service.graphql.model.DataJobPage;
 import com.vmware.taurus.service.graphql.model.V2DataJob;
 import com.vmware.taurus.service.graphql.strategy.FieldStrategy;
 import com.vmware.taurus.service.graphql.strategy.JobFieldStrategyFactory;
 import com.vmware.taurus.service.graphql.strategy.datajob.JobFieldStrategyBy;
 import com.vmware.taurus.service.model.DataJob;
-import com.vmware.taurus.service.model.DataJobPage;
 import com.vmware.taurus.service.model.JobDeploymentStatus;
 import graphql.GraphqlErrorException;
 import graphql.schema.DataFetcher;
@@ -79,7 +79,7 @@ public class GraphQLDataFetchers {
 
          List<V2DataJob> resultList = populateDataJobsPostPagination(dataJobList, dataFetchingEnvironment);
 
-         return buildDataJobPage(queryVar.getPageSize(), count, new ArrayList<>(resultList));
+         return buildResponse(queryVar.getPageSize(), count, resultList);
       };
    }
 
@@ -185,11 +185,14 @@ public class GraphQLDataFetchers {
       return allDataJob;
    }
 
-   private static DataJobPage buildDataJobPage(int pageSize, int count, List<Object> pageList) {
-      var dataJobPage = new DataJobPage();
-      dataJobPage.setContent(pageList);
-      dataJobPage.setTotalPages(((count - 1) / pageSize + 1));
-      dataJobPage.setTotalItems(count);
-      return dataJobPage;
+   private static DataJobPage buildResponse(
+         int pageSize,
+         int count,
+         List pageList) {
+
+      return DataJobPage.builder()
+            .content(new ArrayList<>(pageList))
+            .totalPages(((count - 1) / pageSize + 1))
+            .totalItems(count).build();
    }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLProvider.java
@@ -14,7 +14,6 @@ import graphql.schema.idl.RuntimeWiring;
 import graphql.schema.idl.SchemaGenerator;
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 
@@ -29,13 +28,19 @@ public class GraphQLProvider {
 
    private GraphQL graphQL;
 
+   private GraphQLDataFetchers graphQLDataFetchers;
+
+   private ExecutionDataFetcher executionDataFetcher;
+
+   public GraphQLProvider(GraphQLDataFetchers graphQLDataFetchers, ExecutionDataFetcher executionDataFetcher) {
+      this.graphQLDataFetchers = graphQLDataFetchers;
+      this.executionDataFetcher = executionDataFetcher;
+   }
+
    @Bean
    public GraphQL graphQL() {
       return graphQL;
    }
-
-   @Autowired
-   GraphQLDataFetchers graphQLDataFetchers;
 
    @PostConstruct
    public void init() throws IOException {
@@ -57,7 +62,8 @@ public class GraphQLProvider {
       return RuntimeWiring.newRuntimeWiring()
             .scalar(ExtendedScalars.DateTime)
             .type(newTypeWiring("Query")
-                  .dataFetcher("jobs", graphQLDataFetchers.findAllAndBuildDataJobPage()))
+                  .dataFetcher(GraphQLUtils.JOBS_QUERY, graphQLDataFetchers.findAllAndBuildDataJobPage())
+                  .dataFetcher(GraphQLUtils.EXECUTIONS_QUERY, executionDataFetcher.findAllAndBuildResponse()))
             .build();
    }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLUtils.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLUtils.java
@@ -13,9 +13,14 @@ import org.springframework.data.domain.Sort;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Set;
 
 @UtilityClass
 public class GraphQLUtils {
+
+   public static final String JOBS_QUERY = "jobs";
+   public static final String EXECUTIONS_QUERY = "executions";
+   public static final Set<String> QUERIES = Set.of(JOBS_QUERY, EXECUTIONS_QUERY);
 
    /**
     * GraphQL's library parses json query variables to List of LinkedHashMaps. In order to use later the

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionFilter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionFilter.java
@@ -12,13 +12,18 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
-import com.vmware.taurus.controlplane.model.data.DataJobExecution;
+import com.vmware.taurus.service.model.ExecutionStatus;
 
 @Data
 @AllArgsConstructor
 @Builder
 public class DataJobExecutionFilter {
+
+   public static final String START_TIME_GTE_FIELD = "startTimeGte";
+   public static final String END_TIME_GTE_FIELD = "endTimeGte";
+   public static final String STATUS_IN_FIELD = "statusIn";
+
    private OffsetDateTime startTimeGte;
    private OffsetDateTime endTimeGte;
-   private List<DataJobExecution.StatusEnum> statusIn;
+   private List<ExecutionStatus> statusIn;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionOrder.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionOrder.java
@@ -5,13 +5,41 @@
 
 package com.vmware.taurus.service.graphql.model;
 
-import lombok.AllArgsConstructor;
+import java.util.Set;
+
+import lombok.Builder;
 import lombok.Data;
 import org.springframework.data.domain.Sort;
 
+import com.vmware.taurus.service.model.DataJobExecution_;
+
 @Data
-@AllArgsConstructor
+@Builder
 public class DataJobExecutionOrder {
+
+   public static final Set<String> AVAILABLE_PROPERTIES = Set.of(
+         DataJobExecution_.MESSAGE,
+         DataJobExecution_.TYPE,
+         DataJobExecution_.JOB_SCHEDULE,
+         DataJobExecution_.START_TIME,
+         DataJobExecution_.END_TIME,
+         DataJobExecution_.JOB_VERSION,
+         DataJobExecution_.ID,
+         DataJobExecution_.OP_ID,
+         DataJobExecution_.LAST_DEPLOYED_DATE,
+         DataJobExecution_.LAST_DEPLOYED_BY,
+         DataJobExecution_.STARTED_BY,
+         DataJobExecution_.STATUS,
+         DataJobExecution_.VDK_VERSION);
+
+   public static final String PROPERTY_FIELD = "property";
+   public static final String DIRECTION_FIELD = "direction";
+
    private String property;
-   private Sort.Direction sort;
+   private Sort.Direction direction;
+
+   public DataJobExecutionOrder(String property, Sort.Direction direction) {
+      this.property = property;
+      this.direction = direction;
+   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionQueryVariables.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionQueryVariables.java
@@ -14,6 +14,12 @@ import lombok.Data;
 
 @Data
 public class DataJobExecutionQueryVariables {
+
+   public static final String PAGE_NUMBER_FIELD = "pageNumber";
+   public static final String PAGE_SIZE_FIELD = "pageSize";
+   public static final String FILTER_FIELD = "filter";
+   public static final String ORDER_FIELD = "order";
+
    private Integer pageSize;
    private Integer pageNumber;
    private DataJobExecutionFilter filter;

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobPage.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobPage.java
@@ -3,13 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.vmware.taurus.service.model;
+package com.vmware.taurus.service.graphql.model;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
+@Builder
+@AllArgsConstructor
 public class DataJobPage {
    private List<Object> content;
    private Integer totalItems;

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/RepositoryUtil.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/RepositoryUtil.java
@@ -11,7 +11,6 @@ import com.vmware.taurus.service.model.*;
 import org.junit.jupiter.api.Assertions;
 
 import java.time.OffsetDateTime;
-import java.util.Random;
 
 public final class RepositoryUtil {
 
@@ -40,19 +39,10 @@ public final class RepositoryUtil {
          String executionId,
          DataJob dataJob,
          ExecutionStatus executionStatus,
-         OffsetDateTime startTime) {
+         OffsetDateTime startTime,
+         OffsetDateTime endTime) {
 
-      return createDataJobExecution(jobExecutionRepository, executionId, dataJob, executionStatus, "test_message", startTime);
-   }
-
-   public static DataJobExecution createDataJobExecution(
-         JobExecutionRepository jobExecutionRepository,
-         String executionId,
-         DataJob dataJob,
-         ExecutionStatus executionStatus,
-         String message) {
-
-      return createDataJobExecution(jobExecutionRepository, executionId, dataJob, executionStatus, message, OffsetDateTime.now());
+      return createDataJobExecution(jobExecutionRepository, executionId, dataJob, executionStatus, "test_message", startTime, endTime);
    }
 
    public static DataJobExecution createDataJobExecution(
@@ -63,10 +53,43 @@ public final class RepositoryUtil {
          String message,
          OffsetDateTime startTime) {
 
+      return createDataJobExecution(jobExecutionRepository, executionId, dataJob, executionStatus, message, startTime, OffsetDateTime.now());
+   }
+
+   public static DataJobExecution createDataJobExecution(
+         JobExecutionRepository jobExecutionRepository,
+         String executionId,
+         DataJob dataJob,
+         ExecutionStatus executionStatus,
+         OffsetDateTime startTime) {
+
+      return createDataJobExecution(jobExecutionRepository, executionId, dataJob, executionStatus, "test_message", startTime, OffsetDateTime.now());
+   }
+
+   public static DataJobExecution createDataJobExecution(
+         JobExecutionRepository jobExecutionRepository,
+         String executionId,
+         DataJob dataJob,
+         ExecutionStatus executionStatus,
+         String message) {
+
+      return createDataJobExecution(jobExecutionRepository, executionId, dataJob, executionStatus, message, OffsetDateTime.now(), OffsetDateTime.now());
+   }
+
+   public static DataJobExecution createDataJobExecution(
+         JobExecutionRepository jobExecutionRepository,
+         String executionId,
+         DataJob dataJob,
+         ExecutionStatus executionStatus,
+         String message,
+         OffsetDateTime startTime,
+         OffsetDateTime endTime) {
+
       var expectedJobExecution = DataJobExecution.builder()
             .id(executionId)
             .dataJob(dataJob)
             .startTime(startTime)
+            .endTime(endTime)
             .type(ExecutionType.MANUAL)
             .status(executionStatus)
             .resourcesCpuRequest(1F)

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobExecutionFilterSpecIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobExecutionFilterSpecIT.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.vmware.taurus.ControlplaneApplication;
+import com.vmware.taurus.RepositoryUtil;
+import com.vmware.taurus.service.graphql.model.DataJobExecutionFilter;
+import com.vmware.taurus.service.model.DataJob;
+import com.vmware.taurus.service.model.DataJobExecution;
+import com.vmware.taurus.service.model.ExecutionStatus;
+
+@SpringBootTest(classes = ControlplaneApplication.class)
+public class JobExecutionFilterSpecIT {
+
+   @Autowired
+   private JobsRepository jobsRepository;
+
+   @Autowired
+   private JobExecutionRepository jobExecutionRepository;
+
+   @BeforeEach
+   public void setUp() throws Exception {
+      jobsRepository.deleteAll();
+   }
+
+   @Test
+   public void testJobExecutionFilterSpec_filerByStatusIn_shouldReturnResult() {
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED);
+      DataJobExecution expectedJobExecution1 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING);
+      DataJobExecution expectedJobExecution2 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED);
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.FAILED);
+
+      DataJobExecutionFilter filter = DataJobExecutionFilter.builder()
+            .statusIn(List.of(ExecutionStatus.RUNNING, ExecutionStatus.SUBMITTED))
+            .build();
+      JobExecutionFilterSpec jobExecutionFilterSpec = new JobExecutionFilterSpec(filter);
+      var actualJobExecutions = jobExecutionRepository.findAll(jobExecutionFilterSpec);
+
+      Assertions.assertNotNull(actualJobExecutions);
+      Assertions.assertEquals(2, actualJobExecutions.size());
+      Assertions.assertEquals(expectedJobExecution1, actualJobExecutions.get(0));
+      Assertions.assertEquals(expectedJobExecution2, actualJobExecutions.get(1));
+   }
+
+   @Test
+   public void testJobExecutionFilterSpec_filerByStartTimeGte_shouldReturnResult() {
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+      OffsetDateTime now = OffsetDateTime.now();
+
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED, now.minusMinutes(2));
+      DataJobExecution expectedJobExecution1 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, now.minusMinutes(1));
+      DataJobExecution expectedJobExecution2 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED, now.minusMinutes(1));
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.FAILED, now.minusMinutes(2));
+
+      DataJobExecutionFilter filter = DataJobExecutionFilter.builder()
+            .startTimeGte(now.minusMinutes(1))
+            .build();
+      JobExecutionFilterSpec jobExecutionFilterSpec = new JobExecutionFilterSpec(filter);
+      var actualJobExecutions = jobExecutionRepository.findAll(jobExecutionFilterSpec);
+
+      Assertions.assertNotNull(actualJobExecutions);
+      Assertions.assertEquals(2, actualJobExecutions.size());
+      Assertions.assertEquals(expectedJobExecution1, actualJobExecutions.get(0));
+      Assertions.assertEquals(expectedJobExecution2, actualJobExecutions.get(1));
+   }
+
+   @Test
+   public void testJobExecutionFilterSpec_filerByEndTimeGte_shouldReturnResult() {
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+      OffsetDateTime now = OffsetDateTime.now();
+
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED, now.minusMinutes(2), now.minusMinutes(2));
+      DataJobExecution expectedJobExecution1 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, now.minusMinutes(1), now.minusMinutes(1));
+      DataJobExecution expectedJobExecution2 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED, now.minusMinutes(1), now.minusMinutes(1));
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.FAILED, now.minusMinutes(2), now.minusMinutes(2));
+
+      DataJobExecutionFilter filter = DataJobExecutionFilter.builder()
+            .endTimeGte(now.minusMinutes(1))
+            .build();
+      JobExecutionFilterSpec jobExecutionFilterSpec = new JobExecutionFilterSpec(filter);
+      var actualJobExecutions = jobExecutionRepository.findAll(jobExecutionFilterSpec);
+
+      Assertions.assertNotNull(actualJobExecutions);
+      Assertions.assertEquals(2, actualJobExecutions.size());
+      Assertions.assertEquals(expectedJobExecution1, actualJobExecutions.get(0));
+      Assertions.assertEquals(expectedJobExecution2, actualJobExecutions.get(1));
+   }
+
+   @Test
+   public void testJobExecutionFilterSpec_filerByAllFields_shouldReturnResult() {
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+      OffsetDateTime now = OffsetDateTime.now();
+
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED, now.minusMinutes(2), now.minusMinutes(2));
+      DataJobExecution expectedJobExecution1 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, now.minusMinutes(1), now.minusMinutes(1));
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED, now.minusMinutes(1), now.minusMinutes(1));
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.FAILED, now.minusMinutes(2), now.minusMinutes(2));
+
+      DataJobExecutionFilter filter = DataJobExecutionFilter.builder()
+            .startTimeGte(now.minusMinutes(1))
+            .endTimeGte(now.minusMinutes(1))
+            .statusIn(List.of(ExecutionStatus.RUNNING))
+            .build();
+      JobExecutionFilterSpec jobExecutionFilterSpec = new JobExecutionFilterSpec(filter);
+      var actualJobExecutions = jobExecutionRepository.findAll(jobExecutionFilterSpec);
+
+      Assertions.assertNotNull(actualJobExecutions);
+      Assertions.assertEquals(1, actualJobExecutions.size());
+      Assertions.assertEquals(expectedJobExecution1, actualJobExecutions.get(0));
+   }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/ExecutionDataFetcherFindAllAndBuildResponseIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/ExecutionDataFetcherFindAllAndBuildResponseIT.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.graphql;
+
+import static com.vmware.taurus.service.graphql.model.DataJobExecutionQueryVariables.FILTER_FIELD;
+import static com.vmware.taurus.service.graphql.model.DataJobExecutionQueryVariables.ORDER_FIELD;
+import static com.vmware.taurus.service.graphql.model.DataJobExecutionQueryVariables.PAGE_NUMBER_FIELD;
+import static com.vmware.taurus.service.graphql.model.DataJobExecutionQueryVariables.PAGE_SIZE_FIELD;
+import static org.mockito.Mockito.when;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+import graphql.GraphQLException;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.vmware.taurus.ControlplaneApplication;
+import com.vmware.taurus.RepositoryUtil;
+import com.vmware.taurus.service.JobExecutionRepository;
+import com.vmware.taurus.service.JobsRepository;
+import com.vmware.taurus.service.graphql.model.DataJobExecutionFilter;
+import com.vmware.taurus.service.graphql.model.DataJobExecutionOrder;
+import com.vmware.taurus.service.graphql.model.DataJobPage;
+import com.vmware.taurus.service.model.DataJob;
+import com.vmware.taurus.service.model.DataJobExecution;
+import com.vmware.taurus.service.model.ExecutionStatus;
+
+@SpringBootTest(classes = ControlplaneApplication.class)
+public class ExecutionDataFetcherFindAllAndBuildResponseIT {
+
+   @Autowired
+   private JobsRepository jobsRepository;
+
+   @Autowired
+   private JobExecutionRepository jobExecutionRepository;
+
+   @Autowired
+   private ExecutionDataFetcher executionDataFetcher;
+
+   @Mock
+   private DataFetchingEnvironment dataFetchingEnvironment;
+
+   @Mock
+   private Map<String, Object> filterRaw;
+
+   @Mock
+   private Map<String, Object> orderRaw;
+
+   @BeforeEach
+   public void setUp() throws Exception {
+      jobsRepository.deleteAll();
+   }
+
+   @Test
+   public void testFindAllAndBuildResponse_withoutFilters_shouldReturnResult() throws Exception {
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED);
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING);
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED);
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.FAILED);
+
+      when(dataFetchingEnvironment.getArgument(FILTER_FIELD)).thenReturn(null);
+      when(dataFetchingEnvironment.getArgument(ORDER_FIELD)).thenReturn(null);
+
+      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+      DataJobPage response = (DataJobPage)allAndBuildResponse.get(dataFetchingEnvironment);
+      List<Object> actualJobExecutions = response.getContent();
+
+      Assertions.assertNotNull(actualJobExecutions);
+      Assertions.assertEquals(4, actualJobExecutions.size());
+   }
+
+   @Test
+   public void testFindAllAndBuildResponse_filerByStatusIn_shouldReturnResult() throws Exception {
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED);
+      DataJobExecution expectedJobExecution1 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING);
+      DataJobExecution expectedJobExecution2 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED);
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.FAILED);
+
+      when(filterRaw.get(DataJobExecutionFilter.STATUS_IN_FIELD)).thenReturn(List.of(
+            com.vmware.taurus.controlplane.model.data.DataJobExecution.StatusEnum.RUNNING.toString(),
+            com.vmware.taurus.controlplane.model.data.DataJobExecution.StatusEnum.SUBMITTED.toString()));
+      when(dataFetchingEnvironment.getArgument(FILTER_FIELD)).thenReturn(filterRaw);
+      when(dataFetchingEnvironment.getArgument(ORDER_FIELD)).thenReturn(null);
+
+      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+      DataJobPage response = (DataJobPage)allAndBuildResponse.get(dataFetchingEnvironment);
+      List<Object> actualJobExecutions = response.getContent();
+
+      Assertions.assertNotNull(actualJobExecutions);
+      Assertions.assertEquals(2, actualJobExecutions.size());
+
+      assertExecutionsEquals(expectedJobExecution1, actualJobExecutions.get(0));
+      assertExecutionsEquals(expectedJobExecution2, actualJobExecutions.get(1));
+   }
+
+   @Test
+   public void testFindAllAndBuildResponse_filerByStartTimeGte_shouldReturnResult() throws Exception {
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+      OffsetDateTime now = OffsetDateTime.now();
+
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED, now.minusMinutes(2));
+      DataJobExecution expectedJobExecution1 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, now.minusMinutes(1));
+      DataJobExecution expectedJobExecution2 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED, now.minusMinutes(1));
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.FAILED, now.minusMinutes(2));
+
+      when(filterRaw.get(DataJobExecutionFilter.START_TIME_GTE_FIELD)).thenReturn(now.minusMinutes(1));
+      when(dataFetchingEnvironment.getArgument(FILTER_FIELD)).thenReturn(filterRaw);
+      when(dataFetchingEnvironment.getArgument(ORDER_FIELD)).thenReturn(null);
+
+      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+      DataJobPage response = (DataJobPage)allAndBuildResponse.get(dataFetchingEnvironment);
+      List<Object> actualJobExecutions = response.getContent();
+
+      Assertions.assertNotNull(actualJobExecutions);
+      Assertions.assertEquals(2, actualJobExecutions.size());
+
+      assertExecutionsEquals(expectedJobExecution1, actualJobExecutions.get(0));
+      assertExecutionsEquals(expectedJobExecution2, actualJobExecutions.get(1));
+   }
+
+   @Test
+   public void testFindAllAndBuildResponse_filerByEndTimeGte_shouldReturnResult() throws Exception {
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+      OffsetDateTime now = OffsetDateTime.now();
+
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED, now.minusMinutes(2), now.minusMinutes(2));
+      DataJobExecution expectedJobExecution1 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, now.minusMinutes(1), now.minusMinutes(1));
+      DataJobExecution expectedJobExecution2 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED, now.minusMinutes(1), now.minusMinutes(1));
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.FAILED, now.minusMinutes(2), now.minusMinutes(2));
+
+      when(filterRaw.get(DataJobExecutionFilter.END_TIME_GTE_FIELD)).thenReturn(now.minusMinutes(1));
+      when(dataFetchingEnvironment.getArgument(FILTER_FIELD)).thenReturn(filterRaw);
+      when(dataFetchingEnvironment.getArgument(ORDER_FIELD)).thenReturn(null);
+
+      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+      DataJobPage response = (DataJobPage)allAndBuildResponse.get(dataFetchingEnvironment);
+      List<Object> actualJobExecutions = response.getContent();
+
+      Assertions.assertNotNull(actualJobExecutions);
+      Assertions.assertEquals(2, actualJobExecutions.size());
+
+      assertExecutionsEquals(expectedJobExecution1, actualJobExecutions.get(0));
+      assertExecutionsEquals(expectedJobExecution2, actualJobExecutions.get(1));
+   }
+
+   @Test
+   public void testFindAllAndBuildResponse_filerByAllFields_shouldReturnResult() throws Exception {
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+      OffsetDateTime now = OffsetDateTime.now();
+
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED, now.minusMinutes(2), now.minusMinutes(2));
+      DataJobExecution expectedJobExecution1 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, now.minusMinutes(1), now.minusMinutes(1));
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED, now.minusMinutes(1), now.minusMinutes(1));
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.FAILED, now.minusMinutes(2), now.minusMinutes(2));
+
+      when(filterRaw.get(DataJobExecutionFilter.START_TIME_GTE_FIELD)).thenReturn(now.minusMinutes(1));
+      when(filterRaw.get(DataJobExecutionFilter.END_TIME_GTE_FIELD)).thenReturn(now.minusMinutes(1));
+      when(filterRaw.get(DataJobExecutionFilter.STATUS_IN_FIELD)).thenReturn(List.of(
+            com.vmware.taurus.controlplane.model.data.DataJobExecution.StatusEnum.RUNNING.toString()));
+
+      when(dataFetchingEnvironment.getArgument(FILTER_FIELD)).thenReturn(filterRaw);
+      when(dataFetchingEnvironment.getArgument(ORDER_FIELD)).thenReturn(null);
+
+      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+      DataJobPage response = (DataJobPage)allAndBuildResponse.get(dataFetchingEnvironment);
+      List<Object> actualJobExecutions = response.getContent();
+
+      Assertions.assertNotNull(actualJobExecutions);
+      Assertions.assertEquals(1, actualJobExecutions.size());
+
+      assertExecutionsEquals(expectedJobExecution1, actualJobExecutions.get(0));
+   }
+
+   @Test
+   public void testFindAllAndBuildResponse_orderByEndTime_shouldReturnResult() throws Exception {
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+
+      DataJobExecution expectedJobExecution1 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED);
+      DataJobExecution expectedJobExecution2 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING);
+      DataJobExecution expectedJobExecution3 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED);
+      DataJobExecution expectedJobExecution4 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.FAILED);
+
+      when(dataFetchingEnvironment.getArgument(FILTER_FIELD)).thenReturn(null);
+
+      when(orderRaw.get(DataJobExecutionOrder.PROPERTY_FIELD)).thenReturn("startTime");
+      when(orderRaw.get(DataJobExecutionOrder.DIRECTION_FIELD)).thenReturn("DESC");
+      when(dataFetchingEnvironment.getArgument(ORDER_FIELD)).thenReturn(orderRaw);
+
+      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+      DataJobPage response = (DataJobPage)allAndBuildResponse.get(dataFetchingEnvironment);
+      List<Object> actualJobExecutions = response.getContent();
+
+      Assertions.assertNotNull(actualJobExecutions);
+      Assertions.assertEquals(4, actualJobExecutions.size());
+
+      assertExecutionsEquals(expectedJobExecution1, actualJobExecutions.get(3));
+      assertExecutionsEquals(expectedJobExecution2, actualJobExecutions.get(2));
+      assertExecutionsEquals(expectedJobExecution3, actualJobExecutions.get(1));
+      assertExecutionsEquals(expectedJobExecution4, actualJobExecutions.get(0));
+   }
+
+   @Test
+   public void testFindAllAndBuildResponse_orderWithoutProperty_shouldReturnResult() {
+      when(dataFetchingEnvironment.getArgument(PAGE_NUMBER_FIELD)).thenReturn(1);
+      when(dataFetchingEnvironment.getArgument(PAGE_SIZE_FIELD)).thenReturn(3);
+      when(dataFetchingEnvironment.getArgument(FILTER_FIELD)).thenReturn(null);
+
+      when(orderRaw.get(DataJobExecutionOrder.PROPERTY_FIELD)).thenReturn("startTime");
+      when(dataFetchingEnvironment.getArgument(ORDER_FIELD)).thenReturn(orderRaw);
+      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+
+      Assertions.assertThrows(GraphQLException.class, () -> allAndBuildResponse.get(dataFetchingEnvironment));
+   }
+
+   @Test
+   public void testFindAllAndBuildResponse_orderWithoutDirection_shouldReturnResult() {
+      when(dataFetchingEnvironment.getArgument(PAGE_NUMBER_FIELD)).thenReturn(1);
+      when(dataFetchingEnvironment.getArgument(PAGE_SIZE_FIELD)).thenReturn(3);
+      when(dataFetchingEnvironment.getArgument(FILTER_FIELD)).thenReturn(null);
+
+      when(orderRaw.get(DataJobExecutionOrder.DIRECTION_FIELD)).thenReturn("DESC");
+      when(dataFetchingEnvironment.getArgument(ORDER_FIELD)).thenReturn(orderRaw);
+      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+
+      Assertions.assertThrows(GraphQLException.class, () -> allAndBuildResponse.get(dataFetchingEnvironment));
+   }
+
+   @Test
+   public void testFindAllAndBuildResponse_withPageNumberAndPageSize_shouldReturnResult() throws Exception {
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+
+      DataJobExecution expectedJobExecution1 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED);
+      DataJobExecution expectedJobExecution2 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING);
+      DataJobExecution expectedJobExecution3 =
+            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED);
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.FAILED);
+
+      when(dataFetchingEnvironment.getArgument(PAGE_NUMBER_FIELD)).thenReturn(1);
+      when(dataFetchingEnvironment.getArgument(PAGE_SIZE_FIELD)).thenReturn(3);
+
+      when(dataFetchingEnvironment.getArgument(FILTER_FIELD)).thenReturn(null);
+      when(dataFetchingEnvironment.getArgument(ORDER_FIELD)).thenReturn(null);
+
+      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+      DataJobPage response = (DataJobPage)allAndBuildResponse.get(dataFetchingEnvironment);
+      List<Object> actualJobExecutions = response.getContent();
+
+      Assertions.assertNotNull(actualJobExecutions);
+      Assertions.assertEquals(3, actualJobExecutions.size());
+
+      assertExecutionsEquals(expectedJobExecution1, actualJobExecutions.get(0));
+      assertExecutionsEquals(expectedJobExecution2, actualJobExecutions.get(1));
+      assertExecutionsEquals(expectedJobExecution3, actualJobExecutions.get(2));
+   }
+
+   @Test
+   public void testFindAllAndBuildResponse_withPageNumber_shouldReturnResult() {
+      when(dataFetchingEnvironment.getArgument(PAGE_NUMBER_FIELD)).thenReturn(1);
+      when(dataFetchingEnvironment.getArgument(FILTER_FIELD)).thenReturn(null);
+      when(dataFetchingEnvironment.getArgument(ORDER_FIELD)).thenReturn(null);
+
+      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+
+      Assertions.assertThrows(GraphQLException.class, () -> allAndBuildResponse.get(dataFetchingEnvironment));
+   }
+
+   @Test
+   public void testFindAllAndBuildResponse_withPageSize_shouldReturnResult() {
+      when(dataFetchingEnvironment.getArgument(PAGE_SIZE_FIELD)).thenReturn(1);
+      when(dataFetchingEnvironment.getArgument(FILTER_FIELD)).thenReturn(null);
+      when(dataFetchingEnvironment.getArgument(ORDER_FIELD)).thenReturn(null);
+
+      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+
+      Assertions.assertThrows(GraphQLException.class, () -> allAndBuildResponse.get(dataFetchingEnvironment));
+   }
+
+   private void assertExecutionsEquals(DataJobExecution expectedJobExecution, Object actualJobExecutionObject) {
+      com.vmware.taurus.controlplane.model.data.DataJobExecution actualJobExecution =
+            (com.vmware.taurus.controlplane.model.data.DataJobExecution)actualJobExecutionObject;
+
+      Assertions.assertEquals(expectedJobExecution.getId(), actualJobExecution.getId());
+      Assertions.assertEquals(expectedJobExecution.getStartTime(), actualJobExecution.getStartTime());
+      Assertions.assertEquals(expectedJobExecution.getEndTime(), actualJobExecution.getEndTime());
+      Assertions.assertEquals(expectedJobExecution.getJobVersion(), actualJobExecution.getDeployment().getJobVersion());
+   }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLDataFetchersTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLDataFetchersTest.java
@@ -20,7 +20,7 @@ import com.vmware.taurus.service.graphql.strategy.datajob.JobFieldStrategyBySche
 import com.vmware.taurus.service.graphql.strategy.datajob.JobFieldStrategyBySourceUrl;
 import com.vmware.taurus.service.graphql.strategy.datajob.JobFieldStrategyByTeam;
 import com.vmware.taurus.service.model.DataJob;
-import com.vmware.taurus.service.model.DataJobPage;
+import com.vmware.taurus.service.graphql.model.DataJobPage;
 import com.vmware.taurus.service.model.ExecutionStatus;
 import com.vmware.taurus.service.model.JobConfig;
 import com.vmware.taurus.service.model.JobDeploymentStatus;
@@ -28,7 +28,6 @@ import graphql.GraphQLException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingFieldSelectionSet;
-import graphql.schema.SelectedField;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -57,16 +56,19 @@ class GraphQLDataFetchersTest {
 
    @Mock
    private ExecutionDataFetcher executionDataFetcher;
+
    @Mock
    private JobsRepository jobsRepository;
+
    @Mock
    private DeploymentService deploymentService;
+
    @Mock
    private DataFetchingEnvironment dataFetchingEnvironment;
+
    @Mock
    private DataFetchingFieldSelectionSet dataFetchingFieldSelectionSet;
-   @Mock
-   private SelectedField selectedField;
+
    private DataFetcher<Object> findDataJobs;
 
    @BeforeEach

--- a/projects/control-service/projects/versions-of-external-dependencies.gradle
+++ b/projects/control-service/projects/versions-of-external-dependencies.gradle
@@ -47,6 +47,7 @@ project.ext {
             'io.swagger:swagger-models'                                          : 'io.swagger:swagger-models:1.5.22', //1.6.2
             'io.micrometer:micrometer-core'                                      : 'io.micrometer:micrometer-core:1.7.2',
             'com.squareup.okio:okio'                                             : 'com.squareup.okio:okio:2.10.0',
-            'org.apache.commons:commons-compress'                                : 'org.apache.commons:commons-compress:1.21'
+            'org.apache.commons:commons-compress'                                : 'org.apache.commons:commons-compress:1.21',
+            'org.hibernate:hibernate-jpamodelgen'                                : 'org.hibernate:hibernate-jpamodelgen:5.6.1.Final'
     ]
 }


### PR DESCRIPTION
Extended the existing GraphQL data fetcher for executions
(com.vmware.taurus.service.graphql.ExecutionDataFetcher)
to support filtering and sorting. The filtering and sorting
work at the database level for better performance
and resource (memory, network traffic, etc.) utilization.
The queries are be built dynamically based on the filters.

Sample GraphQL query:
```
{{ baseUrl  }}/data-jobs/for-team/no-team-specified/jobs?query={
  executions(pageNumber: 1, pageSize: 100, filter: {statusIn: [RUNNING, SUBMITTED]}, order: {property: "status", direction: DESC}]) {
    content {
          id
          startTime
          endTime
          status
          jobName
    }
  }
}
```
Sample GraphQL response:
```json
{
  "errors": [],
  "data": {
    "content": [
     {
        "id": "tms-staging-vdk-1633680894-1634638440",
        "startTime": "2021-10-19T10:14:47Z",
        "endTime": null,
        "status": "running",
        "jobName": "test_job1",
      },
     {
        "id": "tms-staging-vdk-1643242444-2131231312",
        "startTime": "2021-10-19T10:14:47Z",
        "endTime": null,
        "status": "submitted",
        "jobName": "test_job3",
      },
     {
        "id": "tms-staging-vdk-121321314-12312312333",
        "startTime": "2021-10-19T10:14:47Z",
        "endTime": null,
        "status": "running",
        "jobName": "test_job2",
      }
    ],
    "totalItems": 0,
    "totalPages": 0
  }
}
```

Testing: unit tests

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com