### PR TITLE
[vdk-core] Implementation of new ingestion interfaces

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_base.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_base.py
@@ -45,6 +45,8 @@ class IngesterBase(IIngester):
         op_id: str,
         ingester: IIngesterPlugin,
         ingest_config: IngesterConfiguration,
+        pre_processors: Optional[List[IIngesterPlugin]] = None,
+        post_processors: Optional[List[IIngesterPlugin]] = None,
     ):
         """
         This constructor must be called by inheritors.
@@ -55,10 +57,19 @@ class IngesterBase(IIngester):
             OpId of the data job run.
         :param ingest_config: IngesterConfiguration
             Configuration related to the core ingestion API.
+        :param pre_processors: Optional[List[IIngesterPlugin]]
+            A list of initialized IIngesterPlugin instances, whose purpose
+            is to process the payload before it is ingested.
+        :param post_processors: Optional[List[IIngesterPlugin]]
+            A list of initialized IIngesterPlugin instances, whose purpose
+            is to process the ingestion metadata after the ingestion of the
+            payload.
         """
         self._data_job_name = data_job_name
         self._op_id = op_id
         self._ingester = ingester
+        self._pre_processors = pre_processors
+        self._post_processors = post_processors
         self._number_of_worker_threads = ingest_config.get_number_of_worker_threads()
         self._payload_size_bytes_threshold = (
             ingest_config.get_payload_size_bytes_threshold()
@@ -472,67 +483,85 @@ class IngesterBase(IIngester):
         data, etc.) and ingesting the data.
         """
         while self._closed.value == 0:
-            payload: Optional[Tuple] = None
-            ingestion_metadata: Optional[IIngesterPlugin.IngestionMetadata] = None
-            exception: Optional[Exception] = None
             try:
-                payload = self._payloads_queue.get()
-                payload_dict, destination_table, method, target, collection_id = payload
-
+                ingestion_metadata: Optional[IIngesterPlugin.IngestionMetadata] = None
+                exception: Optional[Exception] = None
+                payload_obj: Optional[List] = None
+                destination_table: Optional[str] = None
+                target: Optional[str] = None
+                collection_id: Optional[str] = None
                 try:
-                    ingestion_metadata = self._ingester.ingest_payload(
-                        payload=payload_dict,
+                    payload = self._payloads_queue.get()
+                    payload_obj, destination_table, _, target, collection_id = payload
+
+                    # If there are any pre-processors set, pass the payload object
+                    # through them.
+                    if self._pre_processors:
+                        payload_obj, ingestion_metadata = self._pre_process_payload(
+                            payload=payload_obj,
+                            destination_table=destination_table,
+                            target=target,
+                            collection_id=collection_id,
+                            metadata=ingestion_metadata,
+                        )
+
+                    try:
+                        ingestion_metadata = self._ingester.ingest_payload(
+                            payload=payload_obj,
+                            destination_table=destination_table,
+                            target=target,
+                            collection_id=collection_id,
+                            metadata=ingestion_metadata,
+                        )
+
+                        self._success_count.increment()
+                    except VdkConfigurationError:
+                        # TODO: logging for every error might be too much
+                        # There could be million of uploads and millions of error logs would be hard to use.
+                        # But until we have a way to aggregate the errors and show
+                        # the most relevant errors it's better to make sure we do not hide an issue
+                        # and be verbose.
+                        log.exception(
+                            "A configuration error occurred while ingesting data."
+                        )
+                        raise
+                    except UserCodeError:
+                        log.exception("An user error occurred while ingesting data.")
+                        raise
+                    except Exception:
+                        log.exception("A platform error occurred while ingesting data.")
+                        raise
+
+                except Exception as e:
+                    self._fail_count.increment()
+                    if self._log_upload_errors:
+                        # TODO: When working on row count telemetry we can add the exact number of rows not ingested.
+                        log.warning(
+                            "Failed to ingest a payload. "
+                            "One or more rows were not ingested.\n"
+                            "Exception was: {}".format(str(e))
+                        )
+                    exception = e
+                finally:
+                    self._payloads_queue.task_done()
+
+                # If there are any post-processors set, complete the post-process
+                # operations
+                if self._post_processors:
+                    self._execute_post_process_operations(
+                        payload=payload_obj,
                         destination_table=destination_table,
                         target=target,
                         collection_id=collection_id,
+                        metadata=ingestion_metadata,
+                        exception=exception,
                     )
-
-                    self._success_count.increment()
-                except VdkConfigurationError as e:
-                    self._plugin_errors[VdkConfigurationError].increment()
-                    # TODO: logging for every error might be too much
-                    # There could be million of uploads and millions of error logs would be hard to use.
-                    # But until we have a way to aggregate the errors and show
-                    # the most relevant errors it's better to make sure we do not hide an issue
-                    # and be verbose.
-                    log.exception(
-                        "A configuration error occurred while ingesting data."
-                    )
-                    exception = e
-                except UserCodeError as e:
-                    self._plugin_errors[UserCodeError].increment()
-                    log.exception("An user error occurred while ingesting data.")
-                    exception = e
-                except Exception as e:
-                    self._plugin_errors[PlatformServiceError].increment()
-                    log.exception("A platform error occurred while ingesting data.")
-                    exception = e
-
-            except Exception as e:
-                self._fail_count.increment()
-                if self._log_upload_errors:
-                    # TODO: When working on row count telemetry we can add the exact number of rows not ingested.
-                    log.warning(
-                        "Failed to ingest a payload. "
-                        "One or more rows were not ingested.\n"
-                        "Exception was: {}".format(str(e))
-                    )
-                    exception = e
-            finally:
-                self._payloads_queue.task_done()
-
-            # Complete Post-Ingestion operations
-            try:
-                self._ingester.post_ingest_process(
-                    payload=payload_dict,
-                    metadata=ingestion_metadata,
-                    exception=exception,
-                )
-            except Exception as e:
-                log.info(
-                    "Could not complete the post-ingestion operation. "
-                    f"The error encountered was: {e}",
-                )
+            except VdkConfigurationError:
+                self._plugin_errors[VdkConfigurationError].increment()
+            except UserCodeError:
+                self._plugin_errors[UserCodeError].increment()
+            except Exception:
+                self._plugin_errors[PlatformServiceError].increment()
 
     def _start_workers(self):
         """
