### PR TITLE
pipelines-control-service: publish Swagger UI to /data-jobs path

### DIFF
--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/security/SecurityConfiguration.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/security/SecurityConfiguration.java
@@ -95,11 +95,11 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     public void configure(WebSecurity web) {
         web.ignoring().antMatchers(
                 "/",
-                "/v2/api-docs",
-                "/swagger-resources/**",
-                "/configuration/**",
-                "/swagger-ui.html",
-                "/webjars/**",
+                "/data-jobs/v2/api-docs",
+                "/data-jobs/swagger-resources/**",
+//                "/data-jobs/configuration/**",
+                "/data-jobs/swagger-ui.html",
+                "/data-jobs/webjars/**",
                 // There should not be sensitive data in prometheus, and it makes
                 // integration with the monitoring system easier if no auth is necessary.
                 "/data-jobs/debug/prometheus",

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobCrudIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobCrudIT.java
@@ -68,7 +68,31 @@ public class DataJobCrudIT extends BaseIT {
       testDataJobPostCreateWebHooks();
 
       // Execute get swagger with no user
-      mockMvc.perform(get("/swagger-ui.html")
+      mockMvc.perform(get("/data-jobs/swagger-ui.html")
+              .content(dataJobRequestBody)
+              .contentType(MediaType.APPLICATION_JSON))
+              .andExpect(status().isOk());
+      mockMvc.perform(get("/data-jobs/webjars/springfox-swagger-ui/swagger-ui.css.map")
+                      .content(dataJobRequestBody)
+                      .contentType(MediaType.APPLICATION_JSON))
+              .andExpect(status().isOk());
+      mockMvc.perform(get("/data-jobs/webjars/springfox-swagger-ui/swagger-ui-bundle.js.map")
+                      .content(dataJobRequestBody)
+                      .contentType(MediaType.APPLICATION_JSON))
+              .andExpect(status().isOk());
+      mockMvc.perform(get("/swagger-resources/configuration/ui")
+                      .content(dataJobRequestBody)
+                      .contentType(MediaType.APPLICATION_JSON))
+              .andExpect(status().isOk());
+      mockMvc.perform(get("/swagger-resources/configuration/security")
+                      .content(dataJobRequestBody)
+                      .contentType(MediaType.APPLICATION_JSON))
+              .andExpect(status().isOk());
+      mockMvc.perform(get("/swagger-resources")
+                      .content(dataJobRequestBody)
+                      .contentType(MediaType.APPLICATION_JSON))
+              .andExpect(status().isOk());
+      mockMvc.perform(get("/v2/api-docs")
                       .content(dataJobRequestBody)
                       .contentType(MediaType.APPLICATION_JSON))
               .andExpect(status().isOk());

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/doc/SwaggerConfig.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/doc/SwaggerConfig.java
@@ -11,6 +11,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
@@ -38,6 +40,7 @@ import java.util.List;
 @EnableSwagger2
 @Controller
 public class SwaggerConfig implements WebMvcConfigurer {
+    private static final String PATH = "/data-jobs";
     private static final String AUTHORIZE_KEY_NAME = "Authorization Header (put 'Bearer access_token')";
 
     @Bean
@@ -54,6 +57,25 @@ public class SwaggerConfig implements WebMvcConfigurer {
                         new Tag("Data Jobs Deployment", "(Stable)"),
                         new Tag("Data Jobs Service", "(Stable)"),
                         new Tag("Data Jobs Sources", "(Stable)"));
+    }
+
+
+    @Override
+    public void addViewControllers(ViewControllerRegistry registry) {
+        final var apiDocs = "/v2/api-docs";
+        final var configUi = "/swagger-resources/configuration/ui";
+        final var configSecurity = "/swagger-resources/configuration/security";
+        final var resources = "/swagger-resources";
+
+        registry.addViewController(PATH + apiDocs).setViewName("forward:" + apiDocs);
+        registry.addViewController(PATH + configUi).setViewName("forward:" + configUi);
+        registry.addViewController(PATH + configSecurity).setViewName("forward:" + configSecurity);
+        registry.addViewController(PATH + resources).setViewName("forward:" + resources);
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler(PATH + "/**").addResourceLocations("classpath:/META-INF/resources/");
     }
 
     // springfox does not support Bearer Token Auth from api.yaml so we hack it manually


### PR DESCRIPTION
The Swagger UI is currently available at root / by default. Since the
API is prefixed by /data-jobs, we would like for the Swagger to also be
available under same path, in a consistent fashion. This unblocks
services composition by dedicated path for accessing all features.

Did add Swagger configuration for additional controllers forward and
resource handler. Updated an integration test to verify the paths.
Updated also SecurityConfiguration swagger paths.

Testing Done: did run unit tests, and also verified all
browser-requested resources are loaded and accessible under /data-jobs
locally

Signed-off-by: ikoleva <ikoleva@vmware.com>