### PR TITLE
control-service: set build job impagePullPolicity to default to IfNot…

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
@@ -31,7 +31,6 @@ import static java.util.Map.entry;
 public class JobImageBuilder {
    private static final Logger log = LoggerFactory.getLogger(JobImageBuilder.class);
 
-   static final String BUILDER_IMAGE_PULL_POLICY = "Always";
    private static final int BUILDER_TIMEOUT_SECONDS = 1800;
    private static final String REGISTRY_TYPE_ECR = "ecr";
    private static final String REGISTRY_TYPE_GENERIC = "generic";
@@ -59,7 +58,9 @@ public class JobImageBuilder {
    @Value("${datajobs.deployment.dataJobBaseImage:python:3.9-slim}")
    private String deploymentDataJobBaseImage;
    @Value("${datajobs.deployment.builder.extraArgs:}")
-   private String extraArgs;
+   private String builderJobExtraArgs;
+   @Value("${datajobs.deployment.builder.imagePullPolicy:IfNotPresent}")
+   private String builderJobImagePullPolicy;
    @Value("${datajobs.git.ssl.enabled}")
    private boolean gitDataJobsSslEnabled;
 
@@ -151,7 +152,7 @@ public class JobImageBuilder {
             args,
             null,
             null,
-            BUILDER_IMAGE_PULL_POLICY,
+            builderJobImagePullPolicy,
             kubernetesResources.builderRequests(),
             kubernetesResources.builderLimits());
 
@@ -217,7 +218,7 @@ public class JobImageBuilder {
             entry("JOB_GITHASH", jobVersion),
             entry("IMAGE_REGISTRY_PATH", dockerRepositoryUrl),
             entry("BASE_IMAGE", deploymentDataJobBaseImage),
-            entry("EXTRA_ARGUMENTS", extraArgs),
+            entry("EXTRA_ARGUMENTS", builderJobExtraArgs),
             entry("GIT_SSL_ENABLED", Boolean.toString(gitDataJobsSslEnabled))
       );
    }

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -107,3 +107,8 @@ datajobs.executions.cleanupJob.executionsTtlSeconds=${DATAJOBS_EXECUTION_TTL_SEC
 
 # https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html
 mail.smtp.host=smtp.vmware.com
+
+# Set imagePullPolicy of the job-builder image
+# Correspond to those defined by kubernetes
+# See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+datajobs.deployment.builder.imagePullPolicy=IfNotPresent

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
@@ -59,7 +59,7 @@ public class JobImageBuilderTest {
       ReflectionTestUtils.setField(jobImageBuilder, "dockerRepositoryUrl", "test-docker-repository");
       ReflectionTestUtils.setField(jobImageBuilder, "registryType", "ecr");
       ReflectionTestUtils.setField(jobImageBuilder, "deploymentDataJobBaseImage", "python:3.7-slim");
-      ReflectionTestUtils.setField(jobImageBuilder, "extraArgs", "");
+      ReflectionTestUtils.setField(jobImageBuilder, "builderJobExtraArgs", "");
 
       JobConfig jobConfig = new JobConfig();
       jobConfig.setDbDefaultType(TEST_DB_DEFAULT_TYPE);
@@ -88,7 +88,7 @@ public class JobImageBuilderTest {
 
       verify(kubernetesService).createJob(
             eq(TEST_BUILDER_JOB_NAME), eq(TEST_BUILDER_IMAGE_NAME), eq(false), any(), any(),
-            any(), any(), eq(JobImageBuilder.BUILDER_IMAGE_PULL_POLICY), any(), any());
+            any(), any(), any(), any(), any());
 
       verify(kubernetesService).deleteJob(TEST_BUILDER_JOB_NAME);
       Assertions.assertTrue(result);
@@ -114,7 +114,7 @@ public class JobImageBuilderTest {
       verify(kubernetesService, times(2)).deleteJob(TEST_BUILDER_IMAGE_NAME);
       verify(kubernetesService).createJob(
             eq(TEST_BUILDER_JOB_NAME), eq(TEST_BUILDER_IMAGE_NAME), eq(false), any(), any(),
-            any(), any(), eq(JobImageBuilder.BUILDER_IMAGE_PULL_POLICY), any(), any());
+            any(), any(), any(), any(), any());
       Assertions.assertTrue(result);
    }
 
@@ -156,7 +156,7 @@ public class JobImageBuilderTest {
 
       verify(kubernetesService).createJob(
             eq(TEST_BUILDER_JOB_NAME), eq(TEST_BUILDER_IMAGE_NAME), eq(false), any(), any(),
-            any(), any(), eq(JobImageBuilder.BUILDER_IMAGE_PULL_POLICY), any(), any());
+            any(), any(), any(), any(), any());
 
 
       // verify(kubernetesService).deleteJob(TEST_BUILDER_JOB_NAME); // not called in case of an error


### PR DESCRIPTION
…Present

We rarely change the version (tag) of the builder job image. There's not
point of trying to pull it every time , so this is setting it to
IfNotPresent. This way we can limit the chance of hitting docker limits.

It's made configurable using
`datajobs.deployment.builder.imagePullPolicy` system property in case in
some environments it is necessary.

Testing Done: integration test passed

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>