### PR TITLE
control-service: fix role permissions for pod/logs

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/role.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/role.yaml
@@ -10,7 +10,6 @@ rules:
       - ""
     resources:
       - "pods"
-      - "pods/log"
     verbs:
       - get
       - list
@@ -20,6 +19,15 @@ rules:
       - patch
       - watch
       - deletecollection
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/log"
+    verbs:
+      - get
+      - list
+      - watch
+      - watch
   - apiGroups:
       - "batch"
     resources:

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/role_datajobs.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/role_datajobs.yaml
@@ -10,7 +10,6 @@ rules:
       - ""
     resources:
       - "pods"
-      - "pods/log"
       - "secrets"
     verbs:
       - get
@@ -21,6 +20,14 @@ rules:
       - patch
       - watch
       - deletecollection
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/log"
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - "batch"
     resources:


### PR DESCRIPTION
We are requiring permissions for accessing pods/log subresource that
seem not to be applicable for pods/log See
https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources
and it fails on some kubernetes clusters (I assume newer version of
kubernets is more strict)

Testing Done: helm install relase-foo <edited-helm-chart> and saw it
passed

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>