### PR TITLE
control-service: fix lastDeployedDate and lastDeployedBy

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/ToApiModelConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/ToApiModelConverter.java
@@ -155,6 +155,8 @@ public class ToApiModelConverter {
       v2DataJobDeployment.setJobVersion(jobDeploymentStatus.getGitCommitSha());
       v2DataJobDeployment.setMode(DataJobMode.fromValue(jobDeploymentStatus.getMode()));
       v2DataJobDeployment.setResources(jobDeploymentStatus.getResources());
+      v2DataJobDeployment.setLastDeployedBy(jobDeploymentStatus.getLastDeployedBy());
+      v2DataJobDeployment.setLastDeployedDate(jobDeploymentStatus.getLastDeployedDate());
       // TODO: Get these from the job deployment when they are available there
       v2DataJobDeployment.setLastExecutionStatus(convertStatusEnum(sourceDataJob.getLastExecutionStatus()));
       v2DataJobDeployment.setLastExecutionTime(sourceDataJob.getLastExecutionEndTime());

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/V2DataJobDeployment.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/V2DataJobDeployment.java
@@ -30,4 +30,6 @@ public class V2DataJobDeployment {
    private Integer lastExecutionDuration;
    private Integer successfulExecutions;
    private Integer failedExecutions;
+   private String lastDeployedBy;
+   private String lastDeployedDate;
 }


### PR DESCRIPTION
Currently the lastDeployedBy and lastDeployedDate do not return from
GraphQL API.

Testing Done: unit tests

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com