### PR TITLE
versatile-data-kit: add scripts for AMLD workshop env setup

### DIFF
--- a/projects/control-service/projects/helm_charts/amld/README.md
+++ b/projects/control-service/projects/helm_charts/amld/README.md
@@ -1,0 +1,16 @@
+# Setup environment for AMLD workshop
+
+Here are scripts that preapre the backend enviornment to be used in AMLD workshop
+
+The entry point is the setup-env.sh script.
+It will
+- Install Pipelins Control Service
+- Install trino with mysql as backend catalog
+
+Aside from that because my binder allows connections only on port 80 or 443 (and a few more: https://github.com/jupyterhub/mybinder.org-deploy/blob/master/mybinder/values.yaml#L46)
+we use API gateway to expose those :
+
+https://us-west-1.console.aws.amazon.com/apigateway/main/develop/auth/attach?api=iaclqhm5xk&integration=qbji9io&region=us-west-1&routeKey=&routes=taal8qu&stage=$default
+
+1. Go to API Gateway -> Click Create API -> Follow instructions
+2. Then make sure to set in routes configuration . "$default" so that all paths are proxied

--- a/projects/control-service/projects/helm_charts/amld/setup-env.sh
+++ b/projects/control-service/projects/helm_charts/amld/setup-env.sh
@@ -1,0 +1,22 @@
+
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+source env.sh || echo "Provide env.sh with exported environment variables: VDK_API_TOKEN and GIT_TOKEN"
+
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm upgrade --install --wait --timeout 10m0s  vdk-mysql bitnami/mysql
+
+
+
+envsubst < values.yaml > values-secret.yaml
+
+helm repo add vdk-gitlab https://gitlab.com/api/v4/projects/28814611/packages/helm/stable
+helm upgrade --install --wait --timeout 10m0s amld-vdk vdk-gitlab/pipelines-control-service -f values-secret.yaml
+
+
+export  MYSQL_ROOT_PASSWORD=$(kubectl get secret --namespace vdk-amld vdk-mysql -o jsonpath="{.data.mysql-root-password}" | base64 --decode)
+envsubst < values-trino.yaml > values-trino-secret.yaml
+
+helm repo add valeriano-manassero https://valeriano-manassero.github.io/helm-charts
+helm upgrade --install test-trino valeriano-manassero/trino --version 1.11.0 -f  values-trino-secret.yaml

--- a/projects/control-service/projects/helm_charts/amld/values-trino.yaml
+++ b/projects/control-service/projects/helm_charts/amld/values-trino.yaml
@@ -1,0 +1,37 @@
+
+
+image:
+  repository: trinodb/trino
+
+#service:
+#  type: LoadBalancer
+
+connectors:
+  # Connectors configuration usually contains sensitive data (like passwords, usernames, ...)
+  # so data is stored in a secret
+  # For testing purposes
+  # memory.properties: |-
+  #   connector.name=memory
+  #   memory.max-data-per-node=512MB
+  mysql.properties: |-
+    connector.name=mysql
+    connection-url=jdbc:mysql://vdk-mysql.vdk-amld.svc.cluster.local:3306
+    connection-user=root
+    connection-password=${MYSQL_ROOT_PASSWORD}
+
+resources:
+  limits:
+    cpu: 2
+    memory: 4G
+  requests:
+    cpu: 500m
+    memory: 1G
+
+server:
+  workers: 1
+  config:
+    http:
+      port: 1094
+
+service:
+  type: LoadBalancer

--- a/projects/control-service/projects/helm_charts/amld/values.yaml
+++ b/projects/control-service/projects/helm_charts/amld/values.yaml
@@ -1,0 +1,44 @@
+
+resources:
+  limits:
+    memory: 2G
+
+extraEnvVars:
+  DATAJOBS_TELEMETRY_WEBHOOK_ENDPOINT: "https://vcsa.vmware.com/ph-stg/api/hyper/send?_c=taurus.v0&_i=amld-vdk"
+  LOGGING_LEVEL_COM_VMWARE_TAURUS: DEBUG
+
+vdkOptions: |
+  VDK_API_TOKEN_AUTHORIZATION_URL=https://console-stg.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize
+  VDK_CONTROL_SERVICE_REST_API_URL=http://amld-vdk-svc:8092
+  VDK_API_TOKEN=${VDK_API_TOKEN}
+  VDK_TRINO_USE_SSL=False
+  VDK_TRINO_PORT=1094
+  VDK_TRINO_HOST=a60c369ea7ece4c73b3ac15cb64a7d30-1152784645.us-west-1.elb.amazonaws.com
+
+deploymentGitUrl: "github.com/amld-vdk/data-jobs.git"
+deploymentGitUsername: "amld-vdk"
+deploymentGitPassword: "${GIT_TOKEN}"
+uploadGitReadWriteUsername: "amld-vdk"
+uploadGitReadWritePassword: "${GIT_TOKEN}"
+deploymentDockerRegistryType: generic
+deploymentDockerRegistryUsernameReadOnly: "amld-vdk"
+deploymentDockerRegistryPasswordReadOnly: "${GIT_TOKEN}"
+deploymentDockerRegistryUsername: "amld-vdk"
+deploymentDockerRegistryPassword: "${GIT_TOKEN}"
+deploymentDockerRepository: "ghcr.io/amld-vdk/data-jobs/amld-vdk"
+proxyRepositoryURL: "ghcr.io/amld-vdk/data-jobs/amld-vdk"
+
+security:
+  enabled: true
+  oauth2:
+    jwtJwkSetUri: "https://console-stg.cloud.vmware.com/csp/gateway/am/api/auth/token-public-key?format=jwks"
+    jwtIssuerUrl: https://gaz-preview.csp-vidm-prod.com
+  authorizationEnabled: true
+  authorization:
+    webhookUri: https://httpbin.org/post
+
+credentials:
+  repository: "EMPTY"
+
+service:
+  type: LoadBalancer


### PR DESCRIPTION
I will not be submitting the scripts to the main branch. They will sit in
this branch for reference purposes and sharing. So this is FYI  pull request.

The env is deployed in  Kubernetes used by CICD -
https://github.com/vmware/versatile-data-kit/wiki/Gitlab-CICD

In kubernetes namespace vdk-amld

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>