### PR TITLE
vdk-core: adjust defined type for configuration values

### DIFF
--- a/projects/vdk-core/src/vdk/internal/core/config.py
+++ b/projects/vdk-core/src/vdk/internal/core/config.py
@@ -215,7 +215,6 @@ class ConfigurationBuilder:
             self.__config_key_to_value[key] = convert_value_to_type_of_default_type(
                 key, self.__config_key_to_value[key], default_value
             )
-        pass
 
     def build(self) -> Configuration:
         """

--- a/projects/vdk-core/src/vdk/internal/core/config.py
+++ b/projects/vdk-core/src/vdk/internal/core/config.py
@@ -166,6 +166,7 @@ class ConfigurationBuilder:
             self.__add_public(key, description, default_value)
         elif description:
             self.__add_public(key, description)
+        self.__adjust_type_if_value_set(key, default_value)
         return self
 
     def set_value(self, key: ConfigKey, value: ConfigValue) -> ConfigurationBuilder:
@@ -204,6 +205,17 @@ class ConfigurationBuilder:
         if default_value is not None:
             description += "\nDefault value is: '%s'." % default_value
         self.__config_key_to_description[key] = description
+
+    def __adjust_type_if_value_set(self, key: ConfigKey, default_value: ConfigValue):
+        """
+        As set_value can be called before add (which defines the configuration) we may need to adjust
+        the type of the value if it's already set.
+        """
+        if default_value is not None and key in self.__config_key_to_value:
+            self.__config_key_to_value[key] = convert_value_to_type_of_default_type(
+                key, self.__config_key_to_value[key], default_value
+            )
+        pass
 
     def build(self) -> Configuration:
         """

--- a/projects/vdk-core/tests/vdk/internal/core/test_config.py
+++ b/projects/vdk-core/tests/vdk/internal/core/test_config.py
@@ -83,6 +83,21 @@ def test_set_value_overrides_default():
     assert cfg.get_value("key") == "value"
 
 
+def test_set_value_overrides_default_preserve_types():
+    builder = ConfigurationBuilder()
+    builder.set_value("key", "False")
+    builder.add("key", True, False, "key description")
+    builder.set_value("float", "11.12")
+    builder.add("float", 1.1, False, "key description")
+    cfg = builder.build()
+    assert cfg.get_value("key") == False
+    assert cfg.get_value("float") == 11.12
+
+    builder.set_value("int", "bad-value")
+    with pytest.raises(VdkConfigurationError):
+        builder.add("int", 1, False, "key description")
+
+
 def test_list_config_keys():
     builder = ConfigurationBuilder()
     builder.add("key1", 1)


### PR DESCRIPTION
Variable can be added (has its type defined) by one plugin after its
value is set by 2nd plugin.   In that cases the value would not be cast
to the correct type nor validated. This moves that casting/validation at
the point of definition (when #add is called) if value is already set
for same config key.

Testing Done: see unit tests

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>