### PR TITLE
plugin-template: add sample tests

### DIFF
--- a/projects/vdk-plugins/plugin-template/README.md
+++ b/projects/vdk-plugins/plugin-template/README.md
@@ -1,20 +1,33 @@
-This directory outlines a template which specifies the implementation of all vdk-core
+# The name of the plugin
+
+## Instructions:
+(delete this section after reading and completing the instructions)
+
+This directory outlines a template which specifies the implementation of all vdk
 plugins. It includes a setup.py file, a /src/ directory containing all the plugin hooks
 and additional implementation files, a /tests/ directory containing all plugin-specific
 tests, and a .plugin-ci.yml file which specifies the CI/CD relevant to the plugins.
 
 The CI/CD is separated in two stages, a build stage and a release stage.
-The build stage is made up of three jobs, all which inherit from the same
+The build stage is made up of a few jobs, all which inherit from the same
 job configuration and only differ in the Python version they use (3.7, 3.8, 3.9 and 3.10).
-They run according to three rules, which are ordered in a way such that changes to a
-plugin's directory or the main directory triggers them, but changes to a different plugin
-do not.
+They run according to rules, which are ordered in a way such that changes to a
+plugin's directory trigger the plugin CI, but changes to a different plugin does not.
 
-In order to add a new plugin , copy the plugin-template directory and follow the instructions in the files Generally those are
+In order to add a new plugin, copy the plugin-template directory and follow the instructions in the files Generally those are
 
 * Update the setup.py file with correct name of the plugin;
 * Update `.plugin-ci.yml` file with name of the plugin - make sure to follow comments;
 * Include your implementation files inside the `src` folder;
 * Include any tests inside the `tests` so they can be ran by CI framework automatically.
+
+
+## Usage
+
+<!--
+Explain how your plugin is used, what configuration is exposed and provide examples
+-->
+
+## Build and testing
 
 In order to build and test a plugin go to the plugin directory and use `../build-plugin.sh` script to build it

--- a/projects/vdk-plugins/plugin-template/README.md
+++ b/projects/vdk-plugins/plugin-template/README.md
@@ -14,7 +14,7 @@ job configuration and only differ in the Python version they use (3.7, 3.8, 3.9 
 They run according to rules, which are ordered in a way such that changes to a
 plugin's directory trigger the plugin CI, but changes to a different plugin does not.
 
-In order to add a new plugin, copy the plugin-template directory and follow the instructions in the files Generally those are
+In order to add a new plugin, copy the plugin-template directory and follow the instructions in the files. Generally those are
 
 * Update the setup.py file with correct name of the plugin;
 * Update `.plugin-ci.yml` file with name of the plugin - make sure to follow comments;

--- a/projects/vdk-plugins/plugin-template/requirements.txt
+++ b/projects/vdk-plugins/plugin-template/requirements.txt
@@ -1,1 +1,4 @@
 vdk-core
+
+vdk-test-utils
+pytest

--- a/projects/vdk-plugins/plugin-template/tests/jobs/job-using-a-plugin/10_dummy.py
+++ b/projects/vdk-plugins/plugin-template/tests/jobs/job-using-a-plugin/10_dummy.py
@@ -1,0 +1,11 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+from vdk.api.job_input import IJobInput
+
+log = logging.getLogger(__name__)
+
+
+def run(job_input: IJobInput):
+    log.info(f"Dummy arguments {job_input.get_arguments()}")

--- a/projects/vdk-plugins/plugin-template/tests/test_plugin_template.py
+++ b/projects/vdk-plugins/plugin-template/tests/test_plugin_template.py
@@ -1,6 +1,37 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import os
+import pathlib
+from unittest import mock
+
+from click.testing import Result
+from vdk.plugin.plugin_template import plugin_template
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_funcs import get_test_job_path
+
+"""
+This is a sample test file showing a recommended way to test new plugins.
+A good way to test a new plugin is how it would be used in the command that it extends.
+"""
 
 
-def test_plugin_template():
-    assert True
+def job_path(job_name: str):
+    return get_test_job_path(
+        pathlib.Path(os.path.dirname(os.path.abspath(__file__))), job_name
+    )
+
+
+def test_http_ingestion():
+    with mock.patch.dict(
+        os.environ,
+        {
+            # mock the vdk configuration needed for our test
+        },
+    ):
+        # CliEntryBasedTestRunner (provided by vdk-test-utils) gives a away to simulate vdk command
+        # and mock large parts of it - e.g passed our own plugins
+        runner = CliEntryBasedTestRunner(plugin_template)
+
+        result: Result = runner.invoke(["run", job_path("job-using-a-plugin")])
+        cli_assert_equal(0, result)


### PR DESCRIPTION
Add sample test relying on vdk-test-utils to show the current
recommended way to write tests for plugins.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>