@@ -574,6 +603,72 @@ class IngesterBase(IIngester):
                 f"Failed uploads:{self._fail_count}\n\t\t"
                 f"ingesting plugin errors:{self._plugin_errors}\n\t\t"
             )
+
+    def _pre_process_payload(
+        self,
+        payload: List[dict],
+        destination_table: Optional[str],
+        target: Optional[str],
+        collection_id: Optional[str],
+        metadata: Optional[IIngesterPlugin.IngestionMetadata],
+    ) -> Tuple[List[dict], Optional[IIngesterPlugin.IngestionMetadata]]:
+        for plugin in self._pre_processors:
+            try:
+                payload, metadata = plugin.pre_ingest_process(
+                    payload=payload,
+                    destination_table=destination_table,
+                    target=target,
+                    collection_id=collection_id,
+                    metadata=metadata,
+                )
+            except Exception as e:
+                errors.log_and_throw(
+                    to_be_fixed_by=ResolvableBy.USER_ERROR,
+                    log=log,
+                    what_happened="Failed to pre-process the data.",
+                    why_it_happened=f"User Error occurred. Exception was: {e}",
+                    consequences="Execution of the data job will fail, "
+                    "in order to prevent data corruption.",
+                    countermeasures="Check if the data sent for ingestion "
+                    "is aligned with the requirements, "
+                    "and that the pre-process plugins are "
+                    "configured correctly.",
+                )
+        return payload, metadata
+
+    def _execute_post_process_operations(
+        self,
+        payload: List[dict],
+        destination_table: Optional[str],
+        target: Optional[str],
+        collection_id: Optional[str],
+        metadata: Optional[IIngesterPlugin.IngestionMetadata],
+        exception: Optional[Exception],
+    ):
+        for plugin in self._post_processors:
+            try:
+                metadata = plugin.post_ingest_process(
+                    payload=payload,
+                    destination_table=destination_table,
+                    target=target,
+                    collection_id=collection_id,
+                    metadata=metadata,
+                    exception=exception,
+                )
+            except Exception as e:
+                errors.log_and_throw(
+                    to_be_fixed_by=ResolvableBy.USER_ERROR,
+                    log=log,
+                    what_happened="Could not complete post-ingestion process.",
+                    why_it_happened=f"User Error occurred. Exception was: {e}",
+                    consequences="Execution of the data job will fail, "
+                    "in order to prevent data corruption.",
+                    countermeasures="Check if the data sent for "
+                    "post-processing "
+                    "is aligned with the requirements, "
+                    "and that the post-process plugins are "
+                    "configured correctly.",
+                )
 
     def _handle_results(self):
         if self._plugin_errors.get(UserCodeError, AtomicCounter(0)).value > 0:

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_router.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_router.py
@@ -43,9 +43,6 @@ class IngesterRouter(IIngesterRegistry):
         self._cached_ingesters: Dict[str, IngesterBase] = dict()
         self._ingester_builders: Dict[str, IngesterPluginFactory] = dict()
 
