### PR TITLE
control-service: fix a bug in the GraphQL implementation

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobsRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobsRepository.java
@@ -7,6 +7,7 @@ package com.vmware.taurus.service;
 
 import com.vmware.taurus.service.model.DataJob;
 import com.vmware.taurus.service.model.DeploymentStatus;
+import com.vmware.taurus.service.model.ExecutionStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -15,6 +16,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import javax.transaction.Transactional;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -50,6 +52,15 @@ public interface JobsRepository extends PagingAndSortingRepository<DataJob, Stri
     int updateDataJobEnabledByName(
             @Param(value = "name") String name,
             @Param(value = "enabled") Boolean enabled);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("update DataJob j set j.lastExecutionStatus = :status, j.lastExecutionEndTime = :endTime, j.lastExecutionDuration = :duration where j.name = :name")
+    int updateDataJobLastExecutionByName(
+            @Param(value = "name") String name,
+            @Param(value = "status") ExecutionStatus status,
+            @Param(value = "endTime") OffsetDateTime endTime,
+            @Param(value = "duration") Integer duration);
 
    boolean existsDataJobByNameAndJobConfigTeam(String jobName, String teamName);
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMonitor.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMonitor.java
@@ -192,7 +192,7 @@ public class DataJobMonitor {
             return;
         }
 
-        var dataJob = dataJobOptional.get();
+        DataJob dataJob = dataJobOptional.get();
         if (shouldUpdateTerminationStatus(dataJob, executionId, executionResult.getTerminationStatus())) {
             dataJob = saveTerminationStatus(dataJob, executionId, executionResult.getTerminationStatus());
             updateDataJobTerminationStatusGauge(dataJob);
@@ -201,7 +201,9 @@ public class DataJobMonitor {
         // Update the job execution
         Optional<com.vmware.taurus.service.model.DataJobExecution> execution = jobExecutionService.updateJobExecution(dataJob, jobStatus, executionResult);
         // Update the last execution state with the completed execution
-        execution.ifPresent(jobsService::updateLastExecution);
+        if (execution.isPresent()) {
+            jobsService.updateLastExecution(dataJob, execution.get());
+        }
     }
 
 


### PR DESCRIPTION
The recently introduced functionality to filter and sort
by last execution of data jobs has a bug where older executions
are not properly checked and as a result, the last execution
is always updated, even when the current execution is older
than the last one.

This commit fixes that.

Testing done: new unit test for this use case

Signed-off-by: Tsvetomir Palashki <tpalashki@vmware.com>