### PR TITLE
control-service: graphQl add sorting by notifications

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLDataJobsSortContactsIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLDataJobsSortContactsIT.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.graphql.it;
+
+import com.vmware.taurus.ControlplaneApplication;
+import com.vmware.taurus.controlplane.model.data.DataJobContacts;
+import com.vmware.taurus.datajobs.it.common.BaseIT;
+import com.vmware.taurus.service.JobsRepository;
+import com.vmware.taurus.service.model.DataJob;
+import com.vmware.taurus.service.model.JobConfig;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.List;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = ControlplaneApplication.class)
+public class GraphQLDataJobsSortContactsIT extends BaseIT {
+
+   @Autowired
+   private JobsRepository jobsRepository;
+
+   @AfterEach
+   public void cleanup() {
+      jobsRepository.deleteAll();
+   }
+
+   private String getQuery(String sortOrder) {
+      return "{\n" +
+            "  jobs(\n" +
+            "    pageNumber: 1\n" +
+            "    pageSize: 5\n" +
+            "    filter: [{ property: \"config.contacts.present\", sort:" + sortOrder + "}]\n" +
+            "  ) {\n" +
+            "    content {\n" +
+            "      jobName\n" +
+            "      config {\n" +
+            "        contacts{" +
+            "           notifiedOnJobFailureUserError " +
+            "           notifiedOnJobSuccess" +
+            "        }\n" +
+            "      }\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+   }
+
+   @Test
+   public void testEmptyCall_shouldBeEmpty() throws Exception {
+      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
+                  .queryParam("query", getQuery("DESC"))
+                  .with(user(TEST_USERNAME)))
+            .andExpect(jsonPath("$.data.content").isEmpty());
+   }
+
+   @Test
+   public void testSingleJob_shouldReturnOne() throws Exception {
+      var contacts = new DataJobContacts();
+      contacts.setNotifiedOnJobFailureUserError(List.of("test-notified"));
+      var job = createDummyJob(contacts, "test-job");
+      jobsRepository.save(job);
+
+      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
+                  .queryParam("query", getQuery("DESC"))
+                  .with(user(TEST_USERNAME)))
+            .andExpect(jsonPath("$.data.content[0].config.contacts.notifiedOnJobFailureUserError")
+                  .value("test-notified"));
+   }
+
+   @Test
+   public void testSortingTwoJobs_shouldReturnDescOrder() throws Exception {
+      var contacts = new DataJobContacts();
+      contacts.setNotifiedOnJobFailureUserError(List.of("test-notified"));
+      var job = createDummyJob(contacts, "test-job");
+
+      var contacts2 = new DataJobContacts();
+      var job2 = createDummyJob(contacts2, "test-job2");
+
+      jobsRepository.save(job);
+      jobsRepository.save(job2);
+
+      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
+                  .queryParam("query", getQuery("DESC"))
+                  .with(user(TEST_USERNAME)))
+            .andExpect(jsonPath("$.data.content[0].config.contacts.notifiedOnJobFailureUserError")
+                  .value("test-notified"))
+            .andExpect(jsonPath("$.data.content[1].config.contacts.notifiedOnJobFailureUserError")
+                  .isEmpty());
+   }
+
+   @Test
+   public void testSortingTwoJobs_shouldReturnAscOrder() throws Exception {
+      var contacts = new DataJobContacts();
+      contacts.setNotifiedOnJobSuccess(List.of("test-notified"));
+      var job = createDummyJob(contacts, "test-job");
+
+      var contacts2 = new DataJobContacts();
+      var job2 = createDummyJob(contacts2, "test-job2");
+
+      jobsRepository.save(job);
+      jobsRepository.save(job2);
+
+      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
+                  .queryParam("query", getQuery("ASC"))
+                  .with(user(TEST_USERNAME)))
+            .andExpect(jsonPath("$.data.content[1].config.contacts.notifiedOnJobSuccess")
+                  .value("test-notified"))
+            .andExpect(jsonPath("$.data.content[0].config.contacts.notifiedOnJobSuccess")
+                  .isEmpty());
+   }
+
+   @Test
+   public void testSortingTwoJobsNoContacts_shouldReturnTwo() throws Exception {
+      var contacts = new DataJobContacts();
+      var job = createDummyJob(contacts, "test-job");
+
+      var contacts2 = new DataJobContacts();
+      var job2 = createDummyJob(contacts2, "test-job2");
+
+      jobsRepository.save(job);
+      jobsRepository.save(job2);
+
+      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
+                  .queryParam("query", getQuery("ASC"))
+                  .with(user(TEST_USERNAME)))
+            .andExpect(jsonPath("$.data.content.length()")
+                  .value(2))
+            .andExpect(jsonPath("$.data.content[*].jobName", Matchers.contains("test-job", "test-job2")));
+   }
+
+   @Test
+   public void testSortingTwoJobsWithContacts_shouldReturnTwo() throws Exception {
+      var contacts = new DataJobContacts();
+      contacts.setNotifiedOnJobDeploy(List.of("test"));
+      var job = createDummyJob(contacts, "test-job");
+
+      var contacts2 = new DataJobContacts();
+      contacts2.setNotifiedOnJobFailurePlatformError(List.of("test"));
+      var job2 = createDummyJob(contacts2, "test-job2");
+
+      jobsRepository.save(job);
+      jobsRepository.save(job2);
+
+      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
+                  .queryParam("query", getQuery("ASC"))
+                  .with(user(TEST_USERNAME)))
+            .andExpect(jsonPath("$.data.content.length()")
+                  .value(2))
+            .andExpect(jsonPath("$.data.content[*].jobName", Matchers.contains("test-job", "test-job2")));
+   }
+
+   private DataJob createDummyJob(DataJobContacts contacts, String id) {
+      DataJob job = new DataJob();
+      job.setName(id);
+      JobConfig config = new JobConfig();
+      config.setSchedule("test-schedule");
+      config.setNotifiedOnJobFailureUserError(contacts.getNotifiedOnJobFailureUserError());
+      config.setNotifiedOnJobDeploy(contacts.getNotifiedOnJobDeploy());
+      config.setNotifiedOnJobSuccess(contacts.getNotifiedOnJobSuccess());
+      config.setNotifiedOnJobFailurePlatformError(contacts.getNotifiedOnJobFailurePlatformError());
+      job.setJobConfig(config);
+      return job;
+   }
+
+}

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLDataJobsSortContactsIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLDataJobsSortContactsIT.java
@@ -170,5 +170,4 @@ public class GraphQLDataJobsSortContactsIT extends BaseIT {
       job.setJobConfig(config);
       return job;
    }
