### PR TITLE
vdk-impala: Impala docker image upgrade

### DIFF
--- a/projects/vdk-plugins/vdk-impala/tests/docker-compose.yml
+++ b/projects/vdk-plugins/vdk-impala/tests/docker-compose.yml
@@ -3,6 +3,6 @@
 
 services:
   impala:
-    image: "rooneyp1976/impala"
+    image: "cpcloud86/impala"
     ports:
       - "21050:21050"

--- a/projects/vdk-plugins/vdk-impala/tests/functional/jobs/sql-job-syntax-error/10_bad_query.sql
+++ b/projects/vdk-plugins/vdk-impala/tests/functional/jobs/sql-job-syntax-error/10_bad_query.sql
@@ -1,1 +1,1 @@
-select 1 ;;
+selectt 1 ;;


### PR DESCRIPTION
There were issues with syntax support of the previous Impala docker
image used for tests.

Did search and found a viable solution that runs a newer Impala version.

Testing Done: did run vdk-impala tests locally to verify,
all tests pass, including the ones on Impala templates support draft MR
https://github.com/vmware/versatile-data-kit/pull/671

Signed-off-by: ikoleva <ikoleva@vmware.com>