### PR TITLE
vdk-core: refactor test to use job_path method

### DIFF
--- a/projects/vdk-core/tests/functional/run/test_run_sql_queries.py
+++ b/projects/vdk-core/tests/functional/run/test_run_sql_queries.py
@@ -2,19 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 import os
-import pathlib
 import sqlite3
 from unittest import mock
 
 from click.testing import Result
-from functional.run import util
+from functional.run.util import job_path
 from vdk.api.plugin.hook_markers import hookimpl
 from vdk.internal.builtin_plugins.connection.pep249.interfaces import PEP249Connection
 from vdk.internal.builtin_plugins.connection.recovery_cursor import RecoveryCursor
 from vdk.internal.builtin_plugins.run.job_context import JobContext
 from vdk.plugin.test_utils.util_funcs import cli_assert_equal
 from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
-from vdk.plugin.test_utils.util_funcs import get_test_job_path
 from vdk.plugin.test_utils.util_plugins import DB_TYPE_SQLITE_MEMORY
 from vdk.plugin.test_utils.util_plugins import DecoratedSqLite3MemoryDbPlugin
 from vdk.plugin.test_utils.util_plugins import SqLite3MemoryConnection
@@ -77,7 +75,7 @@ def test_run_dbapi_connection_no_such_db_type():
     result: Result = runner.invoke(
         [
             "run",
-            util.job_path("simple-create-insert"),
+            job_path("simple-create-insert"),
         ]
     )
 
@@ -93,10 +91,7 @@ def test_run_dbapi_connection():
     result: Result = runner.invoke(
         [
             "run",
-            get_test_job_path(
-                pathlib.Path(os.path.dirname(os.path.abspath(__file__))),
-                "simple-create-insert",
-            ),
+            job_path("simple-create-insert"),
         ]
     )
 
@@ -111,10 +106,7 @@ def test_run_managed_connection_and_verify_query_length():
     result: Result = runner.invoke(
         [
             "run",
-            get_test_job_path(
-                pathlib.Path(os.path.dirname(os.path.abspath(__file__))),
-                "simple-create-insert-huge",
-            ),
+            job_path("simple-create-insert-huge"),
         ]
     )
 
@@ -133,10 +125,7 @@ def test_run_managed_connection_and_check_query_comments():
     result: Result = runner.invoke(
         [
             "run",
-            get_test_job_path(
-                pathlib.Path(os.path.dirname(os.path.abspath(__file__))),
-                "simple-create-insert",
-            ),
+            job_path("simple-create-insert"),
         ]
     )
 
@@ -159,10 +148,7 @@ def test_run_managed_connection_and_query_fails():
     result: Result = runner.invoke(
         [
             "run",
-            get_test_job_path(
-                pathlib.Path(os.path.dirname(os.path.abspath(__file__))),
-                "simple-create-insert-failed",
-            ),
+            job_path("simple-create-insert-failed"),
         ]
     )
 
@@ -178,10 +164,7 @@ def test_run_managed_connection_and_query_fails_then_recovers():
     result: Result = runner.invoke(
         [
             "run",
-            get_test_job_path(
-                pathlib.Path(os.path.dirname(os.path.abspath(__file__))),
-                "simple-create-insert-failed",
-            ),
+            job_path("simple-create-insert-failed"),
         ]
     )
 
@@ -196,10 +179,7 @@ def test_run_job_with_arguments():
     result: Result = runner.invoke(
         [
             "run",
-            get_test_job_path(
-                pathlib.Path(os.path.dirname(os.path.abspath(__file__))),
-                "job-with-args",
-            ),
+            job_path("job-with-args"),
             "--arguments",
             '{"table_name": "test_table", "counter": 123}',
         ]


### PR DESCRIPTION
job_path is shorter version to get the jobs path in test in vdk-core

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>