### PR TITLE
[vdk-core] Introduce post-ingest-sequence env var

### DIFF
--- a/projects/vdk-core/cicd/build.sh
+++ b/projects/vdk-core/cicd/build.sh
@@ -23,20 +23,32 @@ export PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL:-https://test.pypi.org/simple/}
 echo "Update pip to newest version"
 pip install -U pip
 
+# Below line uses --use-deprecated=legacy-resolver to temporary workaround a
+# dependency backtracking issue.
+# TODO: Remove the use of the legacy resolver once latest pip works as expected.
 echo "install dependencies from requirements.txt (used for development and testing)"
-pip install --extra-index-url $PIP_EXTRA_INDEX_URL -r requirements.txt
+pip install --use-deprecated="legacy-resolver" --extra-index-url $PIP_EXTRA_INDEX_URL -r requirements.txt
 
 echo "Setup git hook scripts with pre-commit install"
 pre-commit install
 
+# Below line uses --use-deprecated=legacy-resolver to temporary workaround a
+# dependency backtracking issue.
+# TODO: Remove the use of the legacy resolver once latest pip works as expected.
 echo "Install the vdk-core in editable mode (develop mode)"
-pip install -e .
+pip install --use-deprecated="legacy-resolver" -e .
 
+# Below line uses --use-deprecated=legacy-resolver to temporary workaround a
+# dependency backtracking issue.
+# TODO: Remove the use of the legacy resolver once latest pip works as expected.
 echo "Install common vdk test utils library (in editable mode)"
-pip install -e ../vdk-plugins/vdk-test-utils
+pip install --use-deprecated="legacy-resolver" -e ../vdk-plugins/vdk-test-utils
 
+# Below line uses --use-deprecated=legacy-resolver to temporary workaround a
+# dependency backtracking issue.
+# TODO: Remove the use of the legacy resolver once latest pip works as expected.
 echo "Run unit tests and generate coverage report"
-pip install pytest-cov
+pip install --use-deprecated="legacy-resolver" pytest-cov
 pytest --junitxml=tests.xml --cov vdk --cov-report term-missing --cov-report xml:coverage.xml
 
 echo "Done"

--- a/projects/vdk-core/src/vdk/api/plugin/plugin_input.py
+++ b/projects/vdk-core/src/vdk/api/plugin/plugin_input.py
@@ -10,6 +10,7 @@ from typing import Dict
 from typing import List
 from typing import NewType
 from typing import Optional
