### PR TITLE
control-service: fix graphql executions loading

### DIFF
--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -85,7 +85,7 @@ control_service_integration_test:
     - ./gradlew -p ./model build publishToMavenLocal
     - mkdir -p ~/.kube
     - cp $KUBECONFIG ~/.kube/config
-    - ./gradlew :pipelines_control_service:integrationTest --info --stacktrace --fail-fast
+    - ./gradlew :pipelines_control_service:integrationTest --info --stacktrace
   retry: !reference [.control_service_retry, retry_options]
   artifacts:
     when: always

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/ExecutionDataFetcher.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/ExecutionDataFetcher.java
@@ -114,14 +114,16 @@ public class ExecutionDataFetcher {
    }
 
    private Page<DataJobExecution> findAllExecutions(DataJobExecutionQueryVariables dataJobExecutionQueryVariables, String dataJobName) {
-      DataJobExecutionFilter filter = dataJobExecutionQueryVariables.getFilter();
-      if (dataJobName != null && filter != null) {
-         if (filter.getJobNameIn() != null) {
-            throw new GraphQLException("The jobNameIn filter is not supported for nested executions");
-         }
-         filter = filter.toBuilder()
-                 .jobNameIn(List.of(dataJobName))
-                 .build();
+      DataJobExecutionFilter filter = dataJobExecutionQueryVariables.getFilter() != null ?
+            dataJobExecutionQueryVariables.getFilter() :
+            DataJobExecutionFilter.builder().build();
+
+      if (dataJobName != null && filter.getJobNameIn() != null) {
+         throw new GraphQLException("The jobNameIn filter is not supported for nested executions");
+      }
+
+      if (dataJobName != null) {
+         filter.setJobNameIn(List.of(dataJobName));
       }
 
       Specification<DataJobExecution> filterSpec = new JobExecutionFilterSpec(filter);


### PR DESCRIPTION
If we request jobs and their executions without filters at the execution level,
the API will return all executions from the database per each data job.

Testing Done: unit tests

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com