### PR TITLE
vdk-core: Fix error in user code classified as Platform Error

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/data_job.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/data_job.py
@@ -22,6 +22,7 @@ from vdk.internal.builtin_plugins.run.file_based_step import TYPE_SQL
 from vdk.internal.builtin_plugins.run.job_context import JobContext
 from vdk.internal.builtin_plugins.run.run_status import ExecutionStatus
 from vdk.internal.builtin_plugins.run.step import Step
+from vdk.internal.builtin_plugins.run.job_input_error_classifier import whom_to_blame
 from vdk.internal.core import errors
 from vdk.internal.core.context import CoreContext
 from vdk.internal.core.statestore import CommonStoreKeys
@@ -75,10 +76,10 @@ class DataJobDefaultHookImplPlugin:
                 if step_executed
                 else ExecutionStatus.NOT_RUNNABLE
             )
-        except BaseException as e:
+        except Exception as e:
             status = ExecutionStatus.ERROR
             details = errors.MSG_WHY_FROM_EXCEPTION(e)
-            blamee = errors.find_whom_to_blame_from_exception(e)
+            blamee = whom_to_blame(e, __file__)
             exception = e
             errors.log_exception(
                 blamee,

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/data_job.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/data_job.py
@@ -20,9 +20,9 @@ from vdk.internal.builtin_plugins.run.file_based_step import StepFuncFactory
 from vdk.internal.builtin_plugins.run.file_based_step import TYPE_PYTHON
 from vdk.internal.builtin_plugins.run.file_based_step import TYPE_SQL
 from vdk.internal.builtin_plugins.run.job_context import JobContext
+from vdk.internal.builtin_plugins.run.job_input_error_classifier import whom_to_blame
 from vdk.internal.builtin_plugins.run.run_status import ExecutionStatus
 from vdk.internal.builtin_plugins.run.step import Step
-from vdk.internal.builtin_plugins.run.job_input_error_classifier import whom_to_blame
 from vdk.internal.core import errors
 from vdk.internal.core.context import CoreContext
 from vdk.internal.core.statestore import CommonStoreKeys

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/job_input_error_classifier.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/job_input_error_classifier.py
@@ -32,6 +32,7 @@ def whom_to_blame(exception, executor_module):
 
 
 def _is_exception_from_vdk_code(exception, executor_module):
+    exception_in_vdk = False
     executor_module = os.path.abspath(executor_module)
     vdk_code_directory = os.path.dirname(executor_module)
     call_list = traceback.format_tb(exception.__traceback__)
@@ -42,12 +43,13 @@ def _is_exception_from_vdk_code(exception, executor_module):
     for call in call_list:
         caller_module = call.split('"')[1]  # Extract module path from stacktrace call.
         if vdk_code_directory in caller_module and caller_module != executor_module:
-            return True
+            exception_in_vdk = True
         elif (
             caller_module == executor_module
         ):  # User code starts from this module always.
-            break
-    return False
+            return False
+
+    return exception_in_vdk
 
 
 def is_user_error(received_exception: Exception) -> bool:

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/run/job_input_error_classifier_test.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/run/job_input_error_classifier_test.py
@@ -39,7 +39,7 @@ class ErrorClassifierTest(unittest.TestCase):
         f"""File "{EXECUTOR_MODULE_DIR}/file_based_step.py", line 117, in invoke_run_function
     func(**actual_arguments)""",
         """File "/example_project/my-second-job/20_python_step.py", line 24, in run
-    raise Exception("Some test exception from user code") Exception: Some test exception from user code"""
+    raise Exception("Some test exception from user code") Exception: Some test exception from user code""",
     ]
 
     PLATFORM_ERROR_STACKTRACE = [


### PR DESCRIPTION
Currently, if an exception is raised in user code (the run method in a data
job python script), the error is classified as a Platform Error, even though
it is caused by something outside of vdk control.

This happens because in the DataJobDefaultHookImplPlugin class, the exception catching
logic uses errors.find_whom_to_blame_from_exception() method, instead of
job_input_error_classifier.whom_to_blame() method. The former just checks the exception
class, while the latter actually parses the exception traceback, and tries to properly
classify the error.

This change moves error classification from errors.find_whom_to_blame_from_exception() to
job_input_error_classifier.whom_to_blame(), and improves the robustness of the latter in case
there are changes in vdk file paths which could lead to different file paths in user code exceptions.

Testing Done: Unit tests

Signed-off-by: Andon Andonov <andonova@vmware.com>