### PR TITLE
vdk-core: provide needed error details for vdk run 

### DIFF
--- a/projects/vdk-core/src/vdk/api/plugin/core_hook_spec.py
+++ b/projects/vdk-core/src/vdk/api/plugin/core_hook_spec.py
@@ -154,12 +154,12 @@ class JobRunHookSpecs:
 
         E.g
         @hookimpl(tryfirst=True)
-        run_job(context): # decorate with logs
+        create_and_run_data_job(context): # decorate with logs
             log.info(f"Start {context.name}"
             # no return
 
         @hookimpl
-        run_job(context): # alternative execution algorithm
+        create_and_run_data_job(context): # alternative execution algorithm
             results = run_in_parallel(steps)
             return results.all_success
 

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/job_input.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/job_input.py
@@ -21,11 +21,9 @@ from vdk.internal.builtin_plugins.job_properties.Propertiesnotavailable import (
     PropertiesNotAvailable,
 )
 from vdk.internal.builtin_plugins.run.execution_results import ExecutionResult
-from vdk.internal.builtin_plugins.run.execution_state import ExecutionStateStoreKeys
 from vdk.internal.builtin_plugins.run.sql_argument_substitutor import (
     SqlArgumentSubstitutor,
 )
-from vdk.internal.core import errors
 from vdk.internal.core.errors import UserCodeError
 from vdk.internal.core.statestore import CommonStoreKeys
 from vdk.internal.core.statestore import StateStore

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/step.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/step.py
@@ -7,7 +7,6 @@ import pathlib
 from abc import ABC
 from dataclasses import dataclass
 from typing import Callable
-from typing import List
 
 from vdk.api.job_input import IJobInput
 

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/templates/template_impl.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/templates/template_impl.py
@@ -47,8 +47,8 @@ class TemplatesImpl(ITemplateRegistry, ITemplate):
         )
         result = template_job.run(template_args)
         if result.is_failed():
-            if result.get_exception():
-                raise result.get_exception()
+            if result.get_exception_to_raise():
+                raise result.get_exception_to_raise()
             else:
                 errors.log_and_throw(
                     errors.ResolvableBy.PLATFORM_ERROR,

--- a/projects/vdk-core/tests/functional/run/jobs/fail-job/1_step.py
+++ b/projects/vdk-core/tests/functional/run/jobs/fail-job/1_step.py
@@ -1,0 +1,7 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from vdk.api.job_input import IJobInput
+
+
+def run(job_input: IJobInput):
+    raise ArithmeticError("cannot do math :(")

--- a/projects/vdk-core/tests/functional/run/test_run_errors.py
+++ b/projects/vdk-core/tests/functional/run/test_run_errors.py
@@ -1,0 +1,73 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import json
+import os
+import pathlib
+from unittest import mock
+
+import pytest
+from click.testing import Result
+from functional.run import util
+from vdk.api.plugin.hook_markers import hookimpl
+from vdk.internal.builtin_plugins.run.job_context import JobContext
+from vdk.internal.core import errors
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
+
+
+@pytest.fixture(autouse=True)
+def tmp_termination_msg_file(tmpdir) -> pathlib.Path:
+    out_file = str(tmpdir.join("termination-log"))
+    with mock.patch.dict(
+        os.environ,
+        {
+            "VDK_TERMINATION_MESSAGE_WRITER_ENABLED": "true",
+            "VDK_TERMINATION_MESSAGE_WRITER_OUTPUT_FILE": out_file,
+        },
+    ):
+        yield pathlib.Path(out_file)
+
+
+def test_run_user_error(tmp_termination_msg_file):
+    errors.clear_intermediate_errors()
+    runner = CliEntryBasedTestRunner()
+
+    result: Result = runner.invoke(["run", util.job_path("fail-job")])
+    cli_assert_equal(1, result)
+    assert (json.loads(tmp_termination_msg_file.read_text())["status"]) == "User error"
+
+
+def test_run_init_fails(tmp_termination_msg_file: pathlib.Path):
+    errors.clear_intermediate_errors()
+
+    class InitFailsPlugin:
+        @staticmethod
+        @hookimpl
+        def initialize_job(self, context: JobContext):
+            raise OverflowError("Overflow")
+
+    runner = CliEntryBasedTestRunner(InitFailsPlugin())
+
+    result: Result = runner.invoke(["run", util.job_path("simple-job")])
+    cli_assert_equal(1, result)
+    assert (
+        json.loads(tmp_termination_msg_file.read_text())["status"] == "Platform error"
+    )
+
+
+def test_run_job_plugin_fails(tmp_termination_msg_file):
+    errors.clear_intermediate_errors()
+
+    class RunJobFailsPlugin:
+        @staticmethod
+        @hookimpl(hookwrapper=True)
+        def run_job(context: JobContext) -> None:
+            raise OverflowError("Overflow")
+
+    runner = CliEntryBasedTestRunner(RunJobFailsPlugin())
+
+    result: Result = runner.invoke(["run", util.job_path("simple-job")])
+    cli_assert_equal(1, result)
+    assert (
+        json.loads(tmp_termination_msg_file.read_text())["status"] == "Platform error"
+    )

--- a/projects/vdk-core/tests/functional/run/test_run_sql_queries.py
+++ b/projects/vdk-core/tests/functional/run/test_run_sql_queries.py
@@ -12,7 +12,6 @@ from vdk.api.plugin.hook_markers import hookimpl
 from vdk.internal.builtin_plugins.connection.pep249.interfaces import PEP249Connection
 from vdk.internal.builtin_plugins.connection.recovery_cursor import RecoveryCursor
 from vdk.internal.builtin_plugins.run.job_context import JobContext
-from vdk.internal.core.errors import VdkConfigurationError
 from vdk.plugin.test_utils.util_funcs import cli_assert_equal
 from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
 from vdk.plugin.test_utils.util_funcs import get_test_job_path
@@ -83,7 +82,7 @@ def test_run_dbapi_connection_no_such_db_type():
     )
 
     cli_assert_equal(1, result)
