### PR TITLE
vdk-control-cli: Fix traceback shown for broken config.ini

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/configuration/vdk_config.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/configuration/vdk_config.py
@@ -7,6 +7,7 @@ from configparser import ConfigParser
 from pathlib import Path
 
 from vdk.internal.control.exception.vdk_exception import VDKException
+from vdk.internal.control.utils.control_utils import read_config_ini_file
 
 log = logging.getLogger(__name__)
 
@@ -208,7 +209,12 @@ class VDKConfigFolder:
             log.debug(f"Reading configuration file: {configuration_file_path} ...")
 
             config_parser = ConfigParser()
-            config_parser.read(configuration_file_path)
+
+            read_config_ini_file(
+                config_parser=config_parser,
+                configuration_file_path=configuration_file_path,
+            )
+
             return config_parser.get(section=section, option=option, fallback=fallback)
         except OSError as e:
             raise VDKException(

--- a/projects/vdk-control-cli/src/vdk/internal/control/job/job_config.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/job/job_config.py
@@ -3,10 +3,15 @@
 # TODO: this is basically a copy of VDK JobConfig in vdk-core
 import configparser
 import fileinput
+import logging
 import os
 import sys
 
 from vdk.internal.control.exception.vdk_exception import VDKException
+from vdk.internal.control.utils.control_utils import read_config_ini_file
+
+
+log = logging.getLogger(__name__)
 
 
 class JobConfig:
@@ -27,7 +32,9 @@ class JobConfig:
                 "Make sure the file is created "
                 "or double check the data job path is passed correctly.",
             )
-        self._config_ini.read(self._config_file)
+        read_config_ini_file(
+            config_parser=self._config_ini, configuration_file_path=self._config_file
+        )
 
     def get_team(self):
         return self._get_value("owner", "team")

--- a/projects/vdk-control-cli/src/vdk/internal/control/utils/control_utils.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/utils/control_utils.py
@@ -1,0 +1,38 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+from configparser import ConfigParser
+from configparser import MissingSectionHeaderError
+
+from vdk.internal.control.exception.vdk_exception import VDKException
+
+
+log = logging.getLogger(__name__)
+
+
+def read_config_ini_file(
+    config_parser: ConfigParser, configuration_file_path: str
+) -> None:
+    """
+    Read the Data Job config.ini file.
+
+    :param config_parser: ConfigParser instance to be used for reading the
+    configuration file.
+    :param configuration_file_path: Path of the config.ini file
+    """
+    try:
+        config_parser.read(configuration_file_path)
+    except (MissingSectionHeaderError, Exception) as e:
+        log.debug(e, exc_info=True)  # Log the traceback in DEBUG mode.
+        raise VDKException(
+            what="Cannot parse the Data Job configuration file"
+            f" {configuration_file_path}.",
+            why=f"Configuration file config.ini is probably corrupted. Error: {e}",
+            consequence="Cannot deploy and configure the data job "
+            "without "
+            " properly set config.ini file.",
+            countermeasure="config.ini must be UTF-8 compliant. "
+            "Make sure the file does not contain special "
+            "Unicode characters, or that your text editor "
+            "has not added such characters somewhere in the file.",
+        )

--- a/projects/vdk-control-cli/tests/resources/test-broken-vdk-config/vdk-configuration.ini
+++ b/projects/vdk-control-cli/tests/resources/test-broken-vdk-config/vdk-configuration.ini
@@ -1,0 +1,2 @@
+ï»¿;[test-section]
+test-option = test-value

--- a/projects/vdk-control-cli/tests/vdk/internal/control/configuration/test_vdk_config.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/configuration/test_vdk_config.py
@@ -128,6 +128,29 @@ def test_read_configuration():
         assert test_value == read_configuration_output
 
 
+def test_handle_broken_configuration():
+    # Setup
+    test_section = "test-section"
+    test_option = "test-option"
+    input_test_vdk_config_path = find_test_resource("test-broken-vdk-config")
+    input_test_vdk_config_file_path = os.path.join(
+        input_test_vdk_config_path, VDKConfigFolder.CONFIGURATION_FILE
+    )
+    assert os.path.exists(input_test_vdk_config_file_path)
+
+    with tempfile.TemporaryDirectory() as config_dir_path:
+        conf = VDKConfigFolder(config_dir_path)
+        expected_config_path = os.path.join(
+            conf.vdk_config_folder, VDKConfigFolder.CONFIGURATION_FILE
+        )
+        copyfile(src=input_test_vdk_config_file_path, dst=expected_config_path)
+        assert os.path.exists(expected_config_path)
+
+        # Run and verify exception
+        with pytest.raises(VDKException):
+            conf.read_configuration(section=test_section, option=test_option)
+
+
 def test_reset_configuration():
     # Setup
     test_section = "test-section"


### PR DESCRIPTION
Currently, if the config.ini file of a data job contains a special unicode
character, Versatile Data Kit prints the whole traceback, which may confuse
the user as to what is happening.

This change handles the exception and prints a message with more user-friendly
details as to what might be the possible cause for the error. The complete traceback
is printed only in debug mode.

Testing Done: Added a unit test, and tested locally by deploying a data job, whose config.ini
file contained a special unicode character. Verified that no traceback appears in the terminal.
The message shown was:
```
Error: ¯\_(ツ)_/¯

what: Cannot parse the Data Job configuration file.
why: Configuration file config.ini is probably corrupted. Error: File contains no section headers.
file: '/home/andy/Documents/test-jobs/my-second-job/config.ini', line: 1
'Œ; Supported format: https://docs.python.org/3/library/configparser.html#supported-ini-file-structure\n'
consequences: Cannot deploy and configure the data job without properly set config.ini file.
countermeasures: config.ini must be UTF-8 compliant. Make sure the file does not contain special Unicode characters, or that your text editor has not added such characters somewhere in the file.
```

Signed-off-by: Andon Andonov <andonova@vmware.com>