### PR TITLE
[vdk-plugins][vdk-server]: Remove authentication imports

### DIFF
--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/installer.py
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/installer.py
@@ -16,13 +16,7 @@ from kubernetes import config
 from kubernetes import utils
 from kubernetes import watch
 from vdk.internal.control.configuration.defaults_config import (
-    reset_default_authentication_disable,
-)
-from vdk.internal.control.configuration.defaults_config import (
     reset_default_rest_api_url,
-)
-from vdk.internal.control.configuration.defaults_config import (
-    write_default_authentication_disable,
 )
 from vdk.internal.control.configuration.defaults_config import (
     write_default_rest_api_url,
@@ -770,7 +764,6 @@ class Installer:
         log.info("Cleaning up...")
         try:
             reset_default_rest_api_url()
-            reset_default_authentication_disable()
         except Exception as ex:
             log.error(f"Failed to clean up. {str(ex)}")
             exit(1)


### PR DESCRIPTION
After the removal of the reset_default_authentication_disable() and
write_default_authentication_disable() logic from vdk-control-cli in
https://github.com/vmware/versatile-data-kit/commit/307c1c9c14530476a7f33163ed30f72d01193aed
installing vdk-server was not possible due to an ImportError.

This change removes the authentication-related imports from vdk-server's
installer, and fixes the ImportError raised when running `vdk server --install`

Testing Done: Ran `vdk server --install` and observed that vdk-server installs as
expected.

Signed-off-by: Andon Andonov <andonova@vmware.com>