### PR TITLE
control-service: fix deploy notifications and add cc mails

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -58,6 +58,8 @@ spec:
               value: "{{ .Values.notificationOwnerEmail }}"
             - name: NOTIFICATION_OWNER_NAME
               value: "{{ .Values.notificationOwnerName }}"
+            - name: NOTIFICATION_CC_EMAILS
+              value: "{{ .Values.notificationCcEmails }}"
             - name: GIT_URL
               value: "{{ .Values.deploymentGitUrl }}"
             - name: GIT_BRANCH

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -116,6 +116,10 @@ credentials:
 ## The owner name and email address that will be used to send all Versatile Data Kit related email notifications.
 notificationOwnerEmail: "taurus@vmware.com"
 notificationOwnerName: "Versatile Data Kit"
+### Coma separate list of mails which will be cc-ed for Control Service managed notifications
+### This does not apply for notifications managed by external services (like AlertManager)
+#notificationCcEmails: "a1@x.com,a2@x.com"
+
 
 ### deploymentXXX refer to properties used in order to deploy a Data Job.
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/notification/DataJobNotification.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/notification/DataJobNotification.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.AddressException;
+import java.util.List;
 
 /**
  * The DataJobNotification class is the interface used by the Versatile Data Kit service in order to notify
@@ -35,25 +36,29 @@ public class DataJobNotification {
 
     private static final String SUCCESS_STATUS = "success";
 
-    @Value("${datajobs.notification.owner.name}")
+
     private String ownerName;
-    @Value("${datajobs.notification.owner.email}")
+
     private String ownerEmail;
+
+    private List<String> ccEmails;
 
     private EmailNotification notification;
 
-    public DataJobNotification() {}
-
-    public DataJobNotification(EmailNotification notification, String ownerName, String ownerEmail) {
+    public DataJobNotification(EmailNotification notification,
+                               @Value("${datajobs.notification.owner.name}") String ownerName,
+                               @Value("${datajobs.notification.owner.email}") String ownerEmail,
+                               @Value("${datajobs.notification.cc.emails:}") List<String> ccEmails) {
         this.notification = notification;
         this.ownerName = ownerName;
         this.ownerEmail = ownerEmail;
+        this.ccEmails = ccEmails;
     }
 
     public void notifyJobDeploySuccess(JobConfig jobConfig) {
         try {
             NotificationContent notificationContent =
-                    new NotificationContent(jobConfig, DEPLOY_STAGE, SUCCESS_STATUS, ownerName, ownerEmail);
+                    new NotificationContent(jobConfig, DEPLOY_STAGE, SUCCESS_STATUS, ownerName, ownerEmail, ccEmails);
             notification.send(notificationContent);
         } catch (AddressException e) {
             log.warn("Could not send notification due to bad email format", e);
@@ -67,7 +72,7 @@ public class DataJobNotification {
     public void notifyJobDeployError(JobConfig jobConfig, String errorName, String errorBody) {
         try {
             NotificationContent notificationContent =
-                    new NotificationContent(jobConfig, DEPLOY_STAGE, FAILURE_STATUS, errorName, errorBody, ownerName, ownerEmail);
+                    new NotificationContent(jobConfig, DEPLOY_STAGE, FAILURE_STATUS, errorName, errorBody, ownerName, ownerEmail, ccEmails);
             notification.send(notificationContent);
         } catch (AddressException e) {
             log.warn("Could not send notification due to bad email format", e);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/notification/NotificationContent.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/notification/NotificationContent.java
@@ -58,12 +58,14 @@ public class NotificationContent {
     private InternetAddress[] recipients;
     private String subject;
     private String content;
+    private List<String> ccEmails;
 
 
     public NotificationContent(JobConfig jobConfig, String stage,
-                               String status, String ownerName, String ownerEmail)
+                               String status, String ownerName, String ownerEmail, List<String> ccEmails)
             throws AddressException {
         this.sender = new InternetAddress(ownerEmail);
+        this.ccEmails = ccEmails;
         // TODO: all recipients are defined in notified_on_job_deploy in the job's ini file for now
         this.recipients = createInternetAddresses(jobConfig.getNotifiedOnJobDeploy());
         this.subject = formatNotificationSubject(stage, status, jobConfig.getJobName());
@@ -71,9 +73,10 @@ public class NotificationContent {
     }
 
     public NotificationContent(JobConfig jobConfig, String stage,
-                               String status, String errName, String errBody, String ownerName, String ownerEmail)
+                               String status, String errName, String errBody, String ownerName, String ownerEmail, List<String> ccEmails)
             throws AddressException {
         this.sender = new InternetAddress(ownerEmail);
+        this.ccEmails = ccEmails;
         this.recipients = createInternetAddresses(jobConfig.getNotifiedOnJobDeploy());
         this.subject = formatNotificationSubject(stage, status, jobConfig.getJobName());
         String errorContent = formatErrNotificationContent(jobConfig.getJobName(), errName, errBody);
@@ -96,6 +99,9 @@ public class NotificationContent {
 
     private InternetAddress[] createInternetAddresses(List<String> recipients) throws AddressException {
         List<InternetAddress> ccAddresses = new ArrayList();
+        for (String cc : this.ccEmails) {
+            ccAddresses.add(new InternetAddress(cc));
+        }
         for (String receiver : recipients) {
             ccAddresses.add(new InternetAddress(receiver));
         }

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application-prod.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application-prod.properties
@@ -25,6 +25,7 @@ server.max-http-header-size=${SERVER_MAX_HTTP_HEADER_SIZE}
 # The owner name and email address that will be used to send all Versatile Data Kit related email notifications.
 datajobs.notification.owner.email=${NOTIFICATION_OWNER_EMAIL}
 datajobs.notification.owner.name=${NOTIFICATION_OWNER_NAME}
+datajobs.notification.cc.emails=${NOTIFICATION_CC_EMAILS}
 
 # This is DeploymentService configuration injected through environmental variables
 datajobs.deployment.k8s.kubeconfig=${DEPLOYMENT_K8S_KUBECONFIG}

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -52,6 +52,7 @@ datajobs.post.delete.webhook.internal.errors.retries=3
 # The owner name and email address that will be used to send all Versatile Data Kit related email notifications.
 datajobs.notification.owner.email=versatiledatakit@groups.vmware.com
 datajobs.notification.owner.name=Versatile Data Kit
+# datajobs.notification.cc.emails=cc1@x.com,cc2@x.com
 
 # The gitlab repository and credentials for pulling data jobs code when building their images.
 datajobs.git.url=${GIT_URL}

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/notification/DataJobNotificationTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/notification/DataJobNotificationTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -34,7 +33,7 @@ public class DataJobNotificationTest {
         Mockito.when(smtpProperties.smtpWithPrefix()).thenReturn(getMailProperties(this.smptServer.getPort()));
 
         this.dataJobNotification = new DataJobNotification(new EmailNotification(this.smtpProperties),
-                "Example Name","your_username@vmware.com");
+                "Example Name","your_username@vmware.com", Collections.singletonList("cc@dummy.com"));
         this.receiverMail = "dummy@dummy.dummy";
         this.jobConfig = getJobConfig();
     }
@@ -64,7 +63,7 @@ public class DataJobNotificationTest {
         Assertions.assertEquals(1, emails.size());
         var email = emails.get(0);
         Assertions.assertEquals("[deploy][data job failure] example_unittest_job", email.getHeaderValue("Subject"));
-        Assertions.assertEquals(receiverMail, email.getHeaderValue("To"));
+        Assertions.assertEquals("cc@dummy.com, dummy@dummy.dummy", email.getHeaderValue("To"));
     }
 
     @Test
@@ -75,7 +74,7 @@ public class DataJobNotificationTest {
         Assertions.assertEquals(1, emails.size());
         var email = emails.get(0);
         Assertions.assertEquals("[deploy][data job success] example_unittest_job", email.getHeaderValue("Subject"));
-        Assertions.assertEquals(receiverMail, email.getHeaderValue("To"));
+        Assertions.assertEquals("cc@dummy.com, dummy@dummy.dummy", email.getHeaderValue("To"));
     }
 
 

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/notification/NotificationContentTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/notification/NotificationContentTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
+import java.util.Arrays;
 import java.util.Collections;
 
 public class NotificationContentTest {
@@ -20,10 +21,14 @@ public class NotificationContentTest {
         JobConfig jobConfig = createValidJobConfigStub();
         try {
             NotificationContent notificationContent =
-                    new NotificationContent(jobConfig, "run", "failure", "Example Name" , "sender@vmware.com");
+                    new NotificationContent(jobConfig, "run", "failure", "Example Name" , "sender@vmware.com",
+                            Arrays.asList("foo@bar.com", "bar@foo.com"));
 
             InternetAddress expectedSender = new InternetAddress("sender@vmware.com");
-            InternetAddress[] expectedRecipients = new InternetAddress[]{new InternetAddress("receiver@vmware.com")};
+            InternetAddress[] expectedRecipients = new InternetAddress[]{
+                    new InternetAddress("foo@bar.com"),
+                    new InternetAddress("bar@foo.com"),
+                    new InternetAddress("receiver@vmware.com")};
             String expectedSubject = "[run][data job failure] test_job";
             String expectedContent =
                     "<p>Dear Data Pipelines user,<br/>\n" +
@@ -46,7 +51,7 @@ public class NotificationContentTest {
     public void test_address_exception() {
         JobConfig jobConfig = createInvalidJobConfigStub();
         try {
-            new NotificationContent(jobConfig, "run", "failure", "Example Name", "@vmware.com");
+            new NotificationContent(jobConfig, "run", "failure", "Example Name", "@vmware.com", Collections.emptyList());
         } catch (AddressException e) {
             Assertions.assertEquals("Missing local name", e.getMessage());
         }
@@ -58,7 +63,7 @@ public class NotificationContentTest {
         JobConfig jobConfig = createValidJobConfigStub();
         try {
             NotificationContent notificationContent =
-                    new NotificationContent(jobConfig, "run", "failure", "RuntimeError", "Some body", "Example Name", "sender@vmware.com");
+                    new NotificationContent(jobConfig, "run", "failure", "RuntimeError", "Some body", "Example Name", "sender@vmware.com", Collections.emptyList());
 
             InternetAddress expectedSender = new InternetAddress("sender@vmware.com");
             InternetAddress[] expectedRecipients = new InternetAddress[]{new InternetAddress("receiver@vmware.com")};


### PR DESCRIPTION
Deploy notificatoins were not working properly due to auto-wiring issue

We also enable operator teams to set cc mail for all notifications
(using helm chart) in order to have visibilility into what notificatiosn
are sent to data job users

Testing Done: unit tests, locally deployed Control service and reproduce
scenario to get deploy anotifiactions

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>