### PR TITLE
control-service: algorithm for building logs URL

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/build.gradle
+++ b/projects/control-service/projects/pipelines_control_service/build.gradle
@@ -62,6 +62,7 @@ dependencies { // Implementation dependencies are found on compile classpath of 
     implementation versions.'com.graphql-java:graphql-java-spring-boot-starter-webmvc'
     implementation versions.'com.cronutils:cron-utils'
     implementation versions.'commons-io:commons-io'
+    implementation versions.'org.apache.commons:commons-text'
     implementation versions.'net.lingala.zip4j:zip4j'
 
     implementation versions.'net.javacrumbs.shedlock:shedlock-spring'

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionLogsUrlBuilder.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionLogsUrlBuilder.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.execution;
+
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringSubstitutor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.vmware.taurus.service.model.DataJobExecution;
+
+/**
+ * Builds logs URL for each data job execution by specified template
+ * (datajobs.executions.logsUrl.template).
+ *
+ * Supported variables which will be replaced in the template
+ * with the particular execution values:
+ *
+ * <ul>
+ *    <li>{@value VAR_PREFIX}{@value EXECUTION_ID_VAR}{@value VAR_SUFFIX}</li>
+ *    <li>{@value VAR_PREFIX}{@value OP_ID_VAR}{@value VAR_SUFFIX}</li>
+ *    <li>{@value VAR_PREFIX}{@value JOB_NAME_VAR}{@value VAR_SUFFIX}</li>
+ *    <li>{@value VAR_PREFIX}{@value START_TIME_VAR}{@value VAR_SUFFIX}</li>
+ *    <li>{@value VAR_PREFIX}{@value END_TIME_VAR}{@value VAR_SUFFIX}</li>
+ * </ul>
+ *
+ * Example: "https://log-insight-url/li/query/stream?query=%C2%A7%C2%A7%C2%A7AND%C2%A7%C2%A7%C2%A7%C2%
+ * A7{{start_time}}%C2%A7{{end_time}}%C2%A7true%C2%A7COUNT%C2%A7text:CONTAINS:{{execution_id}}*"
+ */
+@Slf4j
+@Component
+public class JobExecutionLogsUrlBuilder {
+
+   // Default for testing purposes
+   static final String VAR_PREFIX = "{{";
+   static final String VAR_SUFFIX = "}}";
+
+   static final String EXECUTION_ID_VAR = "execution_id";
+   static final String OP_ID_VAR = "op_id";
+   static final String JOB_NAME_VAR = "job_name";
+   static final String START_TIME_VAR = "start_time";
+   static final String END_TIME_VAR = "end_time";
+
+   static final String ISO_DATE_FORMAT = "iso";
+   static final String UNIX_DATE_FORMAT = "unix";
+
+   @Value("${datajobs.executions.logsUrl.template}")
+   private String template;
+
+   @Value("${datajobs.executions.logsUrl.dateFormat}")
+   private String dateFormat;
+
+   public String build(DataJobExecution dataJobExecution) {
+      if (StringUtils.isEmpty(template)) {
+         log.warn("The property 'datajobs.executions.logsUrl.template' is empty!");
+         return "";
+      }
+
+      return StringSubstitutor.replace(
+            template,
+            buildVars(dataJobExecution),
+            VAR_PREFIX,
+            VAR_SUFFIX);
+   }
+
+   private Map<String, String> buildVars(DataJobExecution dataJobExecution) {
+      Map<String, String> params = new HashMap<>();
+
+      if (dataJobExecution != null) {
+         params.put(EXECUTION_ID_VAR, dataJobExecution.getId());
+         params.put(OP_ID_VAR, dataJobExecution.getOpId());
+         params.put(
+               JOB_NAME_VAR,
+               Optional.ofNullable(dataJobExecution.getDataJob())
+                     .map(dataJob -> dataJob.getName())
+                     .orElse(""));
+         params.put(START_TIME_VAR, convertDate(dataJobExecution.getStartTime()));
+         params.put(END_TIME_VAR, convertDate(dataJobExecution.getEndTime()));
+      }
+
+      return params;
+   }
+
+   private String convertDate(OffsetDateTime offsetDateTime) {
+      String format = dateFormat;
+
+      if (offsetDateTime == null) {
+         return "";
+      }
+
+      if (StringUtils.isEmpty(format)) {
+         log.warn("The property 'datajobs.executions.logsUrl.dateFormat' is empty, defaults to '{}'", UNIX_DATE_FORMAT);
+         format = UNIX_DATE_FORMAT;
+      }
+
+      switch (format) {
+         case ISO_DATE_FORMAT:
+            return offsetDateTime.toInstant().toString();
+         case UNIX_DATE_FORMAT:
+            return getDateTimeUnix(offsetDateTime);
+         default:
+            log.warn("The property 'datajobs.executions.logsUrl.dateFormat' is not correct '{}', defaults to '{}'", dateFormat, UNIX_DATE_FORMAT);
+            return getDateTimeUnix(offsetDateTime);
+      }
+   }
+
+   private static String getDateTimeUnix(OffsetDateTime offsetDateTime) {
+      return String.valueOf(offsetDateTime.toInstant().toEpochMilli());
+   }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -105,6 +105,20 @@ datajobs.executions.cleanupJob.maximumExecutionsToStore=${DATAJOBS_EXECUTION_MAX
 #executions older than that will get deleted when the clean up job runs
 datajobs.executions.cleanupJob.executionsTtlSeconds=${DATAJOBS_EXECUTION_TTL_SECONDS:1209600}
 
+# This template will be used for building of logs URL for each data job execution returned by API.
+# Supported variables which will be replaced in the template with the particular execution values:
+# {{execution_id}}, {{job_name}}, {{op_id}}, {{start_time}} and {{end_time}}
+# Example: "https://log-insight-url/li/query/stream?query=%C2%A7%C2%A7%C2%A7AND%C2%A7%C2%A7%C2%A7%C2%
+# A7{{start_time}}%C2%A7{{end_time}}%C2%A7true%C2%A7COUNT%C2%A7text:CONTAINS:{{execution_id}}*"
+datajobs.executions.logsUrl.template=${DATAJOBS_EXECUTIONS_LOGS_URL_DATE_TEMPLATE:}
+
+# This variable is used to determine the format of execution.startTime
+# and execution.endTime used in the template (datajobs.executions.logsUrl.template).
+# Supported options: iso (https://bg.wikipedia.org/wiki/ISO_8601) and unix (https://en.wikipedia.org/wiki/Unix_time).
+# If left blank, defaults to unix.
+# Examples: iso -> "2021-12-03T15:34:54.822098Z", unix -> "1638545973226".
+datajobs.executions.logsUrl.dateFormat=${DATAJOBS_EXECUTIONS_LOGS_URL_DATE_FORMAT:unix}
+
 # https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html
 mail.smtp.host=smtp.vmware.com
 

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionLogsUrlBuilderIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionLogsUrlBuilderIT.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.execution;
+
+import java.text.MessageFormat;
+import java.time.OffsetDateTime;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.vmware.taurus.ControlplaneApplication;
+import com.vmware.taurus.service.model.DataJob;
+import com.vmware.taurus.service.model.DataJobExecution;
+import com.vmware.taurus.service.model.JobConfig;
+
+@SpringBootTest(classes = ControlplaneApplication.class)
+public class JobExecutionLogsUrlBuilderIT {
+
+   private static final String TEST_EXECUTION_ID = "test-job-name-1634127142";
+   private static final String TEST_JOB_NAME = "test-job-name";
+   private static final String TEST_OP_ID = "test-op-id-1634127142";
+   private static final OffsetDateTime TEST_START_TIME = OffsetDateTime.now();
+   private static final OffsetDateTime TEST_END_TIME = OffsetDateTime.now();
+
+   private static final String LOGS_URL_TEMPLATE =
+         "https://log-insight-base-url/li/query/stream?query=%C2%A7%C2%A7%C2%A7AND%C" +
+               "2%A7%C2%A7%C2%A7%C2%A7{0}%C2%A7{1}%C2%A7true%C2%A7COUNT%C2%A7*%C2%A7" +
+               "timestamp%C2%A7pageSortPreference:%7B%22sortBy%22%3A%22-{2}-{3}-" +
+               "ingest_timestamp%22%2C%22sortOrder%22%3A%22DESC%22%7D%C2%A7" +
+               "alertDefList:%5B%5D%C2%A7partitions:%C2%A7%C2%A7text:CONTAINS:{4}*";
+
+   private static final String LOGS_URL_TEMPLATE_RAW =
+         MessageFormat.format(
+               LOGS_URL_TEMPLATE,
+               buildVarPlaceholder(JobExecutionLogsUrlBuilder.START_TIME_VAR),
+               buildVarPlaceholder(JobExecutionLogsUrlBuilder.END_TIME_VAR),
+               buildVarPlaceholder(JobExecutionLogsUrlBuilder.JOB_NAME_VAR),
+               buildVarPlaceholder(JobExecutionLogsUrlBuilder.OP_ID_VAR),
+               buildVarPlaceholder(JobExecutionLogsUrlBuilder.EXECUTION_ID_VAR));
+
+   @Autowired
+   private JobExecutionLogsUrlBuilder logsUrlBuilder;
+
+   @Test
+   public void testBuild_allParamsAndDataFormatUnix_shouldReturnLogsUrl() {
+      String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix();
+      assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, expectedLogsUrl);
+   }
+
+   @Test
+   public void testBuild_allParamsAndDataFormatIso_shouldReturnLogsUrl() {
+      String expectedLogsUrl = buildExpectedLogsUrlDateFormatIso();
+      assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, JobExecutionLogsUrlBuilder.ISO_DATE_FORMAT, expectedLogsUrl);
+   }
+
+   @Test
+   public void testBuild_extraParamAndDataFormatUnix_shouldReturnLogsUrl() {
+      String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix() + "{{abc}}";
+      assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW + "{{abc}}", JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, expectedLogsUrl);
+   }
+
+   @Test
+   public void testBuild_partialParamsAndDataFormatUnix_shouldReturnLogsUrl() {
+      String logsUrlRaw = MessageFormat.format(
+            LOGS_URL_TEMPLATE,
+            buildVarPlaceholder(JobExecutionLogsUrlBuilder.START_TIME_VAR),
+            buildVarPlaceholder(JobExecutionLogsUrlBuilder.END_TIME_VAR),
+            buildVarPlaceholder(JobExecutionLogsUrlBuilder.JOB_NAME_VAR),
+            buildVarPlaceholder(JobExecutionLogsUrlBuilder.OP_ID_VAR),
+            "");
+      String expectedLogsUrl = MessageFormat.format(LOGS_URL_TEMPLATE,
+            String.valueOf(TEST_START_TIME.toInstant().toEpochMilli()),
+            String.valueOf(TEST_END_TIME.toInstant().toEpochMilli()),
+            TEST_JOB_NAME,
+            TEST_OP_ID,
+            "");
+
+      assertLogsUrlValid(logsUrlRaw, JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, expectedLogsUrl);
+   }
+
+   @Test
+   public void testBuild_emptyLogsUrlTemplate_shouldReturnEmptyLogsUrl() {
+      assertLogsUrlValid("", JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, "");
+   }
+
+   @Test
+   public void testBuild_nullLogsUrlTemplate_shouldReturnEmptyLogsUrl() {
+      assertLogsUrlValid(null, JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, "");
+   }
+
+   @Test
+   public void testBuild_nullLogsUrlDateFormat_shouldReturnLogsUrlWithDateFormatUnix() {
+      String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix();
+      assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, null, expectedLogsUrl);
+   }
+
+   @Test
+   public void testBuild_emptyLogsUrlDateFormat_shouldReturnLogsUrlWithDateFormatUnix() {
+      String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix();
+      assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, "", expectedLogsUrl);
+   }
+
+   private static String buildVarPlaceholder(String var) {
+      return JobExecutionLogsUrlBuilder.VAR_PREFIX + var + JobExecutionLogsUrlBuilder.VAR_SUFFIX;
+   }
+
+   private static String buildExpectedLogsUrlDateFormatUnix() {
+      return MessageFormat.format(
+            LOGS_URL_TEMPLATE,
+            String.valueOf(TEST_START_TIME.toInstant().toEpochMilli()),
+            String.valueOf(TEST_END_TIME.toInstant().toEpochMilli()),
+            TEST_JOB_NAME,
+            TEST_OP_ID,
+            TEST_EXECUTION_ID);
+   }
+
+   private static String buildExpectedLogsUrlDateFormatIso() {
+      return MessageFormat.format(
+            LOGS_URL_TEMPLATE,
+            TEST_START_TIME.toInstant().toString(),
+            TEST_END_TIME.toInstant().toString(),
+            TEST_JOB_NAME,
+            TEST_OP_ID,
+            TEST_EXECUTION_ID);
+   }
+
+   private void assertLogsUrlValid(String logsUrlTemplate, String logsUrlDateFormat, String expectedLogsUrl) {
+      ReflectionTestUtils.setField(logsUrlBuilder, "template", logsUrlTemplate);
+      ReflectionTestUtils.setField(logsUrlBuilder, "dateFormat", logsUrlDateFormat);
+
+      DataJobExecution execution = DataJobExecution
+            .builder()
+            .id(TEST_EXECUTION_ID)
+            .dataJob(new DataJob(TEST_JOB_NAME, new JobConfig()))
+            .opId(TEST_OP_ID)
+            .startTime(TEST_START_TIME)
+            .endTime(TEST_END_TIME)
+            .build();
+
+      String actualLogsUrl = logsUrlBuilder.build(execution);
+      Assertions.assertEquals(expectedLogsUrl, actualLogsUrl);
+   }
+}

