### PR TITLE
versatile-data-kit: update pre-commit hook to check git messages

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,9 @@
+[general]
+contrib=contrib-body-requires-signed-off-by
+
+[title-match-regex]
+# python like regex (https://docs.python.org/3/library/re.html) that the
+# commit-msg title must be matched to.
+# Note that the regex can contradict with other rules if not used correctly
+# (e.g. title-must-not-contain-word).
+regex=(vdk-.*|versatile-data-kit|control-service|examples): .*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,81 +2,88 @@
 # SPDX-License-Identifier: Apache-2.0
 
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
     hooks:
-    -   id: check-yaml
-        args: ['--unsafe']
+      - id: check-yaml
+        args: [ '--unsafe' ]
         # exclude helm chart templates
         exclude: ^projects/control-service/projects/helm_charts
-    -   id: check-json
-    -   id: check-ast
-    -   id: check-added-large-files
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace
-    -   id: check-executables-have-shebangs
--   repo: https://github.com/psf/black
+      - id: check-json
+      - id: check-ast
+      - id: check-added-large-files
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-executables-have-shebangs
+      - id: requirements-txt-fixer
+      - id: detect-private-key
+      - id: fix-byte-order-marker
+  - repo: https://github.com/jorisroovers/gitlint
+    rev: v0.17.0
+    hooks:
+      - id: gitlint
+  - repo: https://github.com/psf/black
     rev: 22.1.0
     hooks:
-    -   id: black
+      - id: black
         language_version: python3.7
-# ensure pydoc is up-to standard
--   repo: https://github.com/pycqa/pydocstyle
+  # ensure pydoc is up-to standard
+  - repo: https://github.com/pycqa/pydocstyle
     rev: 6.1.1
     hooks:
-        -   id: pydocstyle
-            args: # http://www.pydocstyle.org/en/stable/error_codes.html --convention=pep257 seems too much?
-                - --select=D101,D103,D300
-                - --match='(?!test_).*\.py'
--   repo: https://github.com/pre-commit/mirrors-pylint
+      - id: pydocstyle
+        args: # http://www.pydocstyle.org/en/stable/error_codes.html --convention=pep257 seems too much?
+          - --select=D101,D103,D300
+          - --match='(?!test_).*\.py'
+  - repo: https://github.com/pre-commit/mirrors-pylint
     rev: 'v3.0.0a4'
     hooks:
-        -   id: pylint
-            args: [--exit-zero]
-#-   repo: https://github.com/pre-commit/mirrors-mypy
-#    rev: v0.812
-#    hooks:
-#        -   id: mypy
-#            files: ^(src/|tests/|plugins/)
--   repo: https://github.com/asottile/reorder_python_imports
+      - id: pylint
+        args: [ --exit-zero ]
+  #-   repo: https://github.com/pre-commit/mirrors-mypy
+  #    rev: v0.812
+  #    hooks:
+  #        -   id: mypy
+  #            files: ^(src/|tests/|plugins/)
+  - repo: https://github.com/asottile/reorder_python_imports
     rev: v2.7.1
     hooks:
-        -   id: reorder-python-imports
-            args: [--py37-plus, '--application-directories=.:src']
-# use latest python syntax
--   repo: https://github.com/asottile/pyupgrade
+      - id: reorder-python-imports
+        args: [ --py37-plus, '--application-directories=.:src' ]
+  # use latest python syntax
+  - repo: https://github.com/asottile/pyupgrade
     rev: v2.31.0
     hooks:
-        -   id: pyupgrade
-            args: [--py37-plus]
-# security check
-#- repo: https://github.com/PyCQA/bandit
-#  rev: '1.7.0'
-#  hooks:
-#      - id: bandit
-#        exclude: tests
-#        args: [ -s, B101 ]
-# add copyright notice
-- repo: https://github.com/Lucas-C/pre-commit-hooks
-  rev: v1.1.12
-  hooks:
-    - id: insert-license
-      files: \.java$
-      args:
-        - --license-filepath
-        - NOTICE.txt
-        - --comment-style
-        - /*| *| */
-    - id: insert-license
-      files: \.py$
-      args:
-        - --license-filepath
-        - NOTICE.txt
-    - id: insert-license
-      files: \.sh$
-      args:
-        - --license-filepath
-        - NOTICE.txt
+      - id: pyupgrade
+        args: [ --py37-plus ]
+  # security check
+  #- repo: https://github.com/PyCQA/bandit
+  #  rev: '1.7.0'
+  #  hooks:
+  #      - id: bandit
+  #        exclude: tests
+  #        args: [ -s, B101 ]
+  # add copyright notice
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.1.11
+    hooks:
+      - id: insert-license
+        files: \.java$
+        args:
+          - --license-filepath
+          - NOTICE.txt
+          - --comment-style
+          - /*| *| */
+      - id: insert-license
+        files: \.py$
+        args:
+          - --license-filepath
+          - NOTICE.txt
+      - id: insert-license
+        files: \.sh$
+        args:
+          - --license-filepath
+          - NOTICE.txt
 # License header create issues in helm chart yaml files
 # https://github.com/helm/helm/issues/4409
 #    - id: insert-license

