### PR TITLE
vdk-core: fix error message

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_base.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_base.py
@@ -530,7 +530,7 @@ class IngesterBase(IIngester):
                 )
             except Exception as e:
                 log.info(
-                    "Could not complete the post-ingestion operation. ",
+                    "Could not complete the post-ingestion operation. "
                     f"The error encountered was: {e}",
                 )
 


### PR DESCRIPTION
Info message was failing because it though the second sentence was
second paramter (remove the comma to fix that)

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>