### PR TITLE
vdk-kerberos-auth: provide variable to specify krb5.conf configuration

### DIFF
--- a/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/authenticator_factory.py
+++ b/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/authenticator_factory.py
@@ -23,6 +23,7 @@ class KerberosAuthenticatorFactory:
     ) -> Optional[BaseAuthenticator]:
         if authentication_type == "minikerberos":
             return MinikerberosGSSAPIAuthenticator(
+                self.__configuration.krb5_conf_filename(),
                 self.__configuration.keytab_pathname(),
                 self.__configuration.keytab_principal(),
                 self.__configuration.keytab_realm(),
@@ -30,6 +31,7 @@ class KerberosAuthenticatorFactory:
             )
         elif authentication_type == "kinit":
             return KinitGSSAPIAuthenticator(
+                self.__configuration.krb5_conf_filename(),
                 self.__configuration.keytab_pathname(),
                 self.__configuration.keytab_principal(),
             )  # Can kinit the whole process

--- a/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/kerberos_configuration.py
+++ b/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/kerberos_configuration.py
@@ -7,6 +7,7 @@ from vdk.internal.core.config import ConfigurationBuilder
 
 KRB_AUTH = "KRB_AUTH"
 KEYTAB_FOLDER = "KEYTAB_FOLDER"
+KRB5_CONF_FILENAME = "KRB5_CONF_FILENAME"
 KEYTAB_FILENAME = "KEYTAB_FILENAME"
 KEYTAB_PRINCIPAL = "KEYTAB_PRINCIPAL"
 KEYTAB_REALM = "KEYTAB_REALM"
@@ -36,6 +37,9 @@ class KerberosPluginConfiguration:
 
     def keytab_pathname(self):
         return os.path.join(self.keytab_folder(), self.keytab_filename())
+
+    def krb5_conf_filename(self):
+        return self.__config.get_value(KRB5_CONF_FILENAME)
 
     def keytab_principal(self):
         keytab_principal = self.__config.get_value(KEYTAB_PRINCIPAL)
@@ -70,6 +74,13 @@ def add_definitions(config_builder: ConfigurationBuilder) -> None:
         default_value=None,
         description="Specifies the folder containing the keytab file. "
         "If left empty, the keytab file is expected to be located inside the data job folder.",
+    )
+    config_builder.add(
+        key=KRB5_CONF_FILENAME,
+        default_value=os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "krb5.conf"
+        ),
+        description="Specifies the path to the krb5.conf file that should supply Kerberos configuration.",
     )
     config_builder.add(
         key=KEYTAB_PRINCIPAL,

--- a/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/kinit_authenticator.py
+++ b/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/kinit_authenticator.py
@@ -18,8 +18,10 @@ class KinitGSSAPIAuthenticator(BaseAuthenticator):
     on the machine and the 'kinit' command should be working correctly.
     """
 
-    def __init__(self, keytab_pathname: str, kerberos_principal: str):
-        super().__init__(keytab_pathname, kerberos_principal)
+    def __init__(
+        self, krb5_conf_filename: str, keytab_pathname: str, kerberos_principal: str
+    ):
+        super().__init__(krb5_conf_filename, keytab_pathname, kerberos_principal)
 
         self.__configure_current_os_process_to_use_own_kerberos_credentials_cache()
 

--- a/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/minikerberos_authenticator.py
+++ b/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/minikerberos_authenticator.py
@@ -21,13 +21,18 @@ class MinikerberosGSSAPIAuthenticator(BaseAuthenticator):
 
     def __init__(
         self,
+        krb5_conf_filename: str,
         keytab_pathname: str,
         kerberos_principal: str,
         kerberos_realm: str,
         kerberos_kdc_hostname: str,
     ):
         super().__init__(
-            keytab_pathname, kerberos_principal, kerberos_realm, kerberos_kdc_hostname
+            krb5_conf_filename,
+            keytab_pathname,
+            kerberos_principal,
+            kerberos_realm,
+            kerberos_kdc_hostname,
         )
 
         self._ccache_file = tempfile.NamedTemporaryFile(


### PR DESCRIPTION
Currently, the Kerberos authentication is always using a generic
krb5.conf file built into the plugin. This commits enables specifying
the path to the krb5.conf file via configuration (`KRB5_CONF_FILENAME`).
If the configuration is not set, it defaults to the built-in file.

Testing done: manually running the `run` command with and without the
new configuration and observing that the appropriate krb5.conf file is
being used.

Signed-off-by: Tsvetomir Palashki <tpalashki@vmware.com>