+from typing import Tuple
 from typing import Union
 
 from vdk.internal.builtin_plugins.connection.managed_connection_base import (
@@ -230,6 +231,7 @@ class IIngesterPlugin:
     """
 
     IngestionMetadata = NewType("IngestionMetadata", Dict)
+    ExceptionsList = NewType("ExceptionsList", List)
 
     def ingest_payload(
         self,
@@ -242,29 +244,32 @@ class IIngesterPlugin:
         Do the actual ingestion of the payload
 
         :param payload: List[dict]
-            The payloads to be ingested. Depending on the number of payloads to be
-            processed, there might 0 or many dict objects. Each dict object is a
-            separate payload.
+            The payloads to be ingested. Depending on the number of payloads
+            to be processed, there might be 0 or many dict objects. Each dict
+            object is a separate payload.
             Note: The memory size of the list is dependent on the
             payload_size_bytes_threshold attribute.
         :param destination_table: Optional[string]
-            (Optional) The name of the table, where the data should be ingested into.
-            This argument is optional, and needs to be considered only when the name
-            of the destination table is not included in the payload itself.
+            (Optional) The name of the table, where the data should be
+            ingested into. This argument is optional, and needs to be
+            considered only when the name of the destination table is not
+            included in the payload itself.
         :param target: Optional[string]
             (Optional) Used to identify where the data should be ingested into.
                 Specifies a data source and its destination database.
                 The values for this parameter can be in the format
                 `<some-data-source_and-db-table>`, or as a URL.
-                Example: http://example.com/<some-api>/<data-source_and-db-table>
+                Example:
+                    http://example.com/<some-api>/<data-source_and-db-table>
             This parameter does not need to be used, in case the
-            `INGEST_TARGET_DEFAULT` environment variable is set. This can be made by
-            plugins, which may set default value, or it can be overwritten by users.
+            `INGEST_TARGET_DEFAULT` environment variable is set. This can be
+            made by plugins, which may set default value, or it can be
+            overwritten by users.
         :param collection_id: string
-            (Optional) An identifier to indicate that data from different method
-            invocations belong to same collection. Defaults to "data_job_name|OpID",
-            meaning all method invocations from a data job run will belong to the
-            same collection.
+            (Optional) An identifier to indicate that data from different
+            method invocations belong to same collection. Defaults to
+            "data_job_name|OpID", meaning all method invocations from a data
+            job run will belong to the same collection.
 
         :return: [Optional] IngestionMetadata, containing data about the
         ingestion process (information about the result from the ingestion
@@ -294,15 +299,20 @@ class IIngesterPlugin:
 
                 return metadata
 
-        :exceptions: Exceptions raised while ingesting data can either be
-        handled at plugin level, or they will be automatically caught at the
-        vdk-core level.
+        :exception: Exceptions raised while ingesting data can either be
+            handled at plugin level, or they will be automatically caught at
+            the vdk-core level.
         """
         pass
 
     def pre_ingest_process(
-        self, payload: List[dict], metadata: Optional[IngestionMetadata] = None
-    ) -> (List[dict], Optional[IngestionMetadata]):
+        self,
+        payload: List[dict],
+        destination_table: Optional[str] = None,
+        target: Optional[str] = None,
+        collection_id: Optional[str] = None,
+        metadata: Optional[IngestionMetadata] = None,
+    ) -> Union[List[Dict], Tuple[List[Dict], IngestionMetadata]]:
         """
         Do some processing on the ingestion payload before passing it to the
         actual ingestion.
@@ -317,21 +327,63 @@ class IIngesterPlugin:
                 return [{k: str(v) for (k,v) in i.items()} for i in payload]
 
         :param payload: List[dict] the ingestion payload to be processed.
+            NOTE: A read-only parameter. Whatever modifications are done to
+            this object, once returned, it is treated as a new object.
+        :param destination_table: Optional[string]
+            (Optional) The name of the table, where the data should be
+            ingested into. This argument is optional, and needs to be
+            considered only when the name of the destination table is not
+            included in the payload itself.
+            NOTE: A read-only parameter. It is not expected to be modified and
+            returned.
+        :param target: Optional[string]
+            (Optional) Used to identify where the data should be ingested into.
+                Specifies a data source and its destination database.
+                The values for this parameter can be in the format
+                `<some-data-source_and-db-table>`, or as a URL.
+                Example:
+                      http://example.com/<some-api>/<data-source_and-db-table>
+            This parameter does not need to be used, in case the
+            `INGEST_TARGET_DEFAULT` environment variable is set. This can be
+            made by plugins, which may set default value, or it can be
+            overwritten by users.
+            NOTE: A read-only parameter. It is not expected to be modified and
+            returned.
+        :param collection_id: string
+            (Optional) An identifier to indicate that data from different
+            method invocations belong to same collection. Defaults to
+            "data_job_name|OpID", meaning all method invocations from a data
+            job run will belong to the same collection.
+            NOTE: A read-only parameter. It is not expected to be modified and
+            returned.
         :param metadata: Optional[IngestionMetadata] dict object containing
-        metadata produced by the pre-ingest plugin, and possibly used by
-        other pre-ingest, ingest, or post-ingest plugins.
-        :return: (List[dict], Optional[IngestionMetadata]), a tuple
-        containing the processed payload and possibly an IngestionMetadata
-        object.
+            metadata produced by the pre-ingest plugin, and possibly used by
+            other pre-ingest, ingest, or post-ingest plugins.
+            NOTE: A read-only parameter. Whatever modifications are done to
+            this object, once returned, it is treated as a new object.
+        :return: Union[List[Dict], Tuple[List[Dict], IngestionMetadata]],
+            either only the processed payload objects, or a tuple containing
+            the processed payload objects and an IngestionMetadata object with
+            ingestion metadata information.
+
+        :exception: If an exception occurs during this operation, all other
+            pre-processing operations and the ingestion of the payload would
+            be terminated to prevent data corruption. In case the ingestion is
+            expected to happen regardless if there are exceptions or not,
+            then the exception handling needs to be implemented within this
+            method.
         """
         pass
 
     def post_ingest_process(
         self,
         payload: Optional[List[dict]] = None,
+        destination_table: Optional[str] = None,
+        target: Optional[str] = None,
+        collection_id: Optional[str] = None,
         ingestion_metadata: Optional[IngestionMetadata] = None,
-        exceptions: Optional[List] = None,
-    ) -> None:
+        exception: Optional[Exception] = None,
+    ) -> Optional[IngestionMetadata]:
         """
         Do post-ingestion processing of the ingestion payload
         or metadata from the ingestion operation.
@@ -343,9 +395,13 @@ class IIngesterPlugin:
             def post_ingest_process(
                 self,
                 payload: Optional[List[dict]],
-                ingestion_metadata: Optional[IngestionMetadata]
-                exceptions: Optional[List]
-            ) -> None:
+                destination_table: Optional[str],
+                target: Optional[str],
+                collection_id: Optional[str],
+                ingestion_metadata: Optional[IngestionMetadata],
+                exception: Optional[Exception],
+            ) -> Optional[IngestionMetadata]:
+
                 # Prepare telemetry
                 telemetry = {}
                 payload_sizes = [sys.getsizeof(i) for i in payload]
@@ -354,20 +410,64 @@ class IIngesterPlugin:
                 telemetry |= ingestion_metadata
 
                 # Send telemetry to wherever is needed.
-                requests.post('example.com', data=telemetry)
+                result = requests.post('example.com', data=telemetry)
+                telemetry["telemetry_req_status"] = result.status_code
+
+                return telemetry
 
 
         :param payload: Optional[List[dict]]
             The payloads that have been ingested. Depending on the number
             of payloads to be processed, there might 0 or many dict objects.
             Each dict object is a separate payload.
+            NOTE: A read-only parameter. It is not expected to be modified and
+            returned.
+        :param destination_table: Optional[string]
+            (Optional) The name of the table, where the data should be
+            ingested into. This argument is optional, and needs to be
+            considered only when the name of the destination table is not
+            included in the payload itself.
+            NOTE: A read-only parameter. It is not expected to be modified and
+            returned.
+        :param target: Optional[string]
+            (Optional) Used to identify where the data should be ingested into.
+                Specifies a data source and its destination database.
+                The values for this parameter can be in the format
+                `<some-data-source_and-db-table>`, or as a URL.
+                Example:
+                      http://example.com/<some-api>/<data-source_and-db-table>
+            This parameter does not need to be used, in case the
+            `INGEST_TARGET_DEFAULT` environment variable is set. This can be
+            made by plugins, which may set default value, or it can be
+            overwritten by users.
+            NOTE: A read-only parameter. It is not expected to be modified and
+            returned.
+        :param collection_id: string
+            (Optional) An identifier to indicate that data from different
+            method invocations belong to same collection. Defaults to
+            "data_job_name|OpID", meaning all method invocations from a data
+            job run will belong to the same collection.
+            NOTE: A read-only parameter. It is not expected to be modified and
+            returned.
         :param ingestion_metadata: Optional[IngestionMetadata]
             The metadata from the ingestion operation, that plugin developers
             have decided to process further. This metadata can be either an
             IngestionMetadata object (which is effectively a dictionary), or
             None.
-        :param exceptions: Optional[List]
-            A list of all exceptions (if any) encountered while ingesting data.
+            NOTE: A read-only parameter. Whatever modifications are done to
+            this object, once returned, it is treated as a new object.
+        :param exception: Optional[Exception]
+            A caught exception (if any) encountered while ingesting data.
+            NOTE: A read-only parameter. Whatever modifications are done to
+            this object, once returned, it is treated as a new object.
+        :return: Optional[IngestionMetadata], an IngestionMetadata object
+            with information about this and possibly the previous processes (
+            pre-ingestion, ingestion, post-ingestion).
+        :exception: If an exception occurs during this operation, all other
+            post-processing operations would be terminated to prevent data
+            corruption. In case all post-process operations are expected to
+            be completed regardless if there are exceptions or not, then the
+            exception handling needs to be implemented within this method.
         """
         pass
 

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_base.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_base.py
@@ -473,14 +473,14 @@ class IngesterBase(IIngester):
         """
         while self._closed.value == 0:
             payload: Optional[Tuple] = None
-            ingestion_result: Optional[IIngesterPlugin.IngestionResult] = None
+            ingestion_metadata: Optional[IIngesterPlugin.IngestionMetadata] = None
             exceptions: List = list()
             try:
                 payload = self._payloads_queue.get()
                 payload_dict, destination_table, method, target, collection_id = payload
 
                 try:
-                    ingestion_result = self._ingester.ingest_payload(
+                    ingestion_metadata = self._ingester.ingest_payload(
                         payload=payload_dict,
                         destination_table=destination_table,
                         target=target,
@@ -525,7 +525,7 @@ class IngesterBase(IIngester):
             try:
                 self._ingester.post_ingest_process(
                     payload=payload_dict,
-                    ingestion_result=ingestion_result,
+                    ingestion_metadata=ingestion_metadata,
                     exceptions=exceptions,
                 )
             except Exception as e:

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_base.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_base.py
@@ -474,7 +474,7 @@ class IngesterBase(IIngester):
         while self._closed.value == 0:
             payload: Optional[Tuple] = None
             ingestion_metadata: Optional[IIngesterPlugin.IngestionMetadata] = None
-            exceptions: List = list()
+            exception: Optional[Exception] = None
             try:
                 payload = self._payloads_queue.get()
                 payload_dict, destination_table, method, target, collection_id = payload
@@ -498,15 +498,15 @@ class IngesterBase(IIngester):
                     log.exception(
                         "A configuration error occurred while ingesting data."
                     )
-                    exceptions.append(e)
+                    exception = e
                 except UserCodeError as e:
                     self._plugin_errors[UserCodeError].increment()
                     log.exception("An user error occurred while ingesting data.")
-                    exceptions.append(e)
+                    exception = e
                 except Exception as e:
                     self._plugin_errors[PlatformServiceError].increment()
                     log.exception("A platform error occurred while ingesting data.")
-                    exceptions.append(e)
+                    exception = e
 
             except Exception as e:
                 self._fail_count.increment()
@@ -517,7 +517,7 @@ class IngesterBase(IIngester):
                         "One or more rows were not ingested.\n"
                         "Exception was: {}".format(str(e))
                     )
-                    exceptions.append(e)
+                    exception = e
             finally:
                 self._payloads_queue.task_done()
 
@@ -525,8 +525,8 @@ class IngesterBase(IIngester):
             try:
                 self._ingester.post_ingest_process(
                     payload=payload_dict,
-                    ingestion_metadata=ingestion_metadata,
-                    exceptions=exceptions,
+                    metadata=ingestion_metadata,
+                    exception=exception,
                 )
             except Exception as e:
                 log.info(

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_configuration_plugin.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_configuration_plugin.py
@@ -56,7 +56,27 @@ class IngesterConfigurationPlugin:
             variable.
             NOTE: If an ingestion plugin implements both pre-processing and
             ingestion logic, it would need to be specified both in
-            INGEST_PAYLOAD_PROCESS_SEQUENCE and INGEST_METHOD_DEFAULT.
+            INGEST_PAYLOAD_PREPROCESS_SEQUENCE and INGEST_METHOD_DEFAULT.
+            """,
+        )
+        config_builder.add(
+            key="INGEST_PAYLOAD_POSTPROCESS_SEQUENCE",
+            default_value=None,
+            description="""A string of coma-separated ingestion post-
+            processing plugin method names, indicating the sequence, in which
+            the ingestion post-processing plugins would process the metadata
+            generated during the ingestion.
+            Ecample:
+                    INGEST_PAYLOAD_POSTPROCESS_SEQUENCE="post-ingest-process,
+                    post-process"
+            The above example shows how the ingestion post-processing plugins
+            could be specified. In the example, the metadata generated from
+            the ingestion process would be processed first by the
+            `post-ingest-process`, and then by the `post-process` plugins.
+            NOTE: If an ingestion plugin implements pre-processing, ingestion
+            and post-processing logic, it would need to be specified in the
+            INGEST_PAYLOAD_PREPROCESS_SEQUENCE, INGEST_METHOD_DEFAULT and
+            INGEST_PAYLOAD_POSTPROCESS_SEQUENCE environment variables.
             """,
         )
 

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/ingestion/test_ingester_base.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/ingestion/test_ingester_base.py
@@ -190,14 +190,14 @@ def test_ingest_payload_multiple_destinations():
 def test_ingest_payload_and_post_ingestion_operation():
     test_payload = {"key1": "val1", "key2": "val2", "key3": "val3"}
     test_aggregated_payload = [{"key1": "val1", "key2": "val2", "key3": "val3"}]
