### PR TITLE
vdk-core: Release acceptance test job added to CI/CD

### DIFF
--- a/projects/vdk-core/.gitlab-ci.yml
+++ b/projects/vdk-core/.gitlab-ci.yml
@@ -129,6 +129,27 @@ vdk-core-release-candidate-base-image:
     changes: *vdk_core_locations
 
 
+vdk-core-release-acceptance-test:
+  stage: pre_release_test
+  before_script:
+    - cd projects/vdk-core
+  script:
+    - pip install -U pip
+    - pip install vdk-heartbeat --extra-index-url $PIP_EXTRA_INDEX_URL
+    - export VDKCLI_OAUTH2_REFRESH_TOKEN=$VDK_API_TOKEN
+    - export VDK_HEARTBEAT_DEPLOY_JOB_VDK_VERSION=$(cat version.txt | grep -o '[0-9]\.[0-9]').${CI_PIPELINE_ID}.dev${CI_PIPELINE_IID}
+    - export JOB_NAME=vdk-core-release-test-job$(date +%s)
+    - vdk-heartbeat -f cicd/release_acceptance_test_heartbeat_config.ini
+  artifacts:
+    when: always
+    reports:
+      junit: tests.xml
+  only:
+    refs:
+      - main
+    changes: *vdk_core_locations
+
+
 vdk-core-release:
   stage: release
   before_script:

--- a/projects/vdk-core/cicd/release_acceptance_test_heartbeat_config.ini
+++ b/projects/vdk-core/cicd/release_acceptance_test_heartbeat_config.ini
@@ -1,0 +1,9 @@
+[DEFAULT]
+# Generate with https://console-stg.cloud.vmware.com/csp/gateway/portal/#/user/tokens
+# VDKCLI_OAUTH2_REFRESH_TOKEN= passed as environment variable
+VDKCLI_OAUTH2_URI=https://console-stg.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize
+CONTROL_API_URL=http://cicd-control-service-svc:8092
+
+JOB_RUN_TEST_MODULE_NAME=vdk.internal.heartbeat.empty_run_test
+JOB_RUN_TEST_CLASS_NAME=EmptyRunTest
+DATAJOB_DIRECTORY_NAME=empty


### PR DESCRIPTION
We want to avoid releasing broken distributions of vdk-core as much
as possible. The newly added acceptance test would allow us to
release vdk-core only after vdk-heartbeat runs successfully with
a release candidate vdk-core version containing latest changes.

Run vdk-heartbeat on stage pre_release_test of CI/CD with
release candidate distribution and image created during
previous stages - pre_release and pre_release_image.

Testing done: testing CI/CD pipeline on pull request -
https://gitlab.com/vmware-analytics/versatile-data-kit/-/pipelines/434951809
with hard-coded release candidate version of distribution and image (0.0.430145938.dev3240),
which were already created during a previous pipeline - https://gitlab.com/vmware-analytics/versatile-data-kit/-/pipelines/430145938

Signed-off-by: Yana Zhivkova <yzhivkova@vmware.com>