### PR TITLE
control-service: update the last execution state on job completion

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
@@ -233,14 +233,14 @@ public class JobExecutionService {
     * Updates job execution in database. It does NOT update job execution when the execution status
     * has not changed or if the status is not in the correct order (e.g. from FINISHED to RUNNING).
     */
-   public void updateJobExecution(
+   public Optional<com.vmware.taurus.service.model.DataJobExecution> updateJobExecution(
          final DataJob dataJob,
          final KubernetesService.JobExecution jobExecution,
          ExecutionResult executionResult) {
 
       if (StringUtils.isBlank(jobExecution.getExecutionId())) {
          log.warn("Could not store Data Job execution due to the missing execution id: {}", jobExecution);
-         return;
+         return Optional.empty();
       }
 
       final Optional<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionPersistedOptional =
@@ -263,7 +263,7 @@ public class JobExecutionService {
                "Execution status to be updated {}. New execution status {}",
                dataJobExecutionPersistedOptional.get().getStatus(),
                executionResult.getExecutionStatus());
-         return;
+         return Optional.empty();
       }
 
       final com.vmware.taurus.service.model.DataJobExecution.DataJobExecutionBuilder dataJobExecutionBuilder =
@@ -292,7 +292,7 @@ public class JobExecutionService {
               .lastDeployedDate(jobExecution.getDeployedDate())
               .lastDeployedBy(jobExecution.getDeployedBy())
               .build();
-      jobExecutionRepository.save(dataJobExecution);
+      return Optional.of(jobExecutionRepository.save(dataJobExecution));
    }
 
    /**


### PR DESCRIPTION
As part of the implementation of filtering and sorting of data jobs
by last execution status, time, and duration, save the last
execution information in the data_job table when a data job
execution completes.

Testing done: unit tests

Signed-off-by: Tsvetomir Palashki <tpalashki@vmware.com>