### PR TITLE
vdk-control-cli: Make list command print all jobs on empty team param 

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/list.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/list.py
@@ -207,8 +207,6 @@ vdk list -t taurus -o json
     type=click.STRING,
     default=load_default_team_name(),
     cls=NotRequiredIfAllOperationExists,
-    required=True,
-    prompt="Job Team",
     help="The name of the team that Data Jobs belong to in the searched list."
     " Not required if (-a,--all) option is provided.",
 )
@@ -235,8 +233,9 @@ def list_command(
     team: str, operation_all: str, more_details: int, rest_api_url: str, output: str
 ):
     cmd = JobList(rest_api_url)
-    if team is None:
+    if team == "":
         team = "no-team-specified"
+        operation_all = FilterOperation.ALL.value
     cmd.list_jobs(
         team, (operation_all == FilterOperation.ALL.value), more_details, output
     )

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/logout_group/logout.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/logout_group/logout.py
@@ -5,8 +5,8 @@ from vdk.internal.control.configuration.vdk_config import VDKConfigFolder
 
 
 @click.command(
-    short_help="Logout the user from the Data Jobs Service.",
-    help="Logout the user from the Data Jobs Service by deleting their refresh token stored locally.",
+    short_help="Logout the user from the Control Service.",
+    help="Logout the user from the Control Service by deleting their refresh token stored locally.",
 )
 def logout():
     conf = VDKConfigFolder()

--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_list.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_list.py
@@ -109,6 +109,14 @@ def test_list_all(httpserver: PluginHTTPServer, tmpdir: LocalPath):
         "test-job" in result.output
     ), f"expected data not found in output: {result.output} "
 
+    result = runner.invoke(list_command, ["-u", rest_api_url])
+    assert (
+        result.exit_code == 0
+    ), f"result exit code is not 0, result output: {result.output}, exc: {result.exc_info}"
+    assert (
+        "test-job" in result.output
+    ), f"expected data not found in output: {result.output} "
+
 
 def test_list_without_url(httpserver: PluginHTTPServer, tmpdir: LocalPath):
     runner = CliRunner()

--- a/projects/vdk-plugins/vdk-plugin-control-cli/src/vdk/plugin/control_cli_plugin/vdk_plugin_control_cli.py
+++ b/projects/vdk-plugins/vdk-plugin-control-cli/src/vdk/plugin/control_cli_plugin/vdk_plugin_control_cli.py
@@ -26,7 +26,7 @@ from vdk.internal.core.context import CoreContext
 from vdk.plugin.control_cli_plugin import control_service_configuration
 
 
-@hookimpl
+@hookimpl(tryfirst=True)
 def vdk_command_line(root_command: click.Group):
     root_command.add_command(login)
     root_command.add_command(logout)
@@ -50,7 +50,6 @@ def vdk_command_line(root_command: click.Group):
 
 @hookimpl(tryfirst=True)
 def vdk_configure(config_builder: ConfigurationBuilder) -> None:
-    """"""
     control_service_configuration.add_definitions(config_builder)
 
 


### PR DESCRIPTION
The `list` command will now work when no team has been supplied as
a parameter, in which case it will query for all teams.
Some other small improvements have been made as well.

Testing done: added unittest

Signed-off-by: Gabriel Georgiev <gageorgiev@vmware.com>