### PR TITLE
control-service: fix set vdk version be to set on image

### DIFF
--- a/projects/control-service/CHANGELOG.md
+++ b/projects/control-service/CHANGELOG.md
@@ -11,14 +11,17 @@ MAJOR.MINOR - dd.MM.yyyy
 
 * **Breaking Changes**
 
-=======
 1.3 - 09.11.2021
 ----
 * **Bug fixes**
   * Classify K8s pod OOM errors as UserError.
 
+* **Improvement**
+  * Users can now set vdk version (vdk image tag in reality)
+    This would enable canary release of vdk, A/B testing.
+    https://github.com/vmware/versatile-data-kit/issues/377
 
-=======
+
 1.3 - 03.11.2021
 ----
 * **Bug fixes**

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudIT.java
@@ -5,6 +5,7 @@
 
 package com.vmware.taurus.datajobs.it;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vmware.taurus.ControlplaneApplication;
 import com.vmware.taurus.controlplane.model.data.DataJobDeploymentStatus;
 import com.vmware.taurus.controlplane.model.data.DataJobMode;
@@ -12,7 +13,6 @@ import com.vmware.taurus.controlplane.model.data.DataJobVersion;
 import com.vmware.taurus.datajobs.it.common.BaseIT;
 import com.vmware.taurus.service.deploy.JobImageDeployer;
 import com.vmware.taurus.service.model.JobDeploymentStatus;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -30,15 +30,15 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MvcResult;
 
-import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @Import({DataJobDeploymentCrudIT.TaskExecutorConfig.class})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = ControlplaneApplication.class)
@@ -176,6 +176,8 @@ public class DataJobDeploymentCrudIT extends BaseIT {
       Assertions.assertEquals(true, jobDeployment.getEnabled());
       Assertions.assertEquals(DataJobMode.RELEASE, jobDeployment.getMode());
       Assertions.assertEquals(true, jobDeployment.getEnabled());
+      // by default the version is the same as the tag specified by datajobs.vdk.image
+      // for integration test this is registry.hub.docker.com/versatiledatakit/quickstart-vdk:release
       Assertions.assertEquals("release", jobDeployment.getVdkVersion());
       Assertions.assertEquals("user", jobDeployment.getLastDeployedBy());
       // just check some valid date is returned. It would be too error-prone/brittle to verify exact time.
@@ -224,6 +226,47 @@ public class DataJobDeploymentCrudIT extends BaseIT {
       Assertions.assertTrue(cronJobOptional.isPresent());
       cronJob = cronJobOptional.get();
       Assertions.assertEquals(false, cronJob.getEnabled());
+
+      // Execute set vdk version for deployment
+      mockMvc.perform(patch(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s",
+                      TEST_TEAM_NAME,
+                      TEST_JOB_NAME,
+                      DEPLOYMENT_ID))
+                      .with(user("user"))
+                      .content(getDataJobDeploymentVdkVersionRequestBody("new_vdk_version_tag"))
+                      .contentType(MediaType.APPLICATION_JSON))
+              .andExpect(status().isAccepted());
+
+      // verify vdk version is returned
+      mockMvc.perform(get(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s",
+                      TEST_TEAM_NAME,
+                      TEST_JOB_NAME,
+                      DEPLOYMENT_ID))
+                      .with(user("user"))
+                      .contentType(MediaType.APPLICATION_JSON))
+              .andExpect(status().isOk())
+              .andExpect(jsonPath("$.vdk_version", is("new_vdk_version_tag")));
+
+      // Execute reset back vdk version for deployment
+      mockMvc.perform(patch(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s",
+                      TEST_TEAM_NAME,
+                      TEST_JOB_NAME,
+                      DEPLOYMENT_ID))
+                      .with(user("user"))
+                      .content(getDataJobDeploymentVdkVersionRequestBody(""))
+                      .contentType(MediaType.APPLICATION_JSON))
+              .andExpect(status().isAccepted());
+
+      // verify vdk version is reset correctly
+      mockMvc.perform(get(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s",
+                      TEST_TEAM_NAME,
+                      TEST_JOB_NAME,
+                      DEPLOYMENT_ID))
+                      .with(user("user"))
+                      .contentType(MediaType.APPLICATION_JSON))
+              .andExpect(status().isOk())
+              .andExpect(jsonPath("$.vdk_version", is("release")));
+
 
       // Execute delete deployment with no user
       mockMvc.perform(delete(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s",

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/BaseIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/BaseIT.java
@@ -407,4 +407,10 @@ public class BaseIT extends KerberosSecurityTestcaseJunit5 {
       enable.enabled(enabled);
       return mapper.writeValueAsString(enable);
    }
+
+   public String getDataJobDeploymentVdkVersionRequestBody(String vdkVersion) throws JsonProcessingException {
+      var deployment = new DataJobDeployment();
+      deployment.setVdkVersion(vdkVersion);
+      return mapper.writeValueAsString(deployment);
+   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
@@ -59,6 +59,7 @@ public class DeploymentModelConverter {
 
         mergedDeployment.setMode(newDeployment.getMode() != null ? newDeployment.getMode() : oldDeployment.getMode());
         mergedDeployment.setGitCommitSha(newDeployment.getGitCommitSha() != null ? newDeployment.getGitCommitSha() : oldDeployment.getGitCommitSha());
+        mergedDeployment.setVdkVersion(newDeployment.getVdkVersion() != null ? newDeployment.getVdkVersion() : oldDeployment.getVdkVersion());
         return mergedDeployment;
     }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/DeploymentModelConverterTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/DeploymentModelConverterTest.java
@@ -17,11 +17,13 @@ public class DeploymentModelConverterTest {
         var oldDeployment = getTestJobDeployment();
         var newDeployment = new JobDeployment();
         newDeployment.setEnabled(false);
+        newDeployment.setVdkVersion("new");
 
         var mergedDeployment = DeploymentModelConverter.mergeDeployments(oldDeployment, newDeployment);
 
         Assertions.assertEquals(false, mergedDeployment.getEnabled());
         Assertions.assertEquals(oldDeployment.getMode(), mergedDeployment.getMode());
+        Assertions.assertEquals("new", mergedDeployment.getVdkVersion());
     }
 
     @Test
@@ -44,6 +46,7 @@ public class DeploymentModelConverterTest {
         jobDeployment.setResources(new DataJobResources());
         jobDeployment.setMode("mode");
         jobDeployment.setGitCommitSha("job-version");
+        jobDeployment.setVdkVersion("release");
         return jobDeployment;
     }
 }


### PR DESCRIPTION
The vdk version was not actually being set because the merge logic was
was not merging it and the old version was kept.

Testing Done: started the control service locally and tested with vdk
deploy --update --vdk-version explicitly. Added test in integration test
suite.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>