### PR TITLE
vdk-trino: collect lineage for select/insert and rename table only

### DIFF
--- a/projects/vdk-plugins/vdk-trino/src/vdk/plugin/trino/lineage_utils.py
+++ b/projects/vdk-plugins/vdk-trino/src/vdk/plugin/trino/lineage_utils.py
@@ -1,0 +1,36 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+
+def parse_rename_table_names(query: str) -> tuple:
+    """
+    This method parses the sql query. If and only if it is a rename table query,
+    the method returns the names of the source and destination table.
+    :param query: The SQL query potentially containing a RENAME TABLE operation
+    :return: A tuple with (table_from, table_to) if it is a RENAME TABLE query, None otherwise.
+    """
+    import sqlparse
+    from sqlparse.tokens import Whitespace
+    from sqlparse.sql import Identifier
+
+    formatted_query = sqlparse.format(query, reindent=True, keyword_case="upper")
+    statement = sqlparse.parse(formatted_query)[0]
+    tokens = statement.tokens
+    if (
+        tokens[0].value == "ALTER"
+        and tokens[1].ttype == Whitespace
+        and tokens[2].value == "TABLE"
+        and tokens[3].ttype == Whitespace
+        and isinstance(tokens[4], Identifier)  # table_from
+        and tokens[5].ttype == Whitespace
+        and tokens[6].value == "RENAME"
+        and tokens[7].ttype == Whitespace
+        and tokens[8].value == "TO"
+        and tokens[9].ttype == Whitespace
+        and isinstance(tokens[10], Identifier)  # table_to
+    ):
+        table_from = tokens[4].value
+        table_to = tokens[10].value
+        return table_from, table_to
+    else:
+        return None

--- a/projects/vdk-plugins/vdk-trino/src/vdk/plugin/trino/trino_connection.py
+++ b/projects/vdk-plugins/vdk-trino/src/vdk/plugin/trino/trino_connection.py
@@ -85,18 +85,16 @@ class TrinoConnection(ManagedConnectionBase):
 
     def execute_query(self, query):
         query_id = str(time.time())
-        lineage_data = self._get_lineage_data(query, query_id)
         try:
             res = self.execute_query_with_retries(query)
-            self._send_query_telemetry(query, query_id)
-            self.add_num_rows_after_query(lineage_data, res)
+            if self._lineage_logger:
+                lineage_data = self._get_lineage_data(query, query_id)
+                if lineage_data:
+                    self._lineage_logger.send(lineage_data)
             return res
         except Exception as e:
             self._send_query_telemetry(query, query_id, e)
             raise
