### PR TITLE
[plugins][vdk-impala] Improve error handling to handle view errors

### DIFF
--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_error_handler.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_error_handler.py
@@ -359,7 +359,7 @@ class ImpalaErrorHandler:
                     if "." not in fully_qualified_table_name:
                         try:
                             schema_match = re.search(
-                                r"create table\b\s`?(\w+)`?\.{}".format(
+                                r"create (?:table|view)\b\s`?(\w+)`?\.{}".format(
                                     fully_qualified_table_name
                                 ),
                                 recovery_cursor.get_managed_operation().get_operation(),


### PR DESCRIPTION
Currently, the impala error handling logic fails to properly handle
TableAlreadyExist exceptions, in cases where these are caused while processing
`CREATE VIEW` sql queries.

This change modifies the error handling logic to properly handle exceptions
caused while processing `CREATE VIEW` queries.

Testing Done: Added unit test.

Signed-off-by: Andon Andonov <andonova@vmware.com>