### PR TITLE
control-service: fix LockAcquisitionException

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/build.gradle
+++ b/projects/control-service/projects/pipelines_control_service/build.gradle
@@ -40,6 +40,7 @@ dependencies { // Implementation dependencies are found on compile classpath of 
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.retry:spring-retry'
 
     // Janino is used for conditional processing in the logback-spring.xml file
     implementation 'org.codehaus.janino:janino'

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/RepositoryRetryOperationsConfiguration.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/RepositoryRetryOperationsConfiguration.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.framework.Advised;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.lang.Nullable;
+import org.springframework.retry.interceptor.RetryInterceptorBuilder;
+import org.springframework.retry.interceptor.RetryOperationsInterceptor;
+
+@Slf4j
+@Configuration
+public class RepositoryRetryOperationsConfiguration {
+
+   @Bean
+   public RepositoryRetryOperationsInterceptor repositoryRetryOperationsInterceptor() {
+      return new RepositoryRetryOperationsInterceptor();
+   }
+
+   class RepositoryRetryOperationsInterceptor implements BeanPostProcessor, Ordered {
+
+      @Override
+      public int getOrder() {
+         return Integer.MAX_VALUE;
+      }
+
+      @Override
+      @Nullable
+      public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+         if (bean instanceof JobsRepository || bean instanceof JobExecutionRepository) {
+            Advised advised = (Advised) bean;
+            RetryOperationsInterceptor interceptor = RetryInterceptorBuilder.stateless()
+                  .maxAttempts(3)
+                  .backOffOptions(1000, 2.0, 3000)
+                  .recoverer((args, cause) -> {
+                     log.error("The query retries has been exhausted: " + cause.getMessage());
+                     throw (RuntimeException) cause;
+                  })
+                  .build();
+            advised.addAdvice(0, interceptor);
+         }
+
+         return bean;
+      }
+   }
+}

--- a/projects/control-service/projects/versions-of-external-dependencies.gradle
+++ b/projects/control-service/projects/versions-of-external-dependencies.gradle
@@ -43,6 +43,7 @@ project.ext {
             'org.apache.commons:commons-text'                                    : 'org.apache.commons:commons-text:1.9',
             'com.github.tomakehurst:wiremock'                                    : 'com.github.tomakehurst:wiremock:2.27.2',
             'com.graphql-java:graphql-java-extended-scalars'                     : 'com.graphql-java:graphql-java-extended-scalars:15.0.0',
+            'org.springframework.retry:spring-retry'                             : 'org.springframework.retry:spring-retry:1.3.1',
 
             // transitive dependencies version force (freeze)
             // on next upgrade, revise if those still need to be set explicitly


### PR DESCRIPTION
The following exception has been observed for some time:

```
Dec 20 14:30:43 tpcs-dep-7f94dcdcfc-c7282 	at com.vmware.taurus.datajobs.DataJobsController.jobsQuery(DataJobsController.java:234)
Dec 20 14:30:43 tpcs-dep-7f94dcdcfc-c7282 	at com.vmware.taurus.service.GraphQLJobsQueryService.executeRequest(GraphQLJobsQueryService.java:56)
Dec 20 14:30:43 tpcs-dep-7f94dcdcfc-c7282 	at graphql.GraphQL.execute(GraphQL.java:426)
Dec 20 14:30:43 tpcs-dep-7f94dcdcfc-c7282 	at graphql.GraphQL.executeAsync(GraphQL.java:493)
Dec 20 14:30:43 tpcs-dep-7f94dcdcfc-c7282 	at graphql.GraphQL.parseValidateAndExecute(GraphQL.java:529)
Dec 20 14:30:43 tpcs-dep-7f94dcdcfc-c7282 	at graphql.GraphQL.execute(GraphQL.java:598)
Dec 20 14:30:43 tpcs-dep-7f94dcdcfc-c7282 	at graphql.execution.Execution.execute(Execution.java:108)
Dec 20 14:30:43 tpcs-dep-7f94dcdcfc-c7282 	at graphql.execution.Execution.executeOperation(Execution.java:167)
Dec 20 14:30:43 tpcs-dep-7f94dcdcfc-c7282 	at graphql.execution.AsyncExecutionStrategy.execute(AsyncExecutionStrategy.java:74)
Dec 20 14:30:43 tpcs-dep-7f94dcdcfc-c7282 	at graphql.execution.ExecutionStrategy.fetchField(ExecutionStrategy.java:277)
Dec 20 14:30:43 tpcs-dep-7f94dcdcfc-c7282 	at com.vmware.taurus.service.graphql.GraphQLDataFetchers.lambda$findAllAndBuildDataJobPage$1(GraphQLDataFetchers.java:80)
Dec 20 14:30:43 tpcs-dep-7f94dcdcfc-c7282 	at com.vmware.taurus.service.graphql.GraphQLDataFetchers.populateDataJobsPostPagination(GraphQLDataFetchers.java:88)
Dec 20 14:30:43 tpcs-dep-7f94dcdcfc-c7282 	at com.vmware.taurus.service.graphql.ExecutionDataFetcher.populateExecutions(ExecutionDataFetcher.java:82)
Dec 20 14:30:43 tpcs-dep-7f94dcdcfc-c7282 	at java.base/java.util.ArrayList.forEach(Unknown Source)
Dec 20 14:30:43 tpcs-dep-7f94dcdcfc-c7282 	at com.vmware.taurus.service.graphql.ExecutionDataFetcher.lambda$populateExecutions$2(ExecutionDataFetcher.java:87)
Dec 20 14:30:43 tpcs-dep-7f94dcdcfc-c7282 	at java.base/java.util.Optional.ifPresent(Unknown Source)
Dec 20 14:30:43 tpcs-dep-7f94dcdcfc-c7282 	at com.vmware.taurus.service.graphql.ExecutionDataFetcher.lambda$populateExecutions$1(ExecutionDataFetcher.java:88)
Dec 20 14:30:43 tpcs-dep-7f94dcdcfc-c7282 	at com.vmware.taurus.service.graphql.ExecutionDataFetcher.findAllExecutions(ExecutionDataFetcher.java:140)

Caused by: org.postgresql.util.PSQLException: ERROR: restart transaction: TransactionRetryWithProtoRefreshError: ReadWithinUncertaintyIntervalError: read at time 1640010642.312866367,0 encountered previous write with future timestamp 1640010642.312866367,1 within uncertainty interval `t <= 1640010642.316511067,0`; observed timestamps: [{1 1640010642.312866367,0} {3 1640010642.316511067,0}]
```

The ReadWithinUncertaintyIntervalError can occur when two transactions that start on different gateway nodes attempt to operate on the same data at close to the same time, and one of the operations is a write. The uncertainty comes from the fact that we cannot tell which one started first - the clocks on the two gateway nodes may not be perfectly in sync.

The problem is described in detail [here](https://www.cockroachlabs.com/docs/stable/transaction-retry-error-reference.html#readwithinuncertaintyinterval).

This change follows the Cockroach suggestion "Be prepared to retry on uncertainty (and other) errors, as described in client-side retry handling.", retrying the query in case of an error.

Testing Done: Integration tests

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com