--- a/projects/control-service/projects/versions-of-external-dependencies.gradle
+++ b/projects/control-service/projects/versions-of-external-dependencies.gradle
@@ -40,6 +40,7 @@ project.ext {
             'org.awaitility:awaitility'                                          : 'org.awaitility:awaitility:4.1.0',
             'org.tuckey:urlrewritefilter'                                        : 'org.tuckey:urlrewritefilter:4.0.4',
             'org.apache.commons:commons-lang3'                                   : 'org.apache.commons:commons-lang3:3.12.0',
+            'org.apache.commons:commons-text'                                    : 'org.apache.commons:commons-text:1.9',
             'com.github.tomakehurst:wiremock'                                    : 'com.github.tomakehurst:wiremock:2.27.2',
             'com.graphql-java:graphql-java-extended-scalars'                     : 'com.graphql-java:graphql-java-extended-scalars:15.0.0',
 


### PR DESCRIPTION
Our internal customers want easy access to the logs of each data job execution.
Since they use different log management systems,
we should provide unified method for building of logs URL.

This change aims to provide an algorithm for building logs URL.

Template:
https://base-url/explorer/?existingChartQuery=%7B%22query%22%3A%22{{execution_id}}*%22%2C%22startTimeMillis%22%3A{{start_time}}%2C%22endTimeMillis%22%3A{{end_time}}%2C%22fieldConstraints%22%3A%5B%7B%22internalName%22%3A%22text%22%2C%22operator%22%3A%22CONTAINS%22%2C%22value%22%3A%22vdk%22%7D%5D%7D

Log URL:
https://base-url/explorer/?existingChartQuery=%7B%22query%22%3A%22data-job-name-1637654848*%22%2C%22startTimeMillis%22%3A1637611648682%2C%22endTimeMillis%22%3A1637701648682%2C%22fieldConstraints%22%3A%5B%7B%22internalName%22%3A%22text%22%2C%22operator%22%3A%22CONTAINS%22%2C%22value%22%3A%22vdk%22%7D%5D%7D

Testing Done: unit tests

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com