### PR TITLE
vdk-logging-json: pass op_id attribute to logs

### DIFF
--- a/projects/vdk-plugins/vdk-logging-json/tests/test_logging_json.py
+++ b/projects/vdk-plugins/vdk-logging-json/tests/test_logging_json.py
@@ -6,7 +6,7 @@ from vdk.plugin.logging_json.logging_json import EcsJsonFormatter
 
 
 def test_formatter():
-    formatter = EcsJsonFormatter(job_name="", attempt_id="")
+    formatter = EcsJsonFormatter(job_name="", attempt_id="", op_id="")
 
     log_record = logging.LogRecord(
         name="",
@@ -24,7 +24,7 @@ def test_formatter():
     assert result[43:] == (
         '"message": "test-string", "level": "LEVEL 1", '
         '"lineno": 1, "filename": "", "modulename": "", '
-        '"funcname": "", "jobname": "", "attemptid": ""}'
+        '"funcname": "", "jobname": "", "attemptid": "", "opid": ""}'
     )
 
     log_record.msg = "test\nstring\nwith\nnewlines"
@@ -32,7 +32,7 @@ def test_formatter():
     assert result[43:] == (
         '"message": "test\\nstring\\nwith\\nnewlines", '
         '"level": "LEVEL 1", "lineno": 1, "filename": "", '
-        '"modulename": "", "funcname": "", "jobname": "", "attemptid": ""}'
+        '"modulename": "", "funcname": "", "jobname": "", "attemptid": "", "opid": ""}'
     )
 
     log_record.msg = 'test"string"with"double"quotes'
@@ -40,5 +40,5 @@ def test_formatter():
     assert result[43:] == (
         '"message": "test\\"string\\"with\\"double\\"quotes", '
         '"level": "LEVEL 1", "lineno": 1, "filename": "", '
-        '"modulename": "", "funcname": "", "jobname": "", "attemptid": ""}'
+        '"modulename": "", "funcname": "", "jobname": "", "attemptid": "", "opid": ""}'
     )


### PR DESCRIPTION
[OpID](https://github.com/vmware/versatile-data-kit/blob/main/projects/vdk-core/src/vdk/internal/builtin_plugins/config/vdk_config.py#L72) is used to correlate pipelines of operations going through
difference services so it needs to be available in the logs of the data job. 


Signed-off-by: Antoni Ivanov <aivanov@vmware.com>