### PR TITLE
vdk-control-cli: bump vdk-control-service-api version

### DIFF
--- a/projects/vdk-control-cli/requirements.txt
+++ b/projects/vdk-control-cli/requirements.txt
@@ -6,7 +6,7 @@ pluggy~=0.13
 tabulate
 click-spinner
 
-vdk-control-service-api==1.0.5
+vdk-control-service-api==1.0.6
 requests_oauthlib
 
 # Dependencies for creating HTTP calls against the OAuth2 provider. We can potentially remove those

--- a/projects/vdk-control-cli/setup.cfg
+++ b/projects/vdk-control-cli/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
     requests>=2.25
     setuptools>=47.0
     pluggy==0.*
-    vdk-control-service-api==1.0.5
+    vdk-control-service-api==1.0.6
     tabulate
     requests_oauthlib>=1.0
     urllib3>=1.26.5

--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_show.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_show.py
@@ -61,7 +61,7 @@ def _get_executions_info():
         {
             "id": "test-vdk-latest-1625735700",
             "job_name": "test-job",
-            "status": "failed",
+            "status": "platform_error",
             "type": "scheduled",
             "start_time": "2021-07-08T09:15:08+00:00",
             "op_id": "test-vdk-latest-1625735700",
@@ -69,7 +69,7 @@ def _get_executions_info():
         {
             "id": "test-vdk-latest-1625736000",
             "job_name": "test-job",
-            "status": "failed",
+            "status": "platform_error",
             "type": "scheduled",
             "start_time": "2021-07-08T09:20:22+00:00",
             "op_id": "test-vdk-latest-1625736000",
@@ -80,7 +80,7 @@ def _get_executions_info():
         {
             "id": "test-vdk-latest-1625736300",
             "job_name": "test-job",
-            "status": "failed",
+            "status": "platform_error",
             "type": "scheduled",
             "start_time": "2021-07-08T09:25:10+00:00",
             "op_id": "test-vdk-latest-1625736300",


### PR DESCRIPTION
Bump vdk-control-service-api version to 1.0.6. The new version
changes DataJobExecution statuses.

This change will be merged after https://github.com/vmware/versatile-data-kit/pull/574.

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com