-
 }

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLJobExecutionsStatusCountIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLJobExecutionsStatusCountIT.java
@@ -20,11 +20,11 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.time.OffsetDateTime;
 
+import static org.apache.commons.lang3.RandomStringUtils.random;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -36,15 +36,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class GraphQLJobExecutionsStatusCountIT extends BaseDataJobDeploymentIT {
 
    @Autowired
-   MockMvc mockMvc;
-
-   @Autowired
    JobExecutionRepository jobExecutionRepository;
 
    @Autowired
    JobsRepository jobsRepository;
-
-   private final String uri = "/data-jobs/for-team/supercollider/jobs";
 
    @AfterEach
    public void cleanup() {
@@ -77,10 +72,10 @@ public class GraphQLJobExecutionsStatusCountIT extends BaseDataJobDeploymentIT {
       var expectedEndTimeLarger = OffsetDateTime.now();
       var expectedEndTimeSmaller = OffsetDateTime.now().minusDays(1);
 
-      addJobExecution(expectedEndTimeLarger, "testId", ExecutionStatus.FINISHED, jobName);
-      addJobExecution(expectedEndTimeSmaller, "testId2", ExecutionStatus.FINISHED, jobName);
+      addJobExecution(expectedEndTimeLarger, random(10), ExecutionStatus.FINISHED, jobName);
+      addJobExecution(expectedEndTimeSmaller, random(11), ExecutionStatus.FINISHED, jobName);
 
-      mockMvc.perform(MockMvcRequestBuilders.get(uri).queryParam("query", getQuery(jobName)).with(user(username)))
+      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI).queryParam("query", getQuery(jobName)).with(user(username)))
               .andExpect(status().is(200))
               .andExpect(content().contentType("application/json"))
               .andExpect(jsonPath("$.data.content[0].deployments[0].successfulExecutions").value(2))
@@ -90,7 +85,7 @@ public class GraphQLJobExecutionsStatusCountIT extends BaseDataJobDeploymentIT {
 
    @Test
    public void testExecutionStatusCount_expectNoCounts(String jobName, String username) throws Exception {
-      mockMvc.perform(MockMvcRequestBuilders.get(uri).queryParam("query", getQuery(jobName)).with(user(username)))
+      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI).queryParam("query", getQuery(jobName)).with(user(username)))
               .andExpect(status().is(200))
               .andExpect(content().contentType("application/json"))
               .andExpect(jsonPath("$.data.content[0].deployments[0].successfulExecutions").value(0))
@@ -102,12 +97,12 @@ public class GraphQLJobExecutionsStatusCountIT extends BaseDataJobDeploymentIT {
       var expectedEndTimeLarger = OffsetDateTime.now();
       var expectedEndTimeSmaller = OffsetDateTime.now().minusDays(1);
 
-      addJobExecution(expectedEndTimeLarger, "testId", ExecutionStatus.FINISHED, jobName);
-      addJobExecution(expectedEndTimeSmaller, "testId2", ExecutionStatus.FINISHED, jobName);
-      addJobExecution(expectedEndTimeLarger, "testI3", ExecutionStatus.FAILED, jobName);
-      addJobExecution(expectedEndTimeSmaller, "testId4", ExecutionStatus.FAILED, jobName);
+      addJobExecution(expectedEndTimeLarger, random(10), ExecutionStatus.FINISHED, jobName);
+      addJobExecution(expectedEndTimeSmaller, random(11), ExecutionStatus.FINISHED, jobName);
+      addJobExecution(expectedEndTimeLarger, random(12), ExecutionStatus.FAILED, jobName);
+      addJobExecution(expectedEndTimeSmaller, random(13), ExecutionStatus.FAILED, jobName);
 
-      mockMvc.perform(MockMvcRequestBuilders.get(uri).queryParam("query", getQuery(jobName)).with(user(username)))
+      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI).queryParam("query", getQuery(jobName)).with(user(username)))
               .andExpect(status().is(200))
               .andExpect(content().contentType("application/json"))
               .andExpect(jsonPath("$.data.content[0].deployments[0].successfulExecutions").value(2))
