### PR TITLE
vdk-ingest-http: configurable allow JSON float NaN capability

### DIFF
--- a/projects/vdk-plugins/vdk-ingest-http/src/vdk/plugin/ingest_http/ingest_http_plugin.py
+++ b/projects/vdk-plugins/vdk-ingest-http/src/vdk/plugin/ingest_http/ingest_http_plugin.py
@@ -72,9 +72,9 @@ def vdk_configure(config_builder: ConfigurationBuilder) -> None:
     config_builder.add(
         key="INGEST_OVER_HTTP_ALLOW_NAN",
         default_value=False,
-        description="If set to True, then NaN, Infinity, and -Infinity will be encoded as such."
-        "This behavior is not JSON specification compliant, but is consistent with most JavaScript based "
-        "encoders and decoders. Otherwise, it will be a ValueError to encode such floats.",
+        description="If set to False, then it will be a ``ValueError`` to serialize out of range ``float`` "
+        "values (``nan``, ``inf``, ``-inf``) in strict compliance of the JSON specification, "
+        "instead of using the JavaScript equivalents (``NaN``, ``Infinity``, ``-Infinity``).",
     )
 
 

--- a/projects/vdk-plugins/vdk-ingest-http/src/vdk/plugin/ingest_http/ingest_http_plugin.py
+++ b/projects/vdk-plugins/vdk-ingest-http/src/vdk/plugin/ingest_http/ingest_http_plugin.py
@@ -69,6 +69,13 @@ def vdk_configure(config_builder: ConfigurationBuilder) -> None:
         default_value=None,
         description="A string of comma-separated HTTP status codes that we should force a retry on.",
     )
+    config_builder.add(
+        key="INGEST_OVER_HTTP_ALLOW_NAN",
+        default_value=False,
+        description="If set to True, then NaN, Infinity, and -Infinity will be encoded as such."
+        "This behavior is not JSON specification compliant, but is consistent with most JavaScript based "
+        "encoders and decoders. Otherwise, it will be a ValueError to encode such floats.",
+    )
 
 
 @hookimpl


### PR DESCRIPTION
Based on requests encoder/decoder default configuration, simplejson/json
is used to handle a specification compliant JSON by default. We need a
configurable allow NaN capability, so that when enabled, ingestion
payload NaN values are parsed correctly - instead raising ValueError
interrupting the ingestion.

Introduced `INGEST_OVER_HTTP_ALLOW_NAN` plugin configuration, that is
set to False by default.

Testing Done: did add
`test_ingest_over_http_json_dumps_parameters_propagation` that verifies
`INGEST_OVER_HTTP_ALLOW_NAN` configuration propagation to `json.dumps`

Signed-off-by: ikoleva <ikoleva@vmware.com>