### PR TITLE
control-service: add team to job deployment

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsDeploymentController.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsDeploymentController.java
@@ -78,7 +78,7 @@ public class DataJobsDeploymentController implements DataJobsDeploymentApi {
          Optional<com.vmware.taurus.service.model.DataJob> job = jobsService.getByName(jobName);
 
          if (job.isPresent()) {
-            var jobDeployment = ToModelApiConverter.toJobDeployment(jobName, dataJobDeployment);
+            var jobDeployment = ToModelApiConverter.toJobDeployment(teamName, jobName, dataJobDeployment);
             deploymentService.patchDeployment(job.get(), jobDeployment);
             return ResponseEntity.accepted().build();
          }
@@ -117,7 +117,7 @@ public class DataJobsDeploymentController implements DataJobsDeploymentApi {
       if (jobsService.jobWithTeamExists(jobName, teamName)) {
          Optional<com.vmware.taurus.service.model.DataJob> job = jobsService.getByName(jobName.toLowerCase());
          if (job.isPresent()) {
-            var jobDeployment = ToModelApiConverter.toJobDeployment(jobName.toLowerCase(), dataJobDeployment);
+            var jobDeployment = ToModelApiConverter.toJobDeployment(teamName, jobName.toLowerCase(), dataJobDeployment);
             //TODO: Consider using a Task-oriented API approach
             deploymentService.updateDeployment(job.get(), jobDeployment, sendNotification,
                     operationContext.getUser(), operationContext.getOpId());

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
@@ -18,9 +18,10 @@ import org.springframework.stereotype.Service;
 @AllArgsConstructor
 public class DeploymentModelConverter {
 
-    public static JobDeployment toJobDeployment(JobDeploymentStatus jobDeploymentStatus) {
+    public static JobDeployment toJobDeployment(String teamName, String jobName, JobDeploymentStatus jobDeploymentStatus) {
         JobDeployment deployment = new JobDeployment();
-        deployment.setDataJobName(jobDeploymentStatus.getDataJobName());
+        deployment.setDataJobTeam(teamName);
+        deployment.setDataJobName(jobName);
         deployment.setCronJobName(jobDeploymentStatus.getCronJobName());
         deployment.setImageName(jobDeploymentStatus.getImageName());
         deployment.setEnabled(jobDeploymentStatus.getEnabled());
@@ -39,7 +40,13 @@ public class DeploymentModelConverter {
      */
     public static JobDeployment mergeDeployments(JobDeployment oldDeployment, JobDeployment newDeployment) {
         JobDeployment mergedDeployment = new JobDeployment();
-        mergedDeployment.setDataJobName(oldDeployment.getDataJobName());
+        if (!newDeployment.getDataJobName().equals(oldDeployment.getDataJobName()) ||
+            !newDeployment.getDataJobTeam().equals(oldDeployment.getDataJobTeam())) {
+            throw new IllegalArgumentException("Cannot merge 2 deployments if team or job name is different." +
+                    oldDeployment + " vs " + newDeployment);
+        }
+        mergedDeployment.setDataJobTeam(newDeployment.getDataJobTeam());
+        mergedDeployment.setDataJobName(newDeployment.getDataJobName());
         mergedDeployment.setCronJobName(newDeployment.getCronJobName() != null ? newDeployment.getCronJobName() : oldDeployment.getCronJobName());
         mergedDeployment.setImageName(newDeployment.getImageName() != null ? newDeployment.getImageName() : oldDeployment.getImageName());
         mergedDeployment.setEnabled(newDeployment.getEnabled() != null ? newDeployment.getEnabled() : oldDeployment.getEnabled());

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/ToModelApiConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/ToModelApiConverter.java
@@ -15,9 +15,10 @@ import org.apache.commons.lang3.StringUtils;
 @Slf4j
 public class ToModelApiConverter {
 
-   public static JobDeployment toJobDeployment(String jobName, DataJobDeployment dataJobDeployment) {
+   public static JobDeployment toJobDeployment(String teamName, String jobName, DataJobDeployment dataJobDeployment) {
 
       JobDeployment jobDeployment = new JobDeployment();
+      jobDeployment.setDataJobTeam(teamName);
       jobDeployment.setDataJobName(jobName);
       jobDeployment.setEnabled(dataJobDeployment.getEnabled());
       jobDeployment.setResources(dataJobDeployment.getResources());

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentService.java
@@ -19,11 +19,9 @@ import io.kubernetes.client.ApiException;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -65,7 +63,8 @@ public class DeploymentService {
    public void patchDeployment(DataJob dataJob, JobDeployment jobDeployment) {
       var deploymentStatus = readDeployment(dataJob.getName());
       if (deploymentStatus.isPresent()) {
-         var oldDeployment = DeploymentModelConverter.toJobDeployment(deploymentStatus.get());
+         var oldDeployment = DeploymentModelConverter.toJobDeployment(
+                 dataJob.getJobConfig().getTeam(), dataJob.getName(), deploymentStatus.get());
          var mergedDeployment = DeploymentModelConverter.mergeDeployments(oldDeployment, jobDeployment);
          validateFieldsCanBePatched(oldDeployment, mergedDeployment);
 
@@ -126,7 +125,7 @@ public class DeploymentService {
          deploymentProgress.started(dataJob.getJobConfig(), jobDeployment);
          var deploymentStatus = readDeployment(dataJob.getName());
          if (deploymentStatus.isPresent()) {
-            var oldDeployment = DeploymentModelConverter.toJobDeployment(deploymentStatus.get());
+            var oldDeployment = DeploymentModelConverter.toJobDeployment(dataJob.getJobConfig().getTeam(), dataJob.getName(), deploymentStatus.get());
             jobDeployment = DeploymentModelConverter.mergeDeployments(oldDeployment, jobDeployment);
          }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/JobDeployment.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/JobDeployment.java
@@ -15,6 +15,8 @@ import lombok.Data;
 @Data
 public class JobDeployment {
 
+   private String dataJobTeam;
+
    private String dataJobName;
 
    private String gitCommitSha;

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/DeploymentModelConverterTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/DeploymentModelConverterTest.java
@@ -16,6 +16,8 @@ public class DeploymentModelConverterTest {
     void test_mergeDeployments() {
         var oldDeployment = getTestJobDeployment();
         var newDeployment = new JobDeployment();
+        newDeployment.setDataJobTeam(oldDeployment.getDataJobTeam());
+        newDeployment.setDataJobName(oldDeployment.getDataJobName());
         newDeployment.setEnabled(false);
         newDeployment.setVdkVersion("new");
 
@@ -30,6 +32,8 @@ public class DeploymentModelConverterTest {
     void test_mergeDeployments_resources() {
         var oldDeployment = getTestJobDeployment();
         var newDeployment = new JobDeployment();
+        newDeployment.setDataJobTeam(oldDeployment.getDataJobTeam());
+        newDeployment.setDataJobName(oldDeployment.getDataJobName());
         newDeployment.setGitCommitSha("new-version");
         var newResources = new DataJobResources();
         newResources.setMemoryLimit(2);
@@ -41,6 +45,7 @@ public class DeploymentModelConverterTest {
 
     private static JobDeployment getTestJobDeployment() {
         JobDeployment jobDeployment = new JobDeployment();
+        jobDeployment.setDataJobTeam("job-team");
         jobDeployment.setDataJobName("job-name");
         jobDeployment.setEnabled(true);
         jobDeployment.setResources(new DataJobResources());

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/TestUtils.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/TestUtils.java
@@ -18,6 +18,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class TestUtils {
+
+   public static final String TEST_TEAM_NAME = "test-team-name";
+
    private static final ObjectMapper mapper = new ObjectMapper();
 
    //@NotNull
@@ -92,6 +95,7 @@ public class TestUtils {
 
    public static JobDeployment getJobDeployment() {
       JobDeployment jobDeployment = new JobDeployment();
+      jobDeployment.setDataJobTeam(TestUtils.TEST_TEAM_NAME);
       jobDeployment.setGitCommitSha("version");
       jobDeployment.setEnabled(true);
       jobDeployment.setImageName("test-job-image-name");

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
@@ -124,6 +124,7 @@ public class DeploymentServiceTest {
               .thenReturn(new KubernetesService.Resources("2000m", "1G"));
 
       JobConfig jobConfig = new JobConfig();
+      jobConfig.setTeam(TestUtils.TEST_TEAM_NAME);
       jobConfig.setSchedule(TEST_JOB_SCHEDULE);
       testDataJob = new DataJob();
       testDataJob.setName(TEST_JOB_NAME);
@@ -230,7 +231,8 @@ public class DeploymentServiceTest {
    @Test
    public void patchDeployment() throws ApiException {
       JobDeployment jobDeployment = new JobDeployment();
-      jobDeployment.setDataJobName(TEST_JOB_NAME);
+      jobDeployment.setDataJobTeam(testDataJob.getJobConfig().getTeam());
+      jobDeployment.setDataJobName(testDataJob.getName());
       jobDeployment.setEnabled(true);
 
       deploymentService.patchDeployment(testDataJob, jobDeployment);
@@ -246,6 +248,8 @@ public class DeploymentServiceTest {
    @Test
    public void enableDeployment_sameEnabledStatus_updateSkipped() throws ApiException {
       JobDeployment jobDeployment = new JobDeployment();
+      jobDeployment.setDataJobTeam(testDataJob.getJobConfig().getTeam());
+      jobDeployment.setDataJobName(testDataJob.getName());
       jobDeployment.setEnabled(true);
 
       deploymentService.patchDeployment(testDataJob, jobDeployment);


### PR DESCRIPTION
Issue: https://github.com/vmware/versatile-data-kit/issues/403

API clearly defines that a unique data job  ID is a composite of team
and job name. But we are missing that when reporting job deployment

This causes any reports relying on the correct owner team not to work
properly.

Testing Done: ran control service locally with telemetry webhook set to
https://requestbin.com and saw telemetry contains dataJobTeam

```
{
"class_name_full" :
"com.vmware.taurus.service.deploy.DeploymentProgress",
  "class_name_short" : "DeploymentProgress",

"measurable_args" :
"{\"deployment\":{\"dataJobTeam\":\"ai\",\"dataJobName\":\"ai-test\",\"gitCommitSha\":\"e88267478b4cfa83ec1482acf9f902b904eff12e\",\"enabled\":true,\"mode\":\"release\"}}",
   ....
  "@table" : "taurus_api_call",
}
```

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>