### PR TITLE
control-service: builder job configurable security context

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -216,6 +216,18 @@ spec:
             - name: SECURITY_KERBEROS_KRB5_CONFIG_LOCATION
               value: "/etc/secrets/krb5.conf"
             {{- end }}
+            {{- if .Values.deploymentBuilder.securityContext.runAsUser }}
+            - name: DATAJOBS_DEPLOYMENT_BUILDER_SECURITY_CONTEXT_RUN_AS_USER
+              value: "{{ .Values.deploymentBuilder.securityContext.runAsUser }}"
+            {{- end }}
+            {{- if .Values.deploymentBuilder.securityContext.runAsGroup }}
+            - name: DATAJOBS_DEPLOYMENT_BUILDER_SECURITY_CONTEXT_RUN_AS_GROUP
+              value: "{{ .Values.deploymentBuilder.securityContext.runAsGroup }}"
+            {{- end }}
+            {{- if .Values.deploymentBuilder.securityContext.fsGroup }}
+            - name: DATAJOBS_DEPLOYMENT_BUILDER_SECURITY_CONTEXT_FS_GROUP
+              value: "{{ .Values.deploymentBuilder.securityContext.fsGroup }}"
+            {{- end }}
 {{- if .Values.extraVars }}
 {{ toYaml .Values.extraVars | indent 12 }}
 {{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -27,6 +27,12 @@ deploymentBuilderImage:
   repository: job-builder
   tag: "1.2.3"
 
+deploymentBuilder:
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 1000
+    fsGroup: 1000
+
 
 ## String to partially override pipelines-control-service.fullname template (will maintain the release name)
 ##

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
@@ -64,6 +64,15 @@ public class JobImageBuilder {
    @Value("${datajobs.git.ssl.enabled}")
    private boolean gitDataJobsSslEnabled;
 
+   @Value("${datajobs.deployment.builder.securitycontext.runAsUser}")
+   private long  builderSecurityContextRunAsUser;
+
+   @Value("${datajobs.deployment.builder.securitycontext.runAsGroup}")
+   private long  builderSecurityContextRunAsGroup;
+
+   @Value("${datajobs.deployment.builder.securitycontext.fsGroup}")
+   private long  builderSecurityContextFsGroup;
+
    private final ControlKubernetesService controlKubernetesService;
    private final DockerRegistryService dockerRegistryService;
    private final DeploymentNotificationHelper notificationHelper;
@@ -154,7 +163,10 @@ public class JobImageBuilder {
             null,
             builderJobImagePullPolicy,
             kubernetesResources.builderRequests(),
-            kubernetesResources.builderLimits());
+            kubernetesResources.builderLimits(),
+            builderSecurityContextRunAsUser,
+            builderSecurityContextRunAsGroup,
+            builderSecurityContextFsGroup);
 
       log.debug("Waiting for builder job {} for data job version {}", builderJobName, jobDeployment.getGitCommitSha());
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -167,3 +167,7 @@ mail.smtp.host=smtp.vmware.com
 # Correspond to those defined by kubernetes
 # See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
 datajobs.deployment.builder.imagePullPolicy=IfNotPresent
+
+datajobs.deployment.builder.securitycontext.runAsUser=${DATAJOBS_DEPLOYMENT_BUILDER_SECURITY_CONTEXT_RUN_AS_USER:0}
+datajobs.deployment.builder.securitycontext.runAsGroup=${DATAJOBS_DEPLOYMENT_BUILDER_SECURITY_CONTEXT_RUN_AS_GROUP:1000}
+datajobs.deployment.builder.securitycontext.fsGroup=${DATAJOBS_DEPLOYMENT_BUILDER_SECURITY_CONTEXT_FS_GROUP:1000}

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/MockKubernetes.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/MockKubernetes.java
@@ -102,7 +102,7 @@ public class MockKubernetes {
 
 
       doAnswer(inv -> jobs.put(inv.getArgument(0), inv)).when(mock)
-              .createJob(anyString(), anyString(), anyBoolean(), any(), any(), any(), any(), anyString(), any(), any());
+              .createJob(anyString(), anyString(), anyBoolean(), any(), any(), any(), any(), anyString(), any(), any(), anyLong(), anyLong(), anyLong());
       doAnswer(inv -> jobs.keySet()).when(mock).listCronJobs();
       doAnswer(inv -> jobs.remove(inv.getArgument(0))).when(mock).deleteJob(anyString());
 

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
@@ -88,7 +88,7 @@ public class JobImageBuilderTest {
 
       verify(kubernetesService).createJob(
             eq(TEST_BUILDER_JOB_NAME), eq(TEST_BUILDER_IMAGE_NAME), eq(false), any(), any(),
-            any(), any(), any(), any(), any());
+            any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong());
 
       verify(kubernetesService).deleteJob(TEST_BUILDER_JOB_NAME);
       Assertions.assertTrue(result);
@@ -114,7 +114,7 @@ public class JobImageBuilderTest {
       verify(kubernetesService, times(2)).deleteJob(TEST_BUILDER_IMAGE_NAME);
       verify(kubernetesService).createJob(
             eq(TEST_BUILDER_JOB_NAME), eq(TEST_BUILDER_IMAGE_NAME), eq(false), any(), any(),
-            any(), any(), any(), any(), any());
+            any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong());
       Assertions.assertTrue(result);
    }
 
@@ -131,7 +131,7 @@ public class JobImageBuilderTest {
 
       verify(kubernetesService, never()).createJob(
             anyString(), anyString(), anyBoolean(), any(), any(),
-            any(), any(), anyString(), any(), any());
+            any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong());
       verify(notificationHelper, never())
             .verifyBuilderResult(anyString(), any(), any(), any(), anyString(), anyBoolean());
       Assertions.assertTrue(result);
@@ -156,7 +156,7 @@ public class JobImageBuilderTest {
 
       verify(kubernetesService).createJob(
             eq(TEST_BUILDER_JOB_NAME), eq(TEST_BUILDER_IMAGE_NAME), eq(false), any(), any(),
-            any(), any(), any(), any(), any());
+            any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong());
 
 
       // verify(kubernetesService).deleteJob(TEST_BUILDER_JOB_NAME); // not called in case of an error


### PR DESCRIPTION
Currently, builder job is based on Kaniko and requires root privileges.
However, it runs with the default security context of a particular K8S cluster
since Control Service does not set user and group to K8S Job.

* spec.template.spec.securityContext.fsGroup: 0
* spec.template.spec.securityContext.runAsGroup: 1000
* spec.template.spec.securityContext.runAsUser: 1000

Testing done: unit tests

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com