-    assert isinstance(result.exception, VdkConfigurationError)
+    assert "VdkConfigurationError" in result.output
 
 
 @mock.patch.dict(os.environ, {VDK_DB_DEFAULT_TYPE: DB_TYPE_SQLITE_MEMORY})

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/run/test_cli_run.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/run/test_cli_run.py
@@ -24,7 +24,7 @@ def mock_job_factory(is_failed: bool, exception: BaseException) -> DataJobFactor
     mock_job.run.return_value = mock_execution_result
     mock_execution_result.is_failed.return_value = is_failed
     if exception:
-        mock_execution_result.get_exception.return_value = exception
+        mock_execution_result.get_exception_to_raise.return_value = exception
     job_factory = MagicMock(spec=DataJobFactory)
     job_factory.new_datajob.return_value = mock_job
     return job_factory
@@ -40,7 +40,9 @@ def test_run_job(tmpdir: py.path.local, mock_job_factory: DataJobFactory):
     )
 
     run_impl = CliRunImpl(mock_job_factory)
-    run_impl.run_job(context=context, data_job_directory=job_folder, arguments=None)
+    run_impl.create_and_run_data_job(
+        context=context, data_job_directory=job_folder, arguments=None
+    )
 
 
 @pytest.mark.parametrize("is_failed, exception", [(True, IndexError("foo"))])
@@ -55,7 +57,9 @@ def test_run_job_failed(tmpdir, mock_job_factory):
     run_impl = CliRunImpl(mock_job_factory)
 
     with pytest.raises(IndexError):
-        run_impl.run_job(context=context, data_job_directory=job_folder, arguments=None)
+        run_impl.create_and_run_data_job(
+            context=context, data_job_directory=job_folder, arguments=None
+        )
 
 
 @pytest.mark.parametrize("is_failed, exception", [(False, None)])