-        self._initialized_pre_processors: Optional[List[IIngesterPlugin]] = None
-        self._initialized_post_processors: Optional[List[IIngesterPlugin]] = None
-
     def add_ingester_factory_method(
         self,
         method: str,
@@ -64,17 +61,6 @@ class IngesterRouter(IIngesterRegistry):
         target: Optional[str] = None,
         collection_id: Optional[str] = None,
     ):
-        # Initialize the pre- and post- processors.
-        if not self._initialized_pre_processors:
-            self._initialized_pre_processors = self.__get_initialized_processors(
-                "INGEST_PAYLOAD_PREPROCESS_SEQUENCE"
-            )
-
-        if not self._initialized_post_processors:
-            self._initialized_post_processors = self.__get_initialized_processors(
-                "INGEST_PAYLOAD_POSTPROCESS_SEQUENCE"
-            )
-
         # Use the method and target provided by customer, or load the default ones
         # if set. `method` and `target` provided when the method is called take
         # precedence over the ones set with environment variables.
@@ -127,17 +113,6 @@ class IngesterRouter(IIngesterRegistry):
         target: Optional[str] = None,
         collection_id: Optional[str] = None,
     ):
-        # Initialize the pre- and post- processors.
-        if not self._initialized_pre_processors:
-            self._initialized_pre_processors = self.__get_initialized_processors(
-                "INGEST_PAYLOAD_PREPROCESS_SEQUENCE"
-            )
-
-        if not self._initialized_post_processors:
-            self._initialized_post_processors = self.__get_initialized_processors(
-                "INGEST_PAYLOAD_POSTPROCESS_SEQUENCE"
-            )
-
         # Use the method and target provided by customer, or load the
         # default ones, if set. `method` and `target` provided when the
         # method is called take precedence over the ones set with
@@ -249,13 +224,21 @@ class IngesterRouter(IIngesterRegistry):
                 f"If upgraded recently consider reverting to previous version. Or use another method type.",
             )
         else:
+            # Initialize the pre- and post- processors.
+            initialized_pre_processors = self.__get_initialized_processors(
+                "INGEST_PAYLOAD_PREPROCESS_SEQUENCE"
+            )
+            initialized_post_processors = self.__get_initialized_processors(
+                "INGEST_PAYLOAD_POSTPROCESS_SEQUENCE"
+            )
+
             self._cached_ingesters[method] = IngesterBase(
                 self._state.get(ExecutionStateStoreKeys.JOB_NAME),
                 self._state.get(CommonStoreKeys.OP_ID),
                 ingester_plugin,
                 IngesterConfiguration(config=self._cfg),
-                pre_processors=self._initialized_pre_processors,
-                post_processors=self._initialized_post_processors,
+                pre_processors=initialized_pre_processors,
+                post_processors=initialized_post_processors,
             )
 
         return self._cached_ingesters[method]

--- a/projects/vdk-core/src/vdk/internal/util/utils.py
+++ b/projects/vdk-core/src/vdk/internal/util/utils.py
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 import inspect
 from typing import Any
+from typing import List
+from typing import Optional
+
+from vdk.internal.core.config import Configuration
 
 
 def class_fqname(py_object: Any) -> str:
@@ -13,3 +17,26 @@ def class_fqname(py_object: Any) -> str:
     if module is None:
         return py_object.__class__.__name__
     return f"{py_object.__class__.__module__}.{py_object.__class__.__name__}"
