### PR TITLE
control-service: improve integration tests stability

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobExecutionIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobExecutionIT.java
@@ -9,19 +9,13 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -37,15 +31,10 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MvcResult;
 
 import com.vmware.taurus.controlplane.model.data.DataJobExecution;
-import com.vmware.taurus.controlplane.model.data.DataJobExecutionRequest;
 import com.vmware.taurus.datajobs.it.common.BaseDataJobDeploymentIT;
 import com.vmware.taurus.service.JobExecutionRepository;
-import com.vmware.taurus.service.JobsRepository;
 
-@AutoConfigureMetrics
 public class DataJobExecutionIT extends BaseDataJobDeploymentIT {
-
-    public static final String HEADER_X_OP_ID = "X-OPID";
 
     private static final Logger log = LoggerFactory.getLogger(DataJobExecutionIT.class);
     private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule()); // Used for converting to OffsetDateTime;
@@ -69,21 +58,7 @@ public class DataJobExecutionIT extends BaseDataJobDeploymentIT {
 
         // Execute data job
         String opId = jobName + UUID.randomUUID().toString().toLowerCase();
-        DataJobExecutionRequest dataJobExecutionRequest = new DataJobExecutionRequest()
-              .startedBy(username);
-
-        String triggerDataJobExecutionUrl = String.format(
-              "/data-jobs/for-team/%s/jobs/%s/deployments/%s/executions",
-              teamName,
-              jobName,
-              "release");
-        MvcResult dataJobExecutionResponse = mockMvc.perform(post(triggerDataJobExecutionUrl)
-              .with(user(username))
-              .header(HEADER_X_OP_ID, opId)
-              .content(mapper.writeValueAsString(dataJobExecutionRequest))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().is(202))
-              .andReturn();
+        MvcResult dataJobExecutionResponse = executeDataJob(jobName, teamName, username, opId);
 
         // Check the data job execution status
         String location = dataJobExecutionResponse.getResponse().getHeader("location");

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/BaseDataJobDeploymentIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/BaseDataJobDeploymentIT.java
@@ -5,6 +5,14 @@
 
 package com.vmware.taurus.datajobs.it.common;
 
+import static org.awaitility.Awaitility.await;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -13,8 +21,11 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
 
 import com.vmware.taurus.ControlplaneApplication;
+import com.vmware.taurus.controlplane.model.data.DataJobExecutionRequest;
 
 /**
  * It combines all necessary annotations and constants
@@ -37,5 +48,36 @@ public abstract class BaseDataJobDeploymentIT extends BaseIT {
          // Making them sync for the purposes of this test.
          return new SyncTaskExecutor();
       }
+   }
+
+   protected MvcResult executeDataJob(String jobName, String teamName, String username, String opId) {
+      // Execute data job
+      if (opId == null) {
+         opId = jobName + UUID.randomUUID().toString().toLowerCase();
+      }
+
+      DataJobExecutionRequest dataJobExecutionRequest = new DataJobExecutionRequest()
+            .startedBy(username);
+
+      String triggerDataJobExecutionUrl = String.format(
+            "/data-jobs/for-team/%s/jobs/%s/deployments/%s/executions",
+            teamName,
+            jobName,
+            "release");
+
+      // Wait for the job execution to complete, polling every 15 seconds
+      // See: https://github.com/awaitility/awaitility/wiki/Usage
+      String finalOpId = opId;
+      return await()
+            .atMost(5, TimeUnit.MINUTES)
+            .with()
+            .pollInterval(15, TimeUnit.SECONDS)
+            .until(() -> mockMvc.perform(post(triggerDataJobExecutionUrl)
+                              .with(user(username))
+                              .header(HEADER_X_OP_ID, finalOpId)
+                              .content(mapper.writeValueAsString(dataJobExecutionRequest))
+                              .contentType(MediaType.APPLICATION_JSON))
+                        .andReturn(),
+                  mvcResult -> mvcResult.getResponse().getStatus() == 202);
    }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/BaseIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/BaseIT.java
@@ -60,6 +60,7 @@ public class BaseIT extends KerberosSecurityTestcaseJunit5 {
    protected static final String TEST_USERNAME = "user";
 
    protected static final String JOBS_URI = "/data-jobs/for-team/supercollider/jobs";
+   protected static final String HEADER_X_OP_ID = "X-OPID";
 
    protected static final ObjectMapper mapper = new ObjectMapper();
 

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLJobExecutionsStatusCountIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLJobExecutionsStatusCountIT.java
@@ -23,8 +23,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
-import static org.apache.commons.lang3.RandomStringUtils.random;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -46,9 +46,13 @@ public class GraphQLJobExecutionsStatusCountIT extends BaseDataJobDeploymentIT {
       jobExecutionRepository.deleteAll();
    }
 
-   private void addJobExecution(OffsetDateTime endTime, String executionId, ExecutionStatus executionStatus, String jobName) {
-      var execution = createDataJobExecution(executionId, jobName, executionStatus,
-              "message", OffsetDateTime.now());
+   private void addJobExecution(OffsetDateTime endTime, ExecutionStatus executionStatus, String jobName) {
+      var execution = createDataJobExecution(
+            UUID.randomUUID().toString(),
+            jobName,
+            executionStatus,
+            "message",
+            OffsetDateTime.now());
       execution.setEndTime(endTime);
       jobExecutionRepository.save(execution);
    }
@@ -72,8 +76,8 @@ public class GraphQLJobExecutionsStatusCountIT extends BaseDataJobDeploymentIT {
       var expectedEndTimeLarger = OffsetDateTime.now();
       var expectedEndTimeSmaller = OffsetDateTime.now().minusDays(1);
 
-      addJobExecution(expectedEndTimeLarger, random(10), ExecutionStatus.FINISHED, jobName);
-      addJobExecution(expectedEndTimeSmaller, random(11), ExecutionStatus.FINISHED, jobName);
+      addJobExecution(expectedEndTimeLarger, ExecutionStatus.FINISHED, jobName);
+      addJobExecution(expectedEndTimeSmaller, ExecutionStatus.FINISHED, jobName);
 
       mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI).queryParam("query", getQuery(jobName)).with(user(username)))
               .andExpect(status().is(200))
@@ -97,10 +101,10 @@ public class GraphQLJobExecutionsStatusCountIT extends BaseDataJobDeploymentIT {
       var expectedEndTimeLarger = OffsetDateTime.now();
       var expectedEndTimeSmaller = OffsetDateTime.now().minusDays(1);
 
-      addJobExecution(expectedEndTimeLarger, random(10), ExecutionStatus.FINISHED, jobName);
-      addJobExecution(expectedEndTimeSmaller, random(11), ExecutionStatus.FINISHED, jobName);
-      addJobExecution(expectedEndTimeLarger, random(12), ExecutionStatus.FAILED, jobName);
-      addJobExecution(expectedEndTimeSmaller, random(13), ExecutionStatus.FAILED, jobName);
+      addJobExecution(expectedEndTimeLarger, ExecutionStatus.FINISHED, jobName);
+      addJobExecution(expectedEndTimeSmaller, ExecutionStatus.FINISHED, jobName);
+      addJobExecution(expectedEndTimeLarger, ExecutionStatus.FAILED, jobName);
+      addJobExecution(expectedEndTimeSmaller, ExecutionStatus.FAILED, jobName);
 
       mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI).queryParam("query", getQuery(jobName)).with(user(username)))
               .andExpect(status().is(200))
@@ -114,8 +118,8 @@ public class GraphQLJobExecutionsStatusCountIT extends BaseDataJobDeploymentIT {
    public void testExecutionStatusCount_expectOneSuccessfulOneFailed(String jobName, String username) throws Exception {
       var expectedEndTimeLarger = OffsetDateTime.now();
 
-      addJobExecution(expectedEndTimeLarger, random(10), ExecutionStatus.FINISHED, jobName);
-      addJobExecution(expectedEndTimeLarger, random(11), ExecutionStatus.FAILED, jobName);
+      addJobExecution(expectedEndTimeLarger, ExecutionStatus.FINISHED, jobName);
+      addJobExecution(expectedEndTimeLarger, ExecutionStatus.FAILED, jobName);
 
       mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI).queryParam("query", getQuery(jobName)).with(user(username)))
               .andExpect(status().is(200))


### PR DESCRIPTION
Currently the integration tests depend on the same data job.
Sometimes it may take a little longer to complete the data job execution
between the tests. As a result the API will return 409
and the particular test will fail.

This change adds synchronization between data job executions.

Testing Done: integration tests

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com