### PR TITLE
pipelines-control-service: redirect Swagger webjars resources

### DIFF
--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/security/SecurityConfiguration.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/security/SecurityConfiguration.java
@@ -99,7 +99,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 "/data-jobs/swagger-resources/**",
                 "/data-jobs/configuration/**",
                 "/data-jobs/swagger-ui.html",
-                "/webjars/**",
+                "/data-jobs/webjars/**",
                 // There should not be sensitive data in prometheus, and it makes
                 // integration with the monitoring system easier if no auth is necessary.
                 "/data-jobs/debug/prometheus",

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobCrudIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobCrudIT.java
@@ -72,6 +72,10 @@ public class DataJobCrudIT extends BaseIT {
               .content(dataJobRequestBody)
               .contentType(MediaType.APPLICATION_JSON))
               .andExpect(status().isOk());
+      mockMvc.perform(get("/data-jobs/webjars/springfox-swagger-ui/swagger-ui-bundle.js")
+                      .content(dataJobRequestBody)
+                      .contentType(MediaType.APPLICATION_JSON))
+              .andExpect(status().isOk());
 
       // Validation
       // Validate keytab created

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/doc/SwaggerConfig.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/doc/SwaggerConfig.java
@@ -65,11 +65,13 @@ public class SwaggerConfig implements WebMvcConfigurer {
         final var configUi = "/swagger-resources/configuration/ui";
         final var configSecurity = "/swagger-resources/configuration/security";
         final var resources = "/swagger-resources";
+        final var webjars = "/webjars";
 
         registry.addRedirectViewController(PATH + apiDocs, apiDocs).setKeepQueryParams(true);
         registry.addRedirectViewController(PATH + resources, resources);
         registry.addRedirectViewController(PATH + configUi, configUi);
         registry.addRedirectViewController(PATH + configSecurity, configSecurity);
+        registry.addRedirectViewController(PATH + webjars, webjars);
         registry.addRedirectViewController(PATH, "/");
     }
 


### PR DESCRIPTION
Swagger UI HTML page is not completely rendered. Cause is,
the resources included in swagger-ui.html that are /webjars/**
were not redirected to /data-jobs.

Path-prefixed the webjars for auth purposes. Redirected
webjars to the new path.

Testing Done: did add an integration test to verify availability of
a webjar expected.

Signed-off-by: ikoleva <ikoleva@vmware.com>