### PR TITLE
vdk-heartbeat: Make vdk version configurable

### DIFF
--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/config.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/config.py
@@ -109,6 +109,11 @@ class Config:
             "CONTROL_API_URL", "VDK_HEARTBEAT_CONTROL_SERVICE_URL", is_required=False
         )
 
+        # Deploy the job with a specific vdk version (optional). By default latest vdk is used.
+        self.deploy_job_vdk_version = self.get_value(
+            "VDK_HEARTBEAT_DEPLOY_JOB_VDK_VERSION", is_required=False
+        )
+
         # Job name deployed during the test
         self.job_name = self.get_value(
             "JOB_NAME", f"vdk-heartbeat-data-job-{job_suffix}"

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/hearbeat.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/hearbeat.py
@@ -42,7 +42,7 @@ class Heartbeat:
 
             run_test.setup()
 
-            job_controller.enable_deployment()
+            job_controller.enable_deployment_and_update_vdk_version()
             job_controller.show_job_details()
 
             run_test.execute_test()

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
@@ -51,6 +51,17 @@ class JobController:
         else:
             return []
 
+    # Set data job deployment to use a specific VDK version (if configured)
+    def __get_vdk_version_arg(self):
+        if self.config.deploy_job_vdk_version:
+            return [
+                "--update",
+                "--vdk-version",
+                f"{self.config.deploy_job_vdk_version}",
+            ]
+        else:
+            return []
+
     def _execute(self, command):
         # base_command = [f"python", "-m", "vdk.internal.control.main"]
         base_command = [self.config.vdk_command_name]
@@ -233,7 +244,7 @@ class JobController:
         )
 
     @LogDecorator(log)
-    def enable_deployment(self):
+    def enable_deployment_and_update_vdk_version(self):
         self._execute(
             [
                 "deploy",
@@ -243,6 +254,7 @@ class JobController:
                 "-t",
                 self.config.job_team,
             ]
+            + self.__get_vdk_version_arg()
             + self.__get_rest_api_url_arg()
         )
 


### PR DESCRIPTION
We want to be able to run vdk-heartbeat as a pre-release
step in out CI/CD pipelines. This requires running it with a
specific vdk version.

Add VDK_HEARTBEAT_DEPLOY_JOB_VDK_VERSION configuration variable
in vdk-heartbeat. If set, it updates the job deployment to use
the specified vdk version.

Testing done: run vdk-heartbeat with a specified version against
a local control service and observe that this version is used
in the execution k8s pod. Tested with config.ini:
[DEFAULT]
VDK_HEARTBEAT_DEPLOY_JOB_VDK_VERSION=0.1.374271018

JOB_RUN_TEST_MODULE_NAME=vdk.internal.heartbeat.simple_run_test
JOB_RUN_TEST_CLASS_NAME=SimpleRunTest
DATAJOB_DIRECTORY_NAME=simple
VDK_COMMAND_NAME=vdk

Signed-off-by: Yana Zhivkova yzhivkova@vmware.com