+
+
+def parse_config_sequence(
+    cfg: Configuration, key: str, sep: Optional[str] = None
+) -> List:
+    """
+    Parse a configuration variable, whose value is a string sequence, by a
+    specified delimiter.
+    :param cfg: Configuration
+        The configuration of Versatile Data Kit.
+    :param key: string
+        The name of the configuration variable that is to be parsed.
+    :param sep: string
+        Optional. The delimiter by which the configuration variable string is
+        to be split. If not specified or set as None, any whitespace will be
+        considered a delimiter, and the result from the split will have no
+        empty strings.
+    :return:
+    """
+    sequence = cfg.get_value(key)
+    if sequence:
+        sequence = [i.strip() for i in sequence.split(sep)]
+    return sequence if sequence else []

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/ingestion/test_ingester_base.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/ingestion/test_ingester_base.py
@@ -15,6 +15,19 @@ from vdk.internal.core import errors
 from vdk.internal.core.config import Configuration
 
 
+shared_test_values = {
+    "test_payload1": {"key1": "val1", "key2": "val2", "key3": "val3"},
+    "test_payload2": {"key1": 1, "key2": 2, "key3": 3},
+    "test_expected_payload1": [{"key1": "val1", "key2": "val2", "key3": "val3"}],
+    "test_expected_payload2": [{"key1": 1, "key2": 2, "key3": 3}],
+    "destination_table1": "a_destination_table",
+    "destination_table2": "another_destination_table",
+    "method": "test_method",
+    "target": "some_target",
+    "collection_id": "test_job|42a420",
+}
+
+
 def create_ingester_base(kwargs=None) -> IngesterBase:
     kwargs = kwargs or {}
     config_key_value_pairs = {
@@ -39,17 +52,14 @@ def create_ingester_base(kwargs=None) -> IngesterBase:
 @patch.object(IngesterBase, "_send", spec=True)
 def test_send_object_for_ingestion(mocked_send):
     test_unserializable_payload = {"key1": 42, "key2": datetime.utcnow()}
-    destination_table = "a_destination_table"
-    method = "test_method"
-    target = "some_target"
     ingester_base = create_ingester_base()
 
     with pytest.raises(errors.UserCodeError) as exc_info:
         ingester_base.send_object_for_ingestion(
             payload=None,
-            destination_table=destination_table,
-            method=method,
-            target=target,
+            destination_table=shared_test_values.get("destination_table1"),
+            method=shared_test_values.get("method"),
+            target=shared_test_values.get("target"),
         )
     assert exc_info.type == errors.UserCodeError
 
@@ -57,17 +67,17 @@ def test_send_object_for_ingestion(mocked_send):
         ingester_base.send_object_for_ingestion(
             payload="wrong_payload_type",
             destination_table=None,
-            method=method,
-            target=target,
+            method=shared_test_values.get("method"),
+            target=shared_test_values.get("target"),
         )
     assert exc_info.type == errors.UserCodeError
 
     with pytest.raises(errors.UserCodeError) as exc_info:
         ingester_base.send_object_for_ingestion(
             payload=test_unserializable_payload,
-            destination_table=destination_table,
-            method=method,
-            target=target,
+            destination_table=shared_test_values.get("destination_table1"),
+            method=shared_test_values.get("method"),
+            target=shared_test_values.get("target"),
         )
     assert exc_info.type == errors.UserCodeError
 
@@ -75,28 +85,24 @@ def test_send_object_for_ingestion(mocked_send):
 def test_send_tabular_data_for_ingestion():
     test_rows = iter([["testrow0testcol0", 42, None]])
     test_columns = ["testcol0", "testcol1", "testcol2"]
-    destination_table = "a_destination_table"
     converted_row = [{"testcol0": "testrow0testcol0", "testcol1": 42, "testcol2": None}]
-    method = "test_method"
-    target = "some_target"
-    collection_id = "test_job|42a420"
     metadata = None
     ingester_base = create_ingester_base()
 
     ingester_base.send_tabular_data_for_ingestion(
         rows=test_rows,
         column_names=test_columns,
-        destination_table=destination_table,
-        method=method,
-        target=target,
+        destination_table=shared_test_values.get("destination_table1"),
+        method=shared_test_values.get("method"),
+        target=shared_test_values.get("target"),
     )
     ingester_base.close()
 
     ingester_base._ingester.ingest_payload.assert_called_with(
         payload=converted_row,
-        destination_table=destination_table,
-        target=target,
-        collection_id=collection_id,
+        destination_table=shared_test_values.get("destination_table1"),
+        target=shared_test_values.get("target"),
+        collection_id=shared_test_values.get("collection_id"),
         metadata=metadata,
     )
 
@@ -105,8 +111,8 @@ def test_send_tabular_data_for_ingestion():
             rows=None,
             column_names=test_columns,
             destination_table=None,
-            method=method,
-            target=target,
+            method=shared_test_values.get("method"),
+            target=shared_test_values.get("target"),
         )
     assert exc_info.type == errors.UserCodeError
 
