### PR TITLE
vdk-trino: trino ingest to handle type casting and missing values

### DIFF
--- a/projects/vdk-plugins/vdk-trino/src/vdk/plugin/trino/ingest_to_trino.py
+++ b/projects/vdk-plugins/vdk-trino/src/vdk/plugin/trino/ingest_to_trino.py
@@ -1,13 +1,18 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 import logging
+import math
+from typing import Any
 from typing import List
 from typing import Optional
+from typing import Type
 
 from trino.dbapi import Cursor
 from vdk.internal.builtin_plugins.ingestion.ingester_base import IIngesterPlugin
 from vdk.internal.builtin_plugins.run.job_context import JobContext
 from vdk.internal.core import errors
+from vdk.internal.core.errors import ErrorMessage
+from vdk.internal.core.errors import UserCodeError
 
 log = logging.getLogger(__name__)
 
@@ -57,12 +62,13 @@ class IngestToTrino(IIngesterPlugin):
 
         http.client._MAXLINE = 6553600
 
-        query, fields = self._create_query_and_fields(
+        query, fields, types = self._create_query_and_fields(
             destination_table, len(payload), cur
         )
 
         try:
-            params = tuple(obj[field] for obj in payload for field in fields)
+            payload = self.__lowercase_keys_in_payload(payload)
+            params = self.__get_values_for_fields(payload, fields, types)
             cur.execute(query, params)
             cur.fetchall()
             log.debug("Payload was ingested.")
@@ -70,13 +76,92 @@ class IngestToTrino(IIngesterPlugin):
             errors.log_and_rethrow(
                 errors.find_whom_to_blame_from_exception(e),
                 log,
-                "Failed to sent payload",
+                f"Failed to sent payload into table {destination_table}",
                 "Unknown error. Error message was : " + str(e),
                 "Will not be able to send the payload for ingestion",
                 "See error message for help ",
                 e,
                 wrap_in_vdk_error=True,
             )
+
+    @staticmethod
+    def __to_bool(value: str) -> bool:
+        if value == "true" or value == "True":
+            return True
+        if value == "false" or value == "False":
+            return False
+        raise ValueError("bool cast accept only True/true/False/false values.")
+
+    def __cast(self, key: str, new_value: Any, value_type: Type) -> Any:
+        try:
+            log.debug(f"Cast {key} to type {value_type}")
+            if value_type == bool:
+                return self.__to_bool(new_value)
+            if value_type == float:
+                value_with_float_type = float(new_value)
+                if math.isnan(value_with_float_type):
+                    return None
+                else:
+                    return value_with_float_type
+            else:
+                return value_type(new_value)
+        except Exception as e:
+            raise UserCodeError(
+                ErrorMessage(
+                    "Cannot ingest payload.",
+                    f"The value of the passed with field key (or column name) {key} is not expected type. "
+                    f"Expected field type is {value_type}. ",
+                    f"We could not convert the value to that type. Error is {e}",
+                    f"In order to ensure that we do not overwrite with bad value, "
+                    f"the operation aborts.",
+                    "Inspect the job code and fix the passed data column names or dictionary keys",
+                )
+            ) from e
+
+    @staticmethod
+    def __trino_type_to_python_type_map(trino_type: str):
+        trino_type = trino_type.lower()
+        if "varchar" in trino_type:
+            return str
+        if trino_type in ("double", "real"):
+            return float
+        if "decimal" in trino_type:
+            return float
+        if "boolean" == trino_type:
+            return bool
+        if trino_type in ("bigint", "tinyint", "integer", "smallint"):
+            return int
+        # default to string
+        return str
+
+    def __get_values_for_fields(self, payload: List[dict], fields: list, types: list):
+        types_dict = dict()
+        for field, field_type in zip(fields, types):
+            types_dict[field] = self.__trino_type_to_python_type_map(field_type)
+
+        params = []
+        for obj in payload:
+            for field in fields:
+                if field.lower() in obj:
+                    params.append(
+                        self.__cast(
+                            field.lower(), obj[field.lower()], types_dict[field.lower()]
+                        )
+                    )
+                else:
+                    params.append(None)
+
+        return params
+
+    @staticmethod
+    def __lowercase_keys_in_payload(payload):
+        new_payload = []
+        for obj in payload:
+            new_obj = dict()
+            for k, v in obj.items():
+                new_obj[k.lower()] = v
+            new_payload.append(new_obj)
+        return new_payload
 
     def _create_query_and_fields(
         self, destination_table: str, payload_size: int, cur: Cursor
@@ -93,11 +178,14 @@ class IngestToTrino(IIngesterPlugin):
         """
 
         cur.execute(f"SHOW COLUMNS FROM {destination_table}")
-        fields = [field_tuple[0] for field_tuple in cur.fetchall()]
+        columns_info = cur.fetchall()
+        fields = [field_tuple[0] for field_tuple in columns_info]
+        types = [field_tuple[1] for field_tuple in columns_info]
 
         row_to_be_replaced = f"({', '.join('?' for field in fields)})"
 
         return (
             f"INSERT INTO {destination_table} ({', '.join(fields)}) VALUES {', '.join([row_to_be_replaced for i in range(payload_size)])}",
             fields,
+            types,
         )

--- a/projects/vdk-plugins/vdk-trino/tests/jobs/test_ingest_to_trino_job/10_ingest_to_trino.py
+++ b/projects/vdk-plugins/vdk-trino/tests/jobs/test_ingest_to_trino_job/10_ingest_to_trino.py
@@ -1,11 +1,27 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import math
 
 
 def run(job_input):
-    payload = {"some_data": "some_test_data", "more_data": "more_test_data"}
+    # setup different data types (all passed initially as strings) are cast correctly
+    payload = {
+        "str_data": "string",
+        "int_data": "12",
+        "float_data": "1.2",
+        "bool_data": "True",
+        "decimal_data": "3.2",
+    }
 
     for i in range(5):
         job_input.send_object_for_ingestion(
             payload=payload, destination_table="test_table"
         )
+
+    # this setup:
+    # a) partial payload (only few columns are included)
+    # b) includes float data which is NaN
+    payload2 = {"float_data": math.nan, "decimal_data": math.nan}
+    job_input.send_object_for_ingestion(
+        payload=payload2, destination_table="test_table"
+    )

--- a/projects/vdk-plugins/vdk-trino/tests/test_ingest_to_trino.py
+++ b/projects/vdk-plugins/vdk-trino/tests/test_ingest_to_trino.py
@@ -35,11 +35,20 @@ class IngestToTrinoTests(TestCase):
     def test_ingest_to_trino(self):
         runner = CliEntryBasedTestRunner(trino_plugin)
 
+        runner.invoke(["trino-query", "--query", "DROP TABLE IF EXISTS test_table "])
+
         runner.invoke(
             [
                 "trino-query",
                 "--query",
-                "CREATE TABLE IF NOT EXISTS test_table (some_data varchar, more_data varchar)",
+                "CREATE TABLE IF NOT EXISTS test_table "
+                "("
+                "str_data varchar, "
+                "int_data bigint,"
+                "float_data double,"
+                "bool_data boolean,"
+                "decimal_data decimal(4,2)"
+                ")",
             ]
         )
 
@@ -60,13 +69,14 @@ class IngestToTrinoTests(TestCase):
         )
 
         assert check_result.stdout == (
-            "--------------  --------------\n"
-            "some_test_data  more_test_data\n"
-            "some_test_data  more_test_data\n"
-            "some_test_data  more_test_data\n"
-            "some_test_data  more_test_data\n"
-            "some_test_data  more_test_data\n"
-            "--------------  --------------\n"
+            "------  --  ---  ----  ---\n"
+            "string  12  1.2  True  3.2\n"
+            "string  12  1.2  True  3.2\n"
+            "string  12  1.2  True  3.2\n"
+            "string  12  1.2  True  3.2\n"
+            "string  12  1.2  True  3.2\n"
+            "\n"
+            "------  --  ---  ----  ---\n"
         )
 
     def test_ingest_to_trino_no_dest_table(self):


### PR DESCRIPTION
Fix trino ingestion to handle different data types  more gracefully.
It will make sure the the data type (passed in python) is correctly set
based on the data type in the destination table.

Handle missing values (e.g if a value for column X is missing , it will
set it to None / NULL insted of failing

Handle case insensitive fields. The columns names (or field names) passed by the user can be in any case but trino column names are case insensitive so we normalize them to match.

Testing Done: extended functional tests to cover the new scenarios. Also ran the data job in the https://github.com/vmware/versatile-data-kit/pull/616 (with ingestion using job_input.send_...) and saw it completed successfully and ingested the data correctly in my local trino.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>