### PR TITLE
control-service: add logging when updating last execution

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobsService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobsService.java
@@ -212,7 +212,7 @@ public class JobsService {
       Objects.requireNonNull(dataJobExecution);
 
       if (StringUtils.isBlank(dataJobExecution.getId())) {
-         log.warn("Could not store Data Job execution due to the missing execution id: {}", dataJobExecution.getId());
+         log.warn("Could not store data job execution due to the missing execution id: {}", dataJobExecution.getId());
          return;
       }
 
@@ -240,9 +240,8 @@ public class JobsService {
          return;
       }
 
-      dataJob.setLastExecutionStatus(dataJobExecution.getStatus());
-      dataJob.setLastExecutionEndTime(dataJobExecution.getEndTime());
-      dataJob.setLastExecutionDuration((int)(dataJobExecution.getEndTime().toEpochSecond() - dataJobExecution.getStartTime().toEpochSecond()));
+      log.debug("Updating last execution of data job {}: {}", dataJob.getName(), dataJobExecution);
+
       jobsRepository.updateDataJobLastExecutionByName(
             dataJob.getName(),
             dataJobExecution.getStatus(),


### PR DESCRIPTION
We got reports that the last execution status of a data job
can get out-of-sync with the status persisted in the data_job_execution
table. This commit adds logging to the method that updates the last
execution information of a data job so that it is easier to troubleshoot.

Testing done: unit tests

Signed-off-by: Tsvetomir Palashki <tpalashki@vmware.com>