### PR TITLE
pipelines-control-service: Swagger UI path changes docs update

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/NOTES.txt
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/NOTES.txt
@@ -15,7 +15,7 @@ To access Data Jobs API from outside your K8s cluster, follow the steps below:
 {{- if contains "NodePort" .Values.service.type }}
 
   export SERVICE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo "Data Jobs API URL: http://$SERVICE_IP:{{ .Values.service.internalPort }}/swagger-ui.html"
+  echo "Data Jobs API URL: http://$SERVICE_IP:{{ .Values.service.internalPort }}/data-jobs/swagger-ui.html"
 
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
@@ -23,7 +23,7 @@ To access Data Jobs API from outside your K8s cluster, follow the steps below:
           Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ .Release.Name }}-svc'
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ .Release.Name }}-svc --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo "Data Jobs API URL: http://$SERVICE_IP:{{ .Values.service.internalPort }}/swagger-ui.html"
+  echo "Data Jobs API URL: http://$SERVICE_IP:{{ .Values.service.internalPort }}/data-jobs/swagger-ui.html"
 
 {{- else }}
 

--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/installer.py
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/installer.py
@@ -73,7 +73,9 @@ class Installer:
         self.__install_helm_chart()
         self.__finalize_configuration()
         log.info("Versatile Data Kit Control Service installed successfully")
-        log.info("Access the REST API at http://localhost:8092/swagger-ui.html\n")
+        log.info(
+            "Access the REST API at http://localhost:8092/data-jobs/swagger-ui.html\n"
+        )
         log.info(
             "\n"
             "You can now use the other vdk commands to create, run, and deploy jobs. "
@@ -102,7 +104,9 @@ class Installer:
             and self.__docker_container_exists(self.docker_registry_container_name)
         ):
             log.info("The Versatile Data Kit Control Service is installed")
-            log.info("Access the REST API at http://localhost:8092/swagger-ui.html\n")
+            log.info(
+                "Access the REST API at http://localhost:8092/data-jobs/swagger-ui.html\n"
+            )
         else:
             log.info("No installation found")
 


### PR DESCRIPTION
pipelines-control-service: Swagger UI path changes docs update

Swagger UI path has been changed to /data-jobs/swagger-ui.html

Docs/user-facing messages updated to the new path.

Testing Done: no functional changes made.