### PR TITLE
vdk-trino: fix ingesting value with bool type failing

### DIFF
--- a/projects/vdk-plugins/vdk-trino/src/vdk/plugin/trino/ingest_to_trino.py
+++ b/projects/vdk-plugins/vdk-trino/src/vdk/plugin/trino/ingest_to_trino.py
@@ -90,7 +90,9 @@ class IngestToTrino(IIngesterPlugin):
             )
 
     @staticmethod
-    def __to_bool(value: str) -> bool:
+    def __to_bool(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
         if value == "true" or value == "True":
             return True
         if value == "false" or value == "False":

--- a/projects/vdk-plugins/vdk-trino/tests/jobs/test_ingest_to_trino_job/10_ingest_to_trino.py
+++ b/projects/vdk-plugins/vdk-trino/tests/jobs/test_ingest_to_trino_job/10_ingest_to_trino.py
@@ -18,6 +18,18 @@ def run(job_input):
             payload=payload, destination_table="test_table"
         )
 
+    payload_with_types = {
+        "str_data": "string",
+        "int_data": 12,
+        "float_data": 1.2,
+        "bool_data": True,
+        "decimal_data": 3.2,
+    }
+
+    job_input.send_object_for_ingestion(
+        payload=payload_with_types, destination_table="test_table"
+    )
+
     # this setup:
     # a) partial payload (only few columns are included)
     # b) includes float data which is NaN

--- a/projects/vdk-plugins/vdk-trino/tests/test_ingest_to_trino.py
+++ b/projects/vdk-plugins/vdk-trino/tests/test_ingest_to_trino.py
@@ -75,6 +75,7 @@ class IngestToTrinoTests(TestCase):
             "string  12  1.2  True  3.2\n"
             "string  12  1.2  True  3.2\n"
             "string  12  1.2  True  3.2\n"
+            "string  12  1.2  True  3.2\n"
             "\n"
             "------  --  ---  ----  ---\n"
         )


### PR DESCRIPTION
vdk-trino ingestion was failing if `send_object_for_ingestion` is passed
value with type bool (as it was trying to cast it as if it's stirng.
Error was

"We could not convert the value to that type. Error is bool cast accept
only True/true/False/false values."

Testing Done: unit tests covered the new case

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>