### PR TITLE
vdk-plugins: Fix release job template

### DIFF
--- a/projects/vdk-plugins/.plugin-common.yml
+++ b/projects/vdk-plugins/.plugin-common.yml
@@ -31,10 +31,10 @@
 .release-plugin:
   stage: release
   before_script:
-    - cd projects/vdk-core/
+    - cd projects/vdk-plugins/
   script:
     - echo "Release plugin $PLUGIN_NAME"
-    - cd plugins/$PLUGIN_NAME || exit 1
+    - cd $PLUGIN_NAME/ || exit 1
     - sed -ri "s/__version__ = \"([[:digit:]]\.[[:digit:]]\.).*\"$/__version__ = \"\1${CI_PIPELINE_ID}\"/g" setup.py
     - pip install -U pip setuptools wheel twine
     - python setup.py sdist --formats=gztar
@@ -57,10 +57,10 @@
     DOCKER_DRIVER: overlay2
     DOCKER_TLS_CERTDIR: ""
   before_script:
-    - cd projects/vdk-core/
+    - cd projects/vdk-plugins/
   script:
     - echo "Build and release vdk image of plugin $PLUGIN_NAME"
-    - cd plugins/$PLUGIN_NAME || exit 1
+    - cd $PLUGIN_NAME/ || exit 1
     - sed -ri "s/__version__ = \"([[:digit:]]\.[[:digit:]]\.).*\"$/__version__ = \"\1${CI_PIPELINE_ID}\"/g" setup.py
     - apk add --no-cache git bash python3
     - python3 -V
@@ -68,7 +68,7 @@
     - export VDK_PACKAGE=$(python3 setup.py --name)
     - export VDK_VERSION=$(python3 setup.py --version)
     - export BUILD_TYPE=release
-    - bash -x ../../cicd/deploy-base-vdk-image.sh
+    - bash -x ../../vdk-core/cicd/deploy-base-vdk-image.sh
   retry: !reference [.retry, retry_options]
   rules:
     - if: '$CI_COMMIT_BRANCH == "main"'

--- a/projects/vdk-plugins/vdk-greenplum/README.md
+++ b/projects/vdk-plugins/vdk-greenplum/README.md
@@ -36,7 +36,7 @@ Run vdk config-help - search for those prefixed with "GREENPLUM_" to see what co
 
 # Testing
 
-Testing this plugin locally requires installing the dependencies listed in plugins/vdk-greenplum/requirements.txt
+Testing this plugin locally requires installing the dependencies listed in vdk-plugins/vdk-greenplum/requirements.txt
 
 Run
 ```bash

--- a/projects/vdk-plugins/vdk-impala/README.md
+++ b/projects/vdk-plugins/vdk-impala/README.md
@@ -37,7 +37,7 @@ Run vdk config-help - search for those prefixed with "IMPALA_" to see what confi
 
 # Testing
 
-Testing this plugin locally requires installing the dependencies listed in plugins/vdk-impala/requirements.txt
+Testing this plugin locally requires installing the dependencies listed in vdk-plugins/vdk-impala/requirements.txt
 
 Run
 ```bash

--- a/projects/vdk-plugins/vdk-postgres/README.md
+++ b/projects/vdk-plugins/vdk-postgres/README.md
@@ -25,7 +25,7 @@ Run vdk config-help - search for those prefixed with "POSTGRES_" to see what con
 
 # Testing
 
-Testing this plugin locally requires installing the dependencies listed in plugins/vdk-postgres/requirements.txt
+Testing this plugin locally requires installing the dependencies listed in vdk-plugins/vdk-postgres/requirements.txt
 
 Run
 ```bash

--- a/projects/vdk-plugins/vdk-trino/README.md
+++ b/projects/vdk-plugins/vdk-trino/README.md
@@ -55,7 +55,7 @@ Run vdk config-help - search for those prefixed with "TRINO_" to see what config
 
 # Testing
 
-Testing this plugin locally requires installing the dependencies listed in plugins/vdk-trino/requirements.txt
+Testing this plugin locally requires installing the dependencies listed in vdk-plugins/vdk-trino/requirements.txt
 
 Run
 ```bash

--- a/projects/vdk-plugins/vdk-trino/src/vdk/plugin/trino/templates/README.md
+++ b/projects/vdk-plugins/vdk-trino/src/vdk/plugin/trino/templates/README.md
@@ -1,2 +1,2 @@
 ### Types of data loading templates
-- Slowly Changing Dimension Type 1 - [see details and usage](projects/vdk-core/plugins/vdk-trino/src/vdk/internal/templates/load/dimension/scd1/README.md)
+- Slowly Changing Dimension Type 1 - [see details and usage](projects/vdk-plugins/vdk-trino/src/vdk/internal/templates/load/dimension/scd1/README.md)


### PR DESCRIPTION
The release CI job template in .plugin-common.yml was not fixed
to cd into the new plugins directory. This change fixes it. Also
fixed some links in plugin readmes.

Testing done: making new release of vdk-sqlite to verify job works
https://gitlab.com/vmware-analytics/versatile-data-kit/-/pipelines/415630020

Signed-off-by: Gabriel Georgiev <gageorgiev@vmware.com>