### PR TITLE
vdk-core: print python version with `vdk version`

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/execution_environment.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/execution_environment.py
@@ -5,6 +5,7 @@ import getpass
 import logging
 import platform
 import socket
+import sys
 
 log = logging.getLogger(__name__)
 
@@ -51,4 +52,4 @@ class ExecutionEnvironment:
             lambda: platform.architecture()[0], "python-arch"
         )
 
-        return f"{py_version} {py_arch}"
+        return f"{py_version} {py_arch} ({sys.executable})"

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/version/version.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/version/version.py
@@ -8,6 +8,7 @@ from pkg_resources import DistributionNotFound
 from pkg_resources import get_distribution
 from vdk.api.plugin.hook_markers import GROUP_NAME
 from vdk.internal import vdk_build_info
+from vdk.internal.builtin_plugins.run.execution_environment import ExecutionEnvironment
 
 try:  # importlib.metadata is used in 3.8+, importlib_metadata is used in 3.7
     from importlib import metadata
@@ -71,7 +72,8 @@ def list_installed_plugins_versions():
 def get_version_info():
     return (
         f"Version: {get_version()}{os.linesep}"
-        f"Build details: {build_details()}{os.linesep}{os.linesep}"
+        f"Build details: {build_details()}{os.linesep}"
+        f"Python version: {ExecutionEnvironment().get_python_version()}{os.linesep}{os.linesep}"
         f"Installed plugins:{os.linesep}{list_installed_plugins_versions()}"
     )
 


### PR DESCRIPTION
It is possible to have multiple pythons installed on the same machine.
Even if not it's almost certain there are multiple virtual environments
(or conda envs) and knowing exactly which on you are using can be
valueable when debugging.

Print the details about the python being used to run vdk.

Testing Done: ran `vdk version`:
```
...
Python version: 3.9.5 64bit
(/Users/aivanov/.pyenv/versions/3.9.5/envs/build-vdk-plugin-control-cli39/bin/python3.9)

```

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>