--- a/cicd/build.sh
+++ b/cicd/build.sh
@@ -28,7 +28,7 @@ fi
 
 echo "Setup git hook scripts with pre-commit install"
 pip install -q pre-commit
-pre-commit install
+pre-commit install --hook-type commit-msg --hook-type pre-commit
 
 echo ""
 echo "You are all setup."

--- a/projects/vdk-control-cli/cicd/build.sh
+++ b/projects/vdk-control-cli/cicd/build.sh
@@ -23,7 +23,7 @@ pip install -r requirements.txt
 
 echo "Setup git hook scripts with pre-commit install"
 pip install pre-commit
-pre-commit install
+pre-commit install --hook-type commit-msg --hook-type pre-commit
 
 echo "Install the project in editable mode (develop mode)"
 pip install -e .

--- a/projects/vdk-control-cli/requirements.txt
+++ b/projects/vdk-control-cli/requirements.txt
@@ -1,19 +1,11 @@
 # install dependencies used during development:
 # Usually same (version may be different) as install_requires in setup.cfg
 click~=7.1.2
-setuptools~=47.1
-pluggy~=0.13
-tabulate
 click-spinner
 
-vdk-control-service-api==1.0.6
-requests_oauthlib
-
-# Dependencies for creating HTTP calls against the OAuth2 provider. We can potentially remove those
-# and use requests_oauthlib only, but for now it seems like there are some custom logic with the first
-# OAuth2 provider which needs to be handled that way
-urllib3>=1.26.5
-requests>=2.25
+# Dependencies license report:
+pip-licenses
+pluggy~=0.13
 
 # TESTING dependencies:
 
@@ -23,6 +15,14 @@ pytest
 # So we will run pytest-cov only in gitlab ci and it's commented out here.
 # pytest-cov
 pytest-httpserver
+requests>=2.25
+requests_oauthlib
+setuptools~=47.1
+tabulate
 
-# Dependencies license report:
-pip-licenses
+# Dependencies for creating HTTP calls against the OAuth2 provider. We can potentially remove those
+# and use requests_oauthlib only, but for now it seems like there are some custom logic with the first
+# OAuth2 provider which needs to be handled that way
+urllib3>=1.26.5
+
+vdk-control-service-api==1.0.6

--- a/projects/vdk-core/cicd/build.sh
+++ b/projects/vdk-core/cicd/build.sh
@@ -30,7 +30,7 @@ echo "install dependencies from requirements.txt (used for development and testi
 pip install --use-deprecated="legacy-resolver" --extra-index-url $PIP_EXTRA_INDEX_URL -r requirements.txt
 
 echo "Setup git hook scripts with pre-commit install"
-pre-commit install
+pre-commit install --hook-type commit-msg --hook-type pre-commit
 
 # Below line uses --use-deprecated=legacy-resolver to temporary workaround a
 # dependency backtracking issue.

--- a/projects/vdk-core/requirements.txt
+++ b/projects/vdk-core/requirements.txt
@@ -1,21 +1,21 @@
 # Python dependencies used during build and tests
 # For dependencies used during installation make sure to set them in setup.cfg (install_requires section)
 
+-e ../vdk-plugins/vdk-test-utils
+black
+mypy
+
+# Dependencies license report:
+pip-licenses
 
 # used for git hooks
 pre-commit
-black
-reorder-python-imports
-mypy
 pydocstyle
 
 # testing dependencies
 pytest
-pytest-sugar
-pytest-randomly
-smtpdfix
 pytest-cov
--e ../vdk-plugins/vdk-test-utils
-
-# Dependencies license report:
-pip-licenses
+pytest-randomly
+pytest-sugar
+reorder-python-imports
+smtpdfix

--- a/projects/vdk-heartbeat/requirements.txt
+++ b/projects/vdk-heartbeat/requirements.txt
@@ -1,14 +1,14 @@
 
 --extra-index-url https://test.pypi.org/simple/
-vdk-control-cli
-
-thrift_sasl
-impyla
 
 click
 click-log
-requests
-retrying
+impyla
 pytest
 pytest-cov
+requests
+retrying
+
+thrift_sasl
 trino
+vdk-control-cli

--- a/projects/vdk-plugins/build-plugin.sh
+++ b/projects/vdk-plugins/build-plugin.sh
@@ -9,7 +9,7 @@ echo "Building plugin $PLUGIN_NAME"
 PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL:-'https://pypi.org/simple'}
 
 pip install -U pip setuptools pre-commit
-pre-commit install
+pre-commit install --hook-type commit-msg --hook-type pre-commit
 
 pip install --extra-index-url $PIP_EXTRA_INDEX_URL -r requirements.txt
 pip install -e . --extra-index-url $PIP_EXTRA_INDEX_URL

--- a/projects/vdk-plugins/plugin-template/requirements.txt
+++ b/projects/vdk-plugins/plugin-template/requirements.txt
@@ -1,4 +1,4 @@
+pytest
 vdk-core
 
 vdk-test-utils
-pytest