-        finally:
-            if self._lineage_logger and lineage_data:
-                self._lineage_logger.send(lineage_data)
 
     @retry(
         stop=stop_after_attempt(5),
@@ -109,61 +107,46 @@ class TrinoConnection(ManagedConnectionBase):
         res = super().execute_query(query)
         return res
 
-    def add_num_rows_after_query(self, lineage_data, res):
-        if lineage_data:
-            lineage_data["output_num_rows_after"] = self._get_output_table_num_rows(
-                lineage_data
-            )
-            if "outputTable" in lineage_data:
-                if res and res[0] and res[0][0]:
-                    lineage_data["output_num_rows_updated"] = res[0][0]
-
     def _get_lineage_data(self, query, query_id):
-        if self._lineage_logger:
+
+        from vdk.plugin.trino import lineage_utils
+        import sqlparse
+
+        statement = sqlparse.parse(query)[0]
+
+        if statement.get_type() == "ALTER":
+            rename_table_names = lineage_utils.parse_rename_table_names(query)
+            if rename_table_names:
+                return {
+                    "@id": query_id,
+                    "@type": "rename_table",
+                    "table_from": rename_table_names[0],
+                    "table_to": rename_table_names[1],
+                    "query": query,
+                    "status": "OK",
+                }
+
+        elif statement.get_type() == "SELECT" or statement.get_type() == "INSERT":
             try:
-                with closing_noexcept_on_close(self.__cursor()) as cur:
+                with closing_noexcept_on_close(self._cursor()) as cur:
                     cur.execute(f"EXPLAIN (TYPE IO, FORMAT JSON) {query}")
                     result = cur.fetchall()
                     if result:
                         import json
 
                         data = json.loads(result[0][0])
-                        data["@type"] = "taurus_query_io"
+                        data["@type"] = "insert_select"
                         data["query"] = query
                         data["@id"] = query_id
-                        data[
-                            "output_num_rows_before"
-                        ] = self._get_output_table_num_rows(data)
+                        data["status"] = "OK"
                         return data
             except Exception as e:
                 log.info(
                     f"Failed to get query io details for telemetry: {e}. Will continue with query execution"
                 )
                 return None
-
-    def _get_output_table_num_rows(self, data):
-        if data and "outputTable" in data:
-            try:
-                outputTable = data["outputTable"]
-                catalog = outputTable["catalog"]
-                schema = outputTable["schemaTable"]["schema"]
-                table = outputTable["schemaTable"]["table"]
-                # TODO: escape potential reserved names
-                with closing_noexcept_on_close(self.__cursor()) as cur:
-                    cur.execute(  # nosec
-                        f"select count(1) from {catalog}.{schema}.{table}"
-                    )
-                    res = cur.fetchall()
-                    if res:
-                        return res[0][0]
-                    else:
-                        return None
-            except Exception as e:
-                log.info(
-                    f"Failed to get output table details: {e}. Will continue with query processing as normal"
-                )
-                return None
-        return None
+        else:
+            return None
 
     def _send_query_telemetry(self, query, query_id, exception=None):
         if self._lineage_logger:

--- a/projects/vdk-plugins/vdk-trino/tests/test_vdk_trino_lineage.py
+++ b/projects/vdk-plugins/vdk-trino/tests/test_vdk_trino_lineage.py
@@ -7,6 +7,7 @@ from unittest import mock
 import pytest
 from click.testing import Result
 from vdk.api.plugin.hook_markers import hookimpl
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
 from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
 from vdk.plugin.trino import trino_plugin
 from vdk.plugin.trino.lineage import LineageLogger
@@ -15,6 +16,9 @@ from vdk.plugin.trino.trino_plugin import LINEAGE_LOGGER_KEY
 VDK_DB_DEFAULT_TYPE = "VDK_DB_DEFAULT_TYPE"
 VDK_TRINO_PORT = "VDK_TRINO_PORT"
 VDK_TRINO_USE_SSL = "VDK_TRINO_USE_SSL"
+
+TEST_TABLE_1 = "test_table_1"
+TEST_TABLE_2 = "test_table_2"
 
 
 @pytest.mark.usefixtures("trino_service")
@@ -27,26 +31,133 @@ VDK_TRINO_USE_SSL = "VDK_TRINO_USE_SSL"
     },
 )
 def test_lineage():
-    mock_lineage = mock.MagicMock(LineageLogger)
+
+    mock_lineage_logger = mock.MagicMock(LineageLogger)
 
     class TestConfigPlugin:
         @hookimpl
         def vdk_initialize(self, context):
-            context.state.set(LINEAGE_LOGGER_KEY, mock_lineage)
+            context.state.set(LINEAGE_LOGGER_KEY, mock_lineage_logger)
 
     runner = CliEntryBasedTestRunner(TestConfigPlugin(), trino_plugin)
 
-    result: Result = runner.invoke(["trino-query", "--query", "SELECT 1"])
+    result: Result = runner.invoke(
+        ["trino-query", "--query", f"create table {TEST_TABLE_1} (test_column varchar)"]
+    )
+    cli_assert_equal(0, result)
+    result: Result = runner.invoke(
+        ["trino-query", "--query", f"create table {TEST_TABLE_2} (test_column varchar)"]
+    )
+    cli_assert_equal(0, result)
 
-    class LineageDataMatch:  # the lineage data is different on every run of the test,
-        # so we need this class to generalize the dict which is to be matched
+    #   Test insert query
+    #   -----------------
+
+    insert_query = f"insert into {TEST_TABLE_1} values('test value')"
+    result: Result = runner.invoke(["trino-query", "--query", insert_query])
+    cli_assert_equal(0, result)
+
+    # the lineage data is different on every run of the test,
+    # so we need this class to generalize the dict which is to be matched
+    class InsertLineageDataMatch:
         def __eq__(self, lineage_data):
+            import json
+
+            print(json.dumps(lineage_data, indent=4))
             return (
-                lineage_data.keys() == {"@type", "query", "@id", "status"}
-                and lineage_data["@type"] == "taurus_query"
+                lineage_data.keys()
+                >= {"@type", "query", "@id", "status", "outputTable"}
+                and lineage_data["@type"] == "insert_select"
                 and lineage_data["status"] == "OK"
-                and lineage_data["query"] == "SELECT 1"
+                and lineage_data["query"] == insert_query
                 and re.fullmatch(r"[0-9]{10}\.[0-9]+", lineage_data["@id"])
+                and lineage_data["outputTable"]["schemaTable"]["table"] == TEST_TABLE_1
             )
 
