### PR TITLE
vdk-heartbeat: Make vdkcli_oauth2_uri and control_api_url optional

### DIFF
--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/config.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/config.py
@@ -25,9 +25,11 @@ class Config:
         self.vdkcli_api_refresh_token = self._get_atleast_one_value(
             "VDKCLI_OAUTH2_REFRESH_TOKEN", "VDK_HEARTBEAT_API_TOKEN"
         )
+        # If no value is found, argument will not be passed and default will be used
         self.vdkcli_oauth2_uri = self._get_atleast_one_value(
-            "VDKCLI_OAUTH2_URI", "VDK_HEARTBEAT_API_TOKEN_AUTH_URL"
+            "VDKCLI_OAUTH2_URI", "VDK_HEARTBEAT_API_TOKEN_AUTH_URL", is_required=False
         )
+
         self.op_id = self.get_value("VDK_HEARTBEAT_OP_ID", Config.DEFAULT_OP_ID)
         table_suffix = re.sub("[^a-z0-9_]", "_", self.op_id.lower())
         job_suffix = re.sub("[^a-z0-9-]", "-", self.op_id.lower())
@@ -102,8 +104,9 @@ class Config:
         )
 
         # The Control Service API URL (http://url/data-jobs) without data-jobs suffix
+        # If no value is found, argument will not be passed and default will be used
         self.control_api_url = self._get_atleast_one_value(
-            "CONTROL_API_URL", "VDK_HEARTBEAT_CONTROL_SERVICE_URL"
+            "CONTROL_API_URL", "VDK_HEARTBEAT_CONTROL_SERVICE_URL", is_required=False
         )
 
         # Job name deployed during the test
@@ -211,11 +214,11 @@ class Config:
             )
         return value
 
-    def _get_atleast_one_value(self, key1: str, key2: str) -> Optional[str]:
+    def _get_atleast_one_value(self, key1: str, key2: str, is_required=True):
         value1 = self.get_value(key1, is_required=False)
         value2 = self.get_value(key2, is_required=False)
 
