### PR TITLE
pipelines-control-service: publish Swagger UI to /data-jobs path

### DIFF
--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/security/SecurityConfiguration.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/security/SecurityConfiguration.java
@@ -95,10 +95,10 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     public void configure(WebSecurity web) {
         web.ignoring().antMatchers(
                 "/",
-                "/v2/api-docs",
-                "/swagger-resources/**",
-                "/configuration/**",
-                "/swagger-ui.html",
+                "/data-jobs/v2/api-docs",
+                "/data-jobs/swagger-resources/**",
+                "/data-jobs/configuration/**",
+                "/data-jobs/swagger-ui.html",
                 "/webjars/**",
                 // There should not be sensitive data in prometheus, and it makes
                 // integration with the monitoring system easier if no auth is necessary.

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobCrudIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobCrudIT.java
@@ -68,7 +68,7 @@ public class DataJobCrudIT extends BaseIT {
       testDataJobPostCreateWebHooks();
 
       // Execute get swagger with no user
-      mockMvc.perform(get("/swagger-ui.html")
+      mockMvc.perform(get("/data-jobs/swagger-ui.html")
               .content(dataJobRequestBody)
               .contentType(MediaType.APPLICATION_JSON))
               .andExpect(status().isOk());

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/doc/SwaggerConfig.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/doc/SwaggerConfig.java
@@ -11,6 +11,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
@@ -38,6 +40,7 @@ import java.util.List;
 @EnableSwagger2
 @Controller
 public class SwaggerConfig implements WebMvcConfigurer {
+    private static final String PATH = "/data-jobs";
     private static final String AUTHORIZE_KEY_NAME = "Authorization Header (put 'Bearer access_token')";
 
     @Bean
@@ -54,6 +57,25 @@ public class SwaggerConfig implements WebMvcConfigurer {
                         new Tag("Data Jobs Deployment", "(Stable)"),
                         new Tag("Data Jobs Service", "(Stable)"),
                         new Tag("Data Jobs Sources", "(Stable)"));
+    }
+
+    @Override
+    public void addViewControllers(ViewControllerRegistry registry) {
+        final var apiDocs = "/v2/api-docs";
+        final var configUi = "/swagger-resources/configuration/ui";
+        final var configSecurity = "/swagger-resources/configuration/security";
+        final var resources = "/swagger-resources";
+
+        registry.addRedirectViewController(PATH + apiDocs, apiDocs).setKeepQueryParams(true);
+        registry.addRedirectViewController(PATH + resources, resources);
+        registry.addRedirectViewController(PATH + configUi, configUi);
+        registry.addRedirectViewController(PATH + configSecurity, configSecurity);
+        registry.addRedirectViewController(PATH, "/");
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler(PATH + "/**").addResourceLocations("classpath:/META-INF/resources/");
     }
 
     // springfox does not support Bearer Token Auth from api.yaml so we hack it manually
@@ -84,5 +106,4 @@ public class SwaggerConfig implements WebMvcConfigurer {
                 .useBasicAuthenticationWithAccessCodeGrant(false)
                 .build();
     }
-
 }


### PR DESCRIPTION
The Swagger UI is currently available at root / by default. Since the
API is prefixed by /data-jobs, we would like for the Swagger to also be
available under same path, in a consistent fashion. This unblocks
services composition by dedicated path for accessing all features.

Did add Swagger configuration for additional controllers redirect and
resource handler. Updated an integration test to verify the path.
Updated also SecurityConfiguration swagger paths.

Testing Done: did run unit tests, and also verified swagger-ui.html is
accessible under /data-jobs locally

Signed-off-by: ikoleva <ikoleva@vmware.com>