### PR TITLE
vdk-impala: template .sql missing from python distro

### DIFF
--- a/projects/vdk-plugins/vdk-impala/MANIFEST.in
+++ b/projects/vdk-plugins/vdk-impala/MANIFEST.in
@@ -1,0 +1,4 @@
+global-include *.sql
+
+# this only work for source distribution (setup.py sdist) and not for binary distribution (bdist)
+# https://packaging.python.org/guides/using-manifest-in/


### PR DESCRIPTION
When running templates, no data is being handled. The cause is
all template .sql steps are missing when python distribution is
bundled.

Added MANIFEST.in file including *.sql files.

Testing Done: did run python sdist, then verified the .sql files
are bundled-in.

Signed-off-by: ikoleva <ikoleva@vmware.com>