### PR TITLE
vdk-core: Rework new version printout

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/version/new_version_check_plugin.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/version/new_version_check_plugin.py
@@ -1,7 +1,9 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 import logging
+import textwrap
 from enum import Enum
+from typing import List
 
 import click
 from vdk.api.plugin.hook_markers import hookimpl
@@ -19,7 +21,7 @@ class ConfigKey(str, Enum):
     VERSION_CHECK_PLUGINS = "VERSION_CHECK_PLUGINS"
 
 
-def new_package(package_index, package_name):
+def new_package(package_name: str, package_index: str) -> Package:
     return Package(package_name, package_index)
 
 
@@ -43,17 +45,23 @@ class NewVersionCheckPlugin:
         )
 
     @hookimpl
-    def vdk_initialize(self, context: CoreContext) -> None:
+    def vdk_exit(self, context: CoreContext) -> None:
         try:
+            package_list = []
             cfg = context.configuration
+
             package_name = cfg.get_value(ConfigKey.PACKAGE_NAME)
             package_index = cfg.get_value(ConfigKey.PACKAGE_INDEX)
-            self.check_version(package_name, package_index)
+            if new_package(package_name, package_index).check():
+                package_list.append(package_name)
 
             if cfg.get_value(ConfigKey.VERSION_CHECK_PLUGINS):
-                log.debug("Will check for newer versions all installed plugins.")
+                log.debug("Will check for newer versions for all installed plugins.")
                 for dist_name, _ in version.list_installed_plugins():
-                    self.check_version(dist_name, package_index, is_plugin=True)
+                    if new_package(dist_name, package_index).check():
+                        package_list.append(dist_name)
+
+            self._check_version(package_list, package_index)
         except Exception as e:
             log.info(
                 f"Could not check for new version release. "
@@ -61,30 +69,38 @@ class NewVersionCheckPlugin:
             )
 
     @staticmethod
-    def check_version(package_name, package_index, is_plugin=False):
-        if new_package(package_index, package_name).check():
-            # if package index is not specified that we fetch it from pip repo (pypi.org)
-            extra_index_if_needed = (
-                f"--extra-index-url {package_index}" if package_index else ""
-            )
-            message = (
-                f"New version for a plugin {package_name} is Available"
-                if is_plugin
-                else f"New Version of {package_name} is Available"
-            )
-            # We are using eager strategy so that if there's new version of a plugin that satisfies the requirements
-            # of the main package we want to upgrade to it.
-            pip_command = "pip install --upgrade-strategy eager -U"
-            click.echo(
-                f"""
-                **********************************************************************************************************************
+    def _check_version(package_list: List[str], package_index: str) -> None:
+        """
+        Prints out a new version message for the listed packages.
 
-                                                {message}
+        :param package_list: list of package names
+        :param package_index: package index included in the printed `pip install` command
+        """
+        not_single_package = len(package_list) > 1
 
-                  Please update to latest version by using:
-                  {pip_command} {package_name} {extra_index_if_needed}
+        # if package index is not specified that we fetch it from pip repo (pypi.org)
+        extra_index_if_needed = (
+            f"--extra-index-url {package_index}"
+            if (package_index and (package_index != "https://pypi.org"))
+            else ""
+        )
+        pip_command = "pip install --upgrade-strategy eager -U"
+        main_message = f"New version{'s' if not_single_package else ''} for {', '.join(package_list)} {'are' if not_single_package else 'is'} available."
+        install_message = (
+            f"{pip_command} {' '.join(package_list)} {extra_index_if_needed}"
+        )
+        # We are using eager strategy so that if there's new version of a plugin that satisfies the requirements
+        # of the main package we want to upgrade to it.
+        click.echo(
+            f"""
+    ******************************************************************************************
 
-                **********************************************************************************************************************
-                """,
-                err=True,
-            )
+    {textwrap.fill(main_message, 80, subsequent_indent="    ")}
+
+    Please update to latest version by using:
+    {install_message}
+
+    ******************************************************************************************
+            """,
+            err=True,
+        )


### PR DESCRIPTION
If VDK or some plugin has a newer version, VDK automatically
prints out a message stating this and prompting the user to
update. However, this is printed out at the start of the log,
and can be easily missed.
This change moves the printout to the end of the log.
This change also reworks the printout to collect multiple
components into one printout.

Testing done: verified printout appears at the end

if only one package needs an update, we get the following:
```
    ******************************************************************************************

    New version for vdk-core is available.

    Please update to latest version by using:
    pip install --upgrade-strategy eager -U vdk-core

    ******************************************************************************************
```

If multiple packages need an update:
```
    ******************************************************************************************

    New versions for vdk-core, vdk-ingest-http, vdk-ingest-file, vdk-plugin-control-cli,
    vdk-plugin-control-cli, vdk-plugin-control-cli, vdk-server, vdk-sqlite are available.


    Please update to latest version by using:
    pip install --upgrade-strategy eager -U vdk-core vdk-ingest-http vdk-ingest-file vdk-plugin-control-cli vdk-plugin-control-cli vdk-plugin-control-cli vdk-server vdk-sqlite

    ******************************************************************************************
```

Signed-off-by: Gabriel Georgiev <gageorgiev@vmware.com>