### PR TITLE
vdk-core: JobInput get_name and get_job_directory implementation

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/job_context.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/job_context.py
@@ -91,10 +91,12 @@ class JobContext:
         from vdk.internal.builtin_plugins.run.job_input import JobInput
 
         self.job_input = JobInput(
-            cast(ManagedConnectionRouter, self.connections),
-            self.core_context.state,
-            cast(PropertiesRouter, self.properties),
+            self.name,
+            self.job_directory,
+            self.core_context,
             self.job_args,
             cast(ITemplate, self.templates),
+            cast(ManagedConnectionRouter, self.connections),
             cast(IngesterRouter, self.ingester),
+            cast(PropertiesRouter, self.properties),
         )

--- a/projects/vdk-core/tests/functional/run/jobs/job-name-directory/1_step.py
+++ b/projects/vdk-core/tests/functional/run/jobs/job-name-directory/1_step.py
@@ -1,0 +1,13 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import pathlib
+
+from vdk.api.job_input import IJobInput
+
+
+def run(job_input: IJobInput):
+    dir = pathlib.Path(__file__).parent.resolve()
+    name = dir.name
+
+    assert job_input.get_name() == name
+    assert job_input.get_job_directory() == dir

--- a/projects/vdk-core/tests/functional/run/jobs/job-name-directory/1_step.py
+++ b/projects/vdk-core/tests/functional/run/jobs/job-name-directory/1_step.py
@@ -6,8 +6,8 @@ from vdk.api.job_input import IJobInput
 
 
 def run(job_input: IJobInput):
-    dir = pathlib.Path(__file__).parent.resolve()
-    name = dir.name
+    job_directory = pathlib.Path(__file__).parent.resolve()
+    name = job_directory.name
 
     assert job_input.get_name() == name
-    assert job_input.get_job_directory() == dir
+    assert job_input.get_job_directory() == job_directory

--- a/projects/vdk-core/tests/functional/run/test_run_job_name_directory.py
+++ b/projects/vdk-core/tests/functional/run/test_run_job_name_directory.py
@@ -1,0 +1,14 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from click.testing import Result
+from functional.run import util
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
+
+
+def test_run():
+    runner = CliEntryBasedTestRunner()
+
+    result: Result = runner.invoke(["run", util.job_path("job-name-directory")])
+
+    cli_assert_equal(0, result)

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/run/test_input_job_name_directory.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/run/test_input_job_name_directory.py
@@ -1,0 +1,38 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import pathlib
+from unittest.mock import MagicMock
+
+from vdk.internal.builtin_plugins.run.job_input import JobInput
+
+
+def test_job_name_propagation():
+    name = "test_name"
+    job_input = JobInput(
+        name,
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+    )
+
+    assert job_input.get_name() == name
+
+
+def test_job_directory_propagation():
+    job_directory = pathlib.Path(__file__).parent.resolve()
+    job_input = JobInput(
+        MagicMock(),
+        job_directory,
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+    )
+
+    assert job_input.get_job_directory() == job_directory

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/run/test_substitute_query_params.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/run/test_substitute_query_params.py
@@ -29,6 +29,8 @@ def test_substitute_int_arg():
         JobArguments(dict(param=1)),
         MagicMock(),
         MagicMock(),
+        MagicMock(),
+        MagicMock(),
     )
     query = "select {param}"
     result = job_input._substitute_query_params(query).strip("\n")
@@ -42,6 +44,8 @@ def test_substitute_string_arg():
         MagicMock(),
         MagicMock(),
         JobArguments(dict(param="table_name")),
+        MagicMock(),
+        MagicMock(),
         MagicMock(),
         MagicMock(),
     )
@@ -59,6 +63,8 @@ def test_substitute_bool_arg():
         JobArguments(dict(param=True)),
         MagicMock(),
         MagicMock(),
+        MagicMock(),
+        MagicMock(),
     )
     query = "select from {param}"
     result = job_input._substitute_query_params(query).strip("\n")
@@ -72,6 +78,8 @@ def test_substitute_none_arg():
         MagicMock(),
         MagicMock(),
         JobArguments(dict(param=None)),
