### PR TITLE
control-service: ability to add offset to dates in logs URL

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -194,6 +194,14 @@ spec:
             - name: DATAJOBS_EXECUTIONS_LOGS_URL_DATE_FORMAT
               value: "{{ .Values.dataJob.executions.logsUrl.dateFormat }}"
             {{- end }}
+            {{- if .Values.dataJob.executions.logsUrl.startTimeOffsetSeconds }}
+            - name: DATAJOBS_EXECUTIONS_LOGS_URL_START_TIME_OFFSET_SECONDS
+              value: "{{ .Values.dataJob.executions.logsUrl.startTimeOffsetSeconds }}"
+            {{- end }}
+            {{- if .Values.dataJob.executions.logsUrl.endTimeOffsetSeconds }}
+            - name: DATAJOBS_EXECUTIONS_LOGS_URL_END_TIME_OFFSET_SECONDS
+              value: "{{ .Values.dataJob.executions.logsUrl.endTimeOffsetSeconds }}"
+            {{- end }}
 {{- if .Values.extraVars }}
 {{ toYaml .Values.extraVars | indent 12 }}
 {{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -825,3 +825,15 @@ dataJob:
       ## If left blank, defaults to unix.
       ## Examples: iso -> "2021-12-03T15:34:54.822098Z", unix -> "1638545973226".
       dateFormat: "unix"
+      # The offset (expressed in seconds) that will be added to or subtracted from the {{start_time}}
+      # variable during the building of logs URL. It could be either positive or negative number.
+      # In case of positive number it will be added to the {{start_time}}.
+      # In case of negative number it will be subtracted from the {{start_time}}.
+      # If left blank, defaults to 0.
+      startTimeOffsetSeconds: 0
+      # The offset (expressed in seconds) that will be added to or subtracted from the {{end_time}}
+      # variable during the building of logs URL. It could be either positive or negative number.
+      # In case of positive number it will be added to the {{end_time}}.
+      # In case of negative number it will be subtracted from the {{end_time}}.
+      # If left blank, defaults to 0.
+      endTimeOffsetSeconds: 0

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLExecutionsLogsUrlIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLExecutionsLogsUrlIT.java
@@ -53,6 +53,9 @@ public class GraphQLExecutionsLogsUrlIT extends BaseIT {
    private static final String TEST_JOB_NAME_2 = "TEST-JOB-NAME-2";
    private static final String TEST_JOB_NAME_3 = "TEST-JOB-NAME-3";
 
+   private static final long TEST_START_TIME_OFFSET_SECONDS = 1000;
+   private static final long TEST_END_TIME_OFFSET_SECONDS = -1000;
+
    private DataJobExecution dataJobExecution1;
    private DataJobExecution dataJobExecution2;
    private DataJobExecution dataJobExecution3;
@@ -68,6 +71,8 @@ public class GraphQLExecutionsLogsUrlIT extends BaseIT {
             "{{execution_id}}");
       registry.add("datajobs.executions.logsUrl.template", () -> logsUrlTemplate);
       registry.add("datajobs.executions.logsUrl.dateFormat", () -> "unix");
+      registry.add("datajobs.executions.logsUrl.startTimeOffsetSeconds", () -> TEST_START_TIME_OFFSET_SECONDS);
+      registry.add("datajobs.executions.logsUrl.endTimeOffsetSeconds", () -> TEST_END_TIME_OFFSET_SECONDS);
    }
 
    @BeforeEach
@@ -129,8 +134,8 @@ public class GraphQLExecutionsLogsUrlIT extends BaseIT {
 
    private static String buildLogsUrl(DataJobExecution dataJobExecution) {
       return MessageFormat.format(LOGS_URL_TEMPLATE,
-            String.valueOf(dataJobExecution.getStartTime().toInstant().toEpochMilli()),
-            String.valueOf(dataJobExecution.getEndTime().toInstant().toEpochMilli()),
+            String.valueOf(dataJobExecution.getStartTime().toInstant().plusSeconds(TEST_START_TIME_OFFSET_SECONDS).toEpochMilli()),
+            String.valueOf(dataJobExecution.getEndTime().toInstant().plusSeconds(TEST_END_TIME_OFFSET_SECONDS).toEpochMilli()),
             dataJobExecution.getDataJob().getName(),
             dataJobExecution.getOpId(),
             dataJobExecution.getId());

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -119,6 +119,20 @@ datajobs.executions.logsUrl.template=${DATAJOBS_EXECUTIONS_LOGS_URL_DATE_TEMPLAT
 # Examples: iso -> "2021-12-03T15:34:54.822098Z", unix -> "1638545973226".
 datajobs.executions.logsUrl.dateFormat=${DATAJOBS_EXECUTIONS_LOGS_URL_DATE_FORMAT:unix}
 
+# The offset (expressed in seconds) that will be added to or subtracted from the {{start_time}}
+# variable during the building of logs URL. It could be either positive or negative number.
+# In case of positive number it will be added to the {{start_time}}.
+# In case of negative number it will be subtracted from the {{start_time}}.
+# If left blank, defaults to 0.
+datajobs.executions.logsUrl.startTimeOffsetSeconds=${DATAJOBS_EXECUTIONS_LOGS_URL_START_TIME_OFFSET_SECONDS:0}
+
+# The offset (expressed in seconds) that will be added to or subtracted from the {{end_time}}
+# variable during the building of logs URL. It could be either positive or negative number.
+# In case of positive number it will be added to the {{end_time}}.
+# In case of negative number it will be subtracted from the {{end_time}}.
+# If left blank, defaults to 0.
+datajobs.executions.logsUrl.endTimeOffsetSeconds=${DATAJOBS_EXECUTIONS_LOGS_URL_END_TIME_OFFSET_SECONDS:0}
+
 # https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html
 mail.smtp.host=smtp.vmware.com
 

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionLogsUrlBuilderIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionLogsUrlBuilderIT.java
@@ -6,6 +6,7 @@
 package com.vmware.taurus.service.execution;
 
 import java.text.MessageFormat;
+import java.time.Instant;
 import java.time.OffsetDateTime;
 
 import org.junit.jupiter.api.Assertions;
@@ -49,19 +50,43 @@ public class JobExecutionLogsUrlBuilderIT {
 
    @Test
    public void testBuild_allParamsAndDataFormatUnix_shouldReturnLogsUrl() {
-      String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix();
+      String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix(0, 0);
+      assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, expectedLogsUrl);
+   }
+
+   @Test
+   public void testBuild_allParamsAndDataFormatUnixAndPositiveOffset_shouldReturnLogsUrl() {
+      String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix(1000, 2000);
+      assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, expectedLogsUrl);
+   }
+
+   @Test
+   public void testBuild_allParamsAndDataFormatUnixAndNegativeOffset_shouldReturnLogsUrl() {
+      String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix(-1000, -2000);
       assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, expectedLogsUrl);
    }
 
    @Test
    public void testBuild_allParamsAndDataFormatIso_shouldReturnLogsUrl() {
-      String expectedLogsUrl = buildExpectedLogsUrlDateFormatIso();
+      String expectedLogsUrl = buildExpectedLogsUrlDateFormatIso(0, 0);
+      assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, JobExecutionLogsUrlBuilder.ISO_DATE_FORMAT, expectedLogsUrl);
+   }
+
+   @Test
+   public void testBuild_allParamsAndDataFormatIsoAndPositiveOffset_shouldReturnLogsUrl() {
+      String expectedLogsUrl = buildExpectedLogsUrlDateFormatIso(1000, 2000);
+      assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, JobExecutionLogsUrlBuilder.ISO_DATE_FORMAT, expectedLogsUrl);
+   }
+
+   @Test
+   public void testBuild_allParamsAndDataFormatIsoAndNegativeOffset_shouldReturnLogsUrl() {
+      String expectedLogsUrl = buildExpectedLogsUrlDateFormatIso(-1000, -2000);
       assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, JobExecutionLogsUrlBuilder.ISO_DATE_FORMAT, expectedLogsUrl);
    }
 
    @Test
    public void testBuild_extraParamAndDataFormatUnix_shouldReturnLogsUrl() {
-      String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix() + "{{abc}}";
+      String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix(0, 0) + "{{abc}}";
       assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW + "{{abc}}", JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, expectedLogsUrl);
    }
 