-    mock_lineage.send.assert_called_with(LineageDataMatch())
+    mock_lineage_logger.send.assert_called_with(InsertLineageDataMatch())
+
+    #   Test select query
+    #   -----------------
+
+    select_query = f"select * from {TEST_TABLE_1}"
+    result: Result = runner.invoke(["trino-query", "--query", select_query])
+    cli_assert_equal(0, result)
+
+    # the lineage data is different on every run of the test,
+    # so we need this class to generalize the dict which is to be matched
+    class SelectLineageDataMatch:
+        def __eq__(self, lineage_data):
+            import json
+
+            print(json.dumps(lineage_data, indent=4))
+            return (
+                lineage_data.keys()
+                >= {"@type", "query", "@id", "status", "inputTableColumnInfos"}
+                and lineage_data["@type"] == "insert_select"
+                and lineage_data["status"] == "OK"
+                and lineage_data["query"] == select_query
+                and re.fullmatch(r"[0-9]{10}\.[0-9]+", lineage_data["@id"])
+                and lineage_data["inputTableColumnInfos"][0]["table"]["schemaTable"][
+                    "table"
+                ]
+                == TEST_TABLE_1
+            )
+
+    mock_lineage_logger.send.assert_called_with(SelectLineageDataMatch())
+
+    #   Test insert_select query
+    #   -----------------
+
+    select_query = f"insert into {TEST_TABLE_2} select * from {TEST_TABLE_1}"
+    result: Result = runner.invoke(["trino-query", "--query", select_query])
+    cli_assert_equal(0, result)
+
+    # the lineage data is different on every run of the test,
+    # so we need this class to generalize the dict which is to be matched
+    class InsertSelectLineageDataMatch:
+        def __eq__(self, lineage_data):
+            import json
+
+            print(json.dumps(lineage_data, indent=4))
+            return (
+                lineage_data.keys()
+                >= {"@type", "query", "@id", "status", "inputTableColumnInfos"}
+                and lineage_data["@type"] == "insert_select"
+                and lineage_data["status"] == "OK"
+                and lineage_data["query"] == select_query
+                and re.fullmatch(r"[0-9]{10}\.[0-9]+", lineage_data["@id"])
+                and lineage_data["inputTableColumnInfos"][0]["table"]["schemaTable"][
+                    "table"
+                ]
+                == TEST_TABLE_1
+                and lineage_data["outputTable"]["schemaTable"]["table"] == TEST_TABLE_2
+            )
+
+    mock_lineage_logger.send.assert_called_with(InsertSelectLineageDataMatch())
+
+    #   Test rename table query
+    #   -----------------------
+
+    rename_query = f"alter table {TEST_TABLE_1} rename to {TEST_TABLE_1}_renamed"
+    result: Result = runner.invoke(["trino-query", "--query", rename_query])
+    cli_assert_equal(0, result)
+
+    # the lineage data is different on every run of the test,
+    # so we need this class to generalize the dict which is to be matched
+    class RenameTableLineageDataMatch:
+        def __eq__(self, lineage_data):
+            import json
+
+            print(json.dumps(lineage_data, indent=4))
+            return (
+                lineage_data.keys()
+                >= {"@type", "query", "@id", "status", "table_from", "table_to"}
+                and lineage_data["@type"] == "rename_table"
+                and lineage_data["status"] == "OK"
+                and lineage_data["query"] == rename_query
+                and re.fullmatch(r"[0-9]{10}\.[0-9]+", lineage_data["@id"])
+                and lineage_data["table_from"] == TEST_TABLE_1
+                and lineage_data["table_to"] == f"{TEST_TABLE_1}_renamed"
+            )
+
+    mock_lineage_logger.send.assert_called_with(RenameTableLineageDataMatch())


### PR DESCRIPTION
Why:
To make lineage collecting more production ready,
some improvements are needed.

What:
In order to reduce the load on the query engine,
   only plans for insert/select queries are calculated.
For rename table queries, the plan doesn't give information.
   The query is parsed and table names extracted.
Counting the number of rows in the output table before and after
   is removed to reduce the burden on the query engine.

How has this been tested:
Tweaked the test_vdk_trino_lineage.py test
  to be more comprehensive and cover all scenarios.

What type of change are you making?
Bug fix (non-breaking change which fixes an issue)
  or a cosmetic change/minor improvement

Signed-off-by: Philip Alexiev (palexiev@vmware.com)