### PR TITLE
control-service: fix helm image tag type

### DIFF
--- a/projects/control-service/cicd/release-pipelines-service.sh
+++ b/projects/control-service/cicd/release-pipelines-service.sh
@@ -5,7 +5,7 @@
 
 export HELM_REPO=versatile-data-kit-helm-registry
 # TODO: sign chart
-helm pack --version "$CHART_VERSION" --app-version "$CHART_VERSION" --dependency-update "$CHART_NAME" --set image.tag="$IMAGE_TAG"
+helm pack --version "$CHART_VERSION" --app-version "$CHART_VERSION" --dependency-update "$CHART_NAME" --set-string image.tag="$IMAGE_TAG"
 echo "Upload $CHART_NAME version $CHART_VERSION (if version already exists upload will fail)"
 helm repo add $HELM_REPO "$VDK_HELM_REGISTRY_URL" \
       --username "$VDK_HELM_REGISTRY_USERNAME" \


### PR DESCRIPTION
Currently if the commit sha is integer 1647200 the image.tag will be
"1.6472e+06" because of the toString function used here - https://github.com/vmware/versatile-data-kit/blob/main/projects/control-service/projects/helm_charts/pipelines-control-service/templates/_helpers.tpl#L76.

Helm Issue: https://github.com/helm/helm/issues/1694

Testing Done: helm template

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com