### PR TITLE
vdk-control-cli: set vdk version and enabled when deploying new job

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli.py
@@ -162,12 +162,12 @@ vdk deploy --update --job-version <job-version-here> -n example-job -t job-team
 def deploy(
     name: str,
     team: str,
-    job_version: str,
-    vdk_version: str,
+    job_version: Optional[str],
+    vdk_version: Optional[str],
     enabled: Optional[bool],
-    job_path: str,
+    job_path: Optional[str],
     operation: str,
-    reason: str,
+    reason: Optional[str],
     rest_api_url: str,
     output: str,
 ):
@@ -178,7 +178,13 @@ def deploy(
         # default to ask for job version to update
         if not vdk_version and not job_version and enabled is None:
             job_version = get_or_prompt("Job Version", job_version)
-        return cmd.update(name, team, enabled, job_version, vdk_version, output)
+        if job_path:
+            reason = get_or_prompt("Reason", reason)
+            return cmd.create(
+                name, team, job_path, reason, output, vdk_version, enabled
+            )
+        else:
+            return cmd.update(name, team, enabled, job_version, vdk_version, output)
     if operation == DeployOperation.REMOVE:
         name = get_or_prompt("Job Name", name)
         team = get_or_prompt("Job Team", team)
@@ -192,4 +198,4 @@ def deploy(
         default_name = os.path.basename(job_path)
         name = get_or_prompt("Job Name", name, default_name)
         reason = get_or_prompt("Reason", reason)
-        return cmd.create(name, team, job_path, reason, output)
+        return cmd.create(name, team, job_path, reason, output, vdk_version, enabled)

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli_impl.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli_impl.py
@@ -251,7 +251,14 @@ class JobDeploy:
 
     @ApiClientErrorDecorator()
     def create(
-        self, name: str, team: str, job_path: str, reason: str, output: str
+        self,
+        name: str,
+        team: str,
+        job_path: str,
+        reason: str,
+        output: str,
+        vdk_version: Optional[str],
+        enabled: Optional[bool],
     ) -> None:
         log.debug(
             f"Create Deployment of a job {name} of team {team} with local path {job_path} and reason {reason}"
@@ -297,6 +304,8 @@ class JobDeploy:
                 )
 
             self.__update_data_job_deploy_configuration(job_path, name, team)
-            self.update(name, team, None, data_job_version.version_sha, None, output)
+            self.update(
+                name, team, enabled, data_job_version.version_sha, vdk_version, output
+            )
         finally:
             self.__cleanup_archive(archive_path=archive_path)

--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_deploy.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_deploy.py
@@ -38,7 +38,7 @@ def test_deploy(httpserver: PluginHTTPServer, tmpdir: LocalPath):
 def test_deploy_with_vdk_version_disable(
     httpserver: PluginHTTPServer, tmpdir: LocalPath
 ):
-    job_version, deploy_args = prepare_new_deploy(httpserver)
+    _, deploy_args = prepare_new_deploy(httpserver)
 
     runner = CliRunner()
     result = runner.invoke(deploy, [*deploy_args, "-v", "version", "--disable"])

--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_deploy.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_deploy.py
@@ -22,7 +22,7 @@ DEPLOYMENT_ID = "production"
 
 
 def test_deploy(httpserver: PluginHTTPServer, tmpdir: LocalPath):
-    job_version, deploy_args = prepare_new_deploy(httpserver)
+    _, deploy_args = prepare_new_deploy(httpserver)
 
     runner = CliRunner()
     result = runner.invoke(deploy, deploy_args)

--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_deploy.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_deploy.py
@@ -3,10 +3,10 @@
 import json
 import os
 from json import JSONDecodeError
+from typing import Tuple
 
 from click.testing import CliRunner
 from py._path.local import LocalPath
-from pytest_httpserver.httpserver import QueryMatcher
 from pytest_httpserver.pytest_plugin import PluginHTTPServer
 from taurus_datajob_api import DataJob
 from taurus_datajob_api import DataJobConfig
@@ -22,98 +22,69 @@ DEPLOYMENT_ID = "production"
 
 
 def test_deploy(httpserver: PluginHTTPServer, tmpdir: LocalPath):
-    rest_api_url = httpserver.url_for("")
+    job_version, deploy_args = prepare_new_deploy(httpserver)
 
-    mock_base_requests(httpserver)
-
-    job_version = DataJobVersion(version_sha="17012900f60461778c01ab24728807e70a5f2c87")
-
-    httpserver.expect_request(
-        uri="/data-jobs/for-team/test-team/jobs/test-job/sources",
-        method="POST",
-        headers={"Content-Type": "application/octet-stream"},
-        query_string="reason=reason",
-    ).respond_with_json(job_version.to_dict())
+    runner = CliRunner()
+    result = runner.invoke(deploy, deploy_args)
+    test_utils.assert_click_status(result, 0)
 
     test_job_path = find_test_resource("test-job")
+    assert os.path.exists(f"{test_job_path}.zip") is False
 
-    open(f"{test_job_path}.zip", "w")
+    posted_data = json.loads(httpserver.log[3][0].data)
+    assert posted_data["job_version"] is not None
 
-    assert os.path.exists(f"{test_job_path}.zip") is True
+
+def test_deploy_with_vdk_version_disable(
+    httpserver: PluginHTTPServer, tmpdir: LocalPath
+):
+    job_version, deploy_args = prepare_new_deploy(httpserver)
+
+    runner = CliRunner()
+    result = runner.invoke(deploy, [*deploy_args, "-v", "version", "--disable"])
+    test_utils.assert_click_status(result, 0)
+
+    posted_data = json.loads(httpserver.log[3][0].data)
+    assert posted_data["vdk_version"] == "version"
+    assert posted_data["enabled"] == False
+    assert posted_data["job_version"] is not None
+
+
+def test_deploy_update_remove(httpserver: PluginHTTPServer, tmpdir: LocalPath):
+    job_version, deploy_args = prepare_new_deploy(httpserver)
 
     runner = CliRunner()
     result = runner.invoke(
         deploy,
         [
-            "-n",
-            "test-job",
-            "-t",
-            "test-team",
-            "-p",
-            test_job_path,
-            "-u",
-            rest_api_url,
-            "-r",
-            "reason",
-        ],
-    )
-    test_utils.assert_click_status(result, 0)
-
-    result = runner.invoke(
-        deploy,
-        [
             "--update",
-            "-n",
-            "test-job",
-            "-t",
-            "test-team",
+            *deploy_args,
             "-v",
             "version",
-            "-p",
-            test_job_path,
-            "-u",
-            rest_api_url,
-            "-r",
-            "reason",
         ],
     )
     test_utils.assert_click_status(result, 0)
-
-    assert os.path.exists(f"{test_job_path}.zip") is False
 
     result = runner.invoke(
         deploy,
         [
             "--remove",
-            "-n",
-            "test-job",
-            "-t",
-            "test-team",
+            *deploy_args,
             "-v",
             "version",
-            "-p",
-            test_job_path,
-            "-u",
-            rest_api_url,
-            "-r",
-            "reason",
         ],
     )
     test_utils.assert_click_status(result, 0)
 
+
+def test_deploy_with_output_json(httpserver: PluginHTTPServer, tmpdir: LocalPath):
+    job_version, deploy_args = prepare_new_deploy(httpserver)
+
+    runner = CliRunner()
     result = runner.invoke(
         deploy,
         [
-            "-n",
-            "test-job",
-            "-t",
-            "test-team",
-            "-p",
-            test_job_path,
-            "-u",
-            rest_api_url,
-            "-r",
-            "reason",
+            *deploy_args,
             "-o",
             "json",
         ],
@@ -477,6 +448,38 @@ def test_deploy_failed_team_validation(httpserver: PluginHTTPServer, tmpdir: Loc
     )
     test_utils.assert_click_status(result, 2)
     assert "what" in result.output and "why" in result.output
+
+
+def prepare_new_deploy(httpserver) -> Tuple[str, str]:
+    rest_api_url = httpserver.url_for("")
+    mock_base_requests(httpserver)
+    job_version = DataJobVersion(version_sha="17012900f60461778c01ab24728807e70a5f2c87")
+    httpserver.expect_request(
+        uri="/data-jobs/for-team/test-team/jobs/test-job/sources",
+        method="POST",
+        headers={"Content-Type": "application/octet-stream"},
+        query_string="reason=reason",
+    ).respond_with_json(job_version.to_dict())
+    test_job_path = find_test_resource("test-job")
+
+    open(f"{test_job_path}.zip", "w")
+
+    assert os.path.exists(f"{test_job_path}.zip") is True
+
+    deploy_args = [
+        "-n",
+        "test-job",
+        "-t",
+        "test-team",
+        "-p",
+        test_job_path,
+        "-u",
+        rest_api_url,
+        "-r",
+        "reason",
+    ]
+
+    return job_version, deploy_args
 
 
 def mock_base_requests(httpserver):


### PR DESCRIPTION
Currently we cannot create new deployment and at the same time enable it
or set other vdk version in a single operation. This means we have to do
it in two different cli calls which may create race condition (where job
deployment starts with previous configuration before new is applied)

In this change we enable passing --vdk-version and --enabled when
creating deployment
with vdk deploy --create e.g
```
vdk deploy --create --vdk-version 1.2 --disabled
```
would create a new deplloyment which uses vdk version 1.2 and is
disabled.

Testing Done: automated tests included

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>