@@ -96,13 +121,13 @@ public class JobExecutionLogsUrlBuilderIT {
 
    @Test
    public void testBuild_nullLogsUrlDateFormat_shouldReturnLogsUrlWithDateFormatUnix() {
-      String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix();
+      String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix(0, 0);
       assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, null, expectedLogsUrl);
    }
 
    @Test
    public void testBuild_emptyLogsUrlDateFormat_shouldReturnLogsUrlWithDateFormatUnix() {
-      String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix();
+      String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix(0, 0);
       assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, "", expectedLogsUrl);
    }
 
@@ -110,21 +135,31 @@ public class JobExecutionLogsUrlBuilderIT {
       return JobExecutionLogsUrlBuilder.VAR_PREFIX + var + JobExecutionLogsUrlBuilder.VAR_SUFFIX;
    }
 
-   private static String buildExpectedLogsUrlDateFormatUnix() {
+   private Instant getDateTime(OffsetDateTime dateTime, long offset) {
+      return dateTime.toInstant().plusSeconds(offset);
+   }
+
+   private String buildExpectedLogsUrlDateFormatUnix(long startTimeOffset, long endTimeOffset) {
+      ReflectionTestUtils.setField(logsUrlBuilder, "startTimeOffsetSeconds", startTimeOffset);
+      ReflectionTestUtils.setField(logsUrlBuilder, "endTimeOffsetSeconds", endTimeOffset);
+
       return MessageFormat.format(
             LOGS_URL_TEMPLATE,
-            String.valueOf(TEST_START_TIME.toInstant().toEpochMilli()),
-            String.valueOf(TEST_END_TIME.toInstant().toEpochMilli()),
+            String.valueOf(getDateTime(TEST_START_TIME, startTimeOffset).toEpochMilli()),
+            String.valueOf(getDateTime(TEST_END_TIME, endTimeOffset).toEpochMilli()),
             TEST_JOB_NAME,
             TEST_OP_ID,
             TEST_EXECUTION_ID);
    }
 
-   private static String buildExpectedLogsUrlDateFormatIso() {
+   private String buildExpectedLogsUrlDateFormatIso(long startTimeOffset, long endTimeOffset) {
+      ReflectionTestUtils.setField(logsUrlBuilder, "startTimeOffsetSeconds", startTimeOffset);
+      ReflectionTestUtils.setField(logsUrlBuilder, "endTimeOffsetSeconds", endTimeOffset);
+
       return MessageFormat.format(
             LOGS_URL_TEMPLATE,
-            TEST_START_TIME.toInstant().toString(),
-            TEST_END_TIME.toInstant().toString(),
+            getDateTime(TEST_START_TIME, startTimeOffset).toString(),
+            getDateTime(TEST_END_TIME, endTimeOffset).toString(),
             TEST_JOB_NAME,
             TEST_OP_ID,
             TEST_EXECUTION_ID);


### PR DESCRIPTION
Some of the external systems that our customers use
have different time than Control Service.

This change aims to introduce configurable offset
that will be added to both start_time and end_time varibles
during the building of logs URL for each particular execution.

Testing Done: unit and integration tests

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com