### PR TITLE
control-service: graphQL filter by jobName, startTimeLte, endTimeLte

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLExecutionsIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLExecutionsIT.java
@@ -5,22 +5,6 @@
 
 package com.vmware.taurus.graphql.it;
 
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.time.OffsetDateTime;
-import java.util.List;
-
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-
 import com.vmware.taurus.ControlplaneApplication;
 import com.vmware.taurus.datajobs.it.common.BaseIT;
 import com.vmware.taurus.datajobs.it.common.JobExecutionUtil;
@@ -30,6 +14,21 @@ import com.vmware.taurus.service.model.DataJob;
 import com.vmware.taurus.service.model.DataJobExecution;
 import com.vmware.taurus.service.model.ExecutionStatus;
 import com.vmware.taurus.service.model.JobConfig;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = ControlplaneApplication.class)
 public class GraphQLExecutionsIT extends BaseIT {
@@ -132,16 +131,16 @@ public class GraphQLExecutionsIT extends BaseIT {
             .andExpect(content().contentType("application/json"))
             .andExpect(jsonPath(
                   "$.data.content[*].id",
-                  Matchers.contains(dataJobExecution1.getId(), dataJobExecution2.getId())))
+                  Matchers.contains(dataJobExecution2.getId(), dataJobExecution3.getId())))
             .andExpect(jsonPath(
                   "$.data.content[*].jobName",
-                  Matchers.contains(dataJob1.getName(), dataJob2.getName())))
+                  Matchers.contains(dataJob2.getName(), dataJob3.getName())))
             .andExpect(jsonPath(
                   "$.data.content[*].status",
-                  Matchers.contains(dataJobExecution1.getStatus().toString(), dataJobExecution2.getStatus().toString())))
+                  Matchers.contains(dataJobExecution2.getStatus().toString(), dataJobExecution3.getStatus().toString())))
             .andExpect(jsonPath(
                   "$.data.content[*].id",
-                  Matchers.not(Matchers.contains(dataJobExecution3.getId()))));
+                  Matchers.not(Matchers.contains(dataJobExecution1.getId()))));
    }
 
    @Test
@@ -188,16 +187,16 @@ public class GraphQLExecutionsIT extends BaseIT {
             .andExpect(content().contentType("application/json"))
             .andExpect(jsonPath(
                   "$.data.content[*].id",
-                  Matchers.contains(dataJobExecution1.getId(), dataJobExecution2.getId())))
+                  Matchers.contains(dataJobExecution2.getId(), dataJobExecution3.getId())))
             .andExpect(jsonPath(
                   "$.data.content[*].jobName",
-                  Matchers.contains(dataJob1.getName(), dataJob2.getName())))
+                  Matchers.contains(dataJob2.getName(), dataJob3.getName())))
             .andExpect(jsonPath(
                   "$.data.content[*].status",
-                  Matchers.contains(dataJobExecution1.getStatus().toString(), dataJobExecution2.getStatus().toString())))
+                  Matchers.contains(dataJobExecution2.getStatus().toString(), dataJobExecution3.getStatus().toString())))
             .andExpect(jsonPath(
                   "$.data.content[*].id",
-                  Matchers.not(Matchers.contains(dataJobExecution3.getId()))));
+                  Matchers.not(Matchers.contains(dataJobExecution1.getId()))));
    }
 
    @Test
