### PR TITLE
vdk-core: Fix regression in job input error classifier

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/cli_run.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/cli_run.py
@@ -68,7 +68,9 @@ class CliRunImpl:
                 raise execution_result.get_exception()
         except Exception as e:
             errors.log_and_rethrow(
-                job_input_error_classifier.whom_to_blame(e, __file__, data_job_directory),
+                job_input_error_classifier.whom_to_blame(
+                    e, __file__, data_job_directory
+                ),
                 log,
                 what_happened="Failed executing job.",
                 why_it_happened=errors.MSG_WHY_FROM_EXCEPTION(e),

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/cli_run.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/cli_run.py
@@ -68,7 +68,7 @@ class CliRunImpl:
                 raise execution_result.get_exception()
         except Exception as e:
             errors.log_and_rethrow(
-                job_input_error_classifier.whom_to_blame(e, __file__),
+                job_input_error_classifier.whom_to_blame(e, __file__, data_job_directory),
                 log,
                 what_happened="Failed executing job.",
                 why_it_happened=errors.MSG_WHY_FROM_EXCEPTION(e),

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/data_job.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/data_job.py
@@ -79,7 +79,7 @@ class DataJobDefaultHookImplPlugin:
         except Exception as e:
             status = ExecutionStatus.ERROR
             details = errors.MSG_WHY_FROM_EXCEPTION(e)
-            blamee = whom_to_blame(e, __file__)
+            blamee = whom_to_blame(e, __file__, context.job_directory)
             exception = e
             errors.log_exception(
                 blamee,


### PR DESCRIPTION
As part of https://github.com/vmware/versatile-data-kit/pull/566, a regression
was introduced which caused genuine Platform Errors to be classified as User Errors.

This change rollbacks the previous one, and fixes the regression while doing proper
user code error classification.

Testing Done: Unit tests

Signed-off-by: Andon Andonov <andonova@vmware.com>