### PR TITLE
vdk-heartbeat: Make oauth2 refresh token optional

### DIFF
--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/config.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/config.py
@@ -23,7 +23,7 @@ class Config:
 
         # VDK CLI Arguments for vdkcli login
         self.vdkcli_api_refresh_token = self._get_atleast_one_value(
-            "VDKCLI_OAUTH2_REFRESH_TOKEN", "VDK_HEARTBEAT_API_TOKEN"
+            "VDKCLI_OAUTH2_REFRESH_TOKEN", "VDK_HEARTBEAT_API_TOKEN", is_required=False
         )
         # If no value is found, argument will not be passed and default will be used
         self.vdkcli_oauth2_uri = self._get_atleast_one_value(

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
@@ -74,16 +74,19 @@ class JobController:
 
     @LogDecorator(log)
     def login(self):
-        self._execute(
-            [
-                "login",
-                "-a",
-                f"{self.config.vdkcli_api_refresh_token}",
-                "-t",
-                "api-token",
-            ]
-            + self.__get_api_token_authorization_url_arg()
-        )
+        if self.config.vdkcli_api_refresh_token:
+            self._execute(
+                [
+                    "login",
+                    "-a",
+                    f"{self.config.vdkcli_api_refresh_token}",
+                    "-t",
+                    "api-token",
+                ]
+                + self.__get_api_token_authorization_url_arg()
+            )
+        else:
+            log.info("Running against control service without authentication.")
 
     @LogDecorator(log)
     def delete_job(self):


### PR DESCRIPTION
We want to be able to run vdk-heartbeat against a local
control service.

If no VDKCLI_OAUTH2_REFRESH_TOKEN/VDK_HEARTBEAT_API_TOKEN
is set, run login with no params - it defaults to localhost.

Testing done: run locally built vdk-heartbeat with
and without oauth2 refresh token set.

Signed-off-by: Yana Zhivkova <yzhivkova@vmware.com>