@@ -242,14 +241,15 @@ public class GraphQLExecutionsIT extends BaseIT {
             .andExpect(content().contentType("application/json"))
             .andExpect(jsonPath(
                   "$.data.content[*].id",
-                  Matchers.contains(dataJobExecution1.getId(), dataJobExecution2.getId())))
+                  Matchers.contains(dataJobExecution1.getId())))
             .andExpect(jsonPath(
                   "$.data.content[*].jobName",
-                  Matchers.contains(dataJob1.getName(), dataJob2.getName())))
+                  Matchers.contains(dataJob1.getName())))
             .andExpect(jsonPath(
                   "$.data.content[*].status",
-                  Matchers.contains(dataJobExecution1.getStatus().toString(), dataJobExecution2.getStatus().toString())))
-            .andExpect(jsonPath("$.data.content[*].id", Matchers.not(Matchers.contains(dataJobExecution3.getId()))));
+                  Matchers.contains(dataJobExecution1.getStatus().toString())))
+            .andExpect(jsonPath("$.data.content[*].id", Matchers.not(Matchers.contains(dataJobExecution3.getId()))))
+            .andExpect(jsonPath("$.data.content[*].id", Matchers.not(Matchers.contains(dataJobExecution2.getId()))));
    }
 
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobExecutionFilterSpec.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobExecutionFilterSpec.java
@@ -5,20 +5,20 @@
 
 package com.vmware.taurus.service;
 
+import com.vmware.taurus.service.graphql.model.DataJobExecutionFilter;
+import com.vmware.taurus.service.model.DataJobExecution;
+import com.vmware.taurus.service.model.DataJobExecution_;
+import com.vmware.taurus.service.model.DataJob_;
+import lombok.AllArgsConstructor;
+import org.apache.commons.collections.CollectionUtils;
+import org.springframework.data.jpa.domain.Specification;
+
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import java.util.ArrayList;
 import java.util.List;
