### PR TITLE
vdk-heartbeat: make sure op_id is passed everywhere

### DIFF
--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
@@ -57,6 +57,12 @@ class JobController:
         full_command = base_command + command
         log.debug(f"Command: {full_command}")
         try:
+            os.environ.update(
+                {
+                    "VDK_OP_ID": self.config.op_id,
+                    "VDK_OP_ID_OVERRIDE": self.config.op_id,
+                }
+            )
             out = subprocess.check_output(full_command)
             log.debug(f"out: {out}")
             return out

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/log_config.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/log_config.py
@@ -3,10 +3,12 @@
 import time
 from sys import modules
 
+from vdk.internal.heartbeat.config import Config
+
 
 def configure_loggers(
     app_name="vdk-heartbeat",
-    op_id=time.time(),
+    op_id=Config.DEFAULT_OP_ID,
     log_config_type=None,
     vdk_logging_level="INFO",
 ):
@@ -18,12 +20,6 @@ def configure_loggers(
     :param vdk_logging_level: same as logging module. By default it's DEBUG
     """
     import logging.config
-
-    if is_already_configured():
-        log = logging.getLogger(__name__)
-        msg = "Logging already configured. This is a bug. Fix me!"
-        log.warning(msg)
-        return
 
     # Note Log Insight shows the hostname from where the syslog message arrived so no need to include it here.
     DETAILED_FORMAT = (

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/main.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/main.py
@@ -34,6 +34,7 @@ def run(config_file):
     log.info("Starting vdk heartbeat.")
 
     config = Config(config_file)
+    log_config.configure_loggers(op_id=config.op_id)
     heartbeat = Heartbeat(config)
     try:
         heartbeat.run()


### PR DESCRIPTION
[OpId](https://github.com/vmware/versatile-data-kit/blob/main/projects/vdk-core/src/vdk/internal/builtin_plugins/config/vdk_config.py#L72) is used to track the same operation across multiple services, CLIs,
data (ala open tracing style). It helps troubleshooting efficiently -
just search for the op id of the failed process we are troubleshooitng
and you have end to end data flow picture.

Testing Done: vdk-heartbeat -f local.ini  and verified op id is printed
in the local logs and in the logs of the Control service (and passed to
the data job execution)

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>