-    test_ingestion_result = {"some_metadata": "some_ingestion_metadata"}
+    test_ingestion_metadata = {"some_metadata": "some_ingestion_metadata"}
     destination_table = "a_destination_table"
     method = "test_method"
     target = "some_target"
     collection_id = "test_job|42a420"
     ingester_base = create_ingester_base()
 
-    ingester_base._ingester.ingest_payload.return_value = test_ingestion_result
+    ingester_base._ingester.ingest_payload.return_value = test_ingestion_metadata
 
     ingester_base.send_object_for_ingestion(
         payload=test_payload,
@@ -216,8 +216,8 @@ def test_ingest_payload_and_post_ingestion_operation():
     )
     ingester_base._ingester.post_ingest_process.assert_called_with(
         payload=test_aggregated_payload,
-        ingestion_metadata=test_ingestion_result,
-        exceptions=[],
+        metadata=test_ingestion_metadata,
+        exception=None,
     )
 
 
@@ -243,6 +243,6 @@ def test_post_ingestion_operation_with_exceptions():
     ingester_base._ingester.ingest_payload.assert_called_once()
     ingester_base._ingester.post_ingest_process.assert_called_with(
         payload=test_aggregated_payload,
-        ingestion_metadata=None,
-        exceptions=[test_exception],
+        metadata=None,
+        exception=test_exception,
     )

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/ingestion/test_ingester_base.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/ingestion/test_ingester_base.py
@@ -216,7 +216,7 @@ def test_ingest_payload_and_post_ingestion_operation():
     )
     ingester_base._ingester.post_ingest_process.assert_called_with(
         payload=test_aggregated_payload,
-        ingestion_result=test_ingestion_result,
+        ingestion_metadata=test_ingestion_result,
         exceptions=[],
     )
 
@@ -243,6 +243,6 @@ def test_post_ingestion_operation_with_exceptions():
     ingester_base._ingester.ingest_payload.assert_called_once()
     ingester_base._ingester.post_ingest_process.assert_called_with(
         payload=test_aggregated_payload,
-        ingestion_result=None,
+        ingestion_metadata=None,
         exceptions=[test_exception],
     )


### PR DESCRIPTION
As part of the effort to extend the Ingestion API to support plugin
chaining, we need to improve the interfaces that are to be used by
data engineers and plugin developers.

This change adds a new environment variable, `INGEST_PAYLOAD_POSTPROCESS_SEQUENCE`
that data engineers can use to specify a plugin/s that would deal with post-ingestion
processing tasks, such as sending telemetry, etc.

Additionally, the interfaces that plugin developers use in ingestion pre-processing
and post-processing tasks, are extended to pass payload, destination_table, target and
collection_id as read-only parameters to allow for better workflows.

Testing Done: Unit tests pass, and ran a local test ingestion data job as described in
https://github.com/vmware/versatile-data-kit/wiki/Ingesting-data-from-DB-into-Database
to verify that the existing ingestion workflows are not affected by the interface changes.

Signed-off-by: Andon Andonov <andonova@vmware.com>