### PR TITLE
control-service: change default image.pullPolicy

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -18,7 +18,7 @@ image:
    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
    ##
-   pullPolicy: Always
+   pullPolicy: IfNotPresent
 
 # The image configuration for builder jobs used during deployment of data jobs.
 # Generally those should be left as it is.


### PR DESCRIPTION
This change aims to reduce the pulling of docker images. There's no
point of trying to pull it every time if we don't use `latest` tag.

Testing Done: integration test passed

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com