### PR TITLE
vdk-core: Fix inclusion of exception message in log call

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/decoration_cursor.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/decoration_cursor.py
@@ -126,5 +126,5 @@ class DecorationCursor(PEP249Cursor):
             super().execute(operation, parameters)
             self._log.info("Executing decoration query SUCCEEDED.")
         except Exception as e:
-            self._log.warning("Executing decoration query FAILED.", e)
+            self._log.warning(f"Executing decoration query FAILED. Exception: {e}")
             raise e

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/impl/wrapped_connection.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/impl/wrapped_connection.py
@@ -39,5 +39,5 @@ class WrappedConnection(ManagedConnectionBase):
     def _connect(self) -> Any:
         self._log.debug("Establishing Wrapped connection ...")
         conn = self._new_connection_builder_function()
-        self._log.debug("Establishing Wrapped connection DONE: %s", str(conn))
+        self._log.debug(f"Establishing Wrapped connection DONE: {str(conn)}")
         return conn

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
@@ -100,7 +100,7 @@ class ManagedConnectionBase(PEP249Connection, IManagedConnection):
         """
         if not self._is_db_con_open:
             db_con = self._connect()
-            self._log.debug("Established %s", str(db_con))
+            self._log.debug(f"Established {str(db_con)}")
             self._is_db_con_open = True
             self._db_con = db_con
         return self

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/recovery_cursor.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/recovery_cursor.py
@@ -80,7 +80,7 @@ class RecoveryCursor(PEP249Cursor):
             self._log.info("Executing recovery query SUCCEEDED.")
         except Exception as e:
             self.retries_increment()
-            self._log.warning("Executing recovery query FAILED.", e)
+            self._log.warning(f"Executing recovery query FAILED. Exception: {e}")
             raise e
 
     def retry_operation(self) -> None:
@@ -101,7 +101,9 @@ class RecoveryCursor(PEP249Cursor):
             )
             self._log.info(f"Retrying attempt #{retry_number} for query SUCCEEDED.")
         except Exception as e:
-            self._log.warning(f"Retrying attempt #{retry_number} for query FAILED.", e)
+            self._log.warning(
+                f"Retrying attempt #{retry_number} for query FAILED. Exception: {e}"
+            )
             raise e
 
     def retries_increment(self) -> None:

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/file_based_step.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/file_based_step.py
@@ -39,7 +39,7 @@ class JobFilesLocator:
             if (x.name.lower().endswith(".sql") or x.name.lower().endswith(".py"))
         ]
         script_files.sort(key=lambda x: x.name)
-        log.debug("Script files of %s are %s", directory, script_files)
+        log.debug(f"Script files of {directory} are {script_files}")
         return script_files
 
 

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/termination_message/writer.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/termination_message/writer.py
@@ -65,7 +65,7 @@ class TerminationMessageWriterPlugin:
                     file_util, error_overall, user_error, execution_skipped
                 )
         except Exception as e:
-            log.exception("Failed to write termination message. See exception: ", e)
+            log.exception(f"Failed to write termination message. See exception: {e}")
 
     @staticmethod
     def _execute_termination_action(


### PR DESCRIPTION
Certain log calls would include the exception without specifying a
substitution string inside in the logged message for it. This lead
to an error when that log call is executed. This change fixes that
by replacing the log message with an f-string and includes the
exception in it.
Additionally, it replaces certain log calls in the code base with
f-strings as they are the recommended way of formatting strings.

Signed-off-by: Gabriel Georgiev <gageorgiev@vmware.com>