### PR TITLE
vdk-core: update testing readme

### DIFF
--- a/projects/vdk-core/tests/README.md
+++ b/projects/vdk-core/tests/README.md
@@ -2,7 +2,7 @@
 
 ## Directory layout
 
-### taurus
+### vdk
 
 Contains unit tests of the project.
 See https://martinfowler.com/bliki/UnitTest.html


### PR DESCRIPTION
It was using the wrong directory name (we forgot to fix after renaming it)

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>