### PR TITLE
control-service: improve logging during job monitoring

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -1037,7 +1037,7 @@ public abstract class KubernetesService implements InitializingBean {
                 }
             }
         } catch (RuntimeException e) {
-            log.info("Failed to watch jobs. Error was: {}", e.getMessage());
+            log.info("Failed to watch jobs. Error was: {}", e.getMessage(), e);
         }
 
         log.info("Finish watching jobs with labels: {}", labelsToWatch);


### PR DESCRIPTION
Currently, when an exception happens during k8s job watching,
we swallow the exception and log only the exception message.
This prevents us from pinpointing the exact location of the
exception and makes troubleshooting it harder.

This commit also logs the exceptions' stack trace.

Testing done: verified that the stack trace is logged on exception.

Signed-off-by: Tsvetomir Palashki <tpalashki@vmware.com>