### PR TITLE
vdk-control-cli: remove hidden from vdkcli execute

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/execute.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/execute.py
@@ -218,7 +218,6 @@ vdk execute --list -n example-job -t "Example Team"
 vdk execute --logs -n example-job -t "Example Team" --execution-id example-job-1619094633811-cc49d
 
 """,
-    hidden=True,
 )
 @click.option("-n", "--name", type=click.STRING, help="The job name.")
 @click.option(


### PR DESCRIPTION
vdkcli execute is stable command now and no reason to be hidden

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>