### PR TITLE
control-service/vdk-cli/vdk-heartbeat: set Pipeline ID as op_id for vdk-heartbeat run

### DIFF
--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -206,6 +206,7 @@ control_service_post_deployment_test:
     - pip install vdk-heartbeat[trino]
     - vdk version
     - export VDKCLI_OAUTH2_REFRESH_TOKEN=$VDK_API_TOKEN
+    - export VDK_HEARTBEAT_OP_ID="vdkcs-$CI_PIPELINE_ID"
     - vdk-heartbeat -f projects/control-service/cicd/post_deploy_test_heartbeat_config.ini
   retry: !reference [.control_service_retry, retry_options]
   only:

--- a/projects/vdk-control-cli/.gitlab-ci.yml
+++ b/projects/vdk-control-cli/.gitlab-ci.yml
@@ -52,6 +52,7 @@ vdk-control-cli-release-acceptance-test:
     - pip install vdk-heartbeat --extra-index-url $PIP_EXTRA_INDEX_URL
     - vdkcli version
     - export VDKCLI_OAUTH2_REFRESH_TOKEN=$VDK_API_TOKEN
+    - export VDK_HEARTBEAT_OP_ID="vdkcli-$CI_PIPELINE_ID"
     - export JOB_NAME=vdk-control-cli-release-test-job-$(date +%s)
     - vdk-heartbeat -f cicd/release_test_heartbeat_config.ini
   artifacts:

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/config.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/config.py
@@ -116,7 +116,7 @@ class Config:
 
         # Job name deployed during the test
         self.job_name = self.get_value(
-            "JOB_NAME", f"vdk-heartbeat-data-job-{job_suffix}"
+            "JOB_NAME", f"vdk-heartbeat-data-job-{job_suffix}"[0:45]
         )
         """
         The team of the data job ot use.


### PR DESCRIPTION
This PR contains 3 commits 2 of them set op id to be same as $CI_PIPELINE_ID 

By setting op_id to be the Pipeline ID we can easier track a given run of vdk-heartebaet as op_id is printed in the logs, it is passed to the job logs, the job name also contains the Op ID . So one can easier see which pipeline generated which job and vice-versa

And small change in vdk-heartbeat that make sure do not accidentally create job name with too long name (as op id is included in the job name