### PR TITLE
vdk-core: Log version check error to DEBUG

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/version/new_version_check_plugin.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/version/new_version_check_plugin.py
@@ -63,7 +63,7 @@ class NewVersionCheckPlugin:
 
             self._check_version(package_list, package_index)
         except Exception as e:
-            log.info(
+            log.debug(
                 f"Could not check for new version release. "
                 f"Error was {e}. We are ignoring the error."
             )


### PR DESCRIPTION
Until now, if an error occured during checking for a new version,
it would be logged at the end.
This moves it to DEBUG where it belongs.

Signed-off-by: Gabriel Georgiev <gageorgiev@vmware.com>