@@ -119,10 +114,10 @@ public class GraphQLJobExecutionsStatusCountIT extends BaseDataJobDeploymentIT {
    public void testExecutionStatusCount_expectOneSuccessfulOneFailed(String jobName, String username) throws Exception {
       var expectedEndTimeLarger = OffsetDateTime.now();
 
-      addJobExecution(expectedEndTimeLarger, "testId", ExecutionStatus.FINISHED, jobName);
-      addJobExecution(expectedEndTimeLarger, "testI3", ExecutionStatus.FAILED, jobName);
+      addJobExecution(expectedEndTimeLarger, random(10), ExecutionStatus.FINISHED, jobName);
+      addJobExecution(expectedEndTimeLarger, random(11), ExecutionStatus.FAILED, jobName);
 
-      mockMvc.perform(MockMvcRequestBuilders.get(uri).queryParam("query", getQuery(jobName)).with(user(username)))
+      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI).queryParam("query", getQuery(jobName)).with(user(username)))
               .andExpect(status().is(200))
               .andExpect(content().contentType("application/json"))
               .andExpect(jsonPath("$.data.content[0].deployments[0].successfulExecutions").value(1))

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyBy.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyBy.java
@@ -29,7 +29,8 @@ public enum JobFieldStrategyBy {
    DESCRIPTION("config.description", "content/config/description"),
    SOURCE_URL("config.sourceUrl", "content/config/sourceUrl"),
    NEXT_RUN_EPOCH_SECS("config.schedule.nextRunEpochSeconds", "content/config/schedule/nextRunEpochSeconds"),
-   SCHEDULE_CRON("config.schedule.scheduleCron", "content/config/schedule/scheduleCron");
+   SCHEDULE_CRON("config.schedule.scheduleCron", "content/config/schedule/scheduleCron"),
+   DATA_JOB_CONTACTS("config.contacts", "content/config/contacts");
 
    private final String field;
    private final String path;

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyBy.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyBy.java
@@ -30,7 +30,7 @@ public enum JobFieldStrategyBy {
    SOURCE_URL("config.sourceUrl", "content/config/sourceUrl"),
    NEXT_RUN_EPOCH_SECS("config.schedule.nextRunEpochSeconds", "content/config/schedule/nextRunEpochSeconds"),
    SCHEDULE_CRON("config.schedule.scheduleCron", "content/config/schedule/scheduleCron"),
-   DATA_JOB_CONTACTS("config.contacts", "content/config/contacts");
+   DATA_JOB_CONTACTS("config.contacts.present", "content/config/contacts/present");
 
    private final String field;
    private final String path;

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByDataJobContacts.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByDataJobContacts.java
@@ -11,10 +11,12 @@ import com.vmware.taurus.service.graphql.model.Filter;
 import com.vmware.taurus.service.graphql.model.V2DataJob;
 import com.vmware.taurus.service.graphql.strategy.FieldStrategy;
 import org.apache.commons.collections.CollectionUtils;
+import org.springframework.stereotype.Component;
 
 import java.util.Comparator;
 import java.util.function.Predicate;
 
+@Component
 public class JobFieldStrategyByDataJobContacts extends FieldStrategy<V2DataJob> {
    private static final Comparator<V2DataJob> COMPARATOR_DEFAULT = Comparator.comparing(e -> e.getConfig().getContacts(),
          Comparator.nullsLast((o1, o2) -> {

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByDataJobContacts.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByDataJobContacts.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.graphql.strategy.datajob;
+
+import com.vmware.taurus.controlplane.model.data.DataJobContacts;
+import com.vmware.taurus.service.graphql.model.Criteria;
+import com.vmware.taurus.service.graphql.model.Filter;
+import com.vmware.taurus.service.graphql.model.V2DataJob;
+import com.vmware.taurus.service.graphql.strategy.FieldStrategy;
+import org.apache.commons.collections.CollectionUtils;
+
+import java.util.Comparator;
+import java.util.function.Predicate;
+
+public class JobFieldStrategyByDataJobContacts extends FieldStrategy<V2DataJob> {
+   private static final Comparator<V2DataJob> COMPARATOR_DEFAULT = Comparator.comparing(e -> e.getConfig().getContacts(),
+         Comparator.nullsLast((o1, o2) -> {
+            boolean o1ContactPresent = isContactPresent(o1);
+            boolean o2ContactPresent = isContactPresent(o2);
+            return Boolean.compare(o1ContactPresent, o2ContactPresent);
+         }));
+
+   @Override
+   public JobFieldStrategyBy getStrategyName() {
+      return JobFieldStrategyBy.DATA_JOB_CONTACTS;
+   }
+
+   @Override
+   public Criteria<V2DataJob> computeFilterCriteria(Criteria<V2DataJob> criteria, Filter filter) {
+      var predicate = criteria.getPredicate();
+      return new Criteria<>(predicate, detectSortingComparator(filter, COMPARATOR_DEFAULT, criteria));
+   }
+
+   @Override
+   public Predicate<V2DataJob> computeSearchCriteria(String searchStr) {
+      // searching by notification is not meaningful yet
+      return dataJob -> true;
+   }
+
+   private static boolean isContactPresent(DataJobContacts contacts) {
+      return CollectionUtils.isNotEmpty(contacts.getNotifiedOnJobDeploy()) ||
+            CollectionUtils.isNotEmpty(contacts.getNotifiedOnJobFailurePlatformError()) ||
+            CollectionUtils.isNotEmpty(contacts.getNotifiedOnJobFailureUserError()) ||
+            CollectionUtils.isNotEmpty(contacts.getNotifiedOnJobSuccess());
+   }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByContactTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByContactTest.java
@@ -17,6 +17,9 @@ import org.springframework.data.domain.Sort;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JobFieldStrategyByContactTest {
 
@@ -101,6 +104,23 @@ public class JobFieldStrategyByContactTest {
       Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(a));
       Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(b));
       Assertions.assertEquals(-1, v2DataJobCriteria.getComparator().compare(a, b));
+   }
+
+   @Test
+   void testJobContactsStrategy_whenComputingProvidedSearch_shouldReturnValidPredicate() {
+      Predicate<V2DataJob> predicate = strategyByDataJobContacts.computeSearchCriteria("some random string");
+
+      var contactA = new DataJobContacts();
+      var contactB = new DataJobContacts();
+
+      contactB.setNotifiedOnJobFailureUserError(List.of("non-empty"));
+
+      V2DataJob a = createDummyJob(contactA);
+      V2DataJob b = createDummyJob(contactB);
+
+      Assertions.assertTrue(predicate.test(a));
+      Assertions.assertTrue(predicate.test(b));
+
    }
 
    private V2DataJob createDummyJob(DataJobContacts contacts) {

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByContactTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByContactTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.graphql.strategy.datajob;
+
+import com.vmware.taurus.controlplane.model.data.DataJobContacts;
+import com.vmware.taurus.service.graphql.model.Criteria;
+import com.vmware.taurus.service.graphql.model.Filter;
+import com.vmware.taurus.service.graphql.model.V2DataJob;
+import com.vmware.taurus.service.graphql.model.V2DataJobConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+public class JobFieldStrategyByContactTest {
+
+   private final JobFieldStrategyByDataJobContacts strategyByDataJobContacts = new JobFieldStrategyByDataJobContacts();
+
+   @Test
+   public void testDataJobContactsStrategy_whenGettingStrategyName_shouldBeSpecific() {
+      Assertions.assertTrue(strategyByDataJobContacts.getStrategyName().equals(JobFieldStrategyBy.DATA_JOB_CONTACTS));
+   }
+
+   @Test
+   public void testDataJobContactsStrategy_testEmptyContacts_shouldBeEqual() {
+      Criteria<V2DataJob> baseCriteria = new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
+      Filter filter = new Filter("contacts", null, Sort.Direction.ASC);
+
+      V2DataJob a = createDummyJob(new DataJobContacts());
+      V2DataJob b = createDummyJob(new DataJobContacts());
+
+      Criteria<V2DataJob> v2DataJobCriteria = strategyByDataJobContacts.computeFilterCriteria(baseCriteria, filter);
+
+      Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(a));
+      Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(b));
+      Assertions.assertEquals(0, v2DataJobCriteria.getComparator().compare(a, b));
+   }
+
+   @Test
+   public void testDataJobContactsStrategy_testNonEmptyContacts_shouldBeEqual() {
+      Criteria<V2DataJob> baseCriteria = new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
+      Filter filter = new Filter("contacts", null, Sort.Direction.ASC);
+
+      var contactA = new DataJobContacts();
+      var contactB = new DataJobContacts();
+
+      contactA.setNotifiedOnJobDeploy(List.of("non-empty"));
+      contactB.setNotifiedOnJobFailureUserError(List.of("non-empty"));
+
+      V2DataJob a = createDummyJob(contactA);
+      V2DataJob b = createDummyJob(contactB);
+
+      Criteria<V2DataJob> v2DataJobCriteria = strategyByDataJobContacts.computeFilterCriteria(baseCriteria, filter);
+
+      Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(a));
+      Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(b));
+      Assertions.assertEquals(0, v2DataJobCriteria.getComparator().compare(a, b));
+   }
+
+   @Test
+   public void testDataJobContactsStrategy_testEmptyNonEmptyContacts_shouldBeGreater() {
+      Criteria<V2DataJob> baseCriteria = new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
+      Filter filter = new Filter("contacts", null, Sort.Direction.ASC);
+
+      var contactA = new DataJobContacts();
+      var contactB = new DataJobContacts();
+
+      contactA.setNotifiedOnJobDeploy(List.of("non-empty"));
+
+      V2DataJob a = createDummyJob(contactA);
+      V2DataJob b = createDummyJob(contactB);
+
+      Criteria<V2DataJob> v2DataJobCriteria = strategyByDataJobContacts.computeFilterCriteria(baseCriteria, filter);
+
+      Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(a));
+      Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(b));
+      Assertions.assertEquals(1, v2DataJobCriteria.getComparator().compare(a, b));
+   }
+
+   @Test
+   public void testDataJobContactsStrategy_testEmptyNonEmptyContacts_shouldBeLess() {
+      Criteria<V2DataJob> baseCriteria = new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
+      Filter filter = new Filter("contacts", null, Sort.Direction.ASC);
+
+      var contactA = new DataJobContacts();
+      var contactB = new DataJobContacts();
+
+      contactB.setNotifiedOnJobFailureUserError(List.of("non-empty"));
+
+      V2DataJob a = createDummyJob(contactA);
+      V2DataJob b = createDummyJob(contactB);
+
+      Criteria<V2DataJob> v2DataJobCriteria = strategyByDataJobContacts.computeFilterCriteria(baseCriteria, filter);
+
+      Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(a));
+      Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(b));
+      Assertions.assertEquals(-1, v2DataJobCriteria.getComparator().compare(a, b));
+   }
+
+   private V2DataJob createDummyJob(DataJobContacts contacts) {
+      V2DataJob job = new V2DataJob();
+      V2DataJobConfig config = new V2DataJobConfig();
+      config.setDescription("desc");
+      config.setContacts(contacts);
+      job.setConfig(config);
+      return job;
+   }
+
+}

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByContactTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByContactTest.java
@@ -19,8 +19,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class JobFieldStrategyByContactTest {
 
    private final JobFieldStrategyByDataJobContacts strategyByDataJobContacts = new JobFieldStrategyByDataJobContacts();


### PR DESCRIPTION
why: Users requested the ability to sort DataJobs
by notifications. This is a part of the graphql epic.

what: Added the ability to sort by notifications enabled
or not. We check if one of the contacts is populated and
if it is, we threat it as a notification enabled. The DataJobs
will then get sorted by notification enabled status

testing: Added unit tests. 

Signed-off-by: Momchil Zhivkov <mzhivkov@vmware.com>