### PR TITLE
vdk-control-cli: Hide Cannot-cleanup-archive warning

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/download_job.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/download_job.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 import os
-from typing import Optional
 
 import click
 import click_spinner
@@ -61,17 +60,20 @@ class JobDownloadSource:
 
     @staticmethod
     def __cleanup_archive(archive_path: str):
-        try:
-            os.remove(archive_path)
-        except OSError as e:
-            log.warning(
-                VDKException(
-                    what=f"Cannot cleanup archive: {archive_path} as part of deployment.",
-                    why=f"VDK CLI did not clean up after deploying: {e}",
-                    consequence="There is a leftover archive file next to the folder containing the data job",
-                    countermeasure="Clean up the archive file manually or leave it",
-                ).message
-            )
+        if os.path.exists(archive_path):
+            log.debug(f"Cleaning up archive, {archive_path}")
+            try:
+                os.remove(archive_path)
+            except OSError as e:
+                log.warning(
+                    VDKException(
+                        what=f"Cannot cleanup archive: {archive_path} as part of deployment.",
+                        why=f"VDK CLI did not clean up after deploying: {e}",
+                        consequence="There is a leftover archive file next to the folder containing the data job",
+                        countermeasure="Either clean up the archive file "
+                        "manually, or leave it as is.",
+                    ).message
+                )
 
 
 # Below is the definition of the CLI API/UX users will be interacting


### PR DESCRIPTION
Currently, if a client tries to download a data job but misspells the
team name, two exception messages are printed in the terminal similar
to the ones below:
```
Path to the data job directory [C:\some\user\directory]:
Downloading data job <data-job-name> in C:\some\user\directory/<data-job-name> ...
warning: ¯\_(ツ)_/¯
warning:
warning: what: Cannot cleanup archive: C:\some\user\directory\<data-job-name>.zip as part of deployment.
warning: why: VDK CLI did not clean up after deploying: [WinError 2] The system cannot find the file specified: 'C:\\some\\user\\directory\\<data-job-name>.zip'
warning: consequences: There is a leftover archive file next to the folder containing the data job
warning: countermeasures: Clean up the archive file manually or leave it
Usage: vdk download-job [OPTIONS]

Error: ¯\_(ツ)_/¯

what: Control Service Error
why: The requested resource cannot be found. You may have a spelling mistake or the data job has not been created
consequences: Operation cannot complete.
countermeasures: Make sure that the data job name and team name are spelled correctly (it is case-sensitive) . Make sure you have run `vdk create --cloud` before doing this operati
on on a data job.
```

The first exception is actually a logged warning, and is not related in any way to
the fact that a data job with the misspelled team_name does not exist. It
just informs the user that a zip archive with the data job name does not exist on
the local file system. This message, however, could cause unnecessary confusion.

This change adds logic to check if the archive exists, before any attempt is made
to remove it.

Testing Done: unit test

Signed-off-by: Andon Andonov <andonova@vmware.com>