--- a/projects/vdk-plugins/vdk-csv/requirements.txt
+++ b/projects/vdk-plugins/vdk-csv/requirements.txt
@@ -1,5 +1,5 @@
-vdk-core
 pandas
+vdk-core
 
 # testing
 vdk-test-utils

--- a/projects/vdk-plugins/vdk-greenplum/requirements.txt
+++ b/projects/vdk-plugins/vdk-greenplum/requirements.txt
@@ -1,9 +1,9 @@
-vdk-core
-psycopg2-binary
-tabulate
 
 # testing requirements
 click
-vdk-test-utils
-pytest-docker
 docker-compose
+psycopg2-binary
+pytest-docker
+tabulate
+vdk-core
+vdk-test-utils

--- a/projects/vdk-plugins/vdk-impala/requirements.txt
+++ b/projects/vdk-plugins/vdk-impala/requirements.txt
@@ -1,11 +1,11 @@
-vdk-core
-impyla
-tabulate
 
 # testing requirements
 click
-vdk-test-utils
-pytest-docker
 docker-compose
-pydantic
+impyla
 pyarrow
+pydantic
+pytest-docker
+tabulate
+vdk-core
+vdk-test-utils

--- a/projects/vdk-plugins/vdk-ingest-http/requirements.txt
+++ b/projects/vdk-plugins/vdk-ingest-http/requirements.txt
@@ -1,7 +1,7 @@
-requests
-vdk-core
 
 # testing dependencies
 pytest
 pytest-httpserver
+requests
+vdk-core
 vdk-test-utils

--- a/projects/vdk-plugins/vdk-kerberos-auth/requirements.txt
+++ b/projects/vdk-plugins/vdk-kerberos-auth/requirements.txt
@@ -1,9 +1,9 @@
-vdk-core
+docker-compose
 minikerberos==0.1.0
+pytest
+pytest-docker
 requests-kerberos
+vdk-core
 
 # testing requirements
 vdk-test-utils
-pytest
-pytest-docker
-docker-compose

--- a/projects/vdk-plugins/vdk-plugin-control-cli/requirements.txt
+++ b/projects/vdk-plugins/vdk-plugin-control-cli/requirements.txt
@@ -1,7 +1,7 @@
-vdk-core
-vdk-control-cli
+pytest-httpserver
 requests
+vdk-control-cli
+vdk-core
 
 # test deps
 vdk-test-utils
-pytest-httpserver

--- a/projects/vdk-plugins/vdk-postgres/requirements.txt
+++ b/projects/vdk-plugins/vdk-postgres/requirements.txt
@@ -1,9 +1,9 @@
-vdk-core
-psycopg2-binary
-tabulate
 
 # testing requirements
 click
-vdk-test-utils
-pytest-docker
 docker-compose
+psycopg2-binary
+pytest-docker
+tabulate
+vdk-core
+vdk-test-utils

--- a/projects/vdk-plugins/vdk-server/requirements.txt
+++ b/projects/vdk-plugins/vdk-server/requirements.txt
@@ -1,4 +1,3 @@
-vdk-core
 click
 click-spinner
 docker
@@ -6,3 +5,4 @@ kubernetes
 
 pytest
 pytest-cov
+vdk-core

--- a/projects/vdk-plugins/vdk-snowflake/requirements.txt
+++ b/projects/vdk-plugins/vdk-snowflake/requirements.txt
@@ -1,8 +1,8 @@
-vdk-core
 click
+pytest
+pytest-cov
 tabulate
+vdk-core
 
 # testing requirements
 vdk-test-utils
-pytest
-pytest-cov

--- a/projects/vdk-plugins/vdk-sqlite/requirements.txt
+++ b/projects/vdk-plugins/vdk-sqlite/requirements.txt
@@ -1,7 +1,7 @@
-vdk-core
 click
+pytest
+pytest-cov
+vdk-core
 
 # testing requirements
 vdk-test-utils
-pytest
-pytest-cov

--- a/projects/vdk-plugins/vdk-test-utils/requirements.txt
+++ b/projects/vdk-plugins/vdk-test-utils/requirements.txt
@@ -1,2 +1,2 @@
-vdk-core
 click
+vdk-core

--- a/projects/vdk-plugins/vdk-trino/requirements.txt
+++ b/projects/vdk-plugins/vdk-trino/requirements.txt
@@ -1,8 +1,8 @@
-vdk-core
-trino
 
 # testing requirements
 click
-vdk-test-utils
-pytest-docker
 docker-compose
+pytest-docker
+trino
+vdk-core
+vdk-test-utils


### PR DESCRIPTION
Following common standard for our commit messages makes it easier to
track changes, to automate releases notes. This arised recently when
creating release notes for
https://github.com/vmware/versatile-data-kit/releases/tag/0.2 and there
were some unformatted titles.

See all rules in https://jorisroovers.com/gitlint/rules/

Added to some of the standard hooks
(https://github.com/pre-commit/pre-commit-hooks) with new rules:
  - id: requirements-txt-fixer
  - id: detect-private-key
  - id: fix-byte-order-marker

Testing Done: this commit , also tried to commit with bad title and it failed.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>