-        if (value1 is None) and (value2 is None):
+        if is_required and (value1 is None) and (value2 is None):
             raise ValueError(
                 "Error occurred:\n"
                 f"What: Cannot configure heartbeat test\n"

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
@@ -23,11 +23,33 @@ class JobController:
 
     def __init__(self, config: Config):
         self.config = config
-        log.info(
-            f"Using Control Service REST API URL: {config.control_api_url} "
-            f"with job {config.job_name} and team {config.job_team}."
-            f"Authorization endpoint: {config.vdkcli_oauth2_uri}"
+        control_api_url_message = (
+            config.control_api_url
+            or "Not set (default from VDK's configuration will be used)"
         )
+        auth_endpoint_message = (
+            config.vdkcli_oauth2_uri
+            or "Not set (default from VDK's configuration will be used)"
+        )
+        log.info(
+            f"Using Control Service REST API URL: {control_api_url_message} "
+            f"with job {config.job_name} and team {config.job_team}. "
+            f"Authorization endpoint: {auth_endpoint_message}"
+        )
+
+    # If no value is found, argument will not be passed and default configuration will be used
+    def __get_api_token_authorization_url_arg(self):
+        if self.config.vdkcli_oauth2_uri:
+            return ["-u", f"{self.config.vdkcli_oauth2_uri}"]
+        else:
+            return []
+
+    # If no value is found, argument will not be passed and default configuration will be used
+    def __get_rest_api_url_arg(self):
+        if self.config.control_api_url:
+            return ["-u", f"{self.config.control_api_url}"]
+        else:
+            return []
 
     def _execute(self, command):
         # base_command = [f"python", "-m", "vdk.internal.control.main"]
@@ -49,13 +71,12 @@ class JobController:
         self._execute(
             [
                 "login",
-                "-u",
-                f"{self.config.vdkcli_oauth2_uri}",
                 "-a",
                 f"{self.config.vdkcli_api_refresh_token}",
                 "-t",
                 "api-token",
             ]
+            + self.__get_api_token_authorization_url_arg()
         )
 
     @LogDecorator(log)
@@ -63,14 +84,13 @@ class JobController:
         self._execute(
             [
                 "delete",
-                "-u",
-                self.config.control_api_url,
                 "-n",
                 self.config.job_name,
                 "-t",
                 self.config.job_team,
                 "--yes",
             ]
+            + self.__get_rest_api_url_arg()
         )
 
     @LogDecorator(log)
@@ -79,8 +99,6 @@ class JobController:
             self._execute(
                 [
                     "create",
-                    "-u",
-                    self.config.control_api_url,
                     "-n",
                     self.config.job_name,
                     "-t",
@@ -88,6 +106,7 @@ class JobController:
                     "-p",
                     tmpdir,
                 ]
+                + self.__get_rest_api_url_arg()
             )
 
     @LogDecorator(log)
@@ -97,11 +116,10 @@ class JobController:
                 "list",
                 "-o",
                 "json",
-                "-u",
-                self.config.control_api_url,
                 "-t",
                 self.config.job_team,
             ]
+            + self.__get_rest_api_url_arg()
         )
         res = json.loads(res)
         assert filter(
@@ -113,8 +131,6 @@ class JobController:
         res = self._execute(
             [
                 "show",
-                "-u",
-                self.config.control_api_url,
                 "-o",
                 "json",
                 "-n",
@@ -122,6 +138,7 @@ class JobController:
                 "-t",
                 self.config.job_team,
             ]
+            + self.__get_rest_api_url_arg()
         )
         res = json.loads(res)
         log.info(
@@ -133,14 +150,13 @@ class JobController:
         res = self._execute(
             [
                 "execute",
-                "-u",
-                self.config.control_api_url,
                 "--logs",
                 "-n",
                 self.config.job_name,
                 "-t",
                 self.config.job_team,
             ]
+            + self.__get_rest_api_url_arg()
         )
         logs = res.decode("unicode_escape") if res else res
         log.info(
@@ -158,13 +174,12 @@ class JobController:
                     "--show",
                     "-o",
                     "json",
-                    "-u",
-                    self.config.control_api_url,
                     "-n",
                     self.config.job_name,
                     "-t",
                     self.config.job_team,
                 ]
+                + self.__get_rest_api_url_arg()
             )
             deployments = json.loads(deployments)
             if not deployments:
@@ -183,13 +198,12 @@ class JobController:
                 "--list",
                 "-o",
                 "json",
-                "-u",
-                self.config.control_api_url,
                 "-n",
                 self.config.job_name,
                 "-t",
                 self.config.job_team,
             ]
+            + self.__get_rest_api_url_arg()
         )
         return json.loads(res)
 
@@ -201,13 +215,12 @@ class JobController:
                 "--set",
                 key,
                 value,
-                "-u",
-                self.config.control_api_url,
                 "-n",
                 self.config.job_name,
                 "-t",
                 self.config.job_team,
             ]
+            + self.__get_rest_api_url_arg()
         )
 
     @LogDecorator(log)
@@ -216,13 +229,12 @@ class JobController:
             [
                 "deploy",
                 "--enable",
-                "-u",
-                self.config.control_api_url,
                 "-n",
                 self.config.job_name,
                 "-t",
                 self.config.job_team,
             ]
+            + self.__get_rest_api_url_arg()
         )
 
     @LogDecorator(log)
@@ -231,13 +243,12 @@ class JobController:
             [
                 "deploy",
                 "--disable",
-                "-u",
-                self.config.control_api_url,
                 "-n",
                 self.config.job_name,
                 "-t",
                 self.config.job_team,
             ]
+            + self.__get_rest_api_url_arg()
         )
 
     @LogDecorator(log)
@@ -250,8 +261,6 @@ class JobController:
             self._execute(
                 [
                     "deploy",
-                    "-u",
-                    self.config.control_api_url,
                     "-n",
                     self.config.job_name,
                     "-t",
@@ -261,6 +270,7 @@ class JobController:
                     "-r",
                     "Updating heartbeat data job",
                 ]
+                + self.__get_rest_api_url_arg()
             )
 
     @LogDecorator(log)
@@ -276,9 +286,8 @@ class JobController:
                 self.config.job_name,
                 "-o",
                 "json",
-                "-u",
-                self.config.control_api_url,
             ]
+            + self.__get_rest_api_url_arg()
         )
 
         job_execution_id = json.loads(job_execution)["execution_id"]
