### PR TITLE
vdk-control-cli: Parse contacts with both comma "," as delimiter as well

### DIFF
--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_datajob_config.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_datajob_config.py
@@ -86,6 +86,51 @@ class TestSetTeam:
         with pytest.raises(VDKException):
             job_config.get_notification_delay_period_minutes()
 
+    def test_parse_notification_contacts(self):
+        self.__create_config_ini(
+            self.tmp_copy_job_test_config_ini_path,
+            [
+                ("notified_on_job_deploy", "a@abv.bg; b@dir.bg,   c@abv.bg ; d@dir.bg"),
+                (
+                    "notified_on_job_success",
+                    "a@abv.bg; b@dir.bg,   c@abv.bg ; d@dir.bg",
+                ),
+                (
+                    "notified_on_job_failure_user_error",
+                    "a@abv.bg; b@dir.bg,   c@abv.bg ; d@dir.bg",
+                ),
+                (
+                    "notified_on_job_failure_platform_error",
+                    "a@abv.bg; b@dir.bg,   c@abv.bg ; d@dir.bg",
+                ),
+            ],
+        )
+        job_config = JobConfig(self.tmp_copy_job_test_path)
+        assert job_config.get_contacts_notified_on_job_deploy() == [
+            "a@abv.bg",
+            "b@dir.bg",
+            "c@abv.bg",
+            "d@dir.bg",
+        ]
+        assert job_config.get_contacts_notified_on_job_success() == [
+            "a@abv.bg",
+            "b@dir.bg",
+            "c@abv.bg",
+            "d@dir.bg",
+        ]
+        assert job_config.get_contacts_notified_on_job_failure_user_error() == [
+            "a@abv.bg",
+            "b@dir.bg",
+            "c@abv.bg",
+            "d@dir.bg",
+        ]
+        assert job_config.get_contacts_notified_on_job_failure_platform_error() == [
+            "a@abv.bg",
+            "b@dir.bg",
+            "c@abv.bg",
+            "d@dir.bg",
+        ]
+
     @staticmethod
     def __create_config_ini(file, contacts):
         config = configparser.ConfigParser()


### PR DESCRIPTION
Until now we required contacts be separated by ";" semi-colon. This was
error prone as a lot of users are using "," comma and we are not really
preventing them so mails were written as "a@abv.bg,b@dir.bg" as if it is
a single email. T This also meant that people were not getting
notifications.

The fix is to add "," comma as allowed delimiter as a first step.
In a subsequent change we can add a email validator (like
https://pypi.org/project/email-validator)

Testing Done: unit tests including new ones

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>