### PR TITLE
vdk-snowflake: Enable support for Python 3.10

### DIFF
--- a/projects/vdk-plugins/vdk-snowflake/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-snowflake/.plugin-ci.yml
@@ -19,7 +19,7 @@ build-py39-vdk-snowflake:
   extends: .build-vdk-snowflake
   image: "python:3.9"
 
-.build-py310-vdk-snowflake: # TODO: unhide the job(remove the dot) once the snowflake connector has been updated
+build-py310-vdk-snowflake:
   extends: .build-vdk-snowflake
   image: "python:3.10"
 

--- a/projects/vdk-plugins/vdk-snowflake/setup.py
+++ b/projects/vdk-plugins/vdk-snowflake/setup.py
@@ -26,6 +26,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-        #        "Programming Language :: Python :: 3.10", - not supported yet as the connector hasn't been updated
+        "Programming Language :: Python :: 3.10",
     ],
 )


### PR DESCRIPTION
Support for Python 3.10 was disabled due to the fact that the
python-snowflake-connector had not been updated to support it.
It has been now so we can enable support for vdk-snowflake as well.

Signed-off-by: Gabriel Georgiev <gageorgiev@vmware.com>