### PR TITLE
control-service: fix OOM classification as User error

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMonitor.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMonitor.java
@@ -207,9 +207,12 @@ public class DataJobMonitor {
         // Do not update the status when either:
         //   * the status is SKIPPED
         //   * the status and executionId have not changed
+        //   * the executionId has not changed and the old status is final (CANCELLED, FAILED, FINISHED, SKIPPED)
         if (terminationStatus == ExecutionTerminationStatus.SKIPPED ||
                 dataJob.getLatestJobTerminationStatus() == terminationStatus &&
-                        StringUtils.equals(dataJob.getLatestJobExecutionId(), executionId)) {
+                        StringUtils.equals(dataJob.getLatestJobExecutionId(), executionId) ||
+                StringUtils.equals(dataJob.getLatestJobExecutionId(), executionId) &&
+                        dataJob.getLatestJobTerminationStatus() != ExecutionTerminationStatus.NONE) {
             log.debug("The termination status of data job {} will not be updated. Old status is: {}, New status is: {}; Old execution id: {}, New execution id: {}",
                     dataJob.getName(), dataJob.getLatestJobTerminationStatus(), terminationStatus, dataJob.getLatestJobExecutionId(), executionId);
             return false;

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DataJobMonitorTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DataJobMonitorTest.java
@@ -532,6 +532,19 @@ public class DataJobMonitorTest {
         Assertions.assertEquals(jobExecution.getEndTime(), actualJob.get().getLastExecutionEndTime());
     }
 
+    @Test
+    @Order(31)
+    void testRecordJobExecutionStatus_withSameExecutionIdAndOldStatusIsFinal_shouldNotUpdateLastExecution() {
+        JobExecution jobExecution = buildJobExecutionStatus("new-job", "new-execution-id", ExecutionTerminationStatus.USER_ERROR.getString());
+
+        dataJobMonitor.recordJobExecutionStatus(jobExecution);
+
+        Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
+        Assertions.assertFalse(actualJob.isEmpty());
+        // The termination status should not have changed from SUCCESS to USER_ERROR because SUCCESS is a final status
+        Assertions.assertEquals(ExecutionTerminationStatus.SUCCESS, actualJob.get().getLatestJobTerminationStatus());
+    }
+
     private static String randomId(String prefix) {
         return prefix + UUID.randomUUID();
     }


### PR DESCRIPTION
Recently we implemented a fix to classify job executions that run OOM
as User errors. For this purpose, we observe the status of the
executing pod. When the K8s job first terminates, its pod is inspected
and the termination status is correctly set to User error. However,
during subsequent updates, the pod may disappear and this is
interpreted as Platform error.

With this commit, we prevent changes to the termination status of an
execution if the status is final (i.e. not None).

Testing done: new unit tests

Signed-off-by: Tsvetomir Palashki <tpalashki@vmware.com>