### PR TITLE
vdk-heartbeat: Handle execution end_time not string

### DIFF
--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
@@ -379,13 +379,14 @@ class JobController:
         )
         if not execution_list:
             return None
+
         latest_end_date = max(
-            datetime.fromisoformat(e["end_time"]) for e in execution_list
+            self._datetime_from_iso_format(str(e["end_time"])) for e in execution_list
         )
         return [
             e["status"]
             for e in execution_list
-            if datetime.fromisoformat(e["end_time"]) == latest_end_date
+            if self._datetime_from_iso_format(str(e["end_time"])) == latest_end_date
         ].pop()
 
     def _update_config_ini(self, heartbeat_job_dir):
@@ -458,3 +459,16 @@ def run(job_input):
             os.path.join(heartbeat_job_dir, "06_override_properties.py"), "w"
         ) as pyfile:
             pyfile.write(python_script)
+
+    @staticmethod
+    def _datetime_from_iso_format(datetime_string: str):
+        try:
+            return datetime.fromisoformat(datetime_string)
+        except ValueError as e:
+            log.info(
+                "An exception occurred while converting datetime string "
+                f"value of -- {datetime_string} -- to "
+                f"a datetime object. The exception was {e}"
+            )
+
+        return None

--- a/projects/vdk-heartbeat/tests/vdk/internal/test_job_controller.py
+++ b/projects/vdk-heartbeat/tests/vdk/internal/test_job_controller.py
@@ -1,0 +1,43 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from unittest.mock import patch
+
+from vdk.internal.heartbeat.config import Config
+from vdk.internal.heartbeat.job_controller import JobController
+
+
+@patch.object(JobController, "_execute")
+def test_check_job_execution_finished(patched_method):
+    test_config = Config()
+    test_config.control_api_url = None
+    test_config.vdkcli_oauth2_uri = None
+
+    patched_method.return_value = (
+        '[{"status": "finished", "end_time": ' '"2022-03-01"}]'
+    )
+
+    test_controller = JobController(test_config)
+    test_controller.config.RUN_TEST_TIMEOUT_SECONDS = 10
+
+    res = test_controller.check_job_execution_finished()
+    assert res == "finished"
+
+
+@patch.object(JobController, "_execute")
+def test_check_job_execution_finished_no_exceptions_for_value_errors(patched_method):
+    test_config = Config()
+    test_config.control_api_url = None
+    test_config.vdkcli_oauth2_uri = None
+
+    patched_method.return_value = '[{"status": "finished", "end_time": "None"}]'
+
+    test_controller = JobController(test_config)
+    test_controller.config.RUN_TEST_TIMEOUT_SECONDS = 10
+
+    res = test_controller.check_job_execution_finished()
+    assert res == "finished"
+
+    patched_method.return_value = '[{"status": "finished", "end_time": ' "12345}]"
+
+    res = test_controller.check_job_execution_finished()
+    assert res == "finished"


### PR DESCRIPTION
Currently, if for some reason the `end_time` field of the execution object
is not a string (for example, the value is `None`), the `datetime.fromisoformat()`
method throws an exception and fails the heartbeat test.

This change introduces an explicit conversion of the value to string and adds
logging for what the error is along with indication that the heartbeat will fail.

Testing Done: Unit tests added.

Signed-off-by: Andon Andonov <andonova@vmware.com>