### PR TITLE
versatile-data-kit: vdk-health dockerfile

### DIFF
--- a/support/telemetry/vdk-health/Dockerfile
+++ b/support/telemetry/vdk-health/Dockerfile
@@ -1,0 +1,6 @@
+FROM grimoirelab/full
+ADD vdk_project.cfg /project.cfg
+ADD vdk_github_token.cfg /override.cfg
+ADD vdk_projects.json /projects.json
+ENTRYPOINT ["/entrypoint.sh"]
+CMD [ "-c", "/infra.cfg", "/dashboard.cfg", "/project.cfg", "/override.cfg"]

--- a/support/telemetry/vdk-health/README.md
+++ b/support/telemetry/vdk-health/README.md
@@ -1,0 +1,21 @@
+## vdk-health
+
+### Overview
+This directory contains the necessary files to instantiate the Grimoirelab suite which
+will collect data from the VDK repository and present it in a Kibana dashboard.
+
+The purpose of this is to be able to monitor the health of the VDK repository.
+It is almost fully pre-configured to collect data from this repository, and it only requires a Github API
+token.
+
+### How to build and deploy the vdk-health image
+Requires Docker.
+Testing was done using Docker 20.10.5, but it should work using any
+newer version.
+
+1. Create a Github API token - https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token;
+2. Copy the token and paste it in the appropriate field in the `vdk_github_token.cfg` file;
+3. Run `docker build vdk-health/` from the parent directory. This command will output a sha256 hash as a label for the built image.
+4. Run `docker run -p 5601:5601 *sha256 hash from previous output*`.
+5. Wait for all Grimoirelab and extra software to be up and running. Check the container logs if curious.
+6. Open `http://localhost:5601` in a browser and observe your newly created dashboard.

--- a/support/telemetry/vdk-health/vdk_github_token.cfg
+++ b/support/telemetry/vdk-health/vdk_github_token.cfg
@@ -1,0 +1,2 @@
+[github]
+api-token=*Github API token*

--- a/support/telemetry/vdk-health/vdk_project.cfg
+++ b/support/telemetry/vdk-health/vdk_project.cfg
@@ -1,0 +1,30 @@
+# Most of this file was copied from the default project.cfg in the grimoirelab/full image
+
+# Mordred configuration file (Project)
+# Parameters related to the project being analyzed
+# This is maintaned usually by the person knowing the project
+#
+# List: [val1, val2 ...]
+# Int: int_value
+# Int as string: "Int"
+# List as string: "[val1, val2 ...]"
+# String: string_value
+# None: None, none
+# Boolean: true, True, False, false
+
+[general]
+short_name = versatile-data-kit
+
+[sortinghat]
+# Use organizations file
+load_orgs = true
+orgs_file = orgs.json
+
+# Organization name for people not affiliated to any organization
+unaffiliated_group = VDK-devs
+
+# Ids known to be bots
+bots_names = [versatile-data-kit-dev]
+
+# How to autoprofile
+autoprofile = [versatile-data-kit:manual,git,github]

--- a/support/telemetry/vdk-health/vdk_projects.json
+++ b/support/telemetry/vdk-health/vdk_projects.json
@@ -1,0 +1,10 @@
+{
+  "versatile-data-kit": {
+    "github": [
+      "https://github.com/vmware/versatile-data-kit"
+    ],
+    "git": [
+      "https://github.com/vmware/versatile-data-kit"
+    ]
+  }
+}


### PR DESCRIPTION
The VDK project requires some way to monitor the health of the
repository. This change includes a Dockerfile which, when deployed,
instantiates a set of tools which collect data from Github and
present it in a Kibana dashboard.

Testing done: ran locally

Signed-off-by: gageorgiev <gageorgiev@vmware.com>