### PR TITLE
 fix python coverage report

### DIFF
--- a/projects/vdk-control-cli/cicd/build.sh
+++ b/projects/vdk-control-cli/cicd/build.sh
@@ -30,6 +30,6 @@ pip install -e .
 
 echo "Run unit tests and generate coverage report"
 pip install pytest-cov
-pytest --junitxml=tests.xml --cov taurus --cov-report term-missing --cov-report xml:coverage.xml
+pytest --junitxml=tests.xml --cov vdk --cov-report term-missing --cov-report xml:coverage.xml
 
 echo "Done"

--- a/projects/vdk-heartbeat/cicd/build.sh
+++ b/projects/vdk-heartbeat/cicd/build.sh
@@ -13,4 +13,4 @@ pip install -e .
 
 echo "Run unit tests and generate coverage report"
 pip install pytest-cov
-pytest --junitxml=tests.xml --cov taurus --cov-report term-missing --cov-report xml:coverage.xml
+pytest --junitxml=tests.xml --cov vdk --cov-report term-missing --cov-report xml:coverage.xml


### PR DESCRIPTION
Python code coverage was not working correctly because it was scanning the wrong modules 

Testing Done: CI of this PR - checked that coverage was generated correctly: https://gitlab.com/vmware-analytics/versatile-data-kit/-/jobs/1845803340#L327 and https://gitlab.com/vmware-analytics/versatile-data-kit/-/jobs/1845803344#L200