+        MagicMock(),
+        MagicMock(),
         MagicMock(),
         MagicMock(),
     )
@@ -90,6 +98,8 @@ def test_substitute_nested_dict_arg():
         JobArguments(dict(param=nested_dict)),
         MagicMock(),
         MagicMock(),
+        MagicMock(),
+        MagicMock(),
     )
     query = "select from {param}"
     result = job_input._substitute_query_params(query).strip("\n")
@@ -104,6 +114,8 @@ def test_substitute_object_arg():
         MagicMock(),
         MagicMock(),
         JobArguments(dict(param=obj)),
+        MagicMock(),
+        MagicMock(),
         MagicMock(),
         MagicMock(),
     )
@@ -121,6 +133,8 @@ def test_substitute_empty_args():
         JobArguments(dict()),
         MagicMock(),
         MagicMock(),
+        MagicMock(),
+        MagicMock(),
     )
     query = "select from {param}"
     result = job_input._substitute_query_params(query).strip("\n")
@@ -134,6 +148,8 @@ def test_substitute_none_args():
         MagicMock(),
         MagicMock(),
         JobArguments(None),
+        MagicMock(),
+        MagicMock(),
         MagicMock(),
         MagicMock(),
     )
@@ -151,6 +167,8 @@ def test_substitute_bool_args():
         JobArguments(True),
         MagicMock(),
         MagicMock(),
+        MagicMock(),
+        MagicMock(),
     )
     query = "select from {param}"
     result = job_input._substitute_query_params(query).strip("\n")
@@ -166,6 +184,8 @@ def test_substitute_object_args():
         JobArguments(object()),
         MagicMock(),
         MagicMock(),
+        MagicMock(),
+        MagicMock(),
     )
     query = "select from {param}"
     result = job_input._substitute_query_params(query).strip("\n")
@@ -177,10 +197,12 @@ def test_substitute_params_from_args_with_props():
     job_input = JobInput(
         MagicMock(),
         MagicMock(),
-        _get_properties_in_memory(),
+        MagicMock(),
         JobArguments(dict(param=1)),
         MagicMock(),
         MagicMock(),
+        MagicMock(),
+        _get_properties_in_memory(),
     )
     job_input.set_all_properties(dict(not_used="table_name"))
     query = "select {param}"
@@ -193,10 +215,12 @@ def test_substitute_params_from_props_without_args():
     job_input = JobInput(
         MagicMock(),
         MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
         _get_properties_in_memory(),
-        MagicMock(),
-        MagicMock(),
-        MagicMock(),
     )
     job_input.set_all_properties(dict(param=1))
     query = "select {param}"
@@ -209,10 +233,12 @@ def test_substitute_params_from_props_with_args():
     job_input = JobInput(
         MagicMock(),
         MagicMock(),
-        _get_properties_in_memory(),
+        MagicMock(),
         JobArguments(dict(not_used="table_name")),
         MagicMock(),
         MagicMock(),
+        MagicMock(),
+        _get_properties_in_memory(),
     )
     job_input.set_all_properties(dict(param=1))
     query = "select {param}"
@@ -225,10 +251,12 @@ def test_substitute_params_from_props_and_args():
     job_input = JobInput(
         MagicMock(),
         MagicMock(),
-        _get_properties_in_memory(),
+        MagicMock(),
         JobArguments(dict(param_from_args="table_name")),
         MagicMock(),
         MagicMock(),
+        MagicMock(),
+        _get_properties_in_memory(),
     )
     job_input.set_all_properties(dict(param_from_props="schema_name"))
     query = "select * from {param_from_props}.{param_from_args}"


### PR DESCRIPTION
The IJobInput get_name and get_job_directory methods were not
implemented. Yet, we need to utilize those capabilities.

Extended JobInput instantiation performed by job_context.py.
Since modifying the JobInput constructor parameters, did unify with
JobContext constructor params convention (since params matching).

Testing Done: added unit tests for name and job directory propagation;
added functional test for verifying the name and directory retrieved;
adjusted test_substitute_query_params.py to extended JobInput params.

Signed-off-by: ikoleva <ikoleva@vmware.com>