@@ -293,11 +302,10 @@ class JobController:
                 self.config.job_name,
                 "-o",
                 "json",
-                "-u",
-                self.config.control_api_url,
                 "--execution-id",
                 str(job_execution_id),
             ]
+            + self.__get_rest_api_url_arg()
         )
         execution_response = json.loads(response)
 
@@ -325,9 +333,8 @@ class JobController:
                     "-n",
                     self.config.job_name,
                     "-o" "json",
-                    "-u",
-                    self.config.control_api_url,
                 ]
+                + self.__get_rest_api_url_arg()
             )
             execution_list = json.loads(response)
 

--- a/projects/vdk-heartbeat/tests/vdk/internal/test_config.py
+++ b/projects/vdk-heartbeat/tests/vdk/internal/test_config.py
@@ -1,0 +1,94 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import os
+import tempfile
+from unittest import mock
+
+import pytest
+from vdk.internal.heartbeat.config import Config
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "VDKCLI_OAUTH2_REFRESH_TOKEN": "some-test-token",
+    },
+)
+def test_get_atleast_one_value_from_env_vars():
+    config = Config()
+
+    # Both variables set
+    with mock.patch.dict(
+        os.environ,
+        {
+            "VAR1": "value1",
+            "VAR2": "value2",
+        },
+    ):
+        assert "value1" == config._get_atleast_one_value("VAR1", "VAR2")
+
+    # Only first variable set
+    with mock.patch.dict(
+        os.environ,
+        {
+            "VAR1": "value1",
+        },
+    ):
+        assert "value1" == config._get_atleast_one_value("VAR1", "VAR2")
+
+    # Only second variable set
+    with mock.patch.dict(
+        os.environ,
+        {
+            "VAR2": "value2",
+        },
+    ):
+        assert "value2" == config._get_atleast_one_value("VAR1", "VAR2")
+
+    # No value and exception
+    with pytest.raises(Exception):
+        config._get_atleast_one_value("VAR1", "VAR2")
+
+    # No value and no exception
+    assert not config._get_atleast_one_value("VAR1", "VAR2", is_required=False)
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "VDKCLI_OAUTH2_REFRESH_TOKEN": "some-test-token",
+    },
+)
+def test_get_atleast_one_value_from_config_ini():
+    config_ini_path = os.path.join(str(tempfile.gettempdir()), "config.ini")
+    with open(config_ini_path, "w") as text_file:
+        text_file.write(
+            """
+        [DEFAULT]
+            VAR1=False
+            VAR2=None
+            VAR3=
+            VAR4=valid_value
+        """
+        )
+
+    config = Config(config_ini_path)
+
+    # Set var to False
+    assert "False" == config._get_atleast_one_value("VAR1", "VAR2")
+
+    # Set var to None
+    assert "None" == config._get_atleast_one_value("VAR2", "VAR3")
+
+    # Set var to empty string
+    assert "" == config._get_atleast_one_value("VAR3", "VAR4")
+
+    # Set var to valid string
+    assert "valid_value" == config._get_atleast_one_value("VAR4", "VAR5")
+
+    # No value and exception
+    with pytest.raises(Exception):
+        config._get_atleast_one_value("VAR5", "VAR6")
+
+    # No value and no exception
+    assert not config._get_atleast_one_value("VAR5", "VAR6", is_required=False)


### PR DESCRIPTION
If we want to test VDK's configuration and default options, we want
to be able to set those params values in the default vdkcli options
and run vdk-heartbeat.

Make vdkcli_oauth2_uri and control_api_url params optional and don't
pass values if they are not set in the config.ini - thus whatever is
set as default in VDK's configuration will be used.

Tested by: Run locally built vdk-heartbeat in an environment with
properly configured defaults with a config.ini looking like this:
[DEFAULT]
VDKCLI_OAUTH2_REFRESH_TOKEN=***

JOB_RUN_TEST_MODULE_NAME=vdk.internal.heartbeat.simple_run_test
JOB_RUN_TEST_CLASS_NAME=SimpleRunTest
DATAJOB_DIRECTORY_NAME=simple
VDK_COMMAND_NAME=vdk

Signed-off-by: Yana Zhivkova <yzhivkova@vmware.com>