@@ -114,132 +120,146 @@ def test_send_tabular_data_for_ingestion():
         ingester_base.send_tabular_data_for_ingestion(
             rows=None,
             column_names={"wrong_test_columns"},
-            destination_table=destination_table,
-            method=method,
+            destination_table=shared_test_values.get("destination_table1"),
+            method=shared_test_values.get("method"),
             target=None,
         )
     assert exc_info.type == errors.UserCodeError
 
 
 def test_plugin_ingest_payload():
-    test_payload = {"key1": "val1", "key2": "val2", "key3": "val3"}
-    test_aggregated_payload = [{"key1": "val1", "key2": "val2", "key3": "val3"}]
-    destination_table = "a_destination_table"
-    method = "test_method"
-    target = "some_target"
-    collection_id = "test_job|42a420"
     metadata = None
     ingester_base = create_ingester_base()
 
     ingester_base.send_object_for_ingestion(
-        payload=test_payload,
-        destination_table=destination_table,
-        method=method,
-        target=target,
+        payload=shared_test_values.get("test_payload1"),
+        destination_table=shared_test_values.get("destination_table1"),
+        method=shared_test_values.get("method"),
+        target=shared_test_values.get("target"),
     )
     ingester_base.close()
 
     ingester_base._ingester.ingest_payload.assert_called_once()
     ingester_base._ingester.ingest_payload.assert_called_with(
-        payload=test_aggregated_payload,
-        destination_table=destination_table,
-        target=target,
-        collection_id=collection_id,
+        payload=shared_test_values.get("test_expected_payload1"),
+        destination_table=shared_test_values.get("destination_table1"),
+        target=shared_test_values.get("target"),
+        collection_id=shared_test_values.get("collection_id"),
         metadata=metadata,
     )
 
 
 def test_ingest_payload_multiple_destinations():
-    test_payload1 = {"key1": "val1", "key2": "val2", "key3": "val3"}
-    test_payload2 = {"key1": 1, "key2": 2, "key3": 3}
-    test_expected_payload1 = [{"key1": "val1", "key2": "val2", "key3": "val3"}]
-    test_expected_payload2 = [{"key1": 1, "key2": 2, "key3": 3}]
-    destination_table1 = "a_destination_table"
-    destination_table2 = "another_destination_table"
-    method = "test_method"
-    target = "some_target"
-    collection_id = "test_job|42a420"
     metadata = None
     ingester_base = create_ingester_base()
 
     ingester_base.send_object_for_ingestion(
-        payload=test_payload1,
-        destination_table=destination_table1,
-        method=method,
-        target=target,
+        payload=shared_test_values.get("test_payload1"),
+        destination_table=shared_test_values.get("destination_table1"),
+        method=shared_test_values.get("method"),
+        target=shared_test_values.get("target"),
     )
     ingester_base.send_object_for_ingestion(
-        payload=test_payload2,
-        destination_table=destination_table2,
-        method=method,
-        target=target,
+        payload=shared_test_values.get("test_payload2"),
+        destination_table=shared_test_values.get("destination_table2"),
+        method=shared_test_values.get("method"),
+        target=shared_test_values.get("target"),
     )
     ingester_base.close()
 
     assert ingester_base._ingester.ingest_payload.call_count == 2
 
     assert ingester_base._ingester.ingest_payload.call_args_list[0] == call(
-        collection_id=collection_id,
-        target=target,
-        destination_table=destination_table1,
-        payload=test_expected_payload1,
+        collection_id=shared_test_values.get("collection_id"),
+        target=shared_test_values.get("target"),
+        destination_table=shared_test_values.get("destination_table1"),
+        payload=shared_test_values.get("test_expected_payload1"),
         metadata=metadata,
     )
 
     assert ingester_base._ingester.ingest_payload.call_args_list[1] == call(
-        collection_id=collection_id,
-        target=target,
-        destination_table=destination_table2,
-        payload=test_expected_payload2,
+        collection_id=shared_test_values.get("collection_id"),
+        target=shared_test_values.get("target"),
+        destination_table=shared_test_values.get("destination_table2"),
+        payload=shared_test_values.get("test_expected_payload2"),
         metadata=metadata,
     )
 
 
