### PR TITLE
versatile-data-kit: Fix Slack channel link

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ If you are interested in contributing as a developer, visit [CONTRIBUTING.md](CO
 # Contacts
 Feedback is very welcome via the [GitHub site as issues](https://github.com/vmware/versatile-data-kit/issues) or [pull requests](https://github.com/vmware/versatile-data-kit/pulls)
 
-Join our [public slack workspace](https://join.slack.com/t/versatiledata-rgg2437/shared_invite/zt-tvnl62c3-qP0EUYJZJxb6Ws_eQWyDtQ) or [our mailing list](mailto:join-versatiledatakit@groups.vmware.com?subject=Invite%20me%20to%20the%20VDK%20mailing%20list) or [follow us on twitter](https://twitter.com/intent/follow?screen_name=VDKProject).
-Subscribe to [Versatile Data Kit YouTube Channel](https://www.youtube.com/channel/UCasf2Q7X8nF7S4VEmcTHJ0Q)
+Join [our mailing list](mailto:join-versatiledatakit@groups.vmware.com?subject=Invite%20me%20to%20the%20VDK%20mailing%20list) or [follow us on twitter](https://twitter.com/intent/follow?screen_name=VDKProject).
+Subscribe to the [Versatile Data Kit YouTube Channel](https://www.youtube.com/channel/UCasf2Q7X8nF7S4VEmcTHJ0Q).
+Join our dedicated Slack channel on the [CNCF Slack workspace](https://events.linuxfoundation.org/archive/2020/kubecon-cloudnativecon-europe/attend/slack-guidelines/#getting-started) - simply search for #versatile-data-kit.
 
 # Code of Conduct
 Everyone involved in working on the project's source code, or engaging in any issue trackers, Slack channels and mailing lists is expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
As our public Slack workspace is being deprecated in favour of
a channel on the CNCF workspace, the link in the project's
README must be corrected.

Signed-off-by: Gabriel Georgiev <gageorgiev@vmware.com>