### PR TITLE
vdk-impala: Move time.sleep fix to conftest

### DIFF
--- a/projects/vdk-plugins/vdk-impala/tests/conftest.py
+++ b/projects/vdk-plugins/vdk-impala/tests/conftest.py
@@ -53,3 +53,4 @@ def impala_service(docker_ip, docker_services):
     docker_services.wait_until_responsive(
         timeout=90.0, pause=0.3, check=lambda: _is_responsive(runner)
     )
+    time.sleep(10)

--- a/projects/vdk-plugins/vdk-impala/tests/functional/test_impala_connection.py
+++ b/projects/vdk-plugins/vdk-impala/tests/functional/test_impala_connection.py
@@ -38,7 +38,6 @@ class ImpalaConnectionTest(unittest.TestCase):
         },
     )
     def test_execute_query(self) -> None:
-        time.sleep(10)
         result: Result = self.__runner.invoke(
             ["run", jobs_path_from_caller_directory("sql-job")]
         )
@@ -62,7 +61,6 @@ class ImpalaConnectionTest(unittest.TestCase):
     )
     @patch("vdk.plugin.impala.impala_plugin.DecorationCursor.execute")
     def test_execute_query_with_sync_ddl_and_query_pool(self, mock_dc_execute) -> None:
-        time.sleep(10)
         result: Result = self.__runner.invoke(
             ["run", jobs_path_from_caller_directory("sql-job")]
         )


### PR DESCRIPTION
The vdk-impala functional tests would require a time.sleep statement
at their start due to an issue where the Impala would return a response
with exit code 0, but the service would not yet be available, which
would cause tests to fail.
This change moves that time.sleep call to the pytest fixture function
for two reasons: it logically makes more sense for it to be there, and
this way it will only ever be invoked once, instead of at the start of
every single functional test.

Signed-off-by: Gabriel Georgiev <gageorgiev@vmware.com>