@@ -70,7 +74,7 @@ def test_run_job_arguments(tmpdir: py.path.local, mock_job_factory: DataJobFacto
     args_as_json = json.dumps(args)
 
     run_impl = CliRunImpl(mock_job_factory)
-    run_impl.run_job(
+    run_impl.create_and_run_data_job(
         context=context, data_job_directory=job_folder, arguments=args_as_json
     )
 
@@ -91,6 +95,6 @@ def test_run_job_invalid_arguments(
 
     run_impl = CliRunImpl(mock_job_factory)
     with pytest.raises(UserCodeError):
-        run_impl.run_job(
+        run_impl.create_and_run_data_job(
             context=context, data_job_directory=job_folder, arguments=args_as_json
         )

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/run/test_data_job.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/run/test_data_job.py
@@ -23,7 +23,8 @@ def test_run_when_step_fails():
 
     result = data_job.run()
     assert result.is_failed()
-    assert isinstance(result.exception, IndentationError)
+    assert result.exception is None
+    assert isinstance(result.get_exception(), IndentationError)
 
 
 def test_run_when_step_succeeds():

--- a/projects/vdk-core/tests/vdk/internal/plugin/test_plugin.py
+++ b/projects/vdk-core/tests/vdk/internal/plugin/test_plugin.py
@@ -82,6 +82,25 @@ def test_plugin_blocked_name(plugin_registry):
     plugin_registry.load_plugin_with_hooks_impl(FooBarPlugin(), "blocked-name")
 
 
+def test_order_for_firstonly_plugin_hookwrapper_error(plugin_registry):
+    class WrapperPlugin:
+        @hookimpl(hookwrapper=True)
+        def get_first_joke(self):
+            yield
+            raise IndexError("foo")
+
+    class FirstPluginWithError:
+        @hookimpl(tryfirst=True)
+        def get_first_joke(self):
+            return "first"
+
+    plugin_registry.load_plugin_with_hooks_impl(FirstPluginWithError(), "first")
+    plugin_registry.load_plugin_with_hooks_impl(WrapperPlugin(), "wrapper")
+
+    with pytest.raises(IndexError):
+        plugin_registry.hook().get_first_joke()
+
+
 def test_order_for_firstonly_plugin_error(plugin_registry):
     class LastPlugin:
         @hookimpl(trylast=True)


### PR DESCRIPTION
There was some corner cases that error message was missing - if job
failed with an exception for example during initialize or finalize phases.

Also made sure job finishes with summary of job execution so it's easier
for users to see what happened.
Also if job step failed - it was printing the exception twice (at step
level and job level) which is just cluttering the logs

Tesitng Done: unit tests.
Error message looks like this: 
```
  "data_job_name": "sql-job-syntax-error",
  "execution_id": "63d0ccf3-258f-46e1-9d50-b246402ff926-1639474925",
  "start_time": "2021-12-14T09:42:05.656806",
  "end_time": "2021-12-14T09:42:05.690940",
  "status": "error",
  "steps_list": [
    {
      "name": "bad-query.sql",
      "type": "sql",
      "start_time": "2021-12-14T09:42:05.656809",
      "end_time": "2021-12-14T09:42:05.690905",
      "status": "error",
      "details": "An exception occurred, exception message was: Trino query failed\n  WHAT HAPPENED : Trino query failed with user error\nWHY IT HAPPENED : Error message was: line 3:10: mismatched input ';'. Expecting: '%', '*', '+', ',', '-', '.', '/', 'AND', 'AS', 'AT', 'EXCEPT', 'FETCH', 'FROM', 'GROUP', 'HAVING', 'INTERSECT', 'LIMIT', 'OFFSET', 'OR', 'ORDER', 'UNION', 'WHERE', 'WINDOW', '[', '||', <EOF>, <identifier>, <predicate>. Likely the query has an error that needs to be address. See above error for more details.\n   CONSEQUENCES : The SQL query will fail and the job step likely will fail.\nCOUNTERMEASURES : Please fix the error and try again.",
      "exception": {
        "message": "Trino query failed\n  WHAT HAPPENED : Trino query failed with user error\nWHY IT HAPPENED : Error message was: line 3:10: mismatched input ';'. Expecting: '%', '*', '+', ',', '-', '.', '/', 'AND', 'AS', 'AT', 'EXCEPT', 'FETCH', 'FROM', 'GROUP', 'HAVING', 'INTERSECT', 'LIMIT', 'OFFSET', 'OR', 'ORDER', 'UNION', 'WHERE', 'WINDOW', '[', '||', <EOF>, <identifier>, <predicate>. Likely the query has an error that needs to be address. See above error for more details.\n   CONSEQUENCES : The SQL query will fail and the job step likely will fail.\nCOUNTERMEASURES : Please fix the error and try again.",
        "is_logged": true,
        "cause_exception_name": "TrinoUserError",
        "cause_exception": {
          "_error": {
            "message": "line 3:10: mismatched input ';'. Expecting: '%', '*', '+', ',', '-', '.', '/', 'AND', 'AS', 'AT', 'EXCEPT', 'FETCH', 'FROM', 'GROUP', 'HAVING', 'INTERSECT', 'LIMIT', 'OFFSET', 'OR', 'ORDER', 'UNION', 'WHERE', 'WINDOW', '[', '||', <EOF>, <identifier>, <predicate>",
            "errorCode": 1,
            "errorName": "SYNTAX_ERROR",
            "errorType": "USER_ERROR",
            "errorLocation": {
              "lineNumber": 3,
              "columnNumber": 10
            }, 
      },
      "blamee": "User Error"
    }
  ],
  "exception": null,
  "exception_name": "UserCodeError"
}
```

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>