+def test_pre_ingestion_operation():
+    pre_ingest_plugin = MagicMock(spec=IIngesterPlugin)
+    ingester_base = create_ingester_base({"pre_processors": [pre_ingest_plugin]})
+
+    ingester_base.send_object_for_ingestion(
+        payload=shared_test_values.get("test_payload1"),
+        destination_table=shared_test_values.get("destination_table"),
+        method=shared_test_values.get("method"),
+        target=shared_test_values.get("target"),
+    )
+    ingester_base.close()
+
+    ingester_base._pre_processors[0].pre_ingest_process.assert_called_with(
+        payload=shared_test_values.get("test_expected_payload1"),
+        destination_table=shared_test_values.get("destination_table"),
+        target=shared_test_values.get("target"),
+        collection_id=shared_test_values.get("collection_id"),
+        metadata=None,
+    )
+
+
+def test_pre_ingestion_operation_with_exceptions():
+    test_exception = errors.UserCodeError("Test User Exception")
+    pre_ingest_plugin = MagicMock(spec=IIngesterPlugin)
+    ingester_base = create_ingester_base({"pre_processors": [pre_ingest_plugin]})
+
+    ingester_base._pre_processors[0].pre_ingest_process.side_effect = test_exception
+
+    ingester_base.send_object_for_ingestion(
+        payload=shared_test_values.get("test_payload1"),
+        destination_table=shared_test_values.get("destination_table1"),
+        method=shared_test_values.get("method"),
+        target=shared_test_values.get("target"),
+    )
+    ingester_base.close()
+
+    ingester_base._pre_processors[0].pre_ingest_process.assert_called_once()
+    ingester_base._ingester.ingest_payload.assert_not_called()
+
+
 def test_ingest_payload_and_post_ingestion_operation():
-    test_payload = {"key1": "val1", "key2": "val2", "key3": "val3"}
-    test_aggregated_payload = [{"key1": "val1", "key2": "val2", "key3": "val3"}]
     test_ingestion_metadata = {"some_metadata": "some_ingestion_metadata"}
-    destination_table = "a_destination_table"
-    method = "test_method"
-    target = "some_target"
-    collection_id = "test_job|42a420"
     post_ingest_plugin = MagicMock(spec=IIngesterPlugin)
     ingester_base = create_ingester_base({"post_processors": [post_ingest_plugin]})
 
     ingester_base._ingester.ingest_payload.return_value = test_ingestion_metadata
 
     ingester_base.send_object_for_ingestion(
-        payload=test_payload,
-        destination_table=destination_table,
-        method=method,
-        target=target,
+        payload=shared_test_values.get("test_payload1"),
+        destination_table=shared_test_values.get("destination_table"),
+        method=shared_test_values.get("method"),
+        target=shared_test_values.get("target"),
     )
     ingester_base.close()
 
     ingester_base._ingester.ingest_payload.assert_called_once()
     ingester_base._ingester.ingest_payload.assert_called_with(
-        payload=test_aggregated_payload,
-        destination_table=destination_table,
-        target=target,
-        collection_id=collection_id,
+        payload=shared_test_values.get("test_expected_payload1"),
+        destination_table=shared_test_values.get("destination_table"),
+        target=shared_test_values.get("target"),
+        collection_id=shared_test_values.get("collection_id"),
         metadata=None,
     )
     ingester_base._post_processors[0].post_ingest_process.assert_called_with(
-        payload=test_aggregated_payload,
-        destination_table=destination_table,
-        target=target,
-        collection_id=collection_id,
+        payload=shared_test_values.get("test_expected_payload1"),
+        destination_table=shared_test_values.get("destination_table"),
+        target=shared_test_values.get("target"),
+        collection_id=shared_test_values.get("collection_id"),
         metadata=test_ingestion_metadata,
         exception=None,
     )
 
 
 def test_post_ingestion_operation_with_exceptions():
