### PR TITLE
vdk-ingest-http: Add support for compression and ingestion result

### DIFF
--- a/projects/vdk-plugins/vdk-ingest-http/src/vdk/plugin/ingest_http/ingest_http_plugin.py
+++ b/projects/vdk-plugins/vdk-ingest-http/src/vdk/plugin/ingest_http/ingest_http_plugin.py
@@ -8,16 +8,33 @@ import logging
 from vdk.api.plugin.hook_markers import hookimpl
 from vdk.internal.builtin_plugins.ingestion.ingester_base import IIngesterPlugin
 from vdk.internal.builtin_plugins.run.job_context import JobContext
+from vdk.internal.core.config import ConfigurationBuilder
 from vdk.plugin.ingest_http.ingest_over_http import IngestOverHttp
-
 
 log = logging.getLogger(__name__)
 
 
 @hookimpl
+def vdk_configure(config_builder: ConfigurationBuilder) -> None:
+    """
+    Here we define what configuration settings are needed for Greenplum with reasonable defaults
+    """
+    config_builder.add(
+        key="INGEST_OVER_HTTP_COMPRESSION_THRESHOLD_BYTES",
+        default_value=None,
+        description="Threshold used for determining if the payload will be compressed or not",
+    )
+    config_builder.add(
+        key="INGEST_OVER_HTTP_COMPRESSION_ENCODING",
+        default_value="utf-8",
+        description="Encoding used if compressing the payload",
+    )
+
+
+@hookimpl
 def initialize_job(context: JobContext) -> None:
     def new_ingester() -> IIngesterPlugin:
-        ingester_plugin = IngestOverHttp()
+        ingester_plugin = IngestOverHttp(context)
 
         return ingester_plugin
 

--- a/projects/vdk-plugins/vdk-ingest-http/src/vdk/plugin/ingest_http/ingest_http_plugin.py
+++ b/projects/vdk-plugins/vdk-ingest-http/src/vdk/plugin/ingest_http/ingest_http_plugin.py
@@ -17,12 +17,12 @@ log = logging.getLogger(__name__)
 @hookimpl
 def vdk_configure(config_builder: ConfigurationBuilder) -> None:
     """
-    Here we define what configuration settings are needed for Greenplum with reasonable defaults
+    Here we define what configuration settings are needed for the Ingest HTTP plugin with reasonable defaults
     """
     config_builder.add(
         key="INGEST_OVER_HTTP_COMPRESSION_THRESHOLD_BYTES",
         default_value=None,
-        description="Threshold used for determining if the payload will be compressed or not",
+        description="When the payload size exceeds this optional integer threshold, then gzip compression is applied",
     )
     config_builder.add(
         key="INGEST_OVER_HTTP_COMPRESSION_ENCODING",

--- a/projects/vdk-plugins/vdk-ingest-http/tests/test_ingest_over_http.py
+++ b/projects/vdk-plugins/vdk-ingest-http/tests/test_ingest_over_http.py
@@ -47,7 +47,8 @@ def test_ingest_over_http(mock_post):
         target="http://example.com/data-source",
     )
 
-    assert len(mock_post.call_args_list) == 1
+    assert mock_post.call_count == 1
+
     payload["@table"] = "test_table"
 
     mock_post.assert_called_with(
@@ -74,7 +75,7 @@ def test_ingest_over_http_compression(mock_post):
         target="http://example.com/data-source",
     )
 
-    assert len(mock_post.call_args_list) == 1
+    assert mock_post.call_count == 1
     payload["@table"] = "test_table"
 
     mock_post.assert_called_with(


### PR DESCRIPTION
Capability for compressing the ingestion payload if exceeding a
certain configurable threshold was missing. Also, no ingestion result
was returned.

Added configurations for INGEST_OVER_HTTP_COMPRESSION_THRESHOLD_BYTES
and INGEST_OVER_HTTP_COMPRESSION_ENCODING. When payload exceeds the
threshold configured, it gets compressed in gzip format. The ingestion
result is then returned, including metadata about
uncompressed_size_in_bytes, compressed_size_in_bytes and http_status.

Testing Done: added test_ingest_over_http_compression and
test_ingest_over_http_result; verified tests locally

Signed-off-by: ikoleva <ikoleva@vmware.com>