### PR TITLE
control-service: fix graphql schema

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLExecutionsIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLExecutionsIT.java
@@ -142,10 +142,10 @@ public class GraphQLExecutionsIT extends BaseIT {
                   Matchers.contains(dataJobExecution1.getVdkVersion(), dataJobExecution2.getVdkVersion())))
             .andExpect(jsonPath(
                   "$.data.content[*].deployment.resources.cpuRequest",
-                  Matchers.contains(dataJobExecution1.getResourcesCpuRequest().intValue(), dataJobExecution2.getResourcesCpuRequest().intValue())))
+                  Matchers.contains(dataJobExecution1.getResourcesCpuRequest().doubleValue(), dataJobExecution2.getResourcesCpuRequest().doubleValue())))
             .andExpect(jsonPath(
                   "$.data.content[*].deployment.resources.cpuLimit",
-                  Matchers.contains(dataJobExecution1.getResourcesCpuLimit().intValue(), dataJobExecution2.getResourcesCpuLimit().intValue())))
+                  Matchers.contains(dataJobExecution1.getResourcesCpuLimit().doubleValue(), dataJobExecution2.getResourcesCpuLimit().doubleValue())))
             .andExpect(jsonPath(
                   "$.data.content[*].deployment.resources.memoryRequest",
                   Matchers.contains(dataJobExecution1.getResourcesMemoryRequest(), dataJobExecution2.getResourcesMemoryRequest())))

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/schema.graphqls
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/schema.graphqls
@@ -61,8 +61,8 @@ type DataJobContacts {
 }
 
 type DataJobResources {
-    cpuLimit: Int
-    cpuRequest: Int
+    cpuLimit: Float
+    cpuRequest: Float
     empheralStorageLimit: Int
     empheralSorageRequest: Int
     memoryLimit: Int


### PR DESCRIPTION
The types of cpuRequest and cpuLimit differ from the OpenAPI definition.
https://github.com/vmware/versatile-data-kit/blob/main/projects/control-service/projects/model/apidefs/datajob-api/api.yaml#L1315

As a result, the GraphQL API returns the following error:
```json
{
  "errors": [
    {
      "message": "Can't serialize value (/executions/content[0]/deployment/resources/cpuRequest) : Expected type 'Int' but was 'Float'.",
      "path": [
        "executions",
        "content",
        0,
        "deployment",
        "resources",
        "cpuRequest"
      ],
```

Testing Done: integration tests

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com