### PR TITLE
control-service: vdk version was being overwritten when not set

### DIFF
--- a/projects/control-service/projects/model/apidefs/datajob-api/api.yaml
+++ b/projects/control-service/projects/model/apidefs/datajob-api/api.yaml
@@ -1141,7 +1141,6 @@ components:
           description: Enable/disable flag
           type: boolean
           example: false
-          default: true
         deployed_by:
           description: User or service that deployed the Data Job
           type: string
@@ -1175,7 +1174,6 @@ components:
           description: Enable/disable flag
           type: boolean
           example: false
-          default: true
         contacts:
           $ref: '#/components/schemas/DataJobContacts'
         schedule:

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudIT.java
@@ -249,6 +249,17 @@ public class DataJobDeploymentCrudIT extends BaseIT {
               .andExpect(status().isOk())
               .andExpect(jsonPath("$.vdk_version", is("new_vdk_version_tag")));
 
+
+      // Execute disable deployment again to check that the version is not overwritten
+      mockMvc.perform(patch(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s",
+                      TEST_TEAM_NAME,
+                      TEST_JOB_NAME,
+                      DEPLOYMENT_ID))
+                      .with(user("user"))
+                      .content(getDataJobDeploymentEnableRequestBody(false))
+                      .contentType(MediaType.APPLICATION_JSON))
+              .andExpect(status().isAccepted());
+
       // Execute reset back vdk version for deployment
       mockMvc.perform(patch(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s",
                       TEST_TEAM_NAME,

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/BaseIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/BaseIT.java
@@ -196,10 +196,8 @@ public class BaseIT extends KerberosSecurityTestcaseJunit5 {
 
    public static String getDataJobDeploymentRequestBody(String jobVersion) throws JsonProcessingException {
       var jobDeployment = new com.vmware.taurus.controlplane.model.data.DataJobDeployment();
-      jobDeployment.setVdkVersion("");
       jobDeployment.setJobVersion(jobVersion);
       jobDeployment.setMode(DataJobMode.RELEASE);
-      jobDeployment.setEnabled(true);
       jobDeployment.setResources(new DataJobResources());
       jobDeployment.setSchedule(new DataJobSchedule());
       jobDeployment.setId(TEST_JOB_DEPLOYMENT_ID);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
@@ -28,6 +28,7 @@ public class DeploymentModelConverter {
         deployment.setResources(jobDeploymentStatus.getResources());
         deployment.setMode(jobDeploymentStatus.getMode());
         deployment.setGitCommitSha(jobDeploymentStatus.getGitCommitSha());
+        deployment.setVdkVersion(jobDeploymentStatus.getVdkVersion());
 
         return deployment;
     }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
@@ -212,15 +212,16 @@ public class JobImageDeployer {
       var jobAnnotations = getJobAnnotations(dataJob, lastDeployedBy);
 
       String cronJobName = getCronJobName(jobName);
+      boolean enabled = jobDeployment.getEnabled() == null || jobDeployment.getEnabled();
       if (dataJobsKubernetesService.listCronJobs().contains(cronJobName)) {
          dataJobsKubernetesService.updateCronJob(cronJobName, jobDeployment.getImageName(), jobContainerEnvVars, schedule,
-                 jobDeployment.getEnabled(), List.of(), defaultConfigurations.dataJobRequests(),
+                 enabled, List.of(), defaultConfigurations.dataJobRequests(),
                  defaultConfigurations.dataJobLimits(), jobContainer,
                  jobInitContainer, Arrays.asList(volume, secretVolume), jobDeploymentAnnotations, Collections.emptyMap(),
                  jobAnnotations, jobLabels, dockerRegistrySecret);
       } else {
          dataJobsKubernetesService.createCronJob(cronJobName, jobDeployment.getImageName(), jobContainerEnvVars, schedule,
-                 jobDeployment.getEnabled(), List.of(), defaultConfigurations.dataJobRequests(),
+                 enabled, List.of(), defaultConfigurations.dataJobRequests(),
                  defaultConfigurations.dataJobLimits(), jobContainer,
                  jobInitContainer, Arrays.asList(volume, secretVolume), jobDeploymentAnnotations, Collections.emptyMap(),
                  jobAnnotations, jobLabels, dockerRegistrySecret);


### PR DESCRIPTION
When enabling job vdk version was accidentally reset - see
https://github.com/vmware/versatile-data-kit/issues/573

This is caused by DeploymentModelConverter who was not copying vdk
version field correctly.

Also changed API to not set default value for vdk version. If not set,
we take latest configured value or default to True only if not
configured before.

Testing Done: integration tests (incluing new one to cover the scenario)

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>