### PR TITLE
vdk-control-cli: remove unnnecessary options

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/common_group/default.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/common_group/default.py
@@ -1,22 +1,15 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
-from typing import Optional
-
 import click
-from vdk.internal.control.configuration.defaults_config import (
-    reset_default_authentication_disable,
-)
 from vdk.internal.control.configuration.defaults_config import (
     reset_default_rest_api_url,
 )
 from vdk.internal.control.configuration.defaults_config import reset_default_team_name
 from vdk.internal.control.configuration.defaults_config import (
-    write_default_authentication_disable,
-)
-from vdk.internal.control.configuration.defaults_config import (
     write_default_rest_api_url,
 )
 from vdk.internal.control.configuration.defaults_config import write_default_team_name
+
 
 # Default command implies parity for set-default and reset-default sections bellow.
 # Each option that supports set-default is expected to implement reset-default.
@@ -38,23 +31,12 @@ from vdk.internal.control.configuration.defaults_config import write_default_tea
     type=click.STRING,
     help="Set the default REST API url that will be used in all the commands that require it.",
 )
-@click.option(
-    "--authentication-disable",
-    type=click.STRING,
-    is_flag=True,
-    default=None,
-    help="Disables authentication for all the commands that operate against the Control Service.",
-)
 @click.pass_context
-def set_default_command(
-    ctx, team: str, rest_api_url: str, authentication_disable: Optional[bool]
-):
+def set_default_command(ctx, team: str, rest_api_url: str):
     if team is not None:
         write_default_team_name(team)
     if rest_api_url is not None:
         write_default_rest_api_url(rest_api_url)
-    if authentication_disable is not None:
-        write_default_authentication_disable(str(authentication_disable))
 
 
 @click.command(
@@ -78,20 +60,9 @@ def set_default_command(
     default=False,
     help="Reset the default REST API url.",
 )
-@click.option(
-    "--authentication-disable",
-    is_flag=True,
-    flag_value=True,
-    default=False,
-    help="Reset the disable authentication flag.",
-)
 @click.pass_context
-def reset_default_command(
-    ctx, team: bool, rest_api_url: bool, authentication_disable: bool
-):
+def reset_default_command(ctx, team: bool, rest_api_url: bool):
     if team:
         reset_default_team_name()
     if rest_api_url:
         reset_default_rest_api_url()
-    if authentication_disable:
-        reset_default_authentication_disable()

--- a/projects/vdk-control-cli/src/vdk/internal/control/configuration/defaults_config.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/configuration/defaults_config.py
@@ -41,23 +41,3 @@ def reset_default_rest_api_url():
     VDKConfigFolder().reset_configuration(
         section=DEFAULTS_SECTION, option=REST_API_URL_OPTION
     )
-
-
-def load_default_authentication_disable():
-    return VDKConfigFolder().read_configuration(
-        section=DEFAULTS_SECTION, option=AUTHENTICATION_DISABLE
-    )
-
-
-def write_default_authentication_disable(default_authentication_disable):
-    VDKConfigFolder().write_configuration(
-        section=DEFAULTS_SECTION,
-        option=AUTHENTICATION_DISABLE,
-        value=default_authentication_disable,
-    )
-
-
-def reset_default_authentication_disable():
-    VDKConfigFolder().reset_configuration(
-        section=DEFAULTS_SECTION, option=AUTHENTICATION_DISABLE
-    )

--- a/projects/vdk-control-cli/src/vdk/internal/control/rest_lib/factory.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/rest_lib/factory.py
@@ -1,7 +1,6 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 import logging
-import os
 
 from taurus_datajob_api import ApiClient
 from taurus_datajob_api import Configuration
@@ -12,9 +11,6 @@ from taurus_datajob_api import DataJobsPropertiesApi
 from taurus_datajob_api import DataJobsSourcesApi
 from urllib3 import Retry
 from vdk.internal.control.auth.auth import Authentication
-from vdk.internal.control.configuration.defaults_config import (
-    load_default_authentication_disable,
-)
 from vdk.internal.control.configuration.vdk_config import VDKConfig
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
vdk-control-cli no longer has option to disable or enable authentication
as if auth is needed is authomatically detected instead (https://github.com/vmware/versatile-data-kit/pull/305)

So we no longer neet `vdk set-default --authentication-disable` so I am
removing it.

Testing Done: unit tests

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>