### PR TITLE
control-service: improve performance of executions loading

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/db/migration/V20213111120000__create_index_idx_data_job_execution_job_name_start_time.sql
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/db/migration/V20213111120000__create_index_idx_data_job_execution_job_name_start_time.sql
@@ -1,0 +1,2 @@
+create index if not exists idx_data_job_execution_job_name_start_time
+    on data_job_execution (job_name ASC, start_time DESC);

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/db/migration/V20213112120000__create_index_idx_data_job_execution_job_name_end_time.sql
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/db/migration/V20213112120000__create_index_idx_data_job_execution_job_name_end_time.sql
@@ -1,0 +1,2 @@
+create index if not exists idx_data_job_execution_job_name_end_time
+    on data_job_execution (job_name ASC, end_time DESC);


### PR DESCRIPTION
Our internal client reported performance issue when loading data jobs
and executions through GraphQL API.
The performance issue is caused by lack of indexes on the most frequently
filtered columns.

Testing Done: unit tests, integration tests, performance tests against
local CockroachDB (the query with indexes is 7 times faster)

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com