-
-import lombok.AllArgsConstructor;
-import org.apache.commons.collections.CollectionUtils;
-import org.springframework.data.jpa.domain.Specification;
-
-import com.vmware.taurus.service.graphql.model.DataJobExecutionFilter;
-import com.vmware.taurus.service.model.DataJobExecution;
-import com.vmware.taurus.service.model.DataJobExecution_;
 
 @AllArgsConstructor
 public class JobExecutionFilterSpec implements Specification<DataJobExecution> {
@@ -41,6 +41,19 @@ public class JobExecutionFilterSpec implements Specification<DataJobExecution> {
          if (CollectionUtils.isNotEmpty(filter.getStatusIn())) {
             predicates.add(root.get(DataJobExecution_.STATUS).in(filter.getStatusIn()));
          }
+
+         if (filter.getJobNameIn() != null && filter.getJobNameIn().size() > 0) {
+            predicates.add(root.get(DataJobExecution_.DATA_JOB).get(DataJob_.NAME).in(filter.getJobNameIn()));
+         }
+
+         if (filter.getStartTimeLte() != null) {
+            predicates.add(builder.lessThanOrEqualTo(root.get(DataJobExecution_.START_TIME), filter.getStartTimeLte()));
+         }
+
+         if (filter.getEndTimeLte() != null) {
+            predicates.add(builder.lessThanOrEqualTo(root.get(DataJobExecution_.END_TIME), filter.getEndTimeLte()));
+         }
+
       }
 
       return builder.and(predicates.toArray(new Predicate[0]));

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobExecutionFilterSpec.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobExecutionFilterSpec.java
@@ -34,24 +34,24 @@ public class JobExecutionFilterSpec implements Specification<DataJobExecution> {
             predicates.add(builder.greaterThanOrEqualTo(root.get(DataJobExecution_.START_TIME), filter.getStartTimeGte()));
          }
 
+         if (filter.getStartTimeLte() != null) {
+            predicates.add(builder.lessThanOrEqualTo(root.get(DataJobExecution_.START_TIME), filter.getStartTimeLte()));
+         }
+
          if (filter.getEndTimeGte() != null) {
             predicates.add(builder.greaterThanOrEqualTo(root.get(DataJobExecution_.END_TIME), filter.getEndTimeGte()));
+         }
+
+         if (filter.getEndTimeLte() != null) {
+            predicates.add(builder.lessThanOrEqualTo(root.get(DataJobExecution_.END_TIME), filter.getEndTimeLte()));
          }
 
          if (CollectionUtils.isNotEmpty(filter.getStatusIn())) {
             predicates.add(root.get(DataJobExecution_.STATUS).in(filter.getStatusIn()));
          }
 
-         if (filter.getJobNameIn() != null && filter.getJobNameIn().size() > 0) {
+         if (CollectionUtils.isNotEmpty(filter.getJobNameIn())) {
             predicates.add(root.get(DataJobExecution_.DATA_JOB).get(DataJob_.NAME).in(filter.getJobNameIn()));
-         }
-
-         if (filter.getStartTimeLte() != null) {
-            predicates.add(builder.lessThanOrEqualTo(root.get(DataJobExecution_.START_TIME), filter.getStartTimeLte()));
-         }
-
-         if (filter.getEndTimeLte() != null) {
-            predicates.add(builder.lessThanOrEqualTo(root.get(DataJobExecution_.END_TIME), filter.getEndTimeLte()));
          }
 
       }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/ExecutionDataFetcher.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/ExecutionDataFetcher.java
@@ -54,6 +54,7 @@ import java.util.stream.Collectors;
 import static com.vmware.taurus.service.graphql.model.DataJobExecutionOrder.AVAILABLE_PROPERTIES;
 import static com.vmware.taurus.service.graphql.model.DataJobExecutionOrder.DIRECTION_FIELD;
 import static com.vmware.taurus.service.graphql.model.DataJobExecutionOrder.PROPERTY_FIELD;
+import static com.vmware.taurus.service.graphql.model.DataJobExecutionOrder.PUBLIC_NAME_TO_DB_ENTITY_MAP;
 import static com.vmware.taurus.service.graphql.model.DataJobExecutionQueryVariables.FILTER_FIELD;
 import static com.vmware.taurus.service.graphql.model.DataJobExecutionQueryVariables.ORDER_FIELD;
 import static com.vmware.taurus.service.graphql.model.DataJobExecutionQueryVariables.PAGE_NUMBER_FIELD;
@@ -277,8 +278,9 @@ public class ExecutionDataFetcher {
 
          builder.property(
                Optional.ofNullable(orderRaw.get(PROPERTY_FIELD))
-                     .map(o -> (String)o)
+                     .map(o -> (String) o)
                      .filter(p -> AVAILABLE_PROPERTIES.contains(p))
+                     .map(p -> PUBLIC_NAME_TO_DB_ENTITY_MAP.getOrDefault(p, p)) // If no mapping present use user provided property name
                      .orElseThrow(() -> new GraphQLException(String.format(
                            "%s.%s must be in [%s]",
                            ORDER_FIELD,

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/ExecutionDataFetcher.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/ExecutionDataFetcher.java
@@ -246,7 +246,7 @@ public class ExecutionDataFetcher {
 
          builder.statusIn(
                Optional.ofNullable(filterRaw.get(DataJobExecutionFilter.STATUS_IN_FIELD))
-                     .map(statusInRaw -> ((List<String>)statusInRaw))
+                     .map(statusInRaw -> ((List<String>) statusInRaw))
                      .stream()
                      .flatMap(v1Jobs -> v1Jobs.stream())
                      .filter(Objects::nonNull)
@@ -257,8 +257,11 @@ public class ExecutionDataFetcher {
 
          filter = Optional.of(
                builder
-                     .startTimeGte((OffsetDateTime)filterRaw.get(DataJobExecutionFilter.START_TIME_GTE_FIELD))
-                     .endTimeGte((OffsetDateTime)filterRaw.get(DataJobExecutionFilter.END_TIME_GTE_FIELD))
+                     .startTimeGte((OffsetDateTime) filterRaw.get(DataJobExecutionFilter.START_TIME_GTE_FIELD))
+                     .endTimeGte((OffsetDateTime) filterRaw.get(DataJobExecutionFilter.END_TIME_GTE_FIELD))
+                     .startTimeLte((OffsetDateTime) filterRaw.get(DataJobExecutionFilter.START_TIME_LTE_FIELD))
+                     .endTimeLte((OffsetDateTime) filterRaw.get(DataJobExecutionFilter.END_TIME_LTE_FIELD))
+                     .jobNameIn((List<String>) filterRaw.get(DataJobExecutionFilter.JOB_NAME_IN_FIELD))
                      .build()
          );
       }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionFilter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionFilter.java
@@ -5,14 +5,13 @@
 
 package com.vmware.taurus.service.graphql.model;
 
-import java.time.OffsetDateTime;
-import java.util.List;
-
+import com.vmware.taurus.service.model.ExecutionStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
-import com.vmware.taurus.service.model.ExecutionStatus;
+import java.time.OffsetDateTime;
+import java.util.List;
 
 @Data
 @AllArgsConstructor
@@ -22,8 +21,15 @@ public class DataJobExecutionFilter {
    public static final String START_TIME_GTE_FIELD = "startTimeGte";
    public static final String END_TIME_GTE_FIELD = "endTimeGte";
    public static final String STATUS_IN_FIELD = "statusIn";
+   public static final String JOB_NAME_IN_FIELD = "jobNameIn";
+   public static final String START_TIME_LTE_FIELD = "startTimeLte";
+   public static final String END_TIME_LTE_FIELD = "endTimeLte";
 
    private OffsetDateTime startTimeGte;
    private OffsetDateTime endTimeGte;
    private List<ExecutionStatus> statusIn;
+   private List<String> jobNameIn;
+   private OffsetDateTime startTimeLte;
+   private OffsetDateTime endTimeLte;
+
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionOrder.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionOrder.java
@@ -5,13 +5,13 @@
 
 package com.vmware.taurus.service.graphql.model;
 
-import java.util.Set;
-
+import com.vmware.taurus.service.model.DataJobExecution_;
+import com.vmware.taurus.service.model.DataJob_;
 import lombok.Builder;
 import lombok.Data;
 import org.springframework.data.domain.Sort;
 
-import com.vmware.taurus.service.model.DataJobExecution_;
+import java.util.Set;
 
 @Data
 @Builder
@@ -30,7 +30,8 @@ public class DataJobExecutionOrder {
          DataJobExecution_.LAST_DEPLOYED_BY,
          DataJobExecution_.STARTED_BY,
          DataJobExecution_.STATUS,
-         DataJobExecution_.VDK_VERSION);
+         DataJobExecution_.VDK_VERSION,
+         DataJobExecution_.DATA_JOB + "." + DataJob_.NAME);
 
    public static final String PROPERTY_FIELD = "property";
    public static final String DIRECTION_FIELD = "direction";

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionOrder.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionOrder.java
@@ -11,11 +11,14 @@ import lombok.Builder;
 import lombok.Data;
 import org.springframework.data.domain.Sort;
 
+import java.util.Map;
 import java.util.Set;
 
 @Data
 @Builder
 public class DataJobExecutionOrder {
+
+   public static final String DATA_JOB_NAME = "jobName";
 
    public static final Set<String> AVAILABLE_PROPERTIES = Set.of(
          DataJobExecution_.MESSAGE,
@@ -31,7 +34,11 @@ public class DataJobExecutionOrder {
          DataJobExecution_.STARTED_BY,
          DataJobExecution_.STATUS,
          DataJobExecution_.VDK_VERSION,
-         DataJobExecution_.DATA_JOB + "." + DataJob_.NAME);
+         DATA_JOB_NAME);
+
+   public static final Map<String, String> PUBLIC_NAME_TO_DB_ENTITY_MAP = Map.of(
+         DATA_JOB_NAME, DataJobExecution_.DATA_JOB + "." + DataJob_.NAME
+   );
 
    public static final String PROPERTY_FIELD = "property";
    public static final String DIRECTION_FIELD = "direction";

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/schema.graphqls
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/schema.graphqls
@@ -23,7 +23,10 @@ enum Direction {
 input DataJobExecutionFilter {
     startTimeGte: DateTime,
     endTimeGte: DateTime,
-    statusIn: [DataJobExecutionStatus]
+    statusIn: [DataJobExecutionStatus],
+    jobNameIn: [String],
+    startTimeLte: DateTime,
+    endTimeLte: DateTime
 }
 
 input DataJobExecutionOrder {

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/RepositoryUtil.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/RepositoryUtil.java
@@ -7,7 +7,12 @@ package com.vmware.taurus;
 
 import com.vmware.taurus.service.JobExecutionRepository;
 import com.vmware.taurus.service.JobsRepository;
-import com.vmware.taurus.service.model.*;
+import com.vmware.taurus.service.model.DataJob;
+import com.vmware.taurus.service.model.DataJobExecution;
+import com.vmware.taurus.service.model.DeploymentStatus;
+import com.vmware.taurus.service.model.ExecutionStatus;
+import com.vmware.taurus.service.model.ExecutionType;
+import com.vmware.taurus.service.model.JobConfig;
 import org.junit.jupiter.api.Assertions;
 
 import java.time.OffsetDateTime;
@@ -15,10 +20,14 @@ import java.time.OffsetDateTime;
 public final class RepositoryUtil {
 
    public static DataJob createDataJob(JobsRepository jobsRepository) {
+      return createDataJob(jobsRepository, "test-job");
+   }
+
+   public static DataJob createDataJob(JobsRepository jobsRepository, String jobName) {
       JobConfig config = new JobConfig();
       config.setSchedule("schedule");
       config.setTeam("test-team");
-      var expectedJob = new DataJob("test-job", config, DeploymentStatus.NONE);
+      var expectedJob = new DataJob(jobName, config, DeploymentStatus.NONE);
       var actualJob = jobsRepository.save(expectedJob);
       Assertions.assertEquals(expectedJob, actualJob);
 

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/ExecutionDataFetcherFindAllAndBuildResponseIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/ExecutionDataFetcherFindAllAndBuildResponseIT.java
@@ -316,7 +316,7 @@ public class ExecutionDataFetcherFindAllAndBuildResponseIT {
       var expectedJobExecution4 = RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob2, ExecutionStatus.FINISHED);
 
       when(dataFetchingEnvironment.getArgument(FILTER_FIELD)).thenReturn(null);
-      when(orderRaw.get(DataJobExecutionOrder.PROPERTY_FIELD)).thenReturn("dataJob.name");
+      when(orderRaw.get(DataJobExecutionOrder.PROPERTY_FIELD)).thenReturn("jobName");
       when(orderRaw.get(DataJobExecutionOrder.DIRECTION_FIELD)).thenReturn("DESC");
       when(dataFetchingEnvironment.getArgument(ORDER_FIELD)).thenReturn(orderRaw);
 

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/ExecutionDataFetcherFindAllAndBuildResponseIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/ExecutionDataFetcherFindAllAndBuildResponseIT.java
@@ -5,26 +5,6 @@
 
 package com.vmware.taurus.service.graphql;
 
-import static com.vmware.taurus.service.graphql.model.DataJobExecutionQueryVariables.FILTER_FIELD;
-import static com.vmware.taurus.service.graphql.model.DataJobExecutionQueryVariables.ORDER_FIELD;
-import static com.vmware.taurus.service.graphql.model.DataJobExecutionQueryVariables.PAGE_NUMBER_FIELD;
-import static com.vmware.taurus.service.graphql.model.DataJobExecutionQueryVariables.PAGE_SIZE_FIELD;
-import static org.mockito.Mockito.when;
-
-import java.time.OffsetDateTime;
-import java.util.List;
-import java.util.Map;
-
-import graphql.GraphQLException;
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-
 import com.vmware.taurus.ControlplaneApplication;
 import com.vmware.taurus.RepositoryUtil;
 import com.vmware.taurus.service.JobExecutionRepository;
@@ -35,6 +15,25 @@ import com.vmware.taurus.service.graphql.model.DataJobPage;
 import com.vmware.taurus.service.model.DataJob;
 import com.vmware.taurus.service.model.DataJobExecution;
 import com.vmware.taurus.service.model.ExecutionStatus;
+import graphql.GraphQLException;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static com.vmware.taurus.service.graphql.model.DataJobExecutionQueryVariables.FILTER_FIELD;
+import static com.vmware.taurus.service.graphql.model.DataJobExecutionQueryVariables.ORDER_FIELD;
+import static com.vmware.taurus.service.graphql.model.DataJobExecutionQueryVariables.PAGE_NUMBER_FIELD;
+import static com.vmware.taurus.service.graphql.model.DataJobExecutionQueryVariables.PAGE_SIZE_FIELD;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest(classes = ControlplaneApplication.class)
 public class ExecutionDataFetcherFindAllAndBuildResponseIT {
@@ -301,6 +300,136 @@ public class ExecutionDataFetcherFindAllAndBuildResponseIT {
       DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
 
       Assertions.assertThrows(GraphQLException.class, () -> allAndBuildResponse.get(dataFetchingEnvironment));
+   }
+
+   @Test
+   public void testFindAllAndBuildResponse_orderByJobName_shouldReturnResult() throws Exception {
+
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository, "a");
+      DataJob actualDataJob2 = RepositoryUtil.createDataJob(jobsRepository, "b");
+      DataJob actualDataJob3 = RepositoryUtil.createDataJob(jobsRepository, "c");
+      DataJob actualDataJob4 = RepositoryUtil.createDataJob(jobsRepository, "d");
+
+      var expectedJobExecution1 = RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob4, ExecutionStatus.FINISHED);
+      var expectedJobExecution2 = RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.FINISHED);
+      var expectedJobExecution3 = RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob3, ExecutionStatus.FINISHED);
+      var expectedJobExecution4 = RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob2, ExecutionStatus.FINISHED);
+
+      when(dataFetchingEnvironment.getArgument(FILTER_FIELD)).thenReturn(null);
+      when(orderRaw.get(DataJobExecutionOrder.PROPERTY_FIELD)).thenReturn("dataJob.name");
+      when(orderRaw.get(DataJobExecutionOrder.DIRECTION_FIELD)).thenReturn("DESC");
+      when(dataFetchingEnvironment.getArgument(ORDER_FIELD)).thenReturn(orderRaw);
+
+      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+      DataJobPage response = (DataJobPage)allAndBuildResponse.get(dataFetchingEnvironment);
+      List<Object> actualJobExecutions = response.getContent();
+
+      Assertions.assertEquals(4, actualJobExecutions.size());
+      //check sort order by job name is DESC
+      assertExecutionsEquals(expectedJobExecution1, actualJobExecutions.get(0));
+      assertExecutionsEquals(expectedJobExecution3, actualJobExecutions.get(1));
+      assertExecutionsEquals(expectedJobExecution4, actualJobExecutions.get(2));
+      assertExecutionsEquals(expectedJobExecution2, actualJobExecutions.get(3));
+
+   }
+
+   @Test
+   public void testFindAllAndBuildResponse_filterByJobName_shouldReturnResult() throws Exception {
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository, "job-one");
+      DataJob actualDataJob2 = RepositoryUtil.createDataJob(jobsRepository, "job-two");
+
+      OffsetDateTime now = OffsetDateTime.now();
+
+      var expectedExecution = RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED, now.minusMinutes(2), now.minusMinutes(2));
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob2, ExecutionStatus.RUNNING, now.minusMinutes(1), now.minusMinutes(1));
+
+      when(filterRaw.get(DataJobExecutionFilter.JOB_NAME_IN_FIELD)).thenReturn(List.of(actualDataJob.getName()));
+      when(dataFetchingEnvironment.getArgument(FILTER_FIELD)).thenReturn(filterRaw);
+
+      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+      DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
+      List<Object> actualJobExecutions = response.getContent();
+
+      Assertions.assertEquals(1, actualJobExecutions.size());
+      assertExecutionsEquals(expectedExecution, actualJobExecutions.get(0));
+   }
+
+   @Test
+   public void testFindAllAndBuildResponse_filterByEndTimeLte_shouldNotReturnResult() throws Exception {
+
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+      OffsetDateTime now = OffsetDateTime.now();
+
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED, now.minusMinutes(2), now.minusMinutes(2));
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, now.minusMinutes(1), now.minusMinutes(1));
+
+      when(filterRaw.get(DataJobExecutionFilter.END_TIME_LTE_FIELD)).thenReturn(OffsetDateTime.now().minusDays(2));
+      when(dataFetchingEnvironment.getArgument(FILTER_FIELD)).thenReturn(filterRaw);
+
+      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+      DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
+      List<Object> actualJobExecutions = response.getContent();
+
+      Assertions.assertEquals(0, actualJobExecutions.size());
+   }
+
+   @Test
+   public void testFindAllAndBuildResponse_filterByEndTimeLte_shouldReturnResult() throws Exception {
+
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+      OffsetDateTime now = OffsetDateTime.now();
+
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED, now.minusMinutes(2), now.minusMinutes(2));
+      var expected = RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, now, now.minusDays(4));
+
+      when(filterRaw.get(DataJobExecutionFilter.END_TIME_LTE_FIELD)).thenReturn(OffsetDateTime.now().minusDays(2));
+      when(dataFetchingEnvironment.getArgument(FILTER_FIELD)).thenReturn(filterRaw);
+
+      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+      DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
+      List<Object> actualJobExecutions = response.getContent();
+
+      Assertions.assertEquals(1, actualJobExecutions.size());
+      assertExecutionsEquals(expected, actualJobExecutions.get(0));
+   }
+
+   @Test
+   public void testFindAllAndBuildResponse_filterByStartTimeLte_shouldNotReturnResult() throws Exception {
+
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+      OffsetDateTime now = OffsetDateTime.now();
+
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED, now.minusDays(3), now.minusMinutes(2));
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, now.minusDays(3), now.minusMinutes(1));
+
+      when(filterRaw.get(DataJobExecutionFilter.START_TIME_LTE_FIELD)).thenReturn(OffsetDateTime.now().minusDays(4));
+      when(dataFetchingEnvironment.getArgument(FILTER_FIELD)).thenReturn(filterRaw);
+
+      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+      DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
+      List<Object> actualJobExecutions = response.getContent();
+
+      Assertions.assertEquals(0, actualJobExecutions.size());
+   }
+
+   @Test
+   public void testFindAllAndBuildResponse_filterByStartTimeLte_shouldReturnResult() throws Exception {
+
+      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+      OffsetDateTime now = OffsetDateTime.now();
+
+      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED, now.minusMinutes(2), now.minusMinutes(2));
+      var expected = RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, now.minusDays(3), now);
+
+      when(filterRaw.get(DataJobExecutionFilter.START_TIME_LTE_FIELD)).thenReturn(OffsetDateTime.now().minusDays(2));
+      when(dataFetchingEnvironment.getArgument(FILTER_FIELD)).thenReturn(filterRaw);
+
+      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+      DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
+      List<Object> actualJobExecutions = response.getContent();
+
+      Assertions.assertEquals(1, actualJobExecutions.size());
+      assertExecutionsEquals(expected, actualJobExecutions.get(0));
    }
 
    private void assertExecutionsEquals(DataJobExecution expectedJobExecution, Object actualJobExecutionObject) {


### PR DESCRIPTION
why: Users requested additional API functionality which includes
filtering and sorting by data job execution name, start and end
times. This will help operators monitor overall executions status.
Currently to achieve this we have to retrieve all jobs and their 
corresponding executions. 

what: Added new fields to graphql schema and extended
existing control-service functionality to cover requested fields.

testing: Added unit tests which cover the new functionality.

Signed-off-by: Momchil Zhivkov <mzhivkov@vmware.com>