-    test_payload = {"key1": "val1", "key2": "val2", "key3": "val3"}
-    test_aggregated_payload = [{"key1": "val1", "key2": "val2", "key3": "val3"}]
-    destination_table = "a_destination_table"
-    method = "test_method"
-    target = "some_target"
     test_exception = errors.UserCodeError("Test User Exception")
     post_ingest_plugin = MagicMock(spec=IIngesterPlugin)
     ingester_base = create_ingester_base({"post_processors": [post_ingest_plugin]})
@@ -247,19 +267,19 @@ def test_post_ingestion_operation_with_exceptions():
     ingester_base._ingester.ingest_payload.side_effect = test_exception
 
     ingester_base.send_object_for_ingestion(
-        payload=test_payload,
-        destination_table=destination_table,
-        method=method,
-        target=target,
+        payload=shared_test_values.get("test_payload1"),
+        destination_table=shared_test_values.get("destination_table1"),
+        method=shared_test_values.get("method"),
+        target=shared_test_values.get("target"),
     )
     ingester_base.close()
 
     ingester_base._ingester.ingest_payload.assert_called_once()
     ingester_base._post_processors[0].post_ingest_process.assert_called_with(
-        payload=test_aggregated_payload,
-        destination_table=destination_table,
-        target=target,
-        collection_id="test_job|42a420",
+        payload=shared_test_values.get("test_expected_payload1"),
+        destination_table=shared_test_values.get("destination_table1"),
+        target=shared_test_values.get("target"),
+        collection_id=shared_test_values.get("collection_id"),
         metadata=None,
         exception=test_exception,
     )

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/ingestion/test_ingester_router.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/ingestion/test_ingester_router.py
@@ -102,8 +102,8 @@ def test_router_chained_ingest_plugins(mock_ingester_base: MagicMock):
     mock_ingester_base.return_value.send_object_for_ingestion.assert_called_with(
         {"a": "b"}, None, "test", None, None
     )
-    assert len(router._initialized_pre_processors) == 1
-    assert len(router._initialized_post_processors) == 1
+    assert len(mock_ingester_base.call_args[1]["pre_processors"]) == 1
+    assert len(mock_ingester_base.call_args[1]["post_processors"]) == 1
 
 
 @patch(f"{IngesterRouter.__module__}.{IngesterBase.__name__}", spec=IngesterBase)
@@ -121,8 +121,8 @@ def test_router_no_chained_ingest_plugins(mock_ingester_base: MagicMock):
         {"a": "b"}, None, "test", None, None
     )
 
-    assert not router._initialized_pre_processors
-    assert not router._initialized_post_processors
+    assert not mock_ingester_base.call_args[1]["pre_processors"]
+    assert not mock_ingester_base.call_args[1]["post_processors"]
 
 
 def test_router_raise_error_chained_ingest_plugins_not_registered():
@@ -133,6 +133,7 @@ def test_router_raise_error_chained_ingest_plugins_not_registered():
     }
 
     router = create_ingester_router(config)
+    router.add_ingester_factory_method("test", lambda: MagicMock(spec=IIngesterPlugin))
 
     with pytest.raises(VdkConfigurationError):
         router.send_object_for_ingestion({"a": "b"})

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/ingestion/test_ingester_router.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/ingestion/test_ingester_router.py
@@ -9,6 +9,7 @@ from vdk.internal.builtin_plugins.ingestion.ingester_base import IngesterBase
 from vdk.internal.builtin_plugins.ingestion.ingester_router import IngesterRouter
 from vdk.internal.core.config import Configuration
 from vdk.internal.core.errors import UserCodeError
+from vdk.internal.core.errors import VdkConfigurationError
 from vdk.internal.core.statestore import StateStore
 
 
@@ -76,48 +77,71 @@ def test_router_send_tabular_data_for_ingestion_no_default_method(
 
 
 @patch(f"{IngesterRouter.__module__}.{IngesterBase.__name__}", spec=IngesterBase)
-def test_router_use_chained_ingest_plugins_send_object(
-    mock_ingester_base: MagicMock,
-):
-    router = create_ingester_router({"ingest_method_default": "test-ingest"})
+def test_router_chained_ingest_plugins(mock_ingester_base: MagicMock):
+    config = {
+        "ingest_payload_preprocess_sequence": "pre-ingest-test",
+        "ingest_payload_postprocess_sequence": "post-ingest-test",
+        "ingest_method_default": "test",
+    }
 
+    router = create_ingester_router(config)
+
+    # Register plugins
     router.add_ingester_factory_method(
         "pre-ingest-test", lambda: MagicMock(spec=IIngesterPlugin)
     )
     router.add_ingester_factory_method(
-        "test-ingest", lambda: MagicMock(spec=IIngesterPlugin)
+        "post-ingest-test", lambda: MagicMock(spec=IIngesterPlugin)
     )
+    router.add_ingester_factory_method("test", lambda: MagicMock(spec=IIngesterPlugin))
+
+    # Send data for ingestion
+    router.send_object_for_ingestion({"a": "b"})
+
+    # Verify method calls
+    mock_ingester_base.return_value.send_object_for_ingestion.assert_called_with(
+        {"a": "b"}, None, "test", None, None
+    )
+    assert len(router._initialized_pre_processors) == 1
+    assert len(router._initialized_post_processors) == 1
+
+
+@patch(f"{IngesterRouter.__module__}.{IngesterBase.__name__}", spec=IngesterBase)
+def test_router_no_chained_ingest_plugins(mock_ingester_base: MagicMock):
+    router = create_ingester_router({"ingest_method_default": "test"})
+
+    router.add_ingester_factory_method(
+        "pre-ingest-test", lambda: MagicMock(spec=IIngesterPlugin)
+    )
+    router.add_ingester_factory_method("test", lambda: MagicMock(spec=IIngesterPlugin))
 
     router.send_object_for_ingestion({"a": "b"})
 
     mock_ingester_base.return_value.send_object_for_ingestion.assert_called_with(
-        {"a": "b"}, None, "test-ingest", None, None
-    )
-    # TODO: Uncomment when implementation is ready
-    # mock_ingester_base.return_value.send_tabular_data_for_ingestion.assert_called_with(
-    #     ["b"], ["a"], None, "pre-ingest-test", None, None
-    # )
-
-
-@patch(f"{IngesterRouter.__module__}.{IngesterBase.__name__}", spec=IngesterBase)
-def test_router_use_chained_ingest_plugins_tabular_data(
-    mock_ingester_base: MagicMock,
-):
-    router = create_ingester_router({"ingest_method_default": "test-ingest"})
-
-    router.add_ingester_factory_method(
-        "pre-ingest-test", lambda: MagicMock(spec=IIngesterPlugin)
-    )
-    router.add_ingester_factory_method(
-        "test-ingest", lambda: MagicMock(spec=IIngesterPlugin)
+        {"a": "b"}, None, "test", None, None
     )
 
-    router.send_tabular_data_for_ingestion(rows=["b"], column_names=["a"])
+    assert not router._initialized_pre_processors
+    assert not router._initialized_post_processors
 
-    mock_ingester_base.return_value.send_tabular_data_for_ingestion.assert_called_with(
-        ["b"], ["a"], None, "test-ingest", None, None
+
+def test_router_raise_error_chained_ingest_plugins_not_registered():
+    config = {
+        "ingest_payload_preprocess_sequence": "pre-ingest-test",
+        "ingest_payload_postprocess_sequence": "post-ingest-test",
+        "ingest_method_default": "test",
+    }
+
+    router = create_ingester_router(config)
+
+    with pytest.raises(VdkConfigurationError):
+        router.send_object_for_ingestion({"a": "b"})
+
+    with pytest.raises(VdkConfigurationError) as exc_info:
+        router.send_tabular_data_for_ingestion(rows=["b"], column_names=["a"])
+
+    error_msg = exc_info.value
+    assert (
+        "Could not create new processor plugin of type pre-ingest-test"
+        in error_msg.message
     )
-    # TODO: Uncomment when implementation is ready
-    # mock_ingester_base.return_value.send_tabular_data_for_ingestion.assert_called_with(
-    #     ["b"], ["a"], None, "pre-ingest-test", None, None
-    # )


### PR DESCRIPTION
As part of https://github.com/vmware/versatile-data-kit/pull/682
and https://github.com/vmware/versatile-data-kit/pull/672 the ingestion
interfaces were extended to support ingestion plugin chaining for pre- and
post- processing operations.

This change introduces the implementation of the extended ingestion functionality.
The IngesterRouter and IngesterBase classes are extended to support the use of pre-
and post- ingestion processing plugins.

Testing Done: unit tests; functional tests to follow in a separate PR.

Signed-off-by: Andon Andonov <andonova@vmware.com>