### PR TITLE
versatile-data-kit: set automatic java formatter

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,15 @@
+name: Google Java Format
+
+on:
+  push:
+    branches: [ "**" ]
+
+jobs:
+
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2 # v2 minimum required
+      - uses: axel-op/googlejavaformat-action@v3
+        with:
+          args: "--skip-sorting-imports --replace"

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/SpringAppPropNames.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/SpringAppPropNames.java
@@ -5,18 +5,21 @@
 
 package com.vmware.taurus;
 
-
 /**
- * Spring properties that can be overridden as per  https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config
+ * Spring properties that can be overridden as per
+ * https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config
  */
 public class SpringAppPropNames {
-    //Sorted alphabetically
+  // Sorted alphabetically
 
-    //https://github.com/spring-projects/spring-boot/blob/2.2.x/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/http/Include.java
-    public static final String HTTPTRACE_INCLUDE = "management.trace.include";
-    public static final String HTTPTRACES_TO_KEEP = "taurus.diag.httptrace.max-traces-in-memory";
-    public static final String MANAGEMENT_ENDPOINTS_WEB_BASE_PATH = "management.endpoints.web.base-path";
-    public static final String MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE = "management.endpoints.web.exposure.include";
-    public static final String MANAGEMENT_ENDPOINT_HEALTH_SHOW_DETAILS = "management.endpoint.health.show-details";
-    public static final String SVC_NAME = "taurus.svc.name";
+  // https://github.com/spring-projects/spring-boot/blob/2.2.x/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/trace/http/Include.java
+  public static final String HTTPTRACE_INCLUDE = "management.trace.include";
+  public static final String HTTPTRACES_TO_KEEP = "taurus.diag.httptrace.max-traces-in-memory";
+  public static final String MANAGEMENT_ENDPOINTS_WEB_BASE_PATH =
+      "management.endpoints.web.base-path";
+  public static final String MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE =
+      "management.endpoints.web.exposure.include";
+  public static final String MANAGEMENT_ENDPOINT_HEALTH_SHOW_DETAILS =
+      "management.endpoint.health.show-details";
+  public static final String SVC_NAME = "taurus.svc.name";
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/base/EnableComponents.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/base/EnableComponents.java
@@ -5,15 +5,12 @@
 
 package com.vmware.taurus.base;
 
-/**
- * This class holds list of properties that can used to switch on/off corresponding beans.
- */
+/** This class holds list of properties that can used to switch on/off corresponding beans. */
 public class EnableComponents {
 
-    // Common package
-    public static final String DIAGNOSTICS = "enable.diagnostic.components";
+  // Common package
+  public static final String DIAGNOSTICS = "enable.diagnostic.components";
 
-    // Server Package
-    public static final String DIAGNOSTICS_INTERCEPTOR = "enable.diagnostics.interceptor.components";
-
+  // Server Package
+  public static final String DIAGNOSTICS_INTERCEPTOR = "enable.diagnostics.interceptor.components";
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/base/FeatureFlags.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/base/FeatureFlags.java
@@ -10,27 +10,25 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Controls if a feature is enabled/disabled.
- * To toggle feature specify featureflag.featureName.enabled .
+ * Controls if a feature is enabled/disabled. To toggle feature specify
+ * featureflag.featureName.enabled .
  *
- * TODO: https://github.com/Unleash/unleash looks powerful
- * and potentially useful for operations team to use to do gradual roll-out of features, canary testing, A/B testing.
+ * <p>TODO: https://github.com/Unleash/unleash looks powerful and potentially useful for operations
+ * team to use to do gradual roll-out of features, canary testing, A/B testing.
  */
 @Configuration
 @Getter
 public class FeatureFlags {
 
-   @Value("${featureflag.security.enabled:false}")
-   private boolean securityEnabled = true;
+  @Value("${featureflag.security.enabled:false}")
+  private boolean securityEnabled = true;
 
-   @Value("${featureflag.authorization.enabled:false}")
-   boolean authorizationEnabled = false;
+  @Value("${featureflag.authorization.enabled:false}")
+  boolean authorizationEnabled = false;
 
+  @Value("${datajobs.security.kerberos.enabled:false}")
+  boolean krbAuthEnabled = false;
 
-   @Value("${datajobs.security.kerberos.enabled:false}")
-   boolean krbAuthEnabled = false;
-
-   @Value("${datajobs.security.oauth2.enabled:false}")
-   boolean oAuth2Enabled = true;
-
+  @Value("${datajobs.security.oauth2.enabled:false}")
+  boolean oAuth2Enabled = true;
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/base/SCCPProperties.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/base/SCCPProperties.java
@@ -9,19 +9,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
-
 @Component
 public class SCCPProperties {
-    private @Autowired
-    Environment environment;
+  private @Autowired Environment environment;
 
-    /*
-     * @see SpringAppPropNames
-     */
-    public String getSpringProperty(String name) {
-        return environment.resolvePlaceholders("${" + name + "}");
-    }
-    public String resolve(String expression) {
-        return environment.resolvePlaceholders(expression);
-    }
+  /*
+   * @see SpringAppPropNames
+   */
+  public String getSpringProperty(String name) {
+    return environment.resolvePlaceholders("${" + name + "}");
+  }
+
+  public String resolve(String expression) {
+    return environment.resolvePlaceholders(expression);
+  }
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/exception/ApiConstraintError.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/exception/ApiConstraintError.java
@@ -7,35 +7,37 @@ package com.vmware.taurus.exception;
 
 import org.springframework.http.HttpStatus;
 
-/**
- * Exception thrown when parameter validation fails
- */
+/** Exception thrown when parameter validation fails */
 public class ApiConstraintError extends DomainError implements UserFacingError {
 
-   /**
-    * Describes a new error of this type
-    *
-    * @param paramName the parameter name that failed validation; must match the name in the API definition
-    * @param paramConstraint human-readable description of required value
-    * @param actualValue actual value, can be null
-    */
-   public ApiConstraintError(String paramName, String paramConstraint, Object actualValue) {
-      this(paramName,
-              paramConstraint,
-              actualValue,
-              String.format("Provide value that is %s.", paramConstraint));
-   }
+  /**
+   * Describes a new error of this type
+   *
+   * @param paramName the parameter name that failed validation; must match the name in the API
+   *     definition
+   * @param paramConstraint human-readable description of required value
+   * @param actualValue actual value, can be null
+   */
+  public ApiConstraintError(String paramName, String paramConstraint, Object actualValue) {
+    this(
+        paramName,
+        paramConstraint,
+        actualValue,
+        String.format("Provide value that is %s.", paramConstraint));
+  }
 
-   public ApiConstraintError(String paramName, String paramConstraint, Object actualValue, String countermeasures) {
-      super(String.format("Parameter %s is not valid.", paramName),
-              String.format("It must be %s, but was %s.", paramConstraint, actualValue),
-              "API call fails with 400 BAD REQUEST.",
-              countermeasures,
-              null);
-   }
+  public ApiConstraintError(
+      String paramName, String paramConstraint, Object actualValue, String countermeasures) {
+    super(
+        String.format("Parameter %s is not valid.", paramName),
+        String.format("It must be %s, but was %s.", paramConstraint, actualValue),
+        "API call fails with 400 BAD REQUEST.",
+        countermeasures,
+        null);
+  }
 
-   @Override
-   public HttpStatus getHttpStatus() {
-      return HttpStatus.BAD_REQUEST;
-   }
+  @Override
+  public HttpStatus getHttpStatus() {
+    return HttpStatus.BAD_REQUEST;
+  }
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/exception/Bug.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/exception/Bug.java
@@ -7,25 +7,27 @@ package com.vmware.taurus.exception;
 
 import org.springframework.http.HttpStatus;
 
-/**
- * Exception used in cases which are not expected to happen - would mean there is a bug.
- */
+/** Exception used in cases which are not expected to happen - would mean there is a bug. */
 public class Bug extends SystemError implements UserFacingError {
-    public Bug(String why, Throwable cause) {
-        super("A coding error (bug) was found.", why,
-                "This call with the current OpId will most likely fail.",
-                "Inspect stack trace and either fix the problem or open a GitHub issue for it.",
-                cause);
-    }
+  public Bug(String why, Throwable cause) {
+    super(
+        "A coding error (bug) was found.",
+        why,
+        "This call with the current OpId will most likely fail.",
+        "Inspect stack trace and either fix the problem or open a GitHub issue for it.",
+        cause);
+  }
 
-    public static ErrorMessage errorMessage(String why, Throwable cause) {
-        return new ErrorMessage("A coding error (bug) was found.", why,
-                "This call with the current OpId will most likely fail.",
-                "Inspect stack trace and either fix the problem or open a GitHub issue for it.");
-    }
+  public static ErrorMessage errorMessage(String why, Throwable cause) {
+    return new ErrorMessage(
+        "A coding error (bug) was found.",
+        why,
+        "This call with the current OpId will most likely fail.",
+        "Inspect stack trace and either fix the problem or open a GitHub issue for it.");
+  }
 
-    @Override
-    public HttpStatus getHttpStatus() {
-        return HttpStatus.INTERNAL_SERVER_ERROR;
-    }
+  @Override
+  public HttpStatus getHttpStatus() {
+    return HttpStatus.INTERNAL_SERVER_ERROR;
+  }
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/exception/DomainError.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/exception/DomainError.java
@@ -5,20 +5,19 @@
 
 package com.vmware.taurus.exception;
 
-/**
- * For user-facing exceptions ({@link UserFacingError}) the HTTP status is likely to be 4xx
- */
+/** For user-facing exceptions ({@link UserFacingError}) the HTTP status is likely to be 4xx */
 public class DomainError extends TaurusExceptionBase {
-    DomainError(String what, String why, String consequences, String countermeasures, Throwable cause) {
-        super(what, why, consequences, countermeasures, null);
-        validate();
-    }
+  DomainError(
+      String what, String why, String consequences, String countermeasures, Throwable cause) {
+    super(what, why, consequences, countermeasures, null);
+    validate();
+  }
 
-    private void validate() {
-        if (this instanceof UserFacingError) {
-            if (!((UserFacingError) this).getHttpStatus().is4xxClientError()) {
-                throw new Bug("User-facing DomainErrors must be associated with a 4xx status code", this);
-            }
-        }
+  private void validate() {
+    if (this instanceof UserFacingError) {
+      if (!((UserFacingError) this).getHttpStatus().is4xxClientError()) {
+        throw new Bug("User-facing DomainErrors must be associated with a 4xx status code", this);
+      }
     }
+  }
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/exception/ErrorMessage.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/exception/ErrorMessage.java
@@ -9,40 +9,44 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonPropertyOrder({"what", "why", "consequences", "countermeasures"})
 public class ErrorMessage {
-    private final String what; //Context
-    private final String why; //Problem
-    private final String countermeasures; //By user
-    private final String consequences; //For user
+  private final String what; // Context
+  private final String why; // Problem
+  private final String countermeasures; // By user
+  private final String consequences; // For user
 
-    public ErrorMessage(String what, String why, String consequences, String countermeasures) {
-        this.why = why;
-        this.countermeasures = countermeasures;
-        this.what = what;
-        this.consequences = consequences;
-    }
+  public ErrorMessage(String what, String why, String consequences, String countermeasures) {
+    this.why = why;
+    this.countermeasures = countermeasures;
+    this.what = what;
+    this.consequences = consequences;
+  }
 
-    public String getWhy() {
-        return why;
-    }
+  public String getWhy() {
+    return why;
+  }
 
-    public String getCountermeasures() {
-        return countermeasures;
-    }
+  public String getCountermeasures() {
+    return countermeasures;
+  }
 
-    public String getWhat() {
-        return what;
-    }
+  public String getWhat() {
+    return what;
+  }
 
-    public String getConsequences() {
-        return consequences;
-    }
+  public String getConsequences() {
+    return consequences;
+  }
 
-    @Override
-    public String toString() {
-        return "An issue occurred:" +
-                "\n\tcontext=" + what +
-                ",\n\tproblem=" + why +
-                ",\n\tconsequences=" + consequences +
-                ",\n\tcountermeasures=" + countermeasures;
-    }
+  @Override
+  public String toString() {
+    return "An issue occurred:"
+        + "\n\tcontext="
+        + what
+        + ",\n\tproblem="
+        + why
+        + ",\n\tconsequences="
+        + consequences
+        + ",\n\tcountermeasures="
+        + countermeasures;
+  }
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/exception/ExceptionControllerAdvice.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/exception/ExceptionControllerAdvice.java
@@ -5,7 +5,6 @@
 
 package com.vmware.taurus.exception;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -15,34 +14,34 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * Adds exception handling to Taurus REST controllers
- */
+/** Adds exception handling to Taurus REST controllers */
 @ControllerAdvice(annotations = RestController.class)
 public class ExceptionControllerAdvice {
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+  private final Logger log = LoggerFactory.getLogger(this.getClass());
 
-    @ExceptionHandler(TaurusExceptionBase.class)
-    public ResponseEntity<ErrorMessage> handleException(TaurusExceptionBase e) {
-        HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
-        if (e instanceof UserFacingError) {
-            httpStatus = ((UserFacingError) e).getHttpStatus();
-        }
-        log.error("REST call finished with error: " + e.getMessage(), e);
-
-        return new ResponseEntity<>(e.getErrorMessage(), httpStatus);
+  @ExceptionHandler(TaurusExceptionBase.class)
+  public ResponseEntity<ErrorMessage> handleException(TaurusExceptionBase e) {
+    HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+    if (e instanceof UserFacingError) {
+      httpStatus = ((UserFacingError) e).getHttpStatus();
     }
+    log.error("REST call finished with error: " + e.getMessage(), e);
 
-    @ExceptionHandler
-    public ResponseEntity<ErrorMessage> handleException(Exception e) {
-        if (e instanceof HttpMessageNotReadableException) {
-            return new ResponseEntity<>(new ErrorMessage("An issue with the JSON body of the request was found",
-                    e.getMessage(),
-                    "The API call will fail with 400 BAD REQUEST.",
-                    "Inspect your input and fix the problem."), HttpStatus.BAD_REQUEST);
-        }
-        //Yes, this is a bug. Only TaurusExceptionBase errors should go through the wire.
-        return handleException(new Bug(e.getMessage(), e));
+    return new ResponseEntity<>(e.getErrorMessage(), httpStatus);
+  }
+
+  @ExceptionHandler
+  public ResponseEntity<ErrorMessage> handleException(Exception e) {
+    if (e instanceof HttpMessageNotReadableException) {
+      return new ResponseEntity<>(
+          new ErrorMessage(
+              "An issue with the JSON body of the request was found",
+              e.getMessage(),
+              "The API call will fail with 400 BAD REQUEST.",
+              "Inspect your input and fix the problem."),
+          HttpStatus.BAD_REQUEST);
     }
-
+    // Yes, this is a bug. Only TaurusExceptionBase errors should go through the wire.
+    return handleException(new Bug(e.getMessage(), e));
+  }
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/exception/SystemError.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/exception/SystemError.java
@@ -5,21 +5,20 @@
 
 package com.vmware.taurus.exception;
 
-/**
- * For user-facing exceptions ({@link UserFacingError}) the HTTP status is likely to be 5xx
- */
+/** For user-facing exceptions ({@link UserFacingError}) the HTTP status is likely to be 5xx */
 public abstract class SystemError extends TaurusExceptionBase {
 
-    protected SystemError(String what, String why, String consequences, String countermeasures, Throwable cause) {
-        super(what, why, consequences, countermeasures, cause);
-        validate();
-    }
+  protected SystemError(
+      String what, String why, String consequences, String countermeasures, Throwable cause) {
+    super(what, why, consequences, countermeasures, cause);
+    validate();
+  }
 
-    private void validate() {
-        if (this instanceof UserFacingError) {
-            if (!((UserFacingError) this).getHttpStatus().is5xxServerError()) {
-                throw new Bug("User-facing SystemErrors must be associated with a 5xx status code", this);
-            }
-        }
+  private void validate() {
+    if (this instanceof UserFacingError) {
+      if (!((UserFacingError) this).getHttpStatus().is5xxServerError()) {
+        throw new Bug("User-facing SystemErrors must be associated with a 5xx status code", this);
+      }
     }
+  }
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/exception/TaurusExceptionBase.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/exception/TaurusExceptionBase.java
@@ -25,7 +25,7 @@ public abstract class TaurusExceptionBase extends RuntimeException {
     super(
         msg.toString(),
         cause); // do not guard against NullPointerException. We want to always fail if msg is not
-                // filled in
+    // filled in
     this.errorMessage = msg;
     if (!validateMessage()) {
       throw new Bug("An error without complete description was defined or thrown.", this);

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/exception/TaurusExceptionBase.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/exception/TaurusExceptionBase.java
@@ -9,50 +9,54 @@ import org.apache.commons.lang3.StringUtils;
 
 /**
  * A class that makes it easier to follow error handling standards.
+ *
  * @see SystemError
  * @see DomainError
  */
 public abstract class TaurusExceptionBase extends RuntimeException {
 
-    private final ErrorMessage errorMessage;
+  private final ErrorMessage errorMessage;
 
-    /**
-     * @param msg
-     * @param cause can be null
-     */
-    TaurusExceptionBase(ErrorMessage msg, Throwable cause) {
-        super(msg.toString(), cause);//do not guard against NullPointerException. We want to always fail if msg is not filled in
-        this.errorMessage = msg;
-        if (!validateMessage()) {
-            throw new Bug("An error without complete description was defined or thrown.", this);
-        }
+  /**
+   * @param msg
+   * @param cause can be null
+   */
+  TaurusExceptionBase(ErrorMessage msg, Throwable cause) {
+    super(
+        msg.toString(),
+        cause); // do not guard against NullPointerException. We want to always fail if msg is not
+                // filled in
+    this.errorMessage = msg;
+    if (!validateMessage()) {
+      throw new Bug("An error without complete description was defined or thrown.", this);
     }
+  }
 
-    TaurusExceptionBase(String what, String why, String consequences, String countermeasures, Throwable cause) {
-        this(new ErrorMessage(what, why, consequences, countermeasures), cause);
+  TaurusExceptionBase(
+      String what, String why, String consequences, String countermeasures, Throwable cause) {
+    this(new ErrorMessage(what, why, consequences, countermeasures), cause);
+  }
+
+  public ErrorMessage getErrorMessage() {
+    return errorMessage;
+  }
+
+  protected boolean validateMessage() {
+    if (null == errorMessage) {
+      return false;
     }
-
-    public ErrorMessage getErrorMessage() {
-        return errorMessage;
+    if (StringUtils.isBlank(errorMessage.getConsequences())) {
+      return false;
     }
-
-    protected boolean validateMessage() {
-        if (null == errorMessage) {
-            return false;
-        }
-        if (StringUtils.isBlank(errorMessage.getConsequences())) {
-            return false;
-        }
-        if (StringUtils.isBlank(errorMessage.getCountermeasures())) {
-            return false;
-        }
-        if (StringUtils.isBlank(errorMessage.getWhat())) {
-            return false;
-        }
-        if (StringUtils.isBlank(errorMessage.getWhy())) {
-            return false;
-        }
-        return true;
+    if (StringUtils.isBlank(errorMessage.getCountermeasures())) {
+      return false;
     }
-
+    if (StringUtils.isBlank(errorMessage.getWhat())) {
+      return false;
+    }
+    if (StringUtils.isBlank(errorMessage.getWhy())) {
+      return false;
+    }
+    return true;
+  }
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/exception/UserFacingError.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/exception/UserFacingError.java
@@ -8,8 +8,8 @@ package com.vmware.taurus.exception;
 import org.springframework.http.HttpStatus;
 
 public interface UserFacingError {
-    /**
-     * @return the HTTP status that user should see for this exception.
-     */
-    abstract public HttpStatus getHttpStatus();
+  /**
+   * @return the HTTP status that user should see for this exception.
+   */
+  public abstract HttpStatus getHttpStatus();
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/exception/WebHookRequestError.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/exception/WebHookRequestError.java
@@ -8,23 +8,24 @@ package com.vmware.taurus.exception;
 import org.springframework.http.HttpStatus;
 
 public class WebHookRequestError extends TaurusExceptionBase implements UserFacingError {
-   private HttpStatus httpStatus;
+  private HttpStatus httpStatus;
 
-   public WebHookRequestError(String operationName,
-                              String webHookMessage,
-                              HttpStatus httpStatus) {
-      super(String.format("Post %s Web Hook call associated with this request returns client error.", operationName),
-              webHookMessage,
-              String.format("This API call fails with %s and the %s operation will not be completed.",
-                      httpStatus,
-                      operationName),
-              "Inspect this message and fix the request to the Web Hook Server." ,
-              null);
-      this.httpStatus = httpStatus;
-   }
+  public WebHookRequestError(String operationName, String webHookMessage, HttpStatus httpStatus) {
+    super(
+        String.format(
+            "Post %s Web Hook call associated with this request returns client error.",
+            operationName),
+        webHookMessage,
+        String.format(
+            "This API call fails with %s and the %s operation will not be completed.",
+            httpStatus, operationName),
+        "Inspect this message and fix the request to the Web Hook Server.",
+        null);
+    this.httpStatus = httpStatus;
+  }
 
-   @Override
-   public HttpStatus getHttpStatus() {
-      return httpStatus;
-   }
+  @Override
+  public HttpStatus getHttpStatus() {
+    return httpStatus;
+  }
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/security/CustomClaimTokenValidator.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/security/CustomClaimTokenValidator.java
@@ -15,32 +15,32 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import java.util.Set;
 
 /**
- * A JWT Token Validator that checks if the caller is allowed to access a
- * resource based on a claim in the token. The name of the claim and the
- * allowed values are configurable.
+ * A JWT Token Validator that checks if the caller is allowed to access a resource based on a claim
+ * in the token. The name of the claim and the allowed values are configurable.
  */
 @AllArgsConstructor
 public class CustomClaimTokenValidator implements OAuth2TokenValidator<Jwt> {
 
-    private final String customClaimName;
-    private final Set<String> authorizedCustomClaimValues;
+  private final String customClaimName;
+  private final Set<String> authorizedCustomClaimValues;
 
-    @Override
-    public OAuth2TokenValidatorResult validate(Jwt jwt) {
-        if (customClaimName.isEmpty() || authorizedCustomClaimValues.isEmpty()) {
-            return OAuth2TokenValidatorResult.success();
-        }
-
-        String customClaimValue = jwt.getClaim(customClaimName);
-        if (authorizedCustomClaimValues.contains(customClaimValue)) {
-            return OAuth2TokenValidatorResult.success();
-        }
-
-        OAuth2Error err = new OAuth2Error(
-                OAuth2ErrorCodes.INSUFFICIENT_SCOPE,
-                "The request requires higher privileges than provided by the access token.",
-                null);
-
-        return OAuth2TokenValidatorResult.failure(err);
+  @Override
+  public OAuth2TokenValidatorResult validate(Jwt jwt) {
+    if (customClaimName.isEmpty() || authorizedCustomClaimValues.isEmpty()) {
+      return OAuth2TokenValidatorResult.success();
     }
+
+    String customClaimValue = jwt.getClaim(customClaimName);
+    if (authorizedCustomClaimValues.contains(customClaimValue)) {
+      return OAuth2TokenValidatorResult.success();
+    }
+
+    OAuth2Error err =
+        new OAuth2Error(
+            OAuth2ErrorCodes.INSUFFICIENT_SCOPE,
+            "The request requires higher privileges than provided by the access token.",
+            null);
+
+    return OAuth2TokenValidatorResult.failure(err);
+  }
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/security/KerberosConfig.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/security/KerberosConfig.java
@@ -15,14 +15,14 @@ import org.springframework.security.kerberos.authentication.sun.GlobalSunJaasKer
 @ConditionalOnProperty(value = "datajobs.security.kerberos.enabled")
 public class KerberosConfig {
 
-   @Value("${datajobs.security.kerberos.krb5ConfigLocation}")
-   private String krb5ConfigLocation;
+  @Value("${datajobs.security.kerberos.krb5ConfigLocation}")
+  private String krb5ConfigLocation;
 
-   @Bean
-   public GlobalSunJaasKerberosConfig globalSunJaasKerberosConfig() {
-      var config = new GlobalSunJaasKerberosConfig();
-      config.setDebug(true);
-      config.setKrbConfLocation(krb5ConfigLocation);
-      return config;
-   }
+  @Bean
+  public GlobalSunJaasKerberosConfig globalSunJaasKerberosConfig() {
+    var config = new GlobalSunJaasKerberosConfig();
+    config.setDebug(true);
+    config.setKrbConfLocation(krb5ConfigLocation);
+    return config;
+  }
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/security/SecurityConfiguration.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/security/SecurityConfiguration.java
@@ -46,225 +46,236 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Authentication and Authorization configuration.
- * <br>
- * If security is enabled (see FeatureFlags) then:
- * <br>
+ * Authentication and Authorization configuration. <br>
+ * If security is enabled (see FeatureFlags) then: <br>
+ *
  * <ul>
- * <li>Only JWK-signed JWTs is supported and following property must be set:
- *     spring.security.oauth2.resourceserver.jwt.jwk-set-uri</li></ul>
+ *   <li>Only JWK-signed JWTs is supported and following property must be set:
+ *       spring.security.oauth2.resourceserver.jwt.jwk-set-uri
+ * </ul>
  */
 @EnableWebSecurity
 @Slf4j
 @Configuration
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
-    private static final String AUTHORITY_PREFIX = "SCOPE_";
+  private static final String AUTHORITY_PREFIX = "SCOPE_";
 
-    private final FeatureFlags featureFlags;
+  private final FeatureFlags featureFlags;
 
-    private final String jwksUri;
-    private final String issuer;
-    private final String authoritiesClaimName;
-    private final String customClaimName;
-    private final Set<String> authorizedCustomClaimValues;
-    private final Set<String> authorizedRoles;
-    public static final String[] ENDPOINTS_TO_IGNORE = {
-          "/",
-          "/data-jobs/v2/api-docs",
-          "/data-jobs/swagger-resources/**",
-//        "/data-jobs/configuration/**",
-          "/data-jobs/swagger-ui.html",
-          "/data-jobs/webjars/**",
-          // There should not be sensitive data in prometheus, and it makes
-          // integration with the monitoring system easier if no auth is necessary.
-          "/data-jobs/debug/prometheus",
-          // TODO: likely /data-jobs/debug is too permissive
-          // but until we can expose them in swagger they are very hard to use with Auth.
-          "/data-jobs/debug/**"};
-    private final String kerberosPrincipal;
-    private final String keytabFileLocation;
-    private static final String KERBEROS_AUTH_ENABLED_PROPERTY = "datajobs.security.kerberos.enabled";
+  private final String jwksUri;
+  private final String issuer;
+  private final String authoritiesClaimName;
+  private final String customClaimName;
+  private final Set<String> authorizedCustomClaimValues;
+  private final Set<String> authorizedRoles;
+  public static final String[] ENDPOINTS_TO_IGNORE = {
+    "/",
+    "/data-jobs/v2/api-docs",
+    "/data-jobs/swagger-resources/**",
+    //        "/data-jobs/configuration/**",
+    "/data-jobs/swagger-ui.html",
+    "/data-jobs/webjars/**",
+    // There should not be sensitive data in prometheus, and it makes
+    // integration with the monitoring system easier if no auth is necessary.
+    "/data-jobs/debug/prometheus",
+    // TODO: likely /data-jobs/debug is too permissive
+    // but until we can expose them in swagger they are very hard to use with Auth.
+    "/data-jobs/debug/**"
+  };
+  private final String kerberosPrincipal;
+  private final String keytabFileLocation;
+  private static final String KERBEROS_AUTH_ENABLED_PROPERTY = "datajobs.security.kerberos.enabled";
 
-    @Autowired
-    public SecurityConfiguration(
-            FeatureFlags featureFlags,
-            @Value("${spring.security.oauth2.resourceserver.jwt.jwk-set-uri:}") String jwksUri,
-            @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri:}") String issuer,
-            @Value("${datajobs.authorization.authorities-claim-name:}") String authoritiesClaimName,
-            @Value("${datajobs.authorization.custom-claim-name:}") String customClaimName,
-            @Value("${datajobs.authorization.authorized-custom-claim-values:}") String authorizedCustomClaimValues,
-            @Value("${datajobs.authorization.authorized-roles:}") String authorizedRoles,
-            @Value("${datajobs.security.kerberos.kerberosPrincipal}") String kerberosPrincipal,
-            @Value("${datajobs.security.kerberos.keytabFileLocation}") String keytabFileLocation) {
-        this.featureFlags = featureFlags;
-        this.jwksUri = jwksUri;
-        this.issuer = issuer;
-        this.authoritiesClaimName = authoritiesClaimName;
-        this.customClaimName = customClaimName;
-        this.authorizedCustomClaimValues = parseOrgIds(authorizedCustomClaimValues);
-        this.authorizedRoles = parseRoles(authorizedRoles);
-        this.kerberosPrincipal = kerberosPrincipal;
-        this.keytabFileLocation = keytabFileLocation;
+  @Autowired
+  public SecurityConfiguration(
+      FeatureFlags featureFlags,
+      @Value("${spring.security.oauth2.resourceserver.jwt.jwk-set-uri:}") String jwksUri,
+      @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri:}") String issuer,
+      @Value("${datajobs.authorization.authorities-claim-name:}") String authoritiesClaimName,
+      @Value("${datajobs.authorization.custom-claim-name:}") String customClaimName,
+      @Value("${datajobs.authorization.authorized-custom-claim-values:}")
+          String authorizedCustomClaimValues,
+      @Value("${datajobs.authorization.authorized-roles:}") String authorizedRoles,
+      @Value("${datajobs.security.kerberos.kerberosPrincipal}") String kerberosPrincipal,
+      @Value("${datajobs.security.kerberos.keytabFileLocation}") String keytabFileLocation) {
+    this.featureFlags = featureFlags;
+    this.jwksUri = jwksUri;
+    this.issuer = issuer;
+    this.authoritiesClaimName = authoritiesClaimName;
+    this.customClaimName = customClaimName;
+    this.authorizedCustomClaimValues = parseOrgIds(authorizedCustomClaimValues);
+    this.authorizedRoles = parseRoles(authorizedRoles);
+    this.kerberosPrincipal = kerberosPrincipal;
+    this.keytabFileLocation = keytabFileLocation;
+  }
+
+  @Override
+  protected void configure(HttpSecurity http) throws Exception {
+    if (featureFlags.isSecurityEnabled()) {
+      enableSecurity(http);
+    } else {
+      log.info("Security is disabled.");
+      http.csrf().disable().authorizeRequests().anyRequest().anonymous();
     }
+  }
+
+  @Override
+  public void configure(WebSecurity web) {
+    web.ignoring().antMatchers(ENDPOINTS_TO_IGNORE);
+  }
+
+  private void enableSecurity(HttpSecurity http) throws Exception {
+    log.info("Security is enabled with OAuth2. JWT Key URI: {}", jwksUri);
+
+    http.anonymous()
+        .disable()
+        .csrf()
+        .disable()
+        .authorizeRequests(
+            authorizeRequests -> {
+              if (!authorizedRoles.isEmpty()) {
+                authorizeRequests
+                    .antMatchers("/**")
+                    .hasAnyAuthority(authorizedRoles.toArray(String[]::new));
+              }
+              authorizeRequests.anyRequest().authenticated();
+            });
+
+    if (featureFlags.isOAuth2Enabled()) {
+      http.oauth2ResourceServer().jwt().jwtAuthenticationConverter(jwtAuthenticationConverter());
+    }
+
+    if (featureFlags.isKrbAuthEnabled()) {
+      http.addFilterBefore(
+          spnegoAuthenticationProcessingFilter(authenticationManagerBean()),
+          BasicAuthenticationFilter.class);
+    }
+  }
+
+  @Bean
+  public JwtAuthenticationConverter jwtAuthenticationConverter() {
+    JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
+    jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(jwtGrantedAuthoritiesConverter());
+
+    return jwtAuthenticationConverter;
+  }
+
+  @Bean
+  public JwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter() {
+    JwtGrantedAuthoritiesConverter grantedAuthoritiesConverter =
+        new JwtGrantedAuthoritiesConverter();
+    // The Authority Prefix cannot be empty
+    grantedAuthoritiesConverter.setAuthorityPrefix(AUTHORITY_PREFIX);
+    if (!authoritiesClaimName.isEmpty()) {
+      grantedAuthoritiesConverter.setAuthoritiesClaimName(authoritiesClaimName);
+    }
+
+    return grantedAuthoritiesConverter;
+  }
+
+  /**
+   * Instantiate the jwtDecoder bean only when security is enabled to avoid having to specify the
+   * required issuer property with disabled authorization.
+   */
+  @Bean
+  @ConditionalOnExpression(
+      "not '${spring.security.oauth2.resourceserver.jwt.issuer-uri:}'.equals('')")
+  public JwtDecoder jwtDecoder() {
+    OAuth2TokenValidator<Jwt> defaultValidators = JwtValidators.createDefaultWithIssuer(issuer);
+    OAuth2TokenValidator<Jwt> customTokenValidator =
+        new CustomClaimTokenValidator(customClaimName, authorizedCustomClaimValues);
+    OAuth2TokenValidator<Jwt> validator =
+        new DelegatingOAuth2TokenValidator<>(customTokenValidator, defaultValidators);
+
+    NimbusJwtDecoder jwtDecoder = JwtDecoders.fromOidcIssuerLocation(issuer);
+    jwtDecoder.setJwtValidator(validator);
+    return jwtDecoder;
+  }
+
+  private Set<String> parseOrgIds(String orgIds) {
+    if (!StringUtils.isBlank(orgIds)) {
+      return Arrays.stream(orgIds.split(","))
+          .filter(id -> !id.isBlank())
+          .collect(Collectors.toSet());
+    }
+    return Collections.emptySet();
+  }
+
+  private Set<String> parseRoles(String roles) {
+    if (!StringUtils.isBlank(roles)) {
+      return Arrays.stream(roles.split(","))
+          .filter(role -> !role.isBlank())
+          .map(role -> AUTHORITY_PREFIX + role)
+          .collect(Collectors.toSet());
+    }
+    return Collections.emptySet();
+  }
+
+  /*
+     KERBEROS config settings, a lot of these are optional.
+  */
+
+  @Override
+  protected void configure(AuthenticationManagerBuilder auth) {
+    if (featureFlags.isKrbAuthEnabled()) {
+      auth.authenticationProvider(kerberosServiceAuthenticationProvider());
+    }
+  }
+
+  @Bean
+  @ConditionalOnProperty(value = KERBEROS_AUTH_ENABLED_PROPERTY)
+  public SpnegoAuthenticationProcessingFilter spnegoAuthenticationProcessingFilter(
+      AuthenticationManager authenticationManager) {
+    SpnegoAuthenticationProcessingFilter filter = new SpnegoAuthenticationProcessingFilter();
+    filter.setAuthenticationManager(authenticationManager);
+    return filter;
+  }
+
+  @Bean
+  @ConditionalOnProperty(value = KERBEROS_AUTH_ENABLED_PROPERTY)
+  public KerberosServiceAuthenticationProvider kerberosServiceAuthenticationProvider() {
+    KerberosServiceAuthenticationProvider provider = new KerberosServiceAuthenticationProvider();
+    provider.setTicketValidator(sunJaasKerberosTicketValidator());
+    provider.setUserDetailsService(dataJobsUserDetailsService());
+    return provider;
+  }
+
+  @Bean
+  @ConditionalOnProperty(value = KERBEROS_AUTH_ENABLED_PROPERTY)
+  public SunJaasKerberosTicketValidator sunJaasKerberosTicketValidator() {
+    SunJaasKerberosTicketValidator ticketValidator = new SunJaasKerberosTicketValidator();
+    ticketValidator.setServicePrincipal(kerberosPrincipal);
+    ticketValidator.setKeyTabLocation(new FileSystemResource(keytabFileLocation));
+    ticketValidator.setDebug(true);
+    return ticketValidator;
+  }
+
+  @Bean
+  @ConditionalOnProperty(value = KERBEROS_AUTH_ENABLED_PROPERTY)
+  public SecurityConfiguration.DataJobsUserDetailsService dataJobsUserDetailsService() {
+    return new SecurityConfiguration.DataJobsUserDetailsService();
+  }
+
+  @Override
+  @Bean
+  @ConditionalOnProperty(value = KERBEROS_AUTH_ENABLED_PROPERTY)
+  public AuthenticationManager authenticationManagerBean() throws Exception {
+    return super.authenticationManagerBean();
+  }
+
+  class DataJobsUserDetailsService implements UserDetailsService {
 
     @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        if (featureFlags.isSecurityEnabled()) {
-            enableSecurity(http);
-        } else {
-            log.info("Security is disabled.");
-            http
-                    .csrf().disable()
-                    .authorizeRequests()
-                    .anyRequest().anonymous();
-        }
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+      return new User(
+          username,
+          "",
+          true,
+          true,
+          true,
+          true,
+          AuthorityUtils.createAuthorityList("ROLE_DATA_JOBS_USER"));
     }
-
-    @Override
-    public void configure(WebSecurity web) {
-        web.ignoring().antMatchers(ENDPOINTS_TO_IGNORE);
-    }
-
-    private void enableSecurity(HttpSecurity http) throws Exception {
-        log.info("Security is enabled with OAuth2. JWT Key URI: {}", jwksUri);
-
-        http.anonymous().disable()
-              .csrf().disable()
-              .authorizeRequests(authorizeRequests -> {
-                  if (!authorizedRoles.isEmpty()) {
-                      authorizeRequests
-                            .antMatchers("/**")
-                            .hasAnyAuthority(authorizedRoles.toArray(String[]::new));
-                  }
-                  authorizeRequests.anyRequest().authenticated();
-              });
-
-        if (featureFlags.isOAuth2Enabled()) {
-            http.oauth2ResourceServer().jwt().jwtAuthenticationConverter(jwtAuthenticationConverter());
-        }
-
-        if (featureFlags.isKrbAuthEnabled()) {
-            http.addFilterBefore(spnegoAuthenticationProcessingFilter(authenticationManagerBean()),
-                  BasicAuthenticationFilter.class);
-        }
-    }
-
-    @Bean
-    public JwtAuthenticationConverter jwtAuthenticationConverter() {
-        JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
-        jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(jwtGrantedAuthoritiesConverter());
-
-        return jwtAuthenticationConverter;
-    }
-
-    @Bean
-    public JwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter() {
-        JwtGrantedAuthoritiesConverter grantedAuthoritiesConverter = new JwtGrantedAuthoritiesConverter();
-        // The Authority Prefix cannot be empty
-        grantedAuthoritiesConverter.setAuthorityPrefix(AUTHORITY_PREFIX);
-        if (!authoritiesClaimName.isEmpty()) {
-            grantedAuthoritiesConverter.setAuthoritiesClaimName(authoritiesClaimName);
-        }
-
-        return grantedAuthoritiesConverter;
-    }
-
-    /**
-     * Instantiate the jwtDecoder bean only when security is enabled to avoid having to specify the
-     * required issuer property with disabled authorization.
-     */
-    @Bean
-    @ConditionalOnExpression("not '${spring.security.oauth2.resourceserver.jwt.issuer-uri:}'.equals('')")
-    public JwtDecoder jwtDecoder() {
-        OAuth2TokenValidator<Jwt> defaultValidators = JwtValidators.createDefaultWithIssuer(issuer);
-        OAuth2TokenValidator<Jwt> customTokenValidator = new CustomClaimTokenValidator(customClaimName, authorizedCustomClaimValues);
-        OAuth2TokenValidator<Jwt> validator = new DelegatingOAuth2TokenValidator<>(customTokenValidator, defaultValidators);
-
-        NimbusJwtDecoder jwtDecoder = JwtDecoders.fromOidcIssuerLocation(issuer);
-        jwtDecoder.setJwtValidator(validator);
-        return jwtDecoder;
-    }
-
-    private Set<String> parseOrgIds(String orgIds) {
-        if (!StringUtils.isBlank(orgIds)) {
-            return Arrays.stream(orgIds.split(","))
-                    .filter(id -> !id.isBlank())
-                    .collect(Collectors.toSet());
-        }
-        return Collections.emptySet();
-    }
-
-    private Set<String> parseRoles(String roles) {
-        if (!StringUtils.isBlank(roles)) {
-            return Arrays.stream(roles.split(","))
-                    .filter(role -> !role.isBlank())
-                    .map(role -> AUTHORITY_PREFIX + role)
-                    .collect(Collectors.toSet());
-        }
-        return Collections.emptySet();
-    }
-
-    /*
-        KERBEROS config settings, a lot of these are optional.
-     */
-
-    @Override
-    protected void configure(AuthenticationManagerBuilder auth) {
-        if (featureFlags.isKrbAuthEnabled()) {
-            auth.authenticationProvider(kerberosServiceAuthenticationProvider());
-        }
-    }
-
-    @Bean
-    @ConditionalOnProperty(value = KERBEROS_AUTH_ENABLED_PROPERTY)
-    public SpnegoAuthenticationProcessingFilter spnegoAuthenticationProcessingFilter(
-          AuthenticationManager authenticationManager) {
-        SpnegoAuthenticationProcessingFilter filter = new SpnegoAuthenticationProcessingFilter();
-        filter.setAuthenticationManager(authenticationManager);
-        return filter;
-    }
-
-    @Bean
-    @ConditionalOnProperty(value = KERBEROS_AUTH_ENABLED_PROPERTY)
-    public KerberosServiceAuthenticationProvider kerberosServiceAuthenticationProvider() {
-        KerberosServiceAuthenticationProvider provider = new KerberosServiceAuthenticationProvider();
-        provider.setTicketValidator(sunJaasKerberosTicketValidator());
-        provider.setUserDetailsService(dataJobsUserDetailsService());
-        return provider;
-    }
-
-    @Bean
-    @ConditionalOnProperty(value = KERBEROS_AUTH_ENABLED_PROPERTY)
-    public SunJaasKerberosTicketValidator sunJaasKerberosTicketValidator() {
-        SunJaasKerberosTicketValidator ticketValidator = new SunJaasKerberosTicketValidator();
-        ticketValidator.setServicePrincipal(kerberosPrincipal);
-        ticketValidator.setKeyTabLocation(new FileSystemResource(keytabFileLocation));
-        ticketValidator.setDebug(true);
-        return ticketValidator;
-    }
-
-    @Bean
-    @ConditionalOnProperty(value = KERBEROS_AUTH_ENABLED_PROPERTY)
-    public SecurityConfiguration.DataJobsUserDetailsService dataJobsUserDetailsService() {
-        return new SecurityConfiguration.DataJobsUserDetailsService();
-    }
-
-    @Override
-    @Bean
-    @ConditionalOnProperty(value = KERBEROS_AUTH_ENABLED_PROPERTY)
-    public AuthenticationManager authenticationManagerBean() throws Exception {
-        return super.authenticationManagerBean();
-    }
-
-    class DataJobsUserDetailsService implements UserDetailsService {
-
-        @Override
-        public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-            return new User(username, "", true, true, true,
-                  true, AuthorityUtils.createAuthorityList("ROLE_DATA_JOBS_USER"));
-        }
-
-    }
-
+  }
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/DiagnosticsController.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/DiagnosticsController.java
@@ -5,7 +5,6 @@
 
 package com.vmware.taurus.service.diag;
 
-
 import com.vmware.taurus.SpringAppPropNames;
 import com.vmware.taurus.service.diag.methodintercept.Measurable;
 import com.vmware.taurus.service.diag.telemetry.ITelemetry;
@@ -25,39 +24,44 @@ import java.time.Instant;
 @RestController
 @RequiredArgsConstructor
 @Slf4j
-@Api(tags = {"Data Jobs Diagnostics"}, hidden = true)
+@Api(
+    tags = {"Data Jobs Diagnostics"},
+    hidden = true)
 @ApiIgnore
 public class DiagnosticsController {
-    //${svc.url.prefix} is read from application.properties (overridden in other services, so e.g. Team service has /team/debug/servertime)
+  // ${svc.url.prefix} is read from application.properties (overridden in other services, so e.g.
+  // Team service has /team/debug/servertime)
 
-    private final ITelemetry telemetryClient;
+  private final ITelemetry telemetryClient;
 
-    @Measurable
-    @RequestMapping("/${" + SpringAppPropNames.SVC_NAME + "}/debug/servertime-millis")
-    public long timeMillis() {
-        return System.currentTimeMillis();
-    }
+  @Measurable
+  @RequestMapping("/${" + SpringAppPropNames.SVC_NAME + "}/debug/servertime-millis")
+  public long timeMillis() {
+    return System.currentTimeMillis();
+  }
 
-    @ApiOperation("Get system clock in UTC")
-    @RequestMapping(value = "/${" + SpringAppPropNames.SVC_NAME + "}/debug/servertime", method = RequestMethod.GET)
-    public Instant timeUTC() {
-        return Instant.now();
-    }
+  @ApiOperation("Get system clock in UTC")
+  @RequestMapping(
+      value = "/${" + SpringAppPropNames.SVC_NAME + "}/debug/servertime",
+      method = RequestMethod.GET)
+  public Instant timeUTC() {
+    return Instant.now();
+  }
 
-    @RequestMapping("/${" + SpringAppPropNames.SVC_NAME + "}/debug/throw")
-    public void throwException() {
-        throw new RuntimeException("Just throwing.");
-    }
+  @RequestMapping("/${" + SpringAppPropNames.SVC_NAME + "}/debug/throw")
+  public void throwException() {
+    throw new RuntimeException("Just throwing.");
+  }
 
-    @RequestMapping({"/${" + SpringAppPropNames.SVC_NAME + "}/debug/echo/{msg}"})
-    public ResponseEntity<String> echo(String msg) {
-        return new ResponseEntity<String>(msg, HttpStatus.OK);
-    }
+  @RequestMapping({"/${" + SpringAppPropNames.SVC_NAME + "}/debug/echo/{msg}"})
+  public ResponseEntity<String> echo(String msg) {
+    return new ResponseEntity<String>(msg, HttpStatus.OK);
+  }
 
-    @RequestMapping({"/${" + SpringAppPropNames.SVC_NAME + "}/debug/report/{message}"})
-    public ResponseEntity<Void> report(String msg) {
-        log.trace(msg);
-        telemetryClient.sendAsync(msg);
-        return ResponseEntity.accepted().build();
-    }
+  @RequestMapping({"/${" + SpringAppPropNames.SVC_NAME + "}/debug/report/{message}"})
+  public ResponseEntity<Void> report(String msg) {
+    log.trace(msg);
+    telemetryClient.sendAsync(msg);
+    return ResponseEntity.accepted().build();
+  }
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/HttpTracer.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/HttpTracer.java
@@ -27,113 +27,117 @@ import java.util.List;
 @Slf4j
 public class HttpTracer implements org.springframework.boot.actuate.trace.http.HttpTraceRepository {
 
-    @Autowired
-    public HttpTracer(@Value("${" + SpringAppPropNames.HTTPTRACES_TO_KEEP + ":3}") int numberOfTracesToKeep,
-                      OperationContext operationContext, ITelemetry telemetryClient,
-                      Environment env) {
-        if (numberOfTracesToKeep < 1) {
-            throw new RuntimeException("Invalid Configuration");
-        }
-        this.numberOfTracesToKeep = numberOfTracesToKeep;
-        this.operationContext = operationContext;
-        this.telemetryClient = telemetryClient;
-        this.environment = env;
+  @Autowired
+  public HttpTracer(
+      @Value("${" + SpringAppPropNames.HTTPTRACES_TO_KEEP + ":3}") int numberOfTracesToKeep,
+      OperationContext operationContext,
+      ITelemetry telemetryClient,
+      Environment env) {
+    if (numberOfTracesToKeep < 1) {
+      throw new RuntimeException("Invalid Configuration");
     }
+    this.numberOfTracesToKeep = numberOfTracesToKeep;
+    this.operationContext = operationContext;
+    this.telemetryClient = telemetryClient;
+    this.environment = env;
+  }
 
-    private final Deque<HttpTrace> deque = new LinkedList<>();
-    private final int numberOfTracesToKeep;
-    private final Environment environment;
-    private final OperationContext operationContext;
-    private final ITelemetry telemetryClient;
+  private final Deque<HttpTrace> deque = new LinkedList<>();
+  private final int numberOfTracesToKeep;
+  private final Environment environment;
+  private final OperationContext operationContext;
+  private final ITelemetry telemetryClient;
 
-    @Override
-    public List<HttpTrace> findAll() {
-        synchronized (deque) {
-            return new LinkedList<>(deque);
-        }
+  @Override
+  public List<HttpTrace> findAll() {
+    synchronized (deque) {
+      return new LinkedList<>(deque);
     }
+  }
 
-    @Override
-    public void add(HttpTrace trace) {
-        if (null != trace) {
-            synchronized (deque){
-                deque.addFirst(trace);
-                while (deque.size() > this.numberOfTracesToKeep) {
-                    deque.removeLast();
-                }
-            }
-            logTheTrace(trace);
-            sendTelemetry(trace);
+  @Override
+  public void add(HttpTrace trace) {
+    if (null != trace) {
+      synchronized (deque) {
+        deque.addFirst(trace);
+        while (deque.size() > this.numberOfTracesToKeep) {
+          deque.removeLast();
         }
+      }
+      logTheTrace(trace);
+      sendTelemetry(trace);
     }
+  }
 
-    private void logTheTrace(HttpTrace trace) {
-        // We have many requests coming to /prometheus /liveness /readiness that would flood the log
-        if (isSystemCall(trace)) {
-            log.trace("[user:{}] {} {} -> {}",
-                    trace.getPrincipal() != null ? trace.getPrincipal().getName() : "anonymous",
-                    trace.getRequest().getMethod(),
-                    trace.getRequest().getUri(),
-                    trace.getResponse().getStatus()
-            );
-        } else {
-            log.info("[user:{}] {} {} -> {}",
-                    trace.getPrincipal() != null ? trace.getPrincipal().getName() : "anonymous",
-                    trace.getRequest().getMethod(),
-                    trace.getRequest().getUri(),
-                    trace.getResponse().getStatus()
-            );
-            if (log.isDebugEnabled()) {
-                try {
-                    ObjectMapper mapper = new ObjectMapper();
-                    mapper.registerModule(new JavaTimeModule());
-                    String jsonString = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(trace);
-                    log.debug(jsonString);
-                } catch (Exception e) {
-                    log.warn("Failed to log the HttpTrace object.", e);
-                }
-            }
+  private void logTheTrace(HttpTrace trace) {
+    // We have many requests coming to /prometheus /liveness /readiness that would flood the log
+    if (isSystemCall(trace)) {
+      log.trace(
+          "[user:{}] {} {} -> {}",
+          trace.getPrincipal() != null ? trace.getPrincipal().getName() : "anonymous",
+          trace.getRequest().getMethod(),
+          trace.getRequest().getUri(),
+          trace.getResponse().getStatus());
+    } else {
+      log.info(
+          "[user:{}] {} {} -> {}",
+          trace.getPrincipal() != null ? trace.getPrincipal().getName() : "anonymous",
+          trace.getRequest().getMethod(),
+          trace.getRequest().getUri(),
+          trace.getResponse().getStatus());
+      if (log.isDebugEnabled()) {
+        try {
+          ObjectMapper mapper = new ObjectMapper();
+          mapper.registerModule(new JavaTimeModule());
+          String jsonString = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(trace);
+          log.debug(jsonString);
+        } catch (Exception e) {
+          log.warn("Failed to log the HttpTrace object.", e);
         }
+      }
     }
+  }
 
-    private boolean isSystemCall(HttpTrace trace) {
-        String path = trace.getRequest().getUri().getPath();
-        if (path.endsWith("/debug/prometheus") ||
-                path.endsWith("/debug/health/liveness")  ||
-                path.endsWith("/debug/health/readiness")) {
-            return true;
-        }
-        return false;
+  private boolean isSystemCall(HttpTrace trace) {
+    String path = trace.getRequest().getUri().getPath();
+    if (path.endsWith("/debug/prometheus")
+        || path.endsWith("/debug/health/liveness")
+        || path.endsWith("/debug/health/readiness")) {
+      return true;
     }
+    return false;
+  }
 
-    void sendTelemetry(HttpTrace trace) {
-        // there are many request for monitoring purposes and there is no point sending telemetry for them
-        if (isSystemCall(trace)) {
-            return;
-        }
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JavaTimeModule());
-        ObjectNode node = mapper.convertValue(trace, ObjectNode.class);
-        node.put("@type", "taurus_httptrace");
-        node.put("deployment_mode", String.join(",", environment.getActiveProfiles()));
-        String opId = operationContext.getOpId();
-        if (null != opId) {
-            node.put("@id", opId);
-        }
-        HttpServletRequest request = operationContext.getRequest();
-        if (null != request) {//methods from the actuator dont have the request set
-            String requestMapping = "" + request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
-            node.put("request_mapping", requestMapping);
-        }
-        String user = operationContext.getUser();
-        if (null != user) {
-            node.put("user", user);
-        }
-        String team = operationContext.getTeam();
-        if (null != team) {
-            node.put("team", team);
-        }
-        String json = node.toPrettyString();
-        this.telemetryClient.sendAsync(json);
+  void sendTelemetry(HttpTrace trace) {
+    // there are many request for monitoring purposes and there is no point sending telemetry for
+    // them
+    if (isSystemCall(trace)) {
+      return;
     }
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new JavaTimeModule());
+    ObjectNode node = mapper.convertValue(trace, ObjectNode.class);
+    node.put("@type", "taurus_httptrace");
+    node.put("deployment_mode", String.join(",", environment.getActiveProfiles()));
+    String opId = operationContext.getOpId();
+    if (null != opId) {
+      node.put("@id", opId);
+    }
+    HttpServletRequest request = operationContext.getRequest();
+    if (null != request) { // methods from the actuator dont have the request set
+      String requestMapping =
+          "" + request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+      node.put("request_mapping", requestMapping);
+    }
+    String user = operationContext.getUser();
+    if (null != user) {
+      node.put("user", user);
+    }
+    String team = operationContext.getTeam();
+    if (null != team) {
+      node.put("team", team);
+    }
+    String json = node.toPrettyString();
+    this.telemetryClient.sendAsync(json);
+  }
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/Metrics.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/Metrics.java
@@ -25,7 +25,7 @@ public enum Metrics {
   ,
 
   error_stacktrace // String: java.lang.RuntimeException: Just throwing. \r\n\tat
-                   // com.vmware.taurus.service.diag.DiagnosticsController.throwException(DiagnosticsController.java:28) ...
+  // com.vmware.taurus.service.diag.DiagnosticsController.throwException(DiagnosticsController.java:28) ...
   ,
 
   http_body_type // String (contains body.getClass.getName() ): java.lang.String

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/Metrics.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/Metrics.java
@@ -6,55 +6,55 @@
 package com.vmware.taurus.service.diag;
 
 public enum Metrics {
-    call_failed //Boolean: false
-    ,
+  call_failed // Boolean: false
+  ,
 
-    class_name_full //String: "com.vmware.taurus.service.diag.DiagnosticsController"
-    ,
+  class_name_full // String: "com.vmware.taurus.service.diag.DiagnosticsController"
+  ,
 
-    class_name_short //String: "DiagnosticsController"
-    ,
+  class_name_short // String: "DiagnosticsController"
+  ,
 
-    cp_svc_name //String (containing Control Plane Service name): "team"
-    ,
+  cp_svc_name // String (containing Control Plane Service name): "team"
+  ,
 
-    error_class //class: class java.lang.RuntimeException
-    ,
+  error_class // class: class java.lang.RuntimeException
+  ,
 
-    error_message //String: Just throwing.
-    ,
+  error_message // String: Just throwing.
+  ,
 
-    error_stacktrace //String: java.lang.RuntimeException: Just throwing. \r\n\tat com.vmware.taurus.service.diag.DiagnosticsController.throwException(DiagnosticsController.java:28) ...
-    ,
+  error_stacktrace // String: java.lang.RuntimeException: Just throwing. \r\n\tat
+                   // com.vmware.taurus.service.diag.DiagnosticsController.throwException(DiagnosticsController.java:28) ...
+  ,
 
-    http_body_type //String (contains body.getClass.getName() ): java.lang.String
-    ,
+  http_body_type // String (contains body.getClass.getName() ): java.lang.String
+  ,
 
-    http_code //Integer: 200
-    ,
+  http_code // Integer: 200
+  ,
 
-    measurable_args //String: somearg
-    ,
+  measurable_args // String: somearg
+  ,
 
-    measurable_tags //String(CSV): [tag1, tag2]
-    ,
+  measurable_tags // String(CSV): [tag1, tag2]
+  ,
 
-    method_execution_time_nanos //Long: 12761970
-    ,
+  method_execution_time_nanos // Long: 12761970
+  ,
 
-    method_execution_end_timestamp // Unix timestamp since epoch in milliseconds: 1613944487926
-    ,
+  method_execution_end_timestamp // Unix timestamp since epoch in milliseconds: 1613944487926
+  ,
 
-    method_name //String: "foo"
-    ,
+  method_name // String: "foo"
+  ,
 
-    method_result //Object: ...
-    ,
+  method_result // Object: ...
+  ,
 
-    op_id //String (contains Long): "01575568907793"
-    ,
+  op_id // String (contains Long): "01575568907793"
+  ,
 
-    request_paths //String (contains CSV): /base/debug/echo/{msg}, /base/debug/echo2/{msg}
-    ,
-
+  request_paths // String (contains CSV): /base/debug/echo/{msg}, /base/debug/echo2/{msg}
+  ,
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/OperationContext.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/OperationContext.java
@@ -5,7 +5,6 @@
 
 package com.vmware.taurus.service.diag;
 
-
 import com.vmware.taurus.service.diag.opid.OpIdSupplier;
 import org.aspectj.lang.JoinPoint;
 import org.slf4j.MDC;
@@ -15,173 +14,164 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.UUID;
 
-
-/**
- * OperationContext - component to set get and remove OpId for a given thread.
- */
+/** OperationContext - component to set get and remove OpId for a given thread. */
 @Component
 public class OperationContext implements OpIdSupplier {
-    private ThreadLocal<String> id = new InheritableThreadLocal<>();
-    private ThreadLocal<String> workflowId = new InheritableThreadLocal<>();
-    private ThreadLocal<String> retryAction = new InheritableThreadLocal<>();
-    private ThreadLocal<UUID> taskId = new InheritableThreadLocal<>();
-    private ThreadLocal<HttpServletRequest> refToRequest = new InheritableThreadLocal<>();
-    private ThreadLocal<HttpServletResponse> refToResponse = new InheritableThreadLocal<>();
-    private ThreadLocal<JoinPoint> refToJoinPoint = new InheritableThreadLocal<>();
-    private ThreadLocal<String> refToUser = new InheritableThreadLocal<>();
-    private ThreadLocal<String> refToTeam = new InheritableThreadLocal<>();
+  private ThreadLocal<String> id = new InheritableThreadLocal<>();
+  private ThreadLocal<String> workflowId = new InheritableThreadLocal<>();
+  private ThreadLocal<String> retryAction = new InheritableThreadLocal<>();
+  private ThreadLocal<UUID> taskId = new InheritableThreadLocal<>();
+  private ThreadLocal<HttpServletRequest> refToRequest = new InheritableThreadLocal<>();
+  private ThreadLocal<HttpServletResponse> refToResponse = new InheritableThreadLocal<>();
+  private ThreadLocal<JoinPoint> refToJoinPoint = new InheritableThreadLocal<>();
+  private ThreadLocal<String> refToUser = new InheritableThreadLocal<>();
+  private ThreadLocal<String> refToTeam = new InheritableThreadLocal<>();
 
-    /*
-     * initId Intialize with new opId and register with MDC.
-     */
-    public void initId() {
-        String id;
-        synchronized (OperationContext.class) {
-            id = OperationContext.class.getCanonicalName() + System.nanoTime();
-        }
-        MDC.put("OpId", id);
-        setId(id);
+  /*
+   * initId Intialize with new opId and register with MDC.
+   */
+  public void initId() {
+    String id;
+    synchronized (OperationContext.class) {
+      id = OperationContext.class.getCanonicalName() + System.nanoTime();
     }
+    MDC.put("OpId", id);
+    setId(id);
+  }
 
-    /*
-     * initId Intialize with passed in opId and register with MDC.
-     */
-    public void initId(UUID workflowId) {
-        initId();
-        setWorkflowId(workflowId.toString());
+  /*
+   * initId Intialize with passed in opId and register with MDC.
+   */
+  public void initId(UUID workflowId) {
+    initId();
+    setWorkflowId(workflowId.toString());
+  }
+
+  public void setId(String id) {
+    this.id.set(id);
+    MDC.put("OpId", id);
+  }
+
+  @Override
+  public String getOpId() {
+    return id.get();
+  }
+
+  /*
+   * removeId Remove all traces from this thread.
+   */
+  public void removeId() {
+    id.remove();
+    MDC.remove("OpId");
+  }
+
+  public void setTaskId(UUID taskId) {
+    this.taskId.set(taskId);
+  }
+
+  public UUID getTaskId() {
+    return taskId.get();
+  }
+
+  public void removeTaskId() {
+    taskId.remove();
+  }
+
+  /*
+   * Set the workflowId.
+   */
+  public void setWorkflowId(String workflowId) {
+    this.workflowId.set(workflowId);
+  }
+
+  /*
+   * Gets the workflowId.
+   */
+  public String getWorkflowId() {
+    return workflowId.get();
+  }
+
+  /*
+   * Removes the workflowId from the threadLocal and MDC.
+   */
+  public void removeWorkflowId() {
+    workflowId.remove();
+  }
+
+  /*
+   * Set the workflowId.
+   */
+  public void setRetryAction(String retryAction) {
+    this.retryAction.set(retryAction);
+  }
+
+  /*
+   * Gets the retryAction value.
+   */
+  public String getRetryAction() {
+    if (retryAction == null) {
+      return Boolean.FALSE.toString();
     }
+    return retryAction.get();
+  }
 
-    public void setId(String id) {
-        this.id.set(id);
-        MDC.put("OpId", id);
-    }
+  /*
+   * Removes the retryAction from the threadLocal and MDC.
+   */
+  public void removeRetryAction() {
+    retryAction.remove();
+  }
 
-    @Override
-    public String getOpId() {
-        return id.get();
-    }
+  /*
+   * Removes the workflowId from the threadLocal and MDC.
+   */
+  public void removeAll() {
+    removeId();
+    removeTaskId();
+    removeWorkflowId();
+  }
 
+  public String toString() {
+    return super.toString() + "[" + "opId:" + getOpId() + "]";
+  }
 
-    /*
-     * removeId Remove all traces from this thread.
-     */
-    public void removeId() {
-        id.remove();
-        MDC.remove("OpId");
-    }
+  public void setHttpRequest(HttpServletRequest request) {
+    this.refToRequest.set(request);
+  }
 
-    public void setTaskId(UUID taskId) {
-        this.taskId.set(taskId);
-    }
+  public HttpServletRequest getRequest() {
+    return refToRequest.get();
+  }
 
-    public UUID getTaskId() {
-        return taskId.get();
-    }
+  public HttpServletResponse getResponse() {
+    return refToResponse.get();
+  }
 
-    public void removeTaskId() {
-        taskId.remove();
-    }
+  public void setHttpResponse(HttpServletResponse response) {
+    this.refToResponse.set(response);
+  }
 
-    /*
-     * Set the workflowId.
-     */
-    public void setWorkflowId(String workflowId) {
-        this.workflowId.set(workflowId);
-    }
+  public JoinPoint getJoinPoint() {
+    return refToJoinPoint.get();
+  }
 
-    /*
-     * Gets the workflowId.
-     */
-    public String getWorkflowId() {
-        return workflowId.get();
-    }
+  public void setJoinPoint(JoinPoint joinPoint) {
+    this.refToJoinPoint.set(joinPoint);
+  }
 
-    /*
-     * Removes the workflowId from the threadLocal and MDC.
-     */
-    public void removeWorkflowId() {
-        workflowId.remove();
-    }
+  public void setUser(String user) {
+    this.refToUser.set(user);
+  }
 
-    /*
-     * Set the workflowId.
-     */
-    public void setRetryAction(String retryAction) {
-        this.retryAction.set(retryAction);
-    }
+  public String getUser() {
+    return refToUser.get();
+  }
 
-    /*
-     * Gets the retryAction value.
-     */
-    public String getRetryAction() {
-        if (retryAction == null) {
-            return Boolean.FALSE.toString();
-        }
-        return retryAction.get();
-    }
+  public void setTeam(String team) {
+    this.refToTeam.set(team);
+  }
 
-    /*
-     * Removes the retryAction from the threadLocal and MDC.
-     */
-    public void removeRetryAction() {
-        retryAction.remove();
-    }
-
-    /*
-     * Removes the workflowId from the threadLocal and MDC.
-     */
-    public void removeAll() {
-        removeId();
-        removeTaskId();
-        removeWorkflowId();
-    }
-
-    public String toString() {
-        return super.toString() + "[" +
-                "opId:" + getOpId() +
-                "]";
-    }
-
-    public void setHttpRequest(HttpServletRequest request) {
-        this.refToRequest.set(request);
-    }
-
-    public HttpServletRequest getRequest() {
-        return refToRequest.get();
-    }
-
-
-    public HttpServletResponse getResponse() {
-        return refToResponse.get();
-    }
-
-
-    public void setHttpResponse(HttpServletResponse response) {
-        this.refToResponse.set(response);
-    }
-
-    public JoinPoint getJoinPoint() {
-        return refToJoinPoint.get();
-    }
-
-    public void setJoinPoint(JoinPoint joinPoint) {
-        this.refToJoinPoint.set(joinPoint);
-    }
-
-    public void setUser(String user) {
-        this.refToUser.set(user);
-    }
-
-    public String getUser() {
-        return refToUser.get();
-    }
-
-    public void setTeam(String team) {
-        this.refToTeam.set(team);
-    }
-
-    public String getTeam() {
-        return refToTeam.get();
-    }
-
+  public String getTeam() {
+    return refToTeam.get();
+  }
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/methodintercept/DiagnosticsContext.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/methodintercept/DiagnosticsContext.java
@@ -5,22 +5,19 @@
 
 package com.vmware.taurus.service.diag.methodintercept;
 
-
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.util.StopWatch;
 
-/**
- * Class encapsulating diagnostic context data.
- */
+/** Class encapsulating diagnostic context data. */
 public class DiagnosticsContext {
 
-    public String opId;
-    public String userName;
-    public JoinPoint joinPoint;
-    public MethodSignature signature;
-    public StopWatch stopWatch;
-    //when this == this.methodResult then this value was not initialized (method threw an exception?)
-    public Object methodResult;
-    public Exception error;
+  public String opId;
+  public String userName;
+  public JoinPoint joinPoint;
+  public MethodSignature signature;
+  public StopWatch stopWatch;
+  // when this == this.methodResult then this value was not initialized (method threw an exception?)
+  public Object methodResult;
+  public Exception error;
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/methodintercept/DiagnosticsPublisher.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/methodintercept/DiagnosticsPublisher.java
@@ -26,85 +26,86 @@ import java.util.TreeMap;
 import java.util.function.Consumer;
 
 @Component
-@org.springframework.boot.autoconfigure.condition.ConditionalOnProperty(value = EnableComponents.DIAGNOSTICS_INTERCEPTOR, havingValue = "true", matchIfMissing = true)
+@org.springframework.boot.autoconfigure.condition.ConditionalOnProperty(
+    value = EnableComponents.DIAGNOSTICS_INTERCEPTOR,
+    havingValue = "true",
+    matchIfMissing = true)
 public class DiagnosticsPublisher implements Consumer<DiagnosticsContext> {
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+  private final Logger log = LoggerFactory.getLogger(this.getClass());
 
-    @Autowired
-    public DiagnosticsPublisher(ITelemetry telemetryClient, SCCPProperties properties) {
-        this.telemetryClient = telemetryClient;
-        this.properties = properties;
-        this.helper = new MetricsHelper();
+  @Autowired
+  public DiagnosticsPublisher(ITelemetry telemetryClient, SCCPProperties properties) {
+    this.telemetryClient = telemetryClient;
+    this.properties = properties;
+    this.helper = new MetricsHelper();
+  }
+
+  private final ITelemetry telemetryClient;
+  private final SCCPProperties properties;
+  private final MetricsHelper helper;
+
+  @Override
+  public void accept(DiagnosticsContext context) {
+
+    Map<Metrics, Object> metrics = contextToMetrics(context);
+    String opId = "" + metrics.get(Metrics.op_id);
+    try {
+      // this modifies the metrics
+      if (metrics.containsKey(Metrics.method_result)) {
+        String result = "" + metrics.get(Metrics.method_result);
+        String resAsStr = result.substring(0, Math.min(666, result.length()));
+        metrics.put(Metrics.method_result, resAsStr);
+      }
+      if (metrics.containsKey(Metrics.error_class)) {
+        String asStr = ("" + metrics.get(Metrics.error_class));
+        metrics.put(Metrics.method_result, asStr);
+      }
+      metrics.put(Metrics.cp_svc_name, properties.getSpringProperty(SpringAppPropNames.SVC_NAME));
+
+      ObjectMapper mapper = new ObjectMapper();
+      ObjectNode node = mapper.convertValue(metrics, ObjectNode.class);
+      node.put("@table", "taurus_api_call");
+      node.put("@id", opId);
+      String json = node.toPrettyString();
+      log.trace("Sending telemetry: {}", json);
+      this.telemetryClient.sendAsync(json);
+
+    } catch (Exception e) {
+      log.warn("Could not send telemetry.\n" + "Data was " + metrics, e);
     }
+  }
 
-    private final ITelemetry telemetryClient;
-    private final SCCPProperties properties;
-    private final MetricsHelper helper;
+  public Map<Metrics, Object> contextToMetrics(DiagnosticsContext context) {
+    Map<Metrics, Object> metrics = new TreeMap<>();
+    MethodSignature signature = (MethodSignature) context.joinPoint.getSignature();
+    helper.signatureToMetricsAboutJavaMethod(signature, metrics);
+    helper.joinPointToMetricsAboutMeasurable(context.joinPoint, metrics);
+    diagContextToMetricsAboutExecution(context, metrics);
+    return metrics;
+  }
 
-    @Override
-    public void accept(DiagnosticsContext context) {
-
-        Map<Metrics, Object> metrics = contextToMetrics(context);
-        String opId = "" + metrics.get(Metrics.op_id);
-        try {
-            //this modifies the metrics
-            if (metrics.containsKey(Metrics.method_result)) {
-                String result = "" + metrics.get(Metrics.method_result);
-                String resAsStr = result.substring(0, Math.min(666, result.length()));
-                metrics.put(Metrics.method_result, resAsStr);
-            }
-            if (metrics.containsKey(Metrics.error_class)) {
-                String asStr = ("" + metrics.get(Metrics.error_class));
-                metrics.put(Metrics.method_result, asStr);
-            }
-            metrics.put(Metrics.cp_svc_name, properties.getSpringProperty(SpringAppPropNames.SVC_NAME));
-
-            ObjectMapper mapper = new ObjectMapper();
-            ObjectNode node = mapper.convertValue(metrics, ObjectNode.class);
-            node.put("@table", "taurus_api_call");
-            node.put("@id", opId);
-            String json = node.toPrettyString();
-            log.trace("Sending telemetry: {}", json);
-            this.telemetryClient.sendAsync(json);
-
-        } catch (Exception e) {
-            log.warn("Could not send telemetry.\n" + "Data was " + metrics, e);
-        }
-
+  public void diagContextToMetricsAboutExecution(
+      DiagnosticsContext context, Map<Metrics, Object> metrics) {
+    metrics.put(Metrics.op_id, context.opId);
+    metrics.put(Metrics.method_execution_time_nanos, context.stopWatch.getTotalTimeNanos());
+    metrics.put(Metrics.method_execution_end_timestamp, System.currentTimeMillis());
+    boolean hasError = null != context.error;
+    metrics.put(Metrics.call_failed, hasError);
+    if (hasError) {
+      metrics.put(Metrics.error_class, context.error.getClass());
+      metrics.put(Metrics.error_message, context.error.getMessage());
+      StringWriter sw = new StringWriter();
+      PrintWriter pw = new PrintWriter(sw);
+      context.error.printStackTrace(pw);
+      metrics.put(Metrics.error_stacktrace, sw.toString());
+    } else if (context != context.methodResult) {
+      metrics.put(Metrics.method_result, context.methodResult);
+      if (context.methodResult instanceof ResponseEntity) {
+        ResponseEntity r = (ResponseEntity) context.methodResult;
+        metrics.put(Metrics.http_code, r.getStatusCodeValue());
+        Object body = r.getBody();
+        if (null != body) metrics.put(Metrics.http_body_type, body.getClass().getName());
+      }
     }
-
-    public Map<Metrics, Object> contextToMetrics(DiagnosticsContext context) {
-        Map<Metrics, Object> metrics = new TreeMap<>();
-        MethodSignature signature = (MethodSignature) context.joinPoint.getSignature();
-        helper.signatureToMetricsAboutJavaMethod(signature, metrics);
-        helper.joinPointToMetricsAboutMeasurable(context.joinPoint, metrics);
-        diagContextToMetricsAboutExecution(context, metrics);
-        return metrics;
-    }
-
-    public void diagContextToMetricsAboutExecution(DiagnosticsContext context, Map<Metrics, Object> metrics) {
-        metrics.put(Metrics.op_id, context.opId);
-        metrics.put(Metrics.method_execution_time_nanos, context.stopWatch.getTotalTimeNanos());
-        metrics.put(Metrics.method_execution_end_timestamp, System.currentTimeMillis());
-        boolean hasError = null != context.error;
-        metrics.put(Metrics.call_failed, hasError);
-        if (hasError) {
-            metrics.put(Metrics.error_class, context.error.getClass());
-            metrics.put(Metrics.error_message, context.error.getMessage());
-            StringWriter sw = new StringWriter();
-            PrintWriter pw = new PrintWriter(sw);
-            context.error.printStackTrace(pw);
-            metrics.put(Metrics.error_stacktrace, sw.toString());
-        } else if (context != context.methodResult) {
-            metrics.put(Metrics.method_result, context.methodResult);
-            if (context.methodResult instanceof ResponseEntity) {
-                ResponseEntity r = (ResponseEntity) context.methodResult;
-                metrics.put(Metrics.http_code, r.getStatusCodeValue());
-                Object body = r.getBody();
-                if (null != body)
-                    metrics.put(Metrics.http_body_type, body.getClass().getName());
-            }
-        }
-    }
-
+  }
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/methodintercept/Measurable.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/methodintercept/Measurable.java
@@ -5,33 +5,29 @@
 
 package com.vmware.taurus.service.diag.methodintercept;
 
-
 import java.lang.annotation.*;
 
-/**
- * Use this annotation to enable diagnostics collection
- * on class or methods.
- */
+/** Use this annotation to enable diagnostics collection on class or methods. */
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Repeatable(MeasurableContainer.class)
 public @interface Measurable {
 
-    /*
-     * the arg ordinal (starting at 0) whose value should be included in the metrics.
-     * Each argument will be serialized in json if possible, if not it will fall-back to toString()
-     * An ordinal is used since the Aspect doesn't actually have access to parameter names.
-     */
-    int includeArg() default -1;
+  /*
+   * the arg ordinal (starting at 0) whose value should be included in the metrics.
+   * Each argument will be serialized in json if possible, if not it will fall-back to toString()
+   * An ordinal is used since the Aspect doesn't actually have access to parameter names.
+   */
+  int includeArg() default -1;
 
-    /*
-     * The name of the argument at index (as specified by includeArg).
-     * If no name is specified at given index then "arg" is used.
-     */
-    String argName() default "arg";
+  /*
+   * The name of the argument at index (as specified by includeArg).
+   * If no name is specified at given index then "arg" is used.
+   */
+  String argName() default "arg";
 
-    /*
-     * List of tags - these are just passed through - to make reporting easier.
-     */
-    String[] tags() default {};
+  /*
+   * List of tags - these are just passed through - to make reporting easier.
+   */
+  String[] tags() default {};
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/methodintercept/MeasurableContainer.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/methodintercept/MeasurableContainer.java
@@ -5,19 +5,15 @@
 
 package com.vmware.taurus.service.diag.methodintercept;
 
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * Enable Measurable to be repeatable annotation
- */
+/** Enable Measurable to be repeatable annotation */
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MeasurableContainer {
 
-    Measurable[] value() default {};
-
+  Measurable[] value() default {};
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/methodintercept/MetricsHelper.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/methodintercept/MetricsHelper.java
@@ -18,65 +18,65 @@ import java.util.*;
 @Slf4j
 public class MetricsHelper {
 
-    private final static ObjectMapper mapper = new ObjectMapper();
+  private static final ObjectMapper mapper = new ObjectMapper();
 
-    public void signatureToMetricsAboutJavaMethod(MethodSignature signature, Map<Metrics, Object> metrics) {
-        String classNameCanonical = signature.getDeclaringType().getCanonicalName();
-        String classNameSimple = signature.getDeclaringType().getSimpleName();
-        String methodName = signature.getName();
-        metrics.put(Metrics.method_name, methodName);
-        metrics.put(Metrics.class_name_short, classNameSimple);
-        metrics.put(Metrics.class_name_full, classNameCanonical);
-    }
+  public void signatureToMetricsAboutJavaMethod(
+      MethodSignature signature, Map<Metrics, Object> metrics) {
+    String classNameCanonical = signature.getDeclaringType().getCanonicalName();
+    String classNameSimple = signature.getDeclaringType().getSimpleName();
+    String methodName = signature.getName();
+    metrics.put(Metrics.method_name, methodName);
+    metrics.put(Metrics.class_name_short, classNameSimple);
+    metrics.put(Metrics.class_name_full, classNameCanonical);
+  }
 
-    public void joinPointToMetricsAboutMeasurable(JoinPoint joinPoint, Map<Metrics, Object> metrics) {
-        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-        List<Measurable> measurables = getMeasurables(signature);
-        if (!measurables.isEmpty()) {
-            Map<String, Object> measurableArgs = new LinkedHashMap();
-            Set<String> tags = new LinkedHashSet<>();
-            for (Measurable measurable : measurables) {
-                Object arg = joinPoint.getArgs()[measurable.includeArg()];
-                measurableArgs.put(measurable.argName(), arg);
-                tags.addAll(Arrays.asList(measurable.tags()));
-            }
-            if (measurableArgs.size() > 0) {
-                metrics.put(Metrics.measurable_args, serializeObject(measurableArgs));
-            }
-            if (tags.size() > 0) {
-                String measurableTags = "" + tags;
-                metrics.put(Metrics.measurable_tags, measurableTags);
-            }
-        }
+  public void joinPointToMetricsAboutMeasurable(JoinPoint joinPoint, Map<Metrics, Object> metrics) {
+    MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+    List<Measurable> measurables = getMeasurables(signature);
+    if (!measurables.isEmpty()) {
+      Map<String, Object> measurableArgs = new LinkedHashMap();
+      Set<String> tags = new LinkedHashSet<>();
+      for (Measurable measurable : measurables) {
+        Object arg = joinPoint.getArgs()[measurable.includeArg()];
+        measurableArgs.put(measurable.argName(), arg);
+        tags.addAll(Arrays.asList(measurable.tags()));
+      }
+      if (measurableArgs.size() > 0) {
+        metrics.put(Metrics.measurable_args, serializeObject(measurableArgs));
+      }
+      if (tags.size() > 0) {
+        String measurableTags = "" + tags;
+        metrics.put(Metrics.measurable_tags, measurableTags);
+      }
     }
+  }
 
-    private static List<Measurable> getMeasurables(MethodSignature signature) {
-        MeasurableContainer measurableContainer = signature.getMethod().getAnnotation(MeasurableContainer.class);
-        Measurable measurableAnnotation = signature.getMethod().getAnnotation(Measurable.class);
-        List<Measurable> measurables = Collections.emptyList();
-        if (null != measurableContainer) {
-            measurables = Arrays.asList(measurableContainer.value());
-        } else if (null != measurableAnnotation) {
-            measurables = Collections.singletonList(measurableAnnotation);
-        }
-        return measurables;
+  private static List<Measurable> getMeasurables(MethodSignature signature) {
+    MeasurableContainer measurableContainer =
+        signature.getMethod().getAnnotation(MeasurableContainer.class);
+    Measurable measurableAnnotation = signature.getMethod().getAnnotation(Measurable.class);
+    List<Measurable> measurables = Collections.emptyList();
+    if (null != measurableContainer) {
+      measurables = Arrays.asList(measurableContainer.value());
+    } else if (null != measurableAnnotation) {
+      measurables = Collections.singletonList(measurableAnnotation);
     }
+    return measurables;
+  }
 
-    /**
-     * Tries to convert it to json and if it fails falls back to "toString()"
-     */
-    private static String serializeObject(Object obj) {
-        if (obj == null) {
-            return null;
-        }
-        String result = "";
-        try {
-            mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-            result = mapper.writeValueAsString(obj);
-        } catch (JsonProcessingException e) {
-            log.debug("Failed to convert object to json: {}: {}", obj.getClass(), e.getMessage());
-            result = "" + obj;
-        }
-        return result;
+  /** Tries to convert it to json and if it fails falls back to "toString()" */
+  private static String serializeObject(Object obj) {
+    if (obj == null) {
+      return null;
     }
+    String result = "";
+    try {
+      mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+      result = mapper.writeValueAsString(obj);
+    } catch (JsonProcessingException e) {
+      log.debug("Failed to convert object to json: {}: {}", obj.getClass(), e.getMessage());
+      result = "" + obj;
+    }
+    return result;
+  }
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/opid/OpIdSupplier.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/opid/OpIdSupplier.java
@@ -4,7 +4,8 @@
  */
 
 package com.vmware.taurus.service.diag.opid;
+
 @FunctionalInterface
-public interface OpIdSupplier  {
-    public String getOpId();
+public interface OpIdSupplier {
+  public String getOpId();
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/opid/RequestInterceptor.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/opid/RequestInterceptor.java
@@ -20,37 +20,32 @@ import javax.servlet.http.HttpServletResponse;
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class RequestInterceptor extends HandlerInterceptorAdapter {
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+  private final Logger log = LoggerFactory.getLogger(this.getClass());
 
-    private OperationContext opCtx;
+  private OperationContext opCtx;
 
-    @Autowired
-    public RequestInterceptor(OperationContext opCtx) {
-        this.opCtx = opCtx;
+  @Autowired
+  public RequestInterceptor(OperationContext opCtx) {
+    this.opCtx = opCtx;
+  }
+
+  @Override
+  public boolean preHandle(
+      HttpServletRequest request, HttpServletResponse response, Object handler) {
+    String opId = request.getHeader("X-OPID");
+    if (null == opId) {
+      opId = "0" + System.currentTimeMillis();
     }
+    opCtx.setId(opId);
+    log.debug(">>>>>> Entering {}", request.getRequestURI());
+    opCtx.setHttpRequest(request);
+    opCtx.setHttpResponse(response);
+    return true;
+  }
 
-    @Override
-    public boolean preHandle(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            Object handler) {
-        String opId = request.getHeader("X-OPID");
-        if (null == opId) {
-            opId = "0" + System.currentTimeMillis();
-        }
-        opCtx.setId(opId);
-        log.debug(">>>>>> Entering {}", request.getRequestURI());
-        opCtx.setHttpRequest(request);
-        opCtx.setHttpResponse(response);
-        return true;
-    }
-
-    @Override
-    public void afterCompletion(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            Object handler,
-            Exception ex) {
-        log.debug("<<<<<<< Exiting {}", request.getRequestURI());
-    }
+  @Override
+  public void afterCompletion(
+      HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+    log.debug("<<<<<<< Exiting {}", request.getRequestURI());
+  }
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/opid/ResponseOpIdSetterAdvice.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/opid/ResponseOpIdSetterAdvice.java
@@ -5,7 +5,6 @@
 
 package com.vmware.taurus.service.diag.opid;
 
-
 import com.vmware.taurus.service.diag.OperationContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,31 +17,34 @@ import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
-/**
- * This class applies header response of opID across all controllers.
- */
+/** This class applies header response of opID across all controllers. */
 @ControllerAdvice
 public class ResponseOpIdSetterAdvice implements ResponseBodyAdvice<Object> {
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
-    private OperationContext opCtx;
+  private final Logger log = LoggerFactory.getLogger(this.getClass());
+  private OperationContext opCtx;
 
-    @Autowired
-    public ResponseOpIdSetterAdvice(OperationContext opCtx) {
-        this.opCtx = opCtx;
-    }
+  @Autowired
+  public ResponseOpIdSetterAdvice(OperationContext opCtx) {
+    this.opCtx = opCtx;
+  }
 
-    @Override
-    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
-        return true;
-    }
+  @Override
+  public boolean supports(
+      MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+    return true;
+  }
 
-    @Override
-    public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
-                                  Class<? extends HttpMessageConverter<?>> selectedConverterType,
-                                  ServerHttpRequest request, ServerHttpResponse response) {
-        String opId = opCtx.getOpId();
-        log.trace("Setting 'X-OPID:{}' header in response", opId);
-        response.getHeaders().add("X-OPID", opId);
-        return body;
-    }
+  @Override
+  public Object beforeBodyWrite(
+      Object body,
+      MethodParameter returnType,
+      MediaType selectedContentType,
+      Class<? extends HttpMessageConverter<?>> selectedConverterType,
+      ServerHttpRequest request,
+      ServerHttpResponse response) {
+    String opId = opCtx.getOpId();
+    log.trace("Setting 'X-OPID:{}' header in response", opId);
+    response.getHeaders().add("X-OPID", opId);
+    return body;
+  }
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/telemetry/ITelemetry.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/telemetry/ITelemetry.java
@@ -6,8 +6,8 @@
 package com.vmware.taurus.service.diag.telemetry;
 
 public interface ITelemetry {
-    /**
-     * @param payload json to be sent as payload.
-     */
-    void sendAsync(String payload);
+  /**
+   * @param payload json to be sent as payload.
+   */
+  void sendAsync(String payload);
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/telemetry/Telemetry.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/telemetry/Telemetry.java
@@ -5,7 +5,6 @@
 
 package com.vmware.taurus.service.diag.telemetry;
 
-
 import com.vmware.taurus.base.EnableComponents;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -20,60 +19,75 @@ import java.net.http.HttpResponse;
 import java.util.concurrent.CompletableFuture;
 
 @Component
-@org.springframework.boot.autoconfigure.condition.ConditionalOnProperty(value = EnableComponents.DIAGNOSTICS, havingValue = "true", matchIfMissing = true)
+@org.springframework.boot.autoconfigure.condition.ConditionalOnProperty(
+    value = EnableComponents.DIAGNOSTICS,
+    havingValue = "true",
+    matchIfMissing = true)
 public class Telemetry implements ITelemetry {
-    private static final Logger log = LoggerFactory.getLogger(Telemetry.class);
+  private static final Logger log = LoggerFactory.getLogger(Telemetry.class);
 
-    public Telemetry(@Value("${datajobs.telemetry.webhook.endpoint:}") String telemetryEndpoint) {
-        this.client = HttpClient.newHttpClient();
-        this.telemetryEndpoint = telemetryEndpoint;
-        if (StringUtils.isBlank(this.telemetryEndpoint)) {
-            log.info("Telemetry endpoint is empty and sending telemetry is skipped");
-        }
+  public Telemetry(@Value("${datajobs.telemetry.webhook.endpoint:}") String telemetryEndpoint) {
+    this.client = HttpClient.newHttpClient();
+    this.telemetryEndpoint = telemetryEndpoint;
+    if (StringUtils.isBlank(this.telemetryEndpoint)) {
+      log.info("Telemetry endpoint is empty and sending telemetry is skipped");
     }
-    // TODO: add support for buffering, re-tries (with back-off)
-    private final String telemetryEndpoint;
-    private final HttpClient client;
+  }
+  // TODO: add support for buffering, re-tries (with back-off)
+  private final String telemetryEndpoint;
+  private final HttpClient client;
 
-    private static <T> CompletableFuture<HttpResponse<T>> handleResponseWithRetry(HttpClient client, HttpRequest request,
-                                      HttpResponse.BodyHandler<T> handler, HttpResponse<T> response) {
-        if (response == null || response.statusCode() >= 500) {
-            return client.sendAsync(request, handler)
-                    .thenApplyAsync( (r) -> {
-                        if (r.statusCode() >= 400) {
-                            log.warn("Failed to send telemetry after re-try:" +
-                                    "telemetry webhook returned HTTP client error: " + r.statusCode()
-                                    + " and content: " + r.body());
-                        }
-                        return r;
-                    });
-        } else {
-            if (response.statusCode() >= 400 && response.statusCode() < 500) {
-                log.warn("Failed to send telemetry: telemetry webhook returned HTTP client error: " + response.statusCode()
-                        + " and content: " + response.body());
-            }
-            return CompletableFuture.completedFuture(response);
-        }
+  private static <T> CompletableFuture<HttpResponse<T>> handleResponseWithRetry(
+      HttpClient client,
+      HttpRequest request,
+      HttpResponse.BodyHandler<T> handler,
+      HttpResponse<T> response) {
+    if (response == null || response.statusCode() >= 500) {
+      return client
+          .sendAsync(request, handler)
+          .thenApplyAsync(
+              (r) -> {
+                if (r.statusCode() >= 400) {
+                  log.warn(
+                      "Failed to send telemetry after re-try:"
+                          + "telemetry webhook returned HTTP client error: "
+                          + r.statusCode()
+                          + " and content: "
+                          + r.body());
+                }
+                return r;
+              });
+    } else {
+      if (response.statusCode() >= 400 && response.statusCode() < 500) {
+        log.warn(
+            "Failed to send telemetry: telemetry webhook returned HTTP client error: "
+                + response.statusCode()
+                + " and content: "
+                + response.body());
+      }
+      return CompletableFuture.completedFuture(response);
     }
+  }
 
-    @Override
-    public void sendAsync(String payload) {
-        if (StringUtils.isBlank(this.telemetryEndpoint)) {
-            return;
-        }
-        log.debug("Sending streaming telemetry to {}", telemetryEndpoint);
-        HttpResponse.BodyHandler<String> handler = HttpResponse.BodyHandlers.ofString();
-
-        HttpRequest request = HttpRequest.newBuilder()
-                .setHeader("accept", "application/json")
-                .setHeader("content-type", "application/json")
-                .uri(URI.create(this.telemetryEndpoint))
-                .POST(HttpRequest.BodyPublishers.ofString(payload))
-                .build();
-        // we re-try once. We assume that most errors are resolved on first re-try.
-        // For better robustness though we should consider more sophisticated re-tries with back off
-        client.sendAsync(request, handler)
-                .thenComposeAsync(r -> handleResponseWithRetry(client, request, handler, r));
+  @Override
+  public void sendAsync(String payload) {
+    if (StringUtils.isBlank(this.telemetryEndpoint)) {
+      return;
     }
+    log.debug("Sending streaming telemetry to {}", telemetryEndpoint);
+    HttpResponse.BodyHandler<String> handler = HttpResponse.BodyHandlers.ofString();
 
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .setHeader("accept", "application/json")
+            .setHeader("content-type", "application/json")
+            .uri(URI.create(this.telemetryEndpoint))
+            .POST(HttpRequest.BodyPublishers.ofString(payload))
+            .build();
+    // we re-try once. We assume that most errors are resolved on first re-try.
+    // For better robustness though we should consider more sophisticated re-tries with back off
+    client
+        .sendAsync(request, handler)
+        .thenComposeAsync(r -> handleResponseWithRetry(client, request, handler, r));
+  }
 }

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/doc/SwaggerConfig.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/doc/SwaggerConfig.java
@@ -21,31 +21,32 @@ import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 /**
- * TODO: currently swagger doc is accessed via http://localhost:8080/swagger-ui.html
- * We need it to become http://localhost:8080/svcname/swagger-ui.html and this is not supported by Swagger, so probably some URL rewriting need be in place (redirects don't work in k8s environment)
+ * TODO: currently swagger doc is accessed via http://localhost:8080/swagger-ui.html We need it to
+ * become http://localhost:8080/svcname/swagger-ui.html and this is not supported by Swagger, so
+ * probably some URL rewriting need be in place (redirects don't work in k8s environment)
  */
 @Configuration
 @EnableSwagger2
 @Controller
 public class SwaggerConfig implements WebMvcConfigurer {
 
-    public SwaggerConfig(@Value("${" + SpringAppPropNames.SVC_NAME + ":base}") String svcName) {
-        this.svcName = svcName;
-    }
+  public SwaggerConfig(@Value("${" + SpringAppPropNames.SVC_NAME + ":base}") String svcName) {
+    this.svcName = svcName;
+  }
 
-    private final String svcName;
+  private final String svcName;
 
-    @Bean
-    @Order(Ordered.LOWEST_PRECEDENCE)
-    public Docket swaggerSpringMvcPlugin() {
-        return new Docket(DocumentationType.SWAGGER_2)
-//                .pathMapping("a") //this causes swagger to show methods as: GET /a/teams/name
-                .select()
-                //Every API (/libraries/model) method is annotated with ApiOperation
-                .apis(RequestHandlerSelectors.withMethodAnnotation(ApiOperation.class))
-                //services are expected to have 2 types of paths: /<team>/* and /<team>s/*.
-                .paths(PathSelectors.ant("/" + svcName + "*/**"))
-                .build()
-                ;
-    }
+  @Bean
+  @Order(Ordered.LOWEST_PRECEDENCE)
+  public Docket swaggerSpringMvcPlugin() {
+    return new Docket(DocumentationType.SWAGGER_2)
+        //                .pathMapping("a") //this causes swagger to show methods as: GET
+        // /a/teams/name
+        .select()
+        // Every API (/libraries/model) method is annotated with ApiOperation
+        .apis(RequestHandlerSelectors.withMethodAnnotation(ApiOperation.class))
+        // services are expected to have 2 types of paths: /<team>/* and /<team>s/*.
+        .paths(PathSelectors.ant("/" + svcName + "*/**"))
+        .build();
+  }
 }

--- a/projects/control-service/projects/base/src/test/java/com/vmware/taurus/ControlplaneApplicationTests.java
+++ b/projects/control-service/projects/base/src/test/java/com/vmware/taurus/ControlplaneApplicationTests.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 
 public class ControlplaneApplicationTests {
 
-    @Test
-    public void smoke() {
-    }
+  @Test
+  public void smoke() {}
 }

--- a/projects/control-service/projects/base/src/test/java/com/vmware/taurus/ExceptionCausedByTest.java
+++ b/projects/control-service/projects/base/src/test/java/com/vmware/taurus/ExceptionCausedByTest.java
@@ -11,11 +11,11 @@ import org.junit.jupiter.api.Test;
 
 public class ExceptionCausedByTest {
 
-    @Test
-    public void exceptionCausedByTest() {
-        String expectedMessage = "foobarbaz";
-        Exception cause = new Exception(expectedMessage);
-        Bug bug = new Bug("why", cause);
-        Assertions.assertEquals(expectedMessage, bug.getCause().getMessage());
-    }
+  @Test
+  public void exceptionCausedByTest() {
+    String expectedMessage = "foobarbaz";
+    Exception cause = new Exception(expectedMessage);
+    Bug bug = new Bug("why", cause);
+    Assertions.assertEquals(expectedMessage, bug.getCause().getMessage());
+  }
 }

--- a/projects/control-service/projects/base/src/test/java/com/vmware/taurus/exception/SystemErrorTest.java
+++ b/projects/control-service/projects/base/src/test/java/com/vmware/taurus/exception/SystemErrorTest.java
@@ -12,19 +12,19 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SystemErrorTest {
 
-    private static class InvalidSystemError extends SystemError implements UserFacingError {
-        InvalidSystemError() {
-            super("bla", "bla", "bla", "bla", null);
-        }
-
-        @Override
-        public HttpStatus getHttpStatus() {
-            return HttpStatus.OK;
-        }
+  private static class InvalidSystemError extends SystemError implements UserFacingError {
+    InvalidSystemError() {
+      super("bla", "bla", "bla", "bla", null);
     }
 
-    @Test
-    public void testValidation() {
-        assertThrows(Bug.class, InvalidSystemError::new);
+    @Override
+    public HttpStatus getHttpStatus() {
+      return HttpStatus.OK;
     }
+  }
+
+  @Test
+  public void testValidation() {
+    assertThrows(Bug.class, InvalidSystemError::new);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobCrudIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobCrudIT.java
@@ -36,461 +36,657 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = ControlplaneApplication.class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = ControlplaneApplication.class)
 public class DataJobCrudIT extends BaseIT {
 
-   @Autowired
-   private JobsRepository jobsRepository;
-
-   @Test
-   public void testDataJobCrud() throws Exception {
-      // Setup
-      String dataJobRequestBody = getDataJobRequestBody(TEST_TEAM_NAME, TEST_JOB_NAME);
-
-      // Execute create job (Post Create WebHook will return success for this call)
-      mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
-            .with(user("user"))
-            .content(dataJobRequestBody)
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isCreated())
-            .andExpect(header().string(HttpHeaders.LOCATION,
-                  lambdaMatcher(s -> s.endsWith(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME,
-                          TEST_JOB_NAME)))));
-      //Validate - the job is created
-      Assertions.assertTrue(jobsRepository.existsById(TEST_JOB_NAME));
-
-      // Execute create job with no user
-      mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
-              .content(dataJobRequestBody)
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isUnauthorized());
-
-      testDataJobPostCreateWebHooks();
-
-      // Execute get swagger with no user
-      mockMvc.perform(get("/data-jobs/swagger-ui.html")
-              .content(dataJobRequestBody)
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk());
-      mockMvc.perform(get("/data-jobs/webjars/springfox-swagger-ui/swagger-ui.css.map")
-                      .content(dataJobRequestBody)
-                      .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk());
-      mockMvc.perform(get("/data-jobs/webjars/springfox-swagger-ui/swagger-ui-bundle.js.map")
-                      .content(dataJobRequestBody)
-                      .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk());
-      mockMvc.perform(get("/data-jobs/swagger-resources/configuration/ui")
-                      .content(dataJobRequestBody)
-                      .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk());
-      mockMvc.perform(get("/data-jobs/swagger-resources/configuration/security")
-                      .content(dataJobRequestBody)
-                      .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk());
-      mockMvc.perform(get("/data-jobs/swagger-resources")
-                      .content(dataJobRequestBody)
-                      .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk());
-      mockMvc.perform(get("/data-jobs/v2/api-docs")
-                      .content(dataJobRequestBody)
-                      .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk());
-
-      // Validation
-      // Validate keytab created
-      var keytabSecretName = JobCredentialsService.getJobKeytabKubernetesSecretName(TEST_JOB_NAME);
-      var keytabSecretData = dataJobsKubernetesService.getSecretData(keytabSecretName);
-      Assertions.assertFalse(keytabSecretData.isEmpty());
-      Assertions.assertTrue(keytabSecretData.containsKey("keytab"));
-      Assertions.assertTrue(ArrayUtils.isNotEmpty(keytabSecretData.get("keytab")));
-
-      // Validate persisted job
-      var jobFromDbOptional= jobsRepository.findById(TEST_JOB_NAME);
-      Assertions.assertTrue(jobFromDbOptional.isPresent());
-      var jobFromDb = jobFromDbOptional.get();
-      Assertions.assertEquals(TEST_JOB_SCHEDULE, jobFromDb.getJobConfig().getSchedule());
-
-      // Execute list jobs
-      // deprecated jobsList in favour of jobsQuery
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s", TEST_TEAM_NAME))
-               .with(user("user")))
-               .andExpect(status().isOk())
-               .andExpect(content().string(lambdaMatcher(s -> s.contains(TEST_JOB_NAME))));
-
-      // Execute list jobs with no user
-      // deprecated jobsList in favour of jobsQuery
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s", TEST_TEAM_NAME)))
-               .andExpect(status().isUnauthorized())
-               .andExpect(content().string(lambdaMatcher(s -> s.isBlank())));
-
-      // Execute get job with user
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME, TEST_JOB_NAME))
-               .with(user("user")))
-               .andExpect(status().isOk()).andExpect(content().string(lambdaMatcher(s -> s.contains(TEST_JOB_NAME))))
-               .andExpect(content().string(lambdaMatcher(s -> s.contains(TEST_JOB_SCHEDULE))));
-
-      // Execute get job with user and wrong team
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_WRONG_NAME, TEST_JOB_NAME))
-              .with(user("user")))
-              .andExpect(status().isNotFound());
-
-      // Execute get job without user
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME, TEST_JOB_NAME)))
-               .andExpect(status().isUnauthorized())
-               .andExpect(content().string(lambdaMatcher(s -> s.isBlank())));
-
-      // Execute update job team with user
-      mockMvc.perform(put(String.format("/data-jobs/for-team/%s/jobs/%s/team/%s", TEST_TEAM_WRONG_NAME, TEST_JOB_NAME, NEW_TEST_TEAM_NAME))
-              .with(user("user")))
-              .andExpect(status().isNotFound());
-
-      // Execute update job team with no user
-      mockMvc.perform(put(String.format("/data-jobs/for-team/%s/jobs/%s/team/%s", TEST_TEAM_NAME, TEST_JOB_NAME, NEW_TEST_TEAM_NAME)))
-              .andExpect(status().isUnauthorized());
-
-      // Execute update job team with same team and user
-      mockMvc.perform(put(String.format("/data-jobs/for-team/%s/jobs/%s/team/%s", TEST_TEAM_NAME, TEST_JOB_NAME, TEST_TEAM_NAME))
-              .with(user("user")))
-              .andExpect(status().isOk());
-
-      // Execute update job team with empty team
-      mockMvc.perform(put(String.format("/data-jobs/for-team/%s/jobs/%s/team/ ", TEST_TEAM_NAME, TEST_JOB_NAME))
-              .with(user("user")))
-              .andExpect(status().isNotFound());
-
-      // Execute update job team with user
-      mockMvc.perform(put(String.format("/data-jobs/for-team/%s/jobs/%s/team/%s", TEST_TEAM_NAME, TEST_JOB_NAME, TEST_TEAM_NAME))
-              .with(user("user")))
-              .andExpect(status().isOk());
-
-      // Execute update job team with non existing job
-      mockMvc.perform(put(String.format("/data-jobs/for-team/%s/jobs/missing-job/team/", TEST_TEAM_NAME))
-              .with(user("user")))
-              .andExpect(status().isNotFound());
-
-      // Execute update job team with empty job name
-      mockMvc.perform(put(String.format("/data-jobs/for-team/%s/jobs/ /team/%s", TEST_TEAM_NAME, NEW_TEST_TEAM_NAME))
-              .with(user("user")))
-              .andExpect(status().isNotFound());
-
-      // Execute update job team with missing job name
-      mockMvc.perform(put(String.format("/data-jobs/for-team/%s/jobs//team/%s", TEST_TEAM_NAME, NEW_TEST_TEAM_NAME))
-              .with(user("user")))
-              .andExpect(status().isNotFound());
-
-      // Execute get not allowed method to job team endpoint
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s/jobs/%s/team/%s", TEST_TEAM_NAME, TEST_JOB_NAME, TEST_TEAM_NAME))
-              .with(user("user")))
-              .andExpect(status().isMethodNotAllowed());
-
-      // Execute put method with user and with wrong team
-      // TODO: uncomment and extend tests to cover all put operations not only NotFound
-       mockMvc.perform(put(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_WRONG_NAME, TEST_JOB_NAME))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON).content(dataJobRequestBody))
-              .andExpect(status().isNotFound());
-
-      // Execute delete job with no user
-      mockMvc.perform(delete(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME, TEST_JOB_NAME))
-               .contentType(MediaType.APPLICATION_JSON))
-               .andExpect(status().isUnauthorized());
-
-      // Execute delete job with user and wrong team
-      mockMvc.perform(delete(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_WRONG_NAME, TEST_JOB_NAME))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isNotFound());
-
-      // Execute delete job with user
-      mockMvc.perform(delete(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME, TEST_JOB_NAME))
-               .with(user("user"))
-               .contentType(MediaType.APPLICATION_JSON))
-               .andExpect(status().isOk());
-
-      // Execute update job team after job is deleted from db and is missing
-      mockMvc.perform(put(String.format("/data-jobs/for-team/%s/jobs/%s/team/%s", TEST_TEAM_NAME, TEST_JOB_NAME, TEST_TEAM_NAME))
-              .with(user("user")))
-              .andExpect(status().isNotFound());
-
-
-      // Validate keytab deleted
-      keytabSecretData = dataJobsKubernetesService.getSecretData(keytabSecretName);
-      Assertions.assertTrue(keytabSecretData.isEmpty());
-
-      // Validate job deleted from db
-      Assertions.assertFalse(jobsRepository.existsById(TEST_JOB_NAME));
-
-      testDataJobPostDeleteWebHooks();
-   }
-
-   private void testDataJobPostCreateWebHooks() throws Exception {
-      // Post Create WebHook will prevent job creation and the result will be propagated error code with no job created
-      String clientErrorDataJobRequestBody = getDataJobRequestBody(TEST_CLIENT_ERROR_TEAM,
-              TEST_CLIENT_ERROR_JOB_NAME);
-      mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs", TEST_CLIENT_ERROR_TEAM))
-              .with(user("user"))
-              .content(clientErrorDataJobRequestBody)
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isBadRequest());
-      // Validate - the job is NOT created
-      Assertions.assertFalse(jobsRepository.existsById(TEST_CLIENT_ERROR_JOB_NAME));
-
-      // Post Create WebHook will prevent job creation and the result will be error 503 with no job created
-      String internalServerErrorDataJobRequestBody = getDataJobRequestBody(TEST_INTERNAL_ERROR_TEAM,
-              TEST_INTERNAL_ERROR_JOB_NAME);
-      mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs", TEST_INTERNAL_ERROR_TEAM))
-              .with(user("user"))
-              .content(internalServerErrorDataJobRequestBody)
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isServiceUnavailable());
-      // Validate - the job is NOT created
-      Assertions.assertFalse(jobsRepository.existsById(TEST_INTERNAL_ERROR_JOB_NAME));
-
-      // Post Create WebHook will retry 2 times and finally will allow job creation
-      String retriedErrorDataJobRequestBody = getDataJobRequestBody(TEST_INTERNAL_ERROR_RETRIED_TEAM,
-              TEST_INTERNAL_ERROR_RETRIED_JOB_NAME);
-      mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs", TEST_INTERNAL_ERROR_RETRIED_TEAM))
-              .with(user("user"))
-              .content(retriedErrorDataJobRequestBody)
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isCreated());
-      // Validate - the job is created
-      Assertions.assertTrue(jobsRepository.existsById(TEST_INTERNAL_ERROR_RETRIED_JOB_NAME));
-   }
-
-   private void testDataJobPostDeleteWebHooks() throws Exception {
-      //Add test job to the repository
-      DataJob clientErrorEntity = getDataJobRepositoryModel(TEST_CLIENT_ERROR_TEAM,
-              TEST_CLIENT_ERROR_JOB_NAME);
-      jobsRepository.save(clientErrorEntity);
-      // Post Delete WebHook will prevent job deletion and the result will be propagated error code
-      mockMvc.perform(delete(String.format("/data-jobs/for-team/%s/jobs/%s",
-              TEST_CLIENT_ERROR_TEAM, TEST_CLIENT_ERROR_JOB_NAME))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isBadRequest());
-      // Validate - the job is NOT deleted
-      Assertions.assertTrue(jobsRepository.existsById(TEST_CLIENT_ERROR_JOB_NAME));
-      //Clean Up
-      jobsRepository.delete(clientErrorEntity);
-
-      //Add test job to the repository
-      DataJob internalServerEntity = getDataJobRepositoryModel(TEST_INTERNAL_ERROR_TEAM,
-              TEST_INTERNAL_ERROR_JOB_NAME);
-      jobsRepository.save(internalServerEntity);
-      // Post Delete WebHook will prevent job deletion and the result will be error 503
-      mockMvc.perform(delete(String.format("/data-jobs/for-team/%s/jobs/%s",
-              TEST_INTERNAL_ERROR_TEAM, TEST_INTERNAL_ERROR_JOB_NAME))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isServiceUnavailable());
-      // Validate - the job is NOT deleted
-      Assertions.assertTrue(jobsRepository.existsById(TEST_INTERNAL_ERROR_JOB_NAME));
-      //Clean Up
-      jobsRepository.delete(internalServerEntity);
-
-      //Add test job to the repository
-      DataJob internalServerRetriedEntity = getDataJobRepositoryModel(TEST_INTERNAL_ERROR_RETRIED_TEAM,
-              TEST_INTERNAL_ERROR_RETRIED_JOB_NAME);
-      jobsRepository.save(internalServerRetriedEntity);
-      // Post Create WebHook will retry 2 times and finally will allow job creation
-      mockMvc.perform(delete(String.format("/data-jobs/for-team/%s/jobs/%s",
-              TEST_INTERNAL_ERROR_RETRIED_TEAM, TEST_INTERNAL_ERROR_RETRIED_JOB_NAME))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk());
-      // Validate - the job is deleted
-      Assertions.assertFalse(jobsRepository.existsById(TEST_INTERNAL_ERROR_RETRIED_JOB_NAME));
-      //Clean Up
-      jobsRepository.delete(internalServerEntity);
-   }
-
-   /**
-    * @deprecated in favour of jobsQuery
-    */
-   @Test
-   @Deprecated
-   public void testDataJobGetPaging() throws Exception {
-
-      // Setup by creating 2 jobs in 2 separate teams
-      String dataJobTestBodyOne = getDataJobRequestBody(TEST_TEAM_NAME, TEST_JOB_1);
-
-      mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
-              .with(user("user"))
-              .content(dataJobTestBodyOne)
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isCreated());
-
-      String dataJobTestBodyTwo = getDataJobRequestBody(TEST_TEAM_NAME, TEST_JOB_2);
-
-      mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
-              .with(user("user"))
-              .content(dataJobTestBodyTwo)
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isCreated());
-
-      String dataJobTestBodyThree = getDataJobRequestBody(NEW_TEST_TEAM_NAME, TEST_JOB_3);
-
-      mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs", NEW_TEST_TEAM_NAME))
-              .with(user("user"))
-              .content(dataJobTestBodyThree)
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isCreated());
-
-      String dataJobTestBodyFour= getDataJobRequestBody(NEW_TEST_TEAM_NAME, TEST_JOB_4);
-
-      mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs", NEW_TEST_TEAM_NAME))
-              .with(user("user"))
-              .content(dataJobTestBodyFour)
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isCreated());
-
-      // Validate - only jobs from the first team are returned
-      // deprecated jobsList in favour of jobsQuery
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s", TEST_TEAM_NAME))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk())
-              .andExpect(content().string(lambdaMatcher(s -> (s.contains(TEST_JOB_1))
-                      && (s.contains(TEST_JOB_2))
-                      && (!s.contains(TEST_JOB_3))
-                      && (!s.contains(TEST_JOB_4)))));
-
-      // Validate - ordered paging of jobs from the first team for page 0
-      // deprecated jobsList in favour of jobsQuery
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s?page_number=0&page_size=1", TEST_TEAM_NAME))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk())
-              .andExpect(content().string(lambdaMatcher(s -> (s.contains(TEST_JOB_1))
-                      && (!s.contains(TEST_JOB_2))
-                      && (!s.contains(TEST_JOB_3))
-                      && (!s.contains(TEST_JOB_4)))));
-
-      // Validate - ordered paging of jobs from the first team for page 1
-      // deprecated jobsList in favour of jobsQuery
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s?page_number=1&page_size=1", TEST_TEAM_NAME))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk())
-              .andExpect(content().string(lambdaMatcher(s -> (!s.contains(TEST_JOB_1))
-                      && (s.contains(TEST_JOB_2))
-                      && (!s.contains(TEST_JOB_3))
-                      && (!s.contains(TEST_JOB_4)))));
-
-      // Validate - only jobs from the second team are returned
-      // deprecated jobsList in favour of jobsQuery
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s", NEW_TEST_TEAM_NAME))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk())
-              .andExpect(content().string(lambdaMatcher(s -> s.contains(TEST_JOB_3)
-                      && s.contains(TEST_JOB_4)
-                      && !s.contains(TEST_JOB_1)
-                      && !s.contains(TEST_JOB_2))));
-
-      // Validate - ordered paging of jobs from the second team for page 0
-      // deprecated jobsList in favour of jobsQuery
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s?page_number=0&page_size=1", NEW_TEST_TEAM_NAME))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk())
-              .andExpect(content().string(lambdaMatcher(s -> s.contains(TEST_JOB_3)
-                      && !s.contains(TEST_JOB_4)
-                      && !s.contains(TEST_JOB_1)
-                      && !s.contains(TEST_JOB_2))));
-
-      // Validate - ordered paging of jobs from the second team for page 1
-      // deprecated jobsList in favour of jobsQuery
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s?page_number=1&page_size=1", NEW_TEST_TEAM_NAME))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk())
-              .andExpect(content().string(lambdaMatcher(s -> !s.contains(TEST_JOB_3)
-                      && s.contains(TEST_JOB_4)
-                      && !s.contains(TEST_JOB_1)
-                      && !s.contains(TEST_JOB_2))));
-
-      // Validate - all jobs are returned in case of all parameter
-
-      // TODO: putting arbitrary team with "all" parameter returns all the jobs which looks strange, we should
-      //  probably introduce special team name like "default" and treat is as if all parameter also in the client
-      //  for simple use cases where the teams authorization chain is disabled
-      // deprecated jobsList in favour of jobsQuery
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s?show_all=true", TEST_TEAM_NAME))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk())
-              .andExpect(content().string(lambdaMatcher(s -> s.contains(TEST_JOB_1)
-                      && s.contains(TEST_JOB_2)
-                      && s.contains(TEST_JOB_3)
-                      && s.contains(TEST_JOB_4))));
-
-      // Validate - validate ordering for first page with two jobs
-      // deprecated jobsList in favour of jobsQuery
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s?show_all=true&page_number=0&page_size=2", TEST_TEAM_NAME))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk())
-              .andExpect(content().string(lambdaMatcher(s -> s.contains(TEST_JOB_1)
-                      && s.contains(TEST_JOB_2)
-                      && !s.contains(TEST_JOB_3)
-                      && !s.contains(TEST_JOB_4))));
-
-      // Validate - validate ordering for second page with two jobs
-      // deprecated jobsList in favour of jobsQuery
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s?show_all=true&page_number=1&page_size=2", TEST_TEAM_NAME))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk())
-              .andExpect(content().string(lambdaMatcher(s -> !s.contains(TEST_JOB_1)
-                      && !s.contains(TEST_JOB_2)
-                      && s.contains(TEST_JOB_3)
-                      && s.contains(TEST_JOB_4))));
-
-      // Clean up
-
-      mockMvc.perform(delete(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME, TEST_JOB_1))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk());
-
-      mockMvc.perform(delete(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME, TEST_JOB_2))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk());
-
-      mockMvc.perform(delete(String.format("/data-jobs/for-team/%s/jobs/%s", NEW_TEST_TEAM_NAME, TEST_JOB_3))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk());
-
-      mockMvc.perform(delete(String.format("/data-jobs/for-team/%s/jobs/%s", NEW_TEST_TEAM_NAME, TEST_JOB_4))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk());
-   }
-
-   @Test
-   public void testDataJobCreateDeleteIdempotency() throws Exception {
-      String dataJobTestBody = getDataJobRequestBody(TEST_TEAM_NAME, TEST_JOB_NAME);
-
-      mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
-              .with(user("user"))
-              .content(dataJobTestBody)
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isCreated());
-
-      mockMvc.perform(delete(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME, TEST_JOB_NAME))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk());
-
-      mockMvc.perform(delete(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME, TEST_JOB_NAME))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isNotFound());
-
-   }
+  @Autowired private JobsRepository jobsRepository;
+
+  @Test
+  public void testDataJobCrud() throws Exception {
+    // Setup
+    String dataJobRequestBody = getDataJobRequestBody(TEST_TEAM_NAME, TEST_JOB_NAME);
+
+    // Execute create job (Post Create WebHook will return success for this call)
+    mockMvc
+        .perform(
+            post(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
+                .with(user("user"))
+                .content(dataJobRequestBody)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated())
+        .andExpect(
+            header()
+                .string(
+                    HttpHeaders.LOCATION,
+                    lambdaMatcher(
+                        s ->
+                            s.endsWith(
+                                String.format(
+                                    "/data-jobs/for-team/%s/jobs/%s",
+                                    TEST_TEAM_NAME, TEST_JOB_NAME)))));
+    // Validate - the job is created
+    Assertions.assertTrue(jobsRepository.existsById(TEST_JOB_NAME));
+
+    // Execute create job with no user
+    mockMvc
+        .perform(
+            post(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
+                .content(dataJobRequestBody)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized());
+
+    testDataJobPostCreateWebHooks();
+
+    // Execute get swagger with no user
+    mockMvc
+        .perform(
+            get("/data-jobs/swagger-ui.html")
+                .content(dataJobRequestBody)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+    mockMvc
+        .perform(
+            get("/data-jobs/webjars/springfox-swagger-ui/swagger-ui.css.map")
+                .content(dataJobRequestBody)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+    mockMvc
+        .perform(
+            get("/data-jobs/webjars/springfox-swagger-ui/swagger-ui-bundle.js.map")
+                .content(dataJobRequestBody)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+    mockMvc
+        .perform(
+            get("/data-jobs/swagger-resources/configuration/ui")
+                .content(dataJobRequestBody)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+    mockMvc
+        .perform(
+            get("/data-jobs/swagger-resources/configuration/security")
+                .content(dataJobRequestBody)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+    mockMvc
+        .perform(
+            get("/data-jobs/swagger-resources")
+                .content(dataJobRequestBody)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+    mockMvc
+        .perform(
+            get("/data-jobs/v2/api-docs")
+                .content(dataJobRequestBody)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+
+    // Validation
+    // Validate keytab created
+    var keytabSecretName = JobCredentialsService.getJobKeytabKubernetesSecretName(TEST_JOB_NAME);
+    var keytabSecretData = dataJobsKubernetesService.getSecretData(keytabSecretName);
+    Assertions.assertFalse(keytabSecretData.isEmpty());
+    Assertions.assertTrue(keytabSecretData.containsKey("keytab"));
+    Assertions.assertTrue(ArrayUtils.isNotEmpty(keytabSecretData.get("keytab")));
+
+    // Validate persisted job
+    var jobFromDbOptional = jobsRepository.findById(TEST_JOB_NAME);
+    Assertions.assertTrue(jobFromDbOptional.isPresent());
+    var jobFromDb = jobFromDbOptional.get();
+    Assertions.assertEquals(TEST_JOB_SCHEDULE, jobFromDb.getJobConfig().getSchedule());
+
+    // Execute list jobs
+    // deprecated jobsList in favour of jobsQuery
+    mockMvc
+        .perform(get(String.format("/data-jobs/for-team/%s", TEST_TEAM_NAME)).with(user("user")))
+        .andExpect(status().isOk())
+        .andExpect(content().string(lambdaMatcher(s -> s.contains(TEST_JOB_NAME))));
+
+    // Execute list jobs with no user
+    // deprecated jobsList in favour of jobsQuery
+    mockMvc
+        .perform(get(String.format("/data-jobs/for-team/%s", TEST_TEAM_NAME)))
+        .andExpect(status().isUnauthorized())
+        .andExpect(content().string(lambdaMatcher(s -> s.isBlank())));
+
+    // Execute get job with user
+    mockMvc
+        .perform(
+            get(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME, TEST_JOB_NAME))
+                .with(user("user")))
+        .andExpect(status().isOk())
+        .andExpect(content().string(lambdaMatcher(s -> s.contains(TEST_JOB_NAME))))
+        .andExpect(content().string(lambdaMatcher(s -> s.contains(TEST_JOB_SCHEDULE))));
+
+    // Execute get job with user and wrong team
+    mockMvc
+        .perform(
+            get(String.format(
+                    "/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_WRONG_NAME, TEST_JOB_NAME))
+                .with(user("user")))
+        .andExpect(status().isNotFound());
+
+    // Execute get job without user
+    mockMvc
+        .perform(
+            get(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME, TEST_JOB_NAME)))
+        .andExpect(status().isUnauthorized())
+        .andExpect(content().string(lambdaMatcher(s -> s.isBlank())));
+
+    // Execute update job team with user
+    mockMvc
+        .perform(
+            put(String.format(
+                    "/data-jobs/for-team/%s/jobs/%s/team/%s",
+                    TEST_TEAM_WRONG_NAME, TEST_JOB_NAME, NEW_TEST_TEAM_NAME))
+                .with(user("user")))
+        .andExpect(status().isNotFound());
+
+    // Execute update job team with no user
+    mockMvc
+        .perform(
+            put(
+                String.format(
+                    "/data-jobs/for-team/%s/jobs/%s/team/%s",
+                    TEST_TEAM_NAME, TEST_JOB_NAME, NEW_TEST_TEAM_NAME)))
+        .andExpect(status().isUnauthorized());
+
+    // Execute update job team with same team and user
+    mockMvc
+        .perform(
+            put(String.format(
+                    "/data-jobs/for-team/%s/jobs/%s/team/%s",
+                    TEST_TEAM_NAME, TEST_JOB_NAME, TEST_TEAM_NAME))
+                .with(user("user")))
+        .andExpect(status().isOk());
+
+    // Execute update job team with empty team
+    mockMvc
+        .perform(
+            put(String.format(
+                    "/data-jobs/for-team/%s/jobs/%s/team/ ", TEST_TEAM_NAME, TEST_JOB_NAME))
+                .with(user("user")))
+        .andExpect(status().isNotFound());
+
+    // Execute update job team with user
+    mockMvc
+        .perform(
+            put(String.format(
+                    "/data-jobs/for-team/%s/jobs/%s/team/%s",
+                    TEST_TEAM_NAME, TEST_JOB_NAME, TEST_TEAM_NAME))
+                .with(user("user")))
+        .andExpect(status().isOk());
+
+    // Execute update job team with non existing job
+    mockMvc
+        .perform(
+            put(String.format("/data-jobs/for-team/%s/jobs/missing-job/team/", TEST_TEAM_NAME))
+                .with(user("user")))
+        .andExpect(status().isNotFound());
+
+    // Execute update job team with empty job name
+    mockMvc
+        .perform(
+            put(String.format(
+                    "/data-jobs/for-team/%s/jobs/ /team/%s", TEST_TEAM_NAME, NEW_TEST_TEAM_NAME))
+                .with(user("user")))
+        .andExpect(status().isNotFound());
+
+    // Execute update job team with missing job name
+    mockMvc
+        .perform(
+            put(String.format(
+                    "/data-jobs/for-team/%s/jobs//team/%s", TEST_TEAM_NAME, NEW_TEST_TEAM_NAME))
+                .with(user("user")))
+        .andExpect(status().isNotFound());
+
+    // Execute get not allowed method to job team endpoint
+    mockMvc
+        .perform(
+            get(String.format(
+                    "/data-jobs/for-team/%s/jobs/%s/team/%s",
+                    TEST_TEAM_NAME, TEST_JOB_NAME, TEST_TEAM_NAME))
+                .with(user("user")))
+        .andExpect(status().isMethodNotAllowed());
+
+    // Execute put method with user and with wrong team
+    // TODO: uncomment and extend tests to cover all put operations not only NotFound
+    mockMvc
+        .perform(
+            put(String.format(
+                    "/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_WRONG_NAME, TEST_JOB_NAME))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(dataJobRequestBody))
+        .andExpect(status().isNotFound());
+
+    // Execute delete job with no user
+    mockMvc
+        .perform(
+            delete(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME, TEST_JOB_NAME))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized());
+
+    // Execute delete job with user and wrong team
+    mockMvc
+        .perform(
+            delete(
+                    String.format(
+                        "/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_WRONG_NAME, TEST_JOB_NAME))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
+
+    // Execute delete job with user
+    mockMvc
+        .perform(
+            delete(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME, TEST_JOB_NAME))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+
+    // Execute update job team after job is deleted from db and is missing
+    mockMvc
+        .perform(
+            put(String.format(
+                    "/data-jobs/for-team/%s/jobs/%s/team/%s",
+                    TEST_TEAM_NAME, TEST_JOB_NAME, TEST_TEAM_NAME))
+                .with(user("user")))
+        .andExpect(status().isNotFound());
+
+    // Validate keytab deleted
+    keytabSecretData = dataJobsKubernetesService.getSecretData(keytabSecretName);
+    Assertions.assertTrue(keytabSecretData.isEmpty());
+
+    // Validate job deleted from db
+    Assertions.assertFalse(jobsRepository.existsById(TEST_JOB_NAME));
+
+    testDataJobPostDeleteWebHooks();
+  }
+
+  private void testDataJobPostCreateWebHooks() throws Exception {
+    // Post Create WebHook will prevent job creation and the result will be propagated error code
+    // with no job created
+    String clientErrorDataJobRequestBody =
+        getDataJobRequestBody(TEST_CLIENT_ERROR_TEAM, TEST_CLIENT_ERROR_JOB_NAME);
+    mockMvc
+        .perform(
+            post(String.format("/data-jobs/for-team/%s/jobs", TEST_CLIENT_ERROR_TEAM))
+                .with(user("user"))
+                .content(clientErrorDataJobRequestBody)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+    // Validate - the job is NOT created
+    Assertions.assertFalse(jobsRepository.existsById(TEST_CLIENT_ERROR_JOB_NAME));
+
+    // Post Create WebHook will prevent job creation and the result will be error 503 with no job
+    // created
+    String internalServerErrorDataJobRequestBody =
+        getDataJobRequestBody(TEST_INTERNAL_ERROR_TEAM, TEST_INTERNAL_ERROR_JOB_NAME);
+    mockMvc
+        .perform(
+            post(String.format("/data-jobs/for-team/%s/jobs", TEST_INTERNAL_ERROR_TEAM))
+                .with(user("user"))
+                .content(internalServerErrorDataJobRequestBody)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isServiceUnavailable());
+    // Validate - the job is NOT created
+    Assertions.assertFalse(jobsRepository.existsById(TEST_INTERNAL_ERROR_JOB_NAME));
+
+    // Post Create WebHook will retry 2 times and finally will allow job creation
+    String retriedErrorDataJobRequestBody =
+        getDataJobRequestBody(
+            TEST_INTERNAL_ERROR_RETRIED_TEAM, TEST_INTERNAL_ERROR_RETRIED_JOB_NAME);
+    mockMvc
+        .perform(
+            post(String.format("/data-jobs/for-team/%s/jobs", TEST_INTERNAL_ERROR_RETRIED_TEAM))
+                .with(user("user"))
+                .content(retriedErrorDataJobRequestBody)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated());
+    // Validate - the job is created
+    Assertions.assertTrue(jobsRepository.existsById(TEST_INTERNAL_ERROR_RETRIED_JOB_NAME));
+  }
+
+  private void testDataJobPostDeleteWebHooks() throws Exception {
+    // Add test job to the repository
+    DataJob clientErrorEntity =
+        getDataJobRepositoryModel(TEST_CLIENT_ERROR_TEAM, TEST_CLIENT_ERROR_JOB_NAME);
+    jobsRepository.save(clientErrorEntity);
+    // Post Delete WebHook will prevent job deletion and the result will be propagated error code
+    mockMvc
+        .perform(
+            delete(
+                    String.format(
+                        "/data-jobs/for-team/%s/jobs/%s",
+                        TEST_CLIENT_ERROR_TEAM, TEST_CLIENT_ERROR_JOB_NAME))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+    // Validate - the job is NOT deleted
+    Assertions.assertTrue(jobsRepository.existsById(TEST_CLIENT_ERROR_JOB_NAME));
+    // Clean Up
+    jobsRepository.delete(clientErrorEntity);
+
+    // Add test job to the repository
+    DataJob internalServerEntity =
+        getDataJobRepositoryModel(TEST_INTERNAL_ERROR_TEAM, TEST_INTERNAL_ERROR_JOB_NAME);
+    jobsRepository.save(internalServerEntity);
+    // Post Delete WebHook will prevent job deletion and the result will be error 503
+    mockMvc
+        .perform(
+            delete(
+                    String.format(
+                        "/data-jobs/for-team/%s/jobs/%s",
+                        TEST_INTERNAL_ERROR_TEAM, TEST_INTERNAL_ERROR_JOB_NAME))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isServiceUnavailable());
+    // Validate - the job is NOT deleted
+    Assertions.assertTrue(jobsRepository.existsById(TEST_INTERNAL_ERROR_JOB_NAME));
+    // Clean Up
+    jobsRepository.delete(internalServerEntity);
+
+    // Add test job to the repository
+    DataJob internalServerRetriedEntity =
+        getDataJobRepositoryModel(
+            TEST_INTERNAL_ERROR_RETRIED_TEAM, TEST_INTERNAL_ERROR_RETRIED_JOB_NAME);
+    jobsRepository.save(internalServerRetriedEntity);
+    // Post Create WebHook will retry 2 times and finally will allow job creation
+    mockMvc
+        .perform(
+            delete(
+                    String.format(
+                        "/data-jobs/for-team/%s/jobs/%s",
+                        TEST_INTERNAL_ERROR_RETRIED_TEAM, TEST_INTERNAL_ERROR_RETRIED_JOB_NAME))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+    // Validate - the job is deleted
+    Assertions.assertFalse(jobsRepository.existsById(TEST_INTERNAL_ERROR_RETRIED_JOB_NAME));
+    // Clean Up
+    jobsRepository.delete(internalServerEntity);
+  }
+
+  /**
+   * @deprecated in favour of jobsQuery
+   */
+  @Test
+  @Deprecated
+  public void testDataJobGetPaging() throws Exception {
+
+    // Setup by creating 2 jobs in 2 separate teams
+    String dataJobTestBodyOne = getDataJobRequestBody(TEST_TEAM_NAME, TEST_JOB_1);
+
+    mockMvc
+        .perform(
+            post(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
+                .with(user("user"))
+                .content(dataJobTestBodyOne)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated());
+
+    String dataJobTestBodyTwo = getDataJobRequestBody(TEST_TEAM_NAME, TEST_JOB_2);
+
+    mockMvc
+        .perform(
+            post(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
+                .with(user("user"))
+                .content(dataJobTestBodyTwo)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated());
+
+    String dataJobTestBodyThree = getDataJobRequestBody(NEW_TEST_TEAM_NAME, TEST_JOB_3);
+
+    mockMvc
+        .perform(
+            post(String.format("/data-jobs/for-team/%s/jobs", NEW_TEST_TEAM_NAME))
+                .with(user("user"))
+                .content(dataJobTestBodyThree)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated());
+
+    String dataJobTestBodyFour = getDataJobRequestBody(NEW_TEST_TEAM_NAME, TEST_JOB_4);
+
+    mockMvc
+        .perform(
+            post(String.format("/data-jobs/for-team/%s/jobs", NEW_TEST_TEAM_NAME))
+                .with(user("user"))
+                .content(dataJobTestBodyFour)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated());
+
+    // Validate - only jobs from the first team are returned
+    // deprecated jobsList in favour of jobsQuery
+    mockMvc
+        .perform(
+            get(String.format("/data-jobs/for-team/%s", TEST_TEAM_NAME))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .string(
+                    lambdaMatcher(
+                        s ->
+                            (s.contains(TEST_JOB_1))
+                                && (s.contains(TEST_JOB_2))
+                                && (!s.contains(TEST_JOB_3))
+                                && (!s.contains(TEST_JOB_4)))));
+
+    // Validate - ordered paging of jobs from the first team for page 0
+    // deprecated jobsList in favour of jobsQuery
+    mockMvc
+        .perform(
+            get(String.format("/data-jobs/for-team/%s?page_number=0&page_size=1", TEST_TEAM_NAME))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .string(
+                    lambdaMatcher(
+                        s ->
+                            (s.contains(TEST_JOB_1))
+                                && (!s.contains(TEST_JOB_2))
+                                && (!s.contains(TEST_JOB_3))
+                                && (!s.contains(TEST_JOB_4)))));
+
+    // Validate - ordered paging of jobs from the first team for page 1
+    // deprecated jobsList in favour of jobsQuery
+    mockMvc
+        .perform(
+            get(String.format("/data-jobs/for-team/%s?page_number=1&page_size=1", TEST_TEAM_NAME))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .string(
+                    lambdaMatcher(
+                        s ->
+                            (!s.contains(TEST_JOB_1))
+                                && (s.contains(TEST_JOB_2))
+                                && (!s.contains(TEST_JOB_3))
+                                && (!s.contains(TEST_JOB_4)))));
+
+    // Validate - only jobs from the second team are returned
+    // deprecated jobsList in favour of jobsQuery
+    mockMvc
+        .perform(
+            get(String.format("/data-jobs/for-team/%s", NEW_TEST_TEAM_NAME))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .string(
+                    lambdaMatcher(
+                        s ->
+                            s.contains(TEST_JOB_3)
+                                && s.contains(TEST_JOB_4)
+                                && !s.contains(TEST_JOB_1)
+                                && !s.contains(TEST_JOB_2))));
+
+    // Validate - ordered paging of jobs from the second team for page 0
+    // deprecated jobsList in favour of jobsQuery
+    mockMvc
+        .perform(
+            get(String.format(
+                    "/data-jobs/for-team/%s?page_number=0&page_size=1", NEW_TEST_TEAM_NAME))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .string(
+                    lambdaMatcher(
+                        s ->
+                            s.contains(TEST_JOB_3)
+                                && !s.contains(TEST_JOB_4)
+                                && !s.contains(TEST_JOB_1)
+                                && !s.contains(TEST_JOB_2))));
+
+    // Validate - ordered paging of jobs from the second team for page 1
+    // deprecated jobsList in favour of jobsQuery
+    mockMvc
+        .perform(
+            get(String.format(
+                    "/data-jobs/for-team/%s?page_number=1&page_size=1", NEW_TEST_TEAM_NAME))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .string(
+                    lambdaMatcher(
+                        s ->
+                            !s.contains(TEST_JOB_3)
+                                && s.contains(TEST_JOB_4)
+                                && !s.contains(TEST_JOB_1)
+                                && !s.contains(TEST_JOB_2))));
+
+    // Validate - all jobs are returned in case of all parameter
+
+    // TODO: putting arbitrary team with "all" parameter returns all the jobs which looks strange,
+    // we should
+    //  probably introduce special team name like "default" and treat is as if all parameter also in
+    // the client
+    //  for simple use cases where the teams authorization chain is disabled
+    // deprecated jobsList in favour of jobsQuery
+    mockMvc
+        .perform(
+            get(String.format("/data-jobs/for-team/%s?show_all=true", TEST_TEAM_NAME))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .string(
+                    lambdaMatcher(
+                        s ->
+                            s.contains(TEST_JOB_1)
+                                && s.contains(TEST_JOB_2)
+                                && s.contains(TEST_JOB_3)
+                                && s.contains(TEST_JOB_4))));
+
+    // Validate - validate ordering for first page with two jobs
+    // deprecated jobsList in favour of jobsQuery
+    mockMvc
+        .perform(
+            get(String.format(
+                    "/data-jobs/for-team/%s?show_all=true&page_number=0&page_size=2",
+                    TEST_TEAM_NAME))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .string(
+                    lambdaMatcher(
+                        s ->
+                            s.contains(TEST_JOB_1)
+                                && s.contains(TEST_JOB_2)
+                                && !s.contains(TEST_JOB_3)
+                                && !s.contains(TEST_JOB_4))));
+
+    // Validate - validate ordering for second page with two jobs
+    // deprecated jobsList in favour of jobsQuery
+    mockMvc
+        .perform(
+            get(String.format(
+                    "/data-jobs/for-team/%s?show_all=true&page_number=1&page_size=2",
+                    TEST_TEAM_NAME))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .string(
+                    lambdaMatcher(
+                        s ->
+                            !s.contains(TEST_JOB_1)
+                                && !s.contains(TEST_JOB_2)
+                                && s.contains(TEST_JOB_3)
+                                && s.contains(TEST_JOB_4))));
+
+    // Clean up
+
+    mockMvc
+        .perform(
+            delete(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME, TEST_JOB_1))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+
+    mockMvc
+        .perform(
+            delete(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME, TEST_JOB_2))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+
+    mockMvc
+        .perform(
+            delete(String.format("/data-jobs/for-team/%s/jobs/%s", NEW_TEST_TEAM_NAME, TEST_JOB_3))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+
+    mockMvc
+        .perform(
+            delete(String.format("/data-jobs/for-team/%s/jobs/%s", NEW_TEST_TEAM_NAME, TEST_JOB_4))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  public void testDataJobCreateDeleteIdempotency() throws Exception {
+    String dataJobTestBody = getDataJobRequestBody(TEST_TEAM_NAME, TEST_JOB_NAME);
+
+    mockMvc
+        .perform(
+            post(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
+                .with(user("user"))
+                .content(dataJobTestBody)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated());
+
+    mockMvc
+        .perform(
+            delete(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME, TEST_JOB_NAME))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+
+    mockMvc
+        .perform(
+            delete(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME, TEST_JOB_NAME))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudIT.java
@@ -37,304 +37,355 @@ import java.util.UUID;
 import static com.vmware.taurus.datajobs.it.common.WebHookServerMockExtension.TEST_TEAM_NAME;
 import static com.vmware.taurus.datajobs.it.common.WebHookServerMockExtension.TEST_TEAM_WRONG_NAME;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @Import({DataJobDeploymentCrudIT.TaskExecutorConfig.class})
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = ControlplaneApplication.class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = ControlplaneApplication.class)
 public class DataJobDeploymentCrudIT extends BaseIT {
 
-   // TODO: those are manually added to repo - it's good idea to be automated
-   private static final String TEST_JOB_NAME = "integration-test-" + UUID.randomUUID().toString().substring(0, 8);
-   private static final Object DEPLOYMENT_ID = "testing";
+  // TODO: those are manually added to repo - it's good idea to be automated
+  private static final String TEST_JOB_NAME =
+      "integration-test-" + UUID.randomUUID().toString().substring(0, 8);
+  private static final Object DEPLOYMENT_ID = "testing";
 
-   @TestConfiguration
-   static class TaskExecutorConfig {
+  @TestConfiguration
+  static class TaskExecutorConfig {
 
-      @Bean
-      @Primary
-      public TaskExecutor taskExecutor() {
-         // Deployment methods are non-blocking (Async) which makes them harder to test.
-         // Making them sync for the purposes of this test.
-         return new SyncTaskExecutor();
-      }
+    @Bean
+    @Primary
+    public TaskExecutor taskExecutor() {
+      // Deployment methods are non-blocking (Async) which makes them harder to test.
+      // Making them sync for the purposes of this test.
+      return new SyncTaskExecutor();
+    }
+  }
 
-   }
+  @BeforeEach
+  public void setup() throws Exception {
+    String dataJobRequestBody = getDataJobRequestBody(TEST_TEAM_NAME, TEST_JOB_NAME);
 
-   @BeforeEach
-   public void setup() throws Exception {
-      String dataJobRequestBody = getDataJobRequestBody(TEST_TEAM_NAME, TEST_JOB_NAME);
+    // Execute create job
+    mockMvc
+        .perform(
+            post(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
+                .with(user("user"))
+                .content(dataJobRequestBody)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated())
+        .andExpect(
+            header()
+                .string(
+                    HttpHeaders.LOCATION,
+                    lambdaMatcher(
+                        s ->
+                            s.endsWith(
+                                String.format(
+                                    "/data-jobs/for-team/%s/jobs/%s",
+                                    TEST_TEAM_NAME, TEST_JOB_NAME)))));
+  }
 
-      // Execute create job
-      mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME)).with(user("user"))
-            .content(dataJobRequestBody)
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isCreated())
-            .andExpect(header().string(HttpHeaders.LOCATION,
-                  lambdaMatcher(s -> s.endsWith(String.format("/data-jobs/for-team/%s/jobs/%s",
-                          TEST_TEAM_NAME,
-                          TEST_JOB_NAME)))));
-   }
+  @Test
+  public void testDataJobDeploymentCrud() throws Exception {
 
-   @Test
-   public void testDataJobDeploymentCrud() throws Exception {
+    // Take the job zip as byte array
+    byte[] jobZipBinary =
+        IOUtils.toByteArray(getClass().getClassLoader().getResourceAsStream("simple_job.zip"));
 
-      // Take the job zip as byte array
-      byte[] jobZipBinary = IOUtils.toByteArray(
-            getClass().getClassLoader().getResourceAsStream("simple_job.zip"));
+    // Execute job upload with no user
+    mockMvc
+        .perform(
+            post(String.format(
+                    "/data-jobs/for-team/%s/jobs/%s/sources", TEST_TEAM_NAME, TEST_JOB_NAME))
+                .content(jobZipBinary)
+                .contentType(MediaType.APPLICATION_OCTET_STREAM))
+        .andExpect(status().isUnauthorized());
 
-      // Execute job upload with no user
-      mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs/%s/sources",
-            TEST_TEAM_NAME,
-            TEST_JOB_NAME))
-            .content(jobZipBinary)
-            .contentType(MediaType.APPLICATION_OCTET_STREAM))
-            .andExpect(status().isUnauthorized());
-
-      // Execute job upload with proper user
-      MvcResult jobUploadResult = mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs/%s/sources",
-            TEST_TEAM_NAME,
-            TEST_JOB_NAME))
-            .with(user("user"))
-            .content(jobZipBinary)
-            .contentType(MediaType.APPLICATION_OCTET_STREAM))
+    // Execute job upload with proper user
+    MvcResult jobUploadResult =
+        mockMvc
+            .perform(
+                post(String.format(
+                        "/data-jobs/for-team/%s/jobs/%s/sources", TEST_TEAM_NAME, TEST_JOB_NAME))
+                    .with(user("user"))
+                    .content(jobZipBinary)
+                    .contentType(MediaType.APPLICATION_OCTET_STREAM))
             .andExpect(status().isOk())
             .andReturn();
 
-      DataJobVersion testDataJobVersion = new ObjectMapper()
+    DataJobVersion testDataJobVersion =
+        new ObjectMapper()
             .readValue(jobUploadResult.getResponse().getContentAsString(), DataJobVersion.class);
-      Assertions.assertNotNull(testDataJobVersion);
+    Assertions.assertNotNull(testDataJobVersion);
 
-      String testJobVersionSha = testDataJobVersion.getVersionSha();
-      Assertions.assertFalse(StringUtils.isBlank(testJobVersionSha));
+    String testJobVersionSha = testDataJobVersion.getVersionSha();
+    Assertions.assertFalse(StringUtils.isBlank(testJobVersionSha));
 
-      // Setup
-      String dataJobDeploymentRequestBody = getDataJobDeploymentRequestBody(testJobVersionSha);
+    // Setup
+    String dataJobDeploymentRequestBody = getDataJobDeploymentRequestBody(testJobVersionSha);
 
-      // Execute job upload with wrong team name and user
-      mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs/%s/sources",
-            TEST_TEAM_WRONG_NAME,
-            TEST_JOB_NAME))
-            .with(user("user"))
-            .content(jobZipBinary)
-            .contentType(MediaType.APPLICATION_OCTET_STREAM))
-            .andExpect(status().isNotFound());
+    // Execute job upload with wrong team name and user
+    mockMvc
+        .perform(
+            post(String.format(
+                    "/data-jobs/for-team/%s/jobs/%s/sources", TEST_TEAM_WRONG_NAME, TEST_JOB_NAME))
+                .with(user("user"))
+                .content(jobZipBinary)
+                .contentType(MediaType.APPLICATION_OCTET_STREAM))
+        .andExpect(status().isNotFound());
 
-      // Execute build and deploy job with no user
-      mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs/%s/deployments", TEST_TEAM_NAME, TEST_JOB_NAME))
-              .content(dataJobDeploymentRequestBody)
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isUnauthorized());
+    // Execute build and deploy job with no user
+    mockMvc
+        .perform(
+            post(String.format(
+                    "/data-jobs/for-team/%s/jobs/%s/deployments", TEST_TEAM_NAME, TEST_JOB_NAME))
+                .content(dataJobDeploymentRequestBody)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized());
 
-      // Execute build and deploy job
-      mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs/%s/deployments", TEST_TEAM_NAME, TEST_JOB_NAME))
-              .with(user("user"))
-              .content(dataJobDeploymentRequestBody)
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isAccepted());
+    // Execute build and deploy job
+    mockMvc
+        .perform(
+            post(String.format(
+                    "/data-jobs/for-team/%s/jobs/%s/deployments", TEST_TEAM_NAME, TEST_JOB_NAME))
+                .with(user("user"))
+                .content(dataJobDeploymentRequestBody)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isAccepted());
 
-      // Execute build and deploy job with wrong team
-      mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs/%s/deployments", TEST_TEAM_WRONG_NAME, TEST_JOB_NAME))
-              .with(user("user"))
-              .content(dataJobDeploymentRequestBody)
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isNotFound());
+    // Execute build and deploy job with wrong team
+    mockMvc
+        .perform(
+            post(String.format(
+                    "/data-jobs/for-team/%s/jobs/%s/deployments",
+                    TEST_TEAM_WRONG_NAME, TEST_JOB_NAME))
+                .with(user("user"))
+                .content(dataJobDeploymentRequestBody)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
 
-      String jobDeploymentName = JobImageDeployer.getCronJobName(TEST_JOB_NAME);
-      // Verify job deployment created
-      Optional<JobDeploymentStatus> cronJobOptional = dataJobsKubernetesService.readCronJob(jobDeploymentName);
-      Assertions.assertTrue(cronJobOptional.isPresent());
-      JobDeploymentStatus cronJob = cronJobOptional.get();
-      Assertions.assertEquals(testJobVersionSha, cronJob.getGitCommitSha());
-      Assertions.assertEquals(DataJobMode.RELEASE.toString(), cronJob.getMode());
-      Assertions.assertEquals(true, cronJob.getEnabled());
-      Assertions.assertTrue(cronJob.getImageName().endsWith(testJobVersionSha));
-      Assertions.assertEquals("user", cronJob.getLastDeployedBy());
+    String jobDeploymentName = JobImageDeployer.getCronJobName(TEST_JOB_NAME);
+    // Verify job deployment created
+    Optional<JobDeploymentStatus> cronJobOptional =
+        dataJobsKubernetesService.readCronJob(jobDeploymentName);
+    Assertions.assertTrue(cronJobOptional.isPresent());
+    JobDeploymentStatus cronJob = cronJobOptional.get();
+    Assertions.assertEquals(testJobVersionSha, cronJob.getGitCommitSha());
+    Assertions.assertEquals(DataJobMode.RELEASE.toString(), cronJob.getMode());
+    Assertions.assertEquals(true, cronJob.getEnabled());
+    Assertions.assertTrue(cronJob.getImageName().endsWith(testJobVersionSha));
+    Assertions.assertEquals("user", cronJob.getLastDeployedBy());
 
-      // Execute get job deployment with no user
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s",
-              TEST_TEAM_NAME,
-              TEST_JOB_NAME,
-              DEPLOYMENT_ID))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isUnauthorized());
+    // Execute get job deployment with no user
+    mockMvc
+        .perform(
+            get(String.format(
+                    "/data-jobs/for-team/%s/jobs/%s/deployments/%s",
+                    TEST_TEAM_NAME, TEST_JOB_NAME, DEPLOYMENT_ID))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized());
 
-      // Execute get job deployment
-      MvcResult result = mockMvc.perform(get(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s",
-              TEST_TEAM_NAME,
-              TEST_JOB_NAME,
-              DEPLOYMENT_ID))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk())
-              .andReturn();
+    // Execute get job deployment
+    MvcResult result =
+        mockMvc
+            .perform(
+                get(String.format(
+                        "/data-jobs/for-team/%s/jobs/%s/deployments/%s",
+                        TEST_TEAM_NAME, TEST_JOB_NAME, DEPLOYMENT_ID))
+                    .with(user("user"))
+                    .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn();
 
-      // Verify response
-      DataJobDeploymentStatus jobDeployment = mapper.readValue(result.getResponse().getContentAsString(),
-              DataJobDeploymentStatus.class);
-      Assertions.assertEquals(testJobVersionSha, jobDeployment.getJobVersion());
-      Assertions.assertEquals(true, jobDeployment.getEnabled());
-      Assertions.assertEquals(DataJobMode.RELEASE, jobDeployment.getMode());
-      Assertions.assertEquals(true, jobDeployment.getEnabled());
-      // by default the version is the same as the tag specified by datajobs.vdk.image
-      // for integration test this is registry.hub.docker.com/versatiledatakit/quickstart-vdk:release
-      Assertions.assertEquals("release", jobDeployment.getVdkVersion());
-      Assertions.assertEquals("user", jobDeployment.getLastDeployedBy());
-      // just check some valid date is returned. It would be too error-prone/brittle to verify exact time.
-      DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(jobDeployment.getLastDeployedDate());
+    // Verify response
+    DataJobDeploymentStatus jobDeployment =
+        mapper.readValue(result.getResponse().getContentAsString(), DataJobDeploymentStatus.class);
+    Assertions.assertEquals(testJobVersionSha, jobDeployment.getJobVersion());
+    Assertions.assertEquals(true, jobDeployment.getEnabled());
+    Assertions.assertEquals(DataJobMode.RELEASE, jobDeployment.getMode());
+    Assertions.assertEquals(true, jobDeployment.getEnabled());
+    // by default the version is the same as the tag specified by datajobs.vdk.image
+    // for integration test this is registry.hub.docker.com/versatiledatakit/quickstart-vdk:release
+    Assertions.assertEquals("release", jobDeployment.getVdkVersion());
+    Assertions.assertEquals("user", jobDeployment.getLastDeployedBy());
+    // just check some valid date is returned. It would be too error-prone/brittle to verify exact
+    // time.
+    DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(jobDeployment.getLastDeployedDate());
 
-      // Execute get job deployment with wrong team
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s",
-              TEST_TEAM_WRONG_NAME,
-              TEST_JOB_NAME,
-              DEPLOYMENT_ID))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isNotFound());
+    // Execute get job deployment with wrong team
+    mockMvc
+        .perform(
+            get(String.format(
+                    "/data-jobs/for-team/%s/jobs/%s/deployments/%s",
+                    TEST_TEAM_WRONG_NAME, TEST_JOB_NAME, DEPLOYMENT_ID))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
 
-      // Execute disable deployment no user
-      mockMvc.perform(patch(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s",
-              TEST_TEAM_NAME,
-              TEST_JOB_NAME,
-              DEPLOYMENT_ID))
-              .content(getDataJobDeploymentEnableRequestBody(false))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isUnauthorized());
+    // Execute disable deployment no user
+    mockMvc
+        .perform(
+            patch(
+                    String.format(
+                        "/data-jobs/for-team/%s/jobs/%s/deployments/%s",
+                        TEST_TEAM_NAME, TEST_JOB_NAME, DEPLOYMENT_ID))
+                .content(getDataJobDeploymentEnableRequestBody(false))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized());
 
-      // Execute disable deployment
-      mockMvc.perform(patch(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s",
-              TEST_TEAM_NAME,
-              TEST_JOB_NAME,
-              DEPLOYMENT_ID))
-              .with(user("user"))
-              .content(getDataJobDeploymentEnableRequestBody(false))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isAccepted());
+    // Execute disable deployment
+    mockMvc
+        .perform(
+            patch(
+                    String.format(
+                        "/data-jobs/for-team/%s/jobs/%s/deployments/%s",
+                        TEST_TEAM_NAME, TEST_JOB_NAME, DEPLOYMENT_ID))
+                .with(user("user"))
+                .content(getDataJobDeploymentEnableRequestBody(false))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isAccepted());
 
-      // Execute disable deployment with wrong team
-      mockMvc.perform(patch(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s",
-              TEST_TEAM_WRONG_NAME,
-              TEST_JOB_NAME,
-              DEPLOYMENT_ID))
-              .with(user("user"))
-              .content(getDataJobDeploymentEnableRequestBody(false))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isNotFound());
+    // Execute disable deployment with wrong team
+    mockMvc
+        .perform(
+            patch(
+                    String.format(
+                        "/data-jobs/for-team/%s/jobs/%s/deployments/%s",
+                        TEST_TEAM_WRONG_NAME, TEST_JOB_NAME, DEPLOYMENT_ID))
+                .with(user("user"))
+                .content(getDataJobDeploymentEnableRequestBody(false))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
 
-      // Verify deployment disabled
-      cronJobOptional = dataJobsKubernetesService.readCronJob(jobDeploymentName);
-      Assertions.assertTrue(cronJobOptional.isPresent());
-      cronJob = cronJobOptional.get();
-      Assertions.assertEquals(false, cronJob.getEnabled());
+    // Verify deployment disabled
+    cronJobOptional = dataJobsKubernetesService.readCronJob(jobDeploymentName);
+    Assertions.assertTrue(cronJobOptional.isPresent());
+    cronJob = cronJobOptional.get();
+    Assertions.assertEquals(false, cronJob.getEnabled());
 
-      // Execute set vdk version for deployment
-      mockMvc.perform(patch(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s",
-                      TEST_TEAM_NAME,
-                      TEST_JOB_NAME,
-                      DEPLOYMENT_ID))
-                      .with(user("user"))
-                      .content(getDataJobDeploymentVdkVersionRequestBody("new_vdk_version_tag"))
-                      .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isAccepted());
+    // Execute set vdk version for deployment
+    mockMvc
+        .perform(
+            patch(
+                    String.format(
+                        "/data-jobs/for-team/%s/jobs/%s/deployments/%s",
+                        TEST_TEAM_NAME, TEST_JOB_NAME, DEPLOYMENT_ID))
+                .with(user("user"))
+                .content(getDataJobDeploymentVdkVersionRequestBody("new_vdk_version_tag"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isAccepted());
 
-      // verify vdk version is returned
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s",
-                      TEST_TEAM_NAME,
-                      TEST_JOB_NAME,
-                      DEPLOYMENT_ID))
-                      .with(user("user"))
-                      .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk())
-              .andExpect(jsonPath("$.vdk_version", is("new_vdk_version_tag")));
+    // verify vdk version is returned
+    mockMvc
+        .perform(
+            get(String.format(
+                    "/data-jobs/for-team/%s/jobs/%s/deployments/%s",
+                    TEST_TEAM_NAME, TEST_JOB_NAME, DEPLOYMENT_ID))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.vdk_version", is("new_vdk_version_tag")));
 
+    // Execute disable deployment again to check that the version is not overwritten
+    mockMvc
+        .perform(
+            patch(
+                    String.format(
+                        "/data-jobs/for-team/%s/jobs/%s/deployments/%s",
+                        TEST_TEAM_NAME, TEST_JOB_NAME, DEPLOYMENT_ID))
+                .with(user("user"))
+                .content(getDataJobDeploymentEnableRequestBody(false))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isAccepted());
 
-      // Execute disable deployment again to check that the version is not overwritten
-      mockMvc.perform(patch(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s",
-                      TEST_TEAM_NAME,
-                      TEST_JOB_NAME,
-                      DEPLOYMENT_ID))
-                      .with(user("user"))
-                      .content(getDataJobDeploymentEnableRequestBody(false))
-                      .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isAccepted());
+    // Execute reset back vdk version for deployment
+    mockMvc
+        .perform(
+            patch(
+                    String.format(
+                        "/data-jobs/for-team/%s/jobs/%s/deployments/%s",
+                        TEST_TEAM_NAME, TEST_JOB_NAME, DEPLOYMENT_ID))
+                .with(user("user"))
+                .content(getDataJobDeploymentVdkVersionRequestBody(""))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isAccepted());
 
-      // Execute reset back vdk version for deployment
-      mockMvc.perform(patch(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s",
-                      TEST_TEAM_NAME,
-                      TEST_JOB_NAME,
-                      DEPLOYMENT_ID))
-                      .with(user("user"))
-                      .content(getDataJobDeploymentVdkVersionRequestBody(""))
-                      .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isAccepted());
+    // verify vdk version is reset correctly
+    mockMvc
+        .perform(
+            get(String.format(
+                    "/data-jobs/for-team/%s/jobs/%s/deployments/%s",
+                    TEST_TEAM_NAME, TEST_JOB_NAME, DEPLOYMENT_ID))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.vdk_version", is("release")));
 
-      // verify vdk version is reset correctly
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s",
-                      TEST_TEAM_NAME,
-                      TEST_JOB_NAME,
-                      DEPLOYMENT_ID))
-                      .with(user("user"))
-                      .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk())
-              .andExpect(jsonPath("$.vdk_version", is("release")));
+    // Execute delete deployment with no user
+    mockMvc
+        .perform(
+            delete(
+                    String.format(
+                        "/data-jobs/for-team/%s/jobs/%s/deployments/%s",
+                        TEST_TEAM_NAME, TEST_JOB_NAME, DEPLOYMENT_ID))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized());
 
+    // Execute delete deployment with wrong team
+    mockMvc
+        .perform(
+            delete(
+                    String.format(
+                        "/data-jobs/for-team/%s/jobs/%s/deployments/%s",
+                        TEST_TEAM_WRONG_NAME, TEST_JOB_NAME, DEPLOYMENT_ID))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
 
-      // Execute delete deployment with no user
-      mockMvc.perform(delete(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s",
-              TEST_TEAM_NAME,
-              TEST_JOB_NAME,
-              DEPLOYMENT_ID))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isUnauthorized());
+    // Execute delete deployment
+    mockMvc
+        .perform(
+            delete(
+                    String.format(
+                        "/data-jobs/for-team/%s/jobs/%s/deployments/%s",
+                        TEST_TEAM_NAME, TEST_JOB_NAME, DEPLOYMENT_ID))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isAccepted());
 
-      // Execute delete deployment with wrong team
-      mockMvc.perform(delete(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s",
-              TEST_TEAM_WRONG_NAME,
-              TEST_JOB_NAME,
-              DEPLOYMENT_ID))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isNotFound());
+    Thread.sleep(5 * 1000); // Wait for deployment to be deleted
 
-      // Execute delete deployment
-      mockMvc.perform(delete(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s",
-              TEST_TEAM_NAME,
-              TEST_JOB_NAME,
-              DEPLOYMENT_ID))
-              .with(user("user"))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isAccepted());
+    // Verify deployment deleted
+    cronJobOptional = dataJobsKubernetesService.readCronJob(jobDeploymentName);
+    Assertions.assertTrue(cronJobOptional.isEmpty());
+  }
 
-      Thread.sleep(5 * 1000); // Wait for deployment to be deleted
+  @AfterEach
+  public void cleanUp() throws Exception {
+    mockMvc
+        .perform(
+            delete(
+                    String.format(
+                        "/data-jobs/for-team/%s/jobs/%s/sources", TEST_TEAM_NAME, TEST_JOB_NAME))
+                .with(user("user")))
+        .andExpect(status().isOk());
+  }
 
-      // Verify deployment deleted
-      cronJobOptional = dataJobsKubernetesService.readCronJob(jobDeploymentName);
-      Assertions.assertTrue(cronJobOptional.isEmpty());
-   }
+  @Test
+  public void testDataJobDeleteSource() throws Exception {
+    byte[] jobZipBinary =
+        IOUtils.toByteArray(getClass().getClassLoader().getResourceAsStream("simple_job.zip"));
 
-   @AfterEach
-   public void cleanUp() throws Exception {
-      mockMvc.perform(delete(String.format("/data-jobs/for-team/%s/jobs/%s/sources",
-            TEST_TEAM_NAME,
-            TEST_JOB_NAME))
-            .with(user("user")))
-            .andExpect(status().isOk());
-   }
-
-
-   @Test
-   public void testDataJobDeleteSource() throws Exception {
-      byte[] jobZipBinary = IOUtils.toByteArray(
-              getClass().getClassLoader().getResourceAsStream("simple_job.zip"));
-
-      mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs/%s/sources",
-              TEST_TEAM_NAME,
-              TEST_JOB_NAME))
-              .with(user("user"))
-              .content(jobZipBinary)
-              .contentType(MediaType.APPLICATION_OCTET_STREAM))
-              .andExpect(status().isOk());
-   }
+    mockMvc
+        .perform(
+            post(String.format(
+                    "/data-jobs/for-team/%s/jobs/%s/sources", TEST_TEAM_NAME, TEST_JOB_NAME))
+                .with(user("user"))
+                .content(jobZipBinary)
+                .contentType(MediaType.APPLICATION_OCTET_STREAM))
+        .andExpect(status().isOk());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobGraphQLIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobGraphQLIT.java
@@ -26,219 +26,268 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = ControlplaneApplication.class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = ControlplaneApplication.class)
 public class DataJobGraphQLIT extends BaseIT {
 
-   private static final String DEFAULT_QUERY_WITH_VARS =
-         "query($filter: [Predicate], $search: String, $pageNumber: Int, $pageSize: Int) {" +
-               "  jobs(pageNumber: $pageNumber, pageSize: $pageSize, filter: $filter, search: $search) {" +
-               "    content {" +
-               "      jobName" +
-               "      config {" +
-               "        team" +
-               "        description" +
-               "        schedule {" +
-               "          scheduleCron" +
-               "        }" +
-               "      }" +
-               "    }" +
-               "    totalPages" +
-               "    totalItems" +
-               "  }" +
-               "}";
+  private static final String DEFAULT_QUERY_WITH_VARS =
+      "query($filter: [Predicate], $search: String, $pageNumber: Int, $pageSize: Int) { "
+          + " jobs(pageNumber: $pageNumber, pageSize: $pageSize, filter: $filter, search: $search)"
+          + " {    content {      jobName      config {        team        description       "
+          + " schedule {          scheduleCron        }      }    }    totalPages    totalItems  }"
+          + "}";
 
-   @Test
-   public void testGraphQLPagination() throws Exception {
-      createDummyJobs();
+  @Test
+  public void testGraphQLPagination() throws Exception {
+    createDummyJobs();
 
-      // Test listing of team jobs by filtering with team property
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
-            .with(user("user"))
-            .param("query", DEFAULT_QUERY_WITH_VARS)
-            .param("variables", "{" +
-                  "\"filter\": [" +
-                  "    {" +
-                  "      \"property\": \"config.team\"," +
-                  "      \"pattern\": \"" + TEST_TEAM_NAME + "\"" +
-                  "    }" +
-                  "  ]," +
-                  "\"pageNumber\": 1," +
-                  "\"pageSize\": 10" +
-                  "}")
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().string(lambdaMatcher(s -> (s.contains(TEST_JOB_1))
-                  && (s.contains(TEST_JOB_2))
-                  && (s.contains(TEST_JOB_6))
-                  && (!s.contains(TEST_JOB_3))
-                  && (!s.contains(TEST_JOB_4))
-                  && (!s.contains(TEST_JOB_5)))));
+    // Test listing of team jobs by filtering with team property
+    mockMvc
+        .perform(
+            get(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
+                .with(user("user"))
+                .param("query", DEFAULT_QUERY_WITH_VARS)
+                .param(
+                    "variables",
+                    "{"
+                        + "\"filter\": ["
+                        + "    {"
+                        + "      \"property\": \"config.team\","
+                        + "      \"pattern\": \""
+                        + TEST_TEAM_NAME
+                        + "\""
+                        + "    }"
+                        + "  ],"
+                        + "\"pageNumber\": 1,"
+                        + "\"pageSize\": 10"
+                        + "}")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .string(
+                    lambdaMatcher(
+                        s ->
+                            (s.contains(TEST_JOB_1))
+                                && (s.contains(TEST_JOB_2))
+                                && (s.contains(TEST_JOB_6))
+                                && (!s.contains(TEST_JOB_3))
+                                && (!s.contains(TEST_JOB_4))
+                                && (!s.contains(TEST_JOB_5)))));
 
-      // Test listing of team jobs by searching for team name
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
-            .with(user("user"))
-            .param("query", DEFAULT_QUERY_WITH_VARS)
-            .param("variables", "{" +
-                  "\"search\": \""+NEW_TEST_TEAM_NAME+"\"," +
-                  "\"pageNumber\": 1," +
-                  "\"pageSize\": 10" +
-                  "}")
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().string(lambdaMatcher(s -> (!s.contains(TEST_JOB_1))
-                  && (!s.contains(TEST_JOB_2))
-                  && (!s.contains(TEST_JOB_6))
-                  && (s.contains(TEST_JOB_3))
-                  && (s.contains(TEST_JOB_4))
-                  && (s.contains(TEST_JOB_5)))));
+    // Test listing of team jobs by searching for team name
+    mockMvc
+        .perform(
+            get(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
+                .with(user("user"))
+                .param("query", DEFAULT_QUERY_WITH_VARS)
+                .param(
+                    "variables",
+                    "{"
+                        + "\"search\": \""
+                        + NEW_TEST_TEAM_NAME
+                        + "\","
+                        + "\"pageNumber\": 1,"
+                        + "\"pageSize\": 10"
+                        + "}")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .string(
+                    lambdaMatcher(
+                        s ->
+                            (!s.contains(TEST_JOB_1))
+                                && (!s.contains(TEST_JOB_2))
+                                && (!s.contains(TEST_JOB_6))
+                                && (s.contains(TEST_JOB_3))
+                                && (s.contains(TEST_JOB_4))
+                                && (s.contains(TEST_JOB_5)))));
 
-      // Test showing only first page
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
-            .with(user("user"))
-            .param("query", DEFAULT_QUERY_WITH_VARS)
-            .param("variables", "{" +
-                  "\"pageNumber\": 1," +
-                  "\"pageSize\": 2" +
-                  "}")
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().string(lambdaMatcher(s -> (s.contains(TEST_JOB_1))
-                  && (s.contains(TEST_JOB_2))
-                  && (!s.contains(TEST_JOB_3))
-                  && (!s.contains(TEST_JOB_4))
-                  && (!s.contains(TEST_JOB_5))
-                  && (!s.contains(TEST_JOB_6)))));
+    // Test showing only first page
+    mockMvc
+        .perform(
+            get(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
+                .with(user("user"))
+                .param("query", DEFAULT_QUERY_WITH_VARS)
+                .param("variables", "{" + "\"pageNumber\": 1," + "\"pageSize\": 2" + "}")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .string(
+                    lambdaMatcher(
+                        s ->
+                            (s.contains(TEST_JOB_1))
+                                && (s.contains(TEST_JOB_2))
+                                && (!s.contains(TEST_JOB_3))
+                                && (!s.contains(TEST_JOB_4))
+                                && (!s.contains(TEST_JOB_5))
+                                && (!s.contains(TEST_JOB_6)))));
 
-      // Test showing only middle page
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
-            .with(user("user"))
-            .param("query", DEFAULT_QUERY_WITH_VARS)
-            .param("variables", "{" +
-                  "\"pageNumber\": 2," +
-                  "\"pageSize\": 2" +
-                  "}")
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().string(lambdaMatcher(s -> (!s.contains(TEST_JOB_1))
-                  && (!s.contains(TEST_JOB_2))
-                  && (s.contains(TEST_JOB_3))
-                  && (s.contains(TEST_JOB_4))
-                  && (!s.contains(TEST_JOB_5))
-                  && (!s.contains(TEST_JOB_6)))));
+    // Test showing only middle page
+    mockMvc
+        .perform(
+            get(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
+                .with(user("user"))
+                .param("query", DEFAULT_QUERY_WITH_VARS)
+                .param("variables", "{" + "\"pageNumber\": 2," + "\"pageSize\": 2" + "}")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .string(
+                    lambdaMatcher(
+                        s ->
+                            (!s.contains(TEST_JOB_1))
+                                && (!s.contains(TEST_JOB_2))
+                                && (s.contains(TEST_JOB_3))
+                                && (s.contains(TEST_JOB_4))
+                                && (!s.contains(TEST_JOB_5))
+                                && (!s.contains(TEST_JOB_6)))));
 
-      // Test showing only last page
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
-            .with(user("user"))
-            .param("query", DEFAULT_QUERY_WITH_VARS)
-            .param("variables", "{" +
-                  "\"pageNumber\": 3," +
-                  "\"pageSize\": 2" +
-                  "}")
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().string(lambdaMatcher(s -> (!s.contains(TEST_JOB_1))
-                  && (!s.contains(TEST_JOB_2))
-                  && (!s.contains(TEST_JOB_3))
-                  && (!s.contains(TEST_JOB_4))
-                  && (s.contains(TEST_JOB_5))
-                  && (s.contains(TEST_JOB_6)))));
+    // Test showing only last page
+    mockMvc
+        .perform(
+            get(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
+                .with(user("user"))
+                .param("query", DEFAULT_QUERY_WITH_VARS)
+                .param("variables", "{" + "\"pageNumber\": 3," + "\"pageSize\": 2" + "}")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .string(
+                    lambdaMatcher(
+                        s ->
+                            (!s.contains(TEST_JOB_1))
+                                && (!s.contains(TEST_JOB_2))
+                                && (!s.contains(TEST_JOB_3))
+                                && (!s.contains(TEST_JOB_4))
+                                && (s.contains(TEST_JOB_5))
+                                && (s.contains(TEST_JOB_6)))));
 
-      // Test showing only first page sorted DESC by jobName
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
-            .with(user("user"))
-            .param("query", DEFAULT_QUERY_WITH_VARS)
-            .param("variables", "{" +
-                  "\"filter\": [" +
-                  "    {" +
-                  "      \"property\": \"jobName\"," +
-                  "      \"sort\": \"DESC\"" +
-                  "    }" +
-                  "  ]," +
-                  "\"pageNumber\": 1," +
-                  "\"pageSize\": 2" +
-                  "}")
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().string(lambdaMatcher(s -> (!s.contains(TEST_JOB_1))
-                  && (!s.contains(TEST_JOB_2))
-                  && (!s.contains(TEST_JOB_3))
-                  && (!s.contains(TEST_JOB_4))
-                  && (s.contains(TEST_JOB_5))
-                  && (s.contains(TEST_JOB_6)))));
+    // Test showing only first page sorted DESC by jobName
+    mockMvc
+        .perform(
+            get(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
+                .with(user("user"))
+                .param("query", DEFAULT_QUERY_WITH_VARS)
+                .param(
+                    "variables",
+                    "{"
+                        + "\"filter\": ["
+                        + "    {"
+                        + "      \"property\": \"jobName\","
+                        + "      \"sort\": \"DESC\""
+                        + "    }"
+                        + "  ],"
+                        + "\"pageNumber\": 1,"
+                        + "\"pageSize\": 2"
+                        + "}")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .string(
+                    lambdaMatcher(
+                        s ->
+                            (!s.contains(TEST_JOB_1))
+                                && (!s.contains(TEST_JOB_2))
+                                && (!s.contains(TEST_JOB_3))
+                                && (!s.contains(TEST_JOB_4))
+                                && (s.contains(TEST_JOB_5))
+                                && (s.contains(TEST_JOB_6)))));
 
-      // Test showing custom filtered, sorted and paged data jobs by multiple parameters
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
-            .with(user("user"))
-            .param("query", DEFAULT_QUERY_WITH_VARS)
-            .param("variables", "{" +
-                  "\"filter\": [" +
-                  "    {" +
-                  "      \"property\": \"config.team\"," +
-                  "      \"pattern\": \"" + TEST_TEAM_NAME + "\"" +
-                  "    }," +
-                  "    {" +
-                  "      \"property\": \"jobName\"," +
-                  "      \"sort\": \"DESC\"" +
-                  "    }" +
-                  "  ]," +
-                  "\"pageNumber\": 1," +
-                  "\"pageSize\": 2" +
-                  "}")
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().string(lambdaMatcher(s -> (!s.contains(TEST_JOB_1))
-                  && (s.contains(TEST_JOB_2))
-                  && (!s.contains(TEST_JOB_3))
-                  && (!s.contains(TEST_JOB_4))
-                  && (!s.contains(TEST_JOB_5))
-                  && (s.contains(TEST_JOB_6)))));
+    // Test showing custom filtered, sorted and paged data jobs by multiple parameters
+    mockMvc
+        .perform(
+            get(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
+                .with(user("user"))
+                .param("query", DEFAULT_QUERY_WITH_VARS)
+                .param(
+                    "variables",
+                    "{"
+                        + "\"filter\": ["
+                        + "    {"
+                        + "      \"property\": \"config.team\","
+                        + "      \"pattern\": \""
+                        + TEST_TEAM_NAME
+                        + "\""
+                        + "    },"
+                        + "    {"
+                        + "      \"property\": \"jobName\","
+                        + "      \"sort\": \"DESC\""
+                        + "    }"
+                        + "  ],"
+                        + "\"pageNumber\": 1,"
+                        + "\"pageSize\": 2"
+                        + "}")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .string(
+                    lambdaMatcher(
+                        s ->
+                            (!s.contains(TEST_JOB_1))
+                                && (s.contains(TEST_JOB_2))
+                                && (!s.contains(TEST_JOB_3))
+                                && (!s.contains(TEST_JOB_4))
+                                && (!s.contains(TEST_JOB_5))
+                                && (s.contains(TEST_JOB_6)))));
 
-      deleteDummyJobs();
-   }
+    deleteDummyJobs();
+  }
 
-   private void createDummyJobs() throws Exception {
-      // Setup by creating 3 jobs in 2 separate teams (6 jobs total)
-      String dataJobTestBodyOne = getDataJobRequestBody(TEST_TEAM_NAME, TEST_JOB_1);
-      createJob(dataJobTestBodyOne, TEST_TEAM_NAME);
+  private void createDummyJobs() throws Exception {
+    // Setup by creating 3 jobs in 2 separate teams (6 jobs total)
+    String dataJobTestBodyOne = getDataJobRequestBody(TEST_TEAM_NAME, TEST_JOB_1);
+    createJob(dataJobTestBodyOne, TEST_TEAM_NAME);
 
-      String dataJobTestBodyTwo = getDataJobRequestBody(TEST_TEAM_NAME, TEST_JOB_2);
-      createJob(dataJobTestBodyTwo, TEST_TEAM_NAME);
+    String dataJobTestBodyTwo = getDataJobRequestBody(TEST_TEAM_NAME, TEST_JOB_2);
+    createJob(dataJobTestBodyTwo, TEST_TEAM_NAME);
 
-      String dataJobTestBodyThree = getDataJobRequestBody(NEW_TEST_TEAM_NAME, TEST_JOB_3);
-      createJob(dataJobTestBodyThree, NEW_TEST_TEAM_NAME);
+    String dataJobTestBodyThree = getDataJobRequestBody(NEW_TEST_TEAM_NAME, TEST_JOB_3);
+    createJob(dataJobTestBodyThree, NEW_TEST_TEAM_NAME);
 
-      String dataJobTestBodyFour = getDataJobRequestBody(NEW_TEST_TEAM_NAME, TEST_JOB_4);
-      createJob(dataJobTestBodyFour, NEW_TEST_TEAM_NAME);
+    String dataJobTestBodyFour = getDataJobRequestBody(NEW_TEST_TEAM_NAME, TEST_JOB_4);
+    createJob(dataJobTestBodyFour, NEW_TEST_TEAM_NAME);
 
-      String dataJobTestBodyFive = getDataJobRequestBody(NEW_TEST_TEAM_NAME, TEST_JOB_5);
-      createJob(dataJobTestBodyFive, NEW_TEST_TEAM_NAME);
+    String dataJobTestBodyFive = getDataJobRequestBody(NEW_TEST_TEAM_NAME, TEST_JOB_5);
+    createJob(dataJobTestBodyFive, NEW_TEST_TEAM_NAME);
 
-      String dataJobTestBodySix = getDataJobRequestBody(TEST_TEAM_NAME, TEST_JOB_6);
-      createJob(dataJobTestBodySix, TEST_TEAM_NAME);
-   }
+    String dataJobTestBodySix = getDataJobRequestBody(TEST_TEAM_NAME, TEST_JOB_6);
+    createJob(dataJobTestBodySix, TEST_TEAM_NAME);
+  }
 
-   private void deleteDummyJobs() throws Exception {
-      // Clean up
-      deleteJob(TEST_JOB_1, TEST_TEAM_NAME);
-      deleteJob(TEST_JOB_2, TEST_TEAM_NAME);
-      deleteJob(TEST_JOB_3, NEW_TEST_TEAM_NAME);
-      deleteJob(TEST_JOB_4, NEW_TEST_TEAM_NAME);
-      deleteJob(TEST_JOB_5, NEW_TEST_TEAM_NAME);
-      deleteJob(TEST_JOB_6, TEST_TEAM_NAME);
-   }
+  private void deleteDummyJobs() throws Exception {
+    // Clean up
+    deleteJob(TEST_JOB_1, TEST_TEAM_NAME);
+    deleteJob(TEST_JOB_2, TEST_TEAM_NAME);
+    deleteJob(TEST_JOB_3, NEW_TEST_TEAM_NAME);
+    deleteJob(TEST_JOB_4, NEW_TEST_TEAM_NAME);
+    deleteJob(TEST_JOB_5, NEW_TEST_TEAM_NAME);
+    deleteJob(TEST_JOB_6, TEST_TEAM_NAME);
+  }
 
-   private void createJob(String body, String teamName) throws Exception {
-      mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs", teamName))
-            .with(user("user"))
-            .content(body)
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isCreated());
-   }
+  private void createJob(String body, String teamName) throws Exception {
+    mockMvc
+        .perform(
+            post(String.format("/data-jobs/for-team/%s/jobs", teamName))
+                .with(user("user"))
+                .content(body)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated());
+  }
 
-   private void deleteJob(String jobName, String teamName) throws Exception {
-      mockMvc.perform(delete(String.format("/data-jobs/for-team/%s/jobs/%s", teamName, jobName))
-            .with(user("user"))
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk());
-   }
+  private void deleteJob(String jobName, String teamName) throws Exception {
+    mockMvc
+        .perform(
+            delete(String.format("/data-jobs/for-team/%s/jobs/%s", teamName, jobName))
+                .with(user("user"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobPropertiesIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobPropertiesIT.java
@@ -22,45 +22,67 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = ControlplaneApplication.class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = ControlplaneApplication.class)
 public class DataJobPropertiesIT extends BaseIT {
 
-   @Autowired
-   private PropertiesRepository propertiesRepository;
+  @Autowired private PropertiesRepository propertiesRepository;
 
-   @Test
-   public void testDataJobProperties() throws Exception {
-      // Setup
-      String dataJobRequestBody = getDataJobRequestBody(TEST_TEAM_NAME, TEST_JOB_NAME);
+  @Test
+  public void testDataJobProperties() throws Exception {
+    // Setup
+    String dataJobRequestBody = getDataJobRequestBody(TEST_TEAM_NAME, TEST_JOB_NAME);
 
-      // Execute create job (Post Create WebHook will return success for this call)
-      mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
-            .with(user("user"))
-            .content(dataJobRequestBody)
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isCreated())
-            .andExpect(header().string(HttpHeaders.LOCATION,
-                  lambdaMatcher(s -> s.endsWith(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME,
-                          TEST_JOB_NAME)))));
+    // Execute create job (Post Create WebHook will return success for this call)
+    mockMvc
+        .perform(
+            post(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
+                .with(user("user"))
+                .content(dataJobRequestBody)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated())
+        .andExpect(
+            header()
+                .string(
+                    HttpHeaders.LOCATION,
+                    lambdaMatcher(
+                        s ->
+                            s.endsWith(
+                                String.format(
+                                    "/data-jobs/for-team/%s/jobs/%s",
+                                    TEST_TEAM_NAME, TEST_JOB_NAME)))));
 
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s/properties", TEST_TEAM_NAME, TEST_JOB_NAME, "dev"))
-              .with(user("user")))
-              .andExpect(status().isOk()).andExpect(content().string("{}"));
+    mockMvc
+        .perform(
+            get(String.format(
+                    "/data-jobs/for-team/%s/jobs/%s/deployments/%s/properties",
+                    TEST_TEAM_NAME, TEST_JOB_NAME, "dev"))
+                .with(user("user")))
+        .andExpect(status().isOk())
+        .andExpect(content().string("{}"));
 
-      var props = new HashMap<String, Object>();
-      props.put("string_key", "string_value");
-      props.put("int_key", 123);
-      props.put("bool_key", true);
-      mockMvc.perform(put(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s/properties", TEST_TEAM_NAME, TEST_JOB_NAME, "dev"))
-              .with(user("user"))
-              .content(mapper.writeValueAsString(props))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isNoContent());
+    var props = new HashMap<String, Object>();
+    props.put("string_key", "string_value");
+    props.put("int_key", 123);
+    props.put("bool_key", true);
+    mockMvc
+        .perform(
+            put(String.format(
+                    "/data-jobs/for-team/%s/jobs/%s/deployments/%s/properties",
+                    TEST_TEAM_NAME, TEST_JOB_NAME, "dev"))
+                .with(user("user"))
+                .content(mapper.writeValueAsString(props))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNoContent());
 
-      mockMvc.perform(get(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s/properties", TEST_TEAM_NAME, TEST_JOB_NAME, "dev"))
-              .with(user("user")))
-              .andExpect(status().isOk()).andExpect(content().json(mapper.writeValueAsString(props)));
-
-
-   }
+    mockMvc
+        .perform(
+            get(String.format(
+                    "/data-jobs/for-team/%s/jobs/%s/deployments/%s/properties",
+                    TEST_TEAM_NAME, TEST_JOB_NAME, "dev"))
+                .with(user("user")))
+        .andExpect(status().isOk())
+        .andExpect(content().json(mapper.writeValueAsString(props)));
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobTerminationStatusIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobTerminationStatusIT.java
@@ -44,279 +44,337 @@ import com.vmware.taurus.service.JobsRepository;
 @AutoConfigureMetrics
 public class DataJobTerminationStatusIT extends BaseDataJobDeploymentIT {
 
-    public static final String INFO_METRICS = "taurus_datajob_info";
-    public static final String TERMINATION_STATUS_METRICS = "taurus_datajob_termination_status";
-    public static final String HEADER_X_OP_ID = "X-OPID";
+  public static final String INFO_METRICS = "taurus_datajob_info";
+  public static final String TERMINATION_STATUS_METRICS = "taurus_datajob_termination_status";
+  public static final String HEADER_X_OP_ID = "X-OPID";
 
-    private static final Logger log = LoggerFactory.getLogger(DataJobTerminationStatusIT.class);
-    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule()); // Used for converting to OffsetDateTime;
+  private static final Logger log = LoggerFactory.getLogger(DataJobTerminationStatusIT.class);
+  private final ObjectMapper objectMapper =
+      new ObjectMapper()
+          .registerModule(new JavaTimeModule()); // Used for converting to OffsetDateTime;
 
-    @Autowired
-    JobsRepository jobsRepository;
+  @Autowired JobsRepository jobsRepository;
 
-    // TODO split this test into job termination status test and data job execution test
-    /**
-     * This test aims to validate the data job execution and termination status monitoring logic in TPCS. For the purpose it does the following:
-     * <ul>
-     *     <li>Creates a new data job (simple_job.zip), configured with:</li>
-     *     <ul>
-     *         <li>schedule (e.g. *&#47;2 * * * *)</li>
-     *         <li>notification emails</li>
-     *         <li>enable_execution_notifications set to false</li>
-     *     </ul>
-     *     <li>Deploys the data job</li>
-     *     <li>Wait for the deployment to complete</li>
-     *     <li>Executes the data job</li>
-     *     <li>Checks data job execution status</li>
-     *     <li>Wait until a single data job execution to complete (using the awaitility for this)</li>
-     *     <li>Checks data job execution status</li>
-     *     <li>Make a rest call to the (/data-jobs/debug/prometheus)</li>
-     *     <li>Parse the result and validate that:</li>
-     *     <ul>
-     *         <li>there is a taurus_datajob_info metrics for the data job used for testing and that it has the
-     *         appropriate email labels (they should be empty because enable_execution_notifications is false)</li>
-     *         <li>there is a taurus_datajob_termination_status metrics for the data job used for testing and it
-     *         has the appropriate value (0.0 in this case; i.e. the job should have succeeded)</li>
-     *     </ul>
-     *     <li>Finally, delete the job deployment and the leftover K8s jobs.</li>
-     * </ul>
-     */
-    @Test
-    public void testDataJobTerminationStatus(String jobName, String teamName, String username) throws Exception {
-        // Execute data job
-        String opId = jobName + UUID.randomUUID().toString().toLowerCase();
-        DataJobExecutionRequest dataJobExecutionRequest = new DataJobExecutionRequest()
-              .startedBy(username);
+  // TODO split this test into job termination status test and data job execution test
+  /**
+   * This test aims to validate the data job execution and termination status monitoring logic in
+   * TPCS. For the purpose it does the following:
+   *
+   * <ul>
+   *   <li>Creates a new data job (simple_job.zip), configured with:
+   *       <ul>
+   *         <li>schedule (e.g. *&#47;2 * * * *)
+   *         <li>notification emails
+   *         <li>enable_execution_notifications set to false
+   *       </ul>
+   *   <li>Deploys the data job
+   *   <li>Wait for the deployment to complete
+   *   <li>Executes the data job
+   *   <li>Checks data job execution status
+   *   <li>Wait until a single data job execution to complete (using the awaitility for this)
+   *   <li>Checks data job execution status
+   *   <li>Make a rest call to the (/data-jobs/debug/prometheus)
+   *   <li>Parse the result and validate that:
+   *       <ul>
+   *         <li>there is a taurus_datajob_info metrics for the data job used for testing and that
+   *             it has the appropriate email labels (they should be empty because
+   *             enable_execution_notifications is false)
+   *         <li>there is a taurus_datajob_termination_status metrics for the data job used for
+   *             testing and it has the appropriate value (0.0 in this case; i.e. the job should
+   *             have succeeded)
+   *       </ul>
+   *   <li>Finally, delete the job deployment and the leftover K8s jobs.
+   * </ul>
+   */
+  @Test
+  public void testDataJobTerminationStatus(String jobName, String teamName, String username)
+      throws Exception {
+    // Execute data job
+    String opId = jobName + UUID.randomUUID().toString().toLowerCase();
+    DataJobExecutionRequest dataJobExecutionRequest =
+        new DataJobExecutionRequest().startedBy(username);
 
-        String triggerDataJobExecutionUrl = String.format(
-              "/data-jobs/for-team/%s/jobs/%s/deployments/%s/executions",
-              teamName,
-              jobName,
-              "release");
-        MvcResult dataJobExecutionResponse = mockMvc.perform(post(triggerDataJobExecutionUrl)
-              .with(user(username))
-              .header(HEADER_X_OP_ID, opId)
-              .content(mapper.writeValueAsString(dataJobExecutionRequest))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().is(202))
-              .andReturn();
+    String triggerDataJobExecutionUrl =
+        String.format(
+            "/data-jobs/for-team/%s/jobs/%s/deployments/%s/executions",
+            teamName, jobName, "release");
+    MvcResult dataJobExecutionResponse =
+        mockMvc
+            .perform(
+                post(triggerDataJobExecutionUrl)
+                    .with(user(username))
+                    .header(HEADER_X_OP_ID, opId)
+                    .content(mapper.writeValueAsString(dataJobExecutionRequest))
+                    .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().is(202))
+            .andReturn();
 
-        // Check the data job execution status
-        String location = dataJobExecutionResponse.getResponse().getHeader("location");
-        String executionId = location.substring(location.lastIndexOf("/") + 1);
-        checkDataJobExecutionStatus(executionId, DataJobExecution.StatusEnum.SUCCEEDED, opId, jobName, teamName, username);
+    // Check the data job execution status
+    String location = dataJobExecutionResponse.getResponse().getHeader("location");
+    String executionId = location.substring(location.lastIndexOf("/") + 1);
+    checkDataJobExecutionStatus(
+        executionId, DataJobExecution.StatusEnum.SUCCEEDED, opId, jobName, teamName, username);
 
-        // Wait for the job execution to complete, polling every 5 seconds
-        // See: https://github.com/awaitility/awaitility/wiki/Usage
-        await().atMost(10, TimeUnit.MINUTES).with().pollInterval(15, TimeUnit.SECONDS).until(terminationMetricsAreAvailable());
+    // Wait for the job execution to complete, polling every 5 seconds
+    // See: https://github.com/awaitility/awaitility/wiki/Usage
+    await()
+        .atMost(10, TimeUnit.MINUTES)
+        .with()
+        .pollInterval(15, TimeUnit.SECONDS)
+        .until(terminationMetricsAreAvailable());
 
-        String scrape = scrapeMetrics();
+    String scrape = scrapeMetrics();
 
-        // Validate that all metrics for the executed data job are correctly exposed
-        // First, validate that there is a taurus_datajob_info metrics for the data job
-        var match = findMetricsWithLabel(scrape, INFO_METRICS, "data_job", jobName);
-        assertTrue(match.isPresent(),
-                String.format("Could not find %s metrics for the data job %s",
-                        INFO_METRICS, jobName));
+    // Validate that all metrics for the executed data job are correctly exposed
+    // First, validate that there is a taurus_datajob_info metrics for the data job
+    var match = findMetricsWithLabel(scrape, INFO_METRICS, "data_job", jobName);
+    assertTrue(
+        match.isPresent(),
+        String.format("Could not find %s metrics for the data job %s", INFO_METRICS, jobName));
 
-        // Validate the labels of the taurus_datajob_info metrics
-        String line = match.get();
-        assertLabelEquals(INFO_METRICS, teamName, "team", line);
-        assertLabelEquals(INFO_METRICS, "", "email_notified_on_success", line);
-        assertLabelEquals(INFO_METRICS, "", "email_notified_on_platform_error", line);
-        assertLabelEquals(INFO_METRICS, "", "email_notified_on_user_error", line);
+    // Validate the labels of the taurus_datajob_info metrics
+    String line = match.get();
+    assertLabelEquals(INFO_METRICS, teamName, "team", line);
+    assertLabelEquals(INFO_METRICS, "", "email_notified_on_success", line);
+    assertLabelEquals(INFO_METRICS, "", "email_notified_on_platform_error", line);
+    assertLabelEquals(INFO_METRICS, "", "email_notified_on_user_error", line);
 
-        // Validate that there is a taurus_datajob_info metrics for the data job
-        match = findMetricsWithLabel(scrape, TERMINATION_STATUS_METRICS, "data_job", jobName);
-        assertTrue(match.isPresent(),
-                String.format("Could not find %s metrics for the data job %s",
-                        TERMINATION_STATUS_METRICS, jobName));
+    // Validate that there is a taurus_datajob_info metrics for the data job
+    match = findMetricsWithLabel(scrape, TERMINATION_STATUS_METRICS, "data_job", jobName);
+    assertTrue(
+        match.isPresent(),
+        String.format(
+            "Could not find %s metrics for the data job %s", TERMINATION_STATUS_METRICS, jobName));
 
-        // Validate that the metrics has a value of 0.0 (i.e. Success)
-        System.out.println(match.get().trim());
-        assertTrue(match.get().trim().endsWith("0.0"), "The value of the taurus_datajob_termination_status metrics does not match");
+    // Validate that the metrics has a value of 0.0 (i.e. Success)
+    System.out.println(match.get().trim());
+    assertTrue(
+        match.get().trim().endsWith("0.0"),
+        "The value of the taurus_datajob_termination_status metrics does not match");
 
-        // Check the data job execution status
-        checkDataJobExecutionStatus(executionId, DataJobExecution.StatusEnum.SUCCEEDED, opId, jobName, teamName, username);
+    // Check the data job execution status
+    checkDataJobExecutionStatus(
+        executionId, DataJobExecution.StatusEnum.SUCCEEDED, opId, jobName, teamName, username);
+  }
+
+  private String scrapeMetrics() throws Exception {
+    return mockMvc
+        .perform(get("/data-jobs/debug/prometheus"))
+        .andExpect(status().isOk())
+        .andReturn()
+        .getResponse()
+        .getContentAsString();
+  }
+
+  private Callable<Boolean> terminationMetricsAreAvailable() {
+    return () -> scrapeMetrics().contains(TERMINATION_STATUS_METRICS);
+  }
+
+  private static Optional<String> findMetricsWithLabel(
+      CharSequence input, String metrics, String label, String labelValue) {
+    Pattern pattern =
+        Pattern.compile(
+            String.format("%s\\{.*%s=\"%s\"[^\\}]*\\} (.*)", metrics, label, labelValue),
+            Pattern.CASE_INSENSITIVE);
+    Matcher matcher = pattern.matcher(input);
+    if (!matcher.find()) {
+      return Optional.empty();
     }
+    return Optional.of(matcher.group());
+  }
 
-    private String scrapeMetrics() throws Exception {
-        return mockMvc.perform(get("/data-jobs/debug/prometheus"))
-                .andExpect(status().isOk())
-                .andReturn()
-                .getResponse()
-                .getContentAsString();
+  private static void assertLabelEquals(
+      String metrics, String expectedValue, String label, String line) {
+    // Label value is captured in the first regex group
+    Matcher matcher =
+        Pattern.compile(String.format(".*%s=\"([^\"]*)\".*", label), Pattern.CASE_INSENSITIVE)
+            .matcher(line);
+    assertTrue(
+        matcher.find(),
+        String.format("The metrics %s does not have a matching label %s", metrics, label));
+    String actualValue = matcher.group(1);
+    assertEquals(
+        expectedValue,
+        actualValue,
+        String.format(
+            "The metrics %s does not have correct value for label %s. Expected: %s, Actual: %s",
+            metrics, label, expectedValue, actualValue));
+  }
+
+  private void checkDataJobExecutionStatus(
+      String executionId,
+      DataJobExecution.StatusEnum executionStatus,
+      String opId,
+      String jobName,
+      String teamName,
+      String username)
+      throws Exception {
+
+    try {
+      testDataJobExecutionRead(executionId, executionStatus, opId, jobName, teamName, username);
+      testDataJobExecutionList(executionId, executionStatus, opId, jobName, teamName, username);
+      testDataJobDeploymentExecutionList(
+          executionId, executionStatus, opId, jobName, teamName, username);
+      testDataJobExecutionLogs(executionId, jobName, teamName, username);
+    } catch (Error e) {
+      try {
+        // print logs in case execution has failed
+        MvcResult dataJobExecutionLogsResult =
+            getExecuteLogs(executionId, jobName, teamName, username);
+        log.info(
+            "Job Execution {} logs:\n{}",
+            executionId,
+            dataJobExecutionLogsResult.getResponse().getContentAsString());
+      } catch (Error ignore) {
+      }
+      throw e;
     }
+  }
 
-    private Callable<Boolean> terminationMetricsAreAvailable() {
-        return () -> scrapeMetrics().contains(TERMINATION_STATUS_METRICS);
-    }
+  private void testDataJobExecutionRead(
+      String executionId,
+      DataJobExecution.StatusEnum executionStatus,
+      String opId,
+      String jobName,
+      String teamName,
+      String username) {
 
-    private static Optional<String> findMetricsWithLabel(CharSequence input, String metrics, String label, String labelValue) {
-        Pattern pattern = Pattern.compile(String.format("%s\\{.*%s=\"%s\"[^\\}]*\\} (.*)", metrics, label, labelValue),
-                Pattern.CASE_INSENSITIVE);
-        Matcher matcher = pattern.matcher(input);
-        if (!matcher.find()) {
-            return Optional.empty();
-        }
-        return Optional.of(matcher.group());
-    }
+    DataJobExecution[] dataJobExecution = new DataJobExecution[1];
 
-    private static void assertLabelEquals(String metrics, String expectedValue, String label, String line) {
-        // Label value is captured in the first regex group
-        Matcher matcher = Pattern.compile(String.format(".*%s=\"([^\"]*)\".*", label), Pattern.CASE_INSENSITIVE).matcher(line);
-        assertTrue(matcher.find(), String.format("The metrics %s does not have a matching label %s", metrics, label));
-        String actualValue = matcher.group(1);
-        assertEquals(expectedValue, actualValue,
-                String.format("The metrics %s does not have correct value for label %s. Expected: %s, Actual: %s",
-                        metrics, label, expectedValue, actualValue));
-    }
+    await()
+        .atMost(5, TimeUnit.MINUTES)
+        .with()
+        .pollInterval(15, TimeUnit.SECONDS)
+        .until(
+            () -> {
+              String dataJobExecutionReadUrl =
+                  String.format(
+                      "/data-jobs/for-team/%s/jobs/%s/executions/%s",
+                      teamName, jobName, executionId);
+              MvcResult dataJobExecutionResult =
+                  mockMvc
+                      .perform(
+                          get(dataJobExecutionReadUrl)
+                              .with(user(username))
+                              .contentType(MediaType.APPLICATION_JSON))
+                      .andExpect(status().isOk())
+                      .andReturn();
 
-    private void checkDataJobExecutionStatus(
-          String executionId,
-          DataJobExecution.StatusEnum executionStatus,
-          String opId,
-          String jobName,
-          String teamName,
-          String username) throws Exception {
+              dataJobExecution[0] =
+                  objectMapper.readValue(
+                      dataJobExecutionResult.getResponse().getContentAsString(),
+                      DataJobExecution.class);
 
-        try {
-            testDataJobExecutionRead(executionId, executionStatus, opId, jobName, teamName, username);
-            testDataJobExecutionList(executionId, executionStatus, opId, jobName, teamName, username);
-            testDataJobDeploymentExecutionList(executionId, executionStatus, opId, jobName, teamName, username);
-            testDataJobExecutionLogs(executionId, jobName, teamName, username);
-        } catch (Error e) {
-            try {
-                // print logs in case execution has failed
-                MvcResult dataJobExecutionLogsResult = getExecuteLogs(executionId, jobName, teamName, username);
-                log.info("Job Execution {} logs:\n{}", executionId, dataJobExecutionLogsResult.getResponse().getContentAsString());
-            } catch(Error ignore) {
-            }
-            throw e;
-        }
-    }
+              return dataJobExecution[0] != null
+                  && executionStatus.equals(dataJobExecution[0].getStatus());
+            });
 
-    private void testDataJobExecutionRead(
-          String executionId,
-          DataJobExecution.StatusEnum executionStatus,
-          String opId,
-          String jobName,
-          String teamName,
-          String username) {
+    assertDataJobExecutionValid(
+        executionId, executionStatus, opId, dataJobExecution[0], jobName, username);
+  }
 
-        DataJobExecution[] dataJobExecution = new DataJobExecution[1];
+  private void testDataJobExecutionList(
+      String executionId,
+      DataJobExecution.StatusEnum executionStatus,
+      String opId,
+      String jobName,
+      String teamName,
+      String username)
+      throws Exception {
 
-        await()
-              .atMost(5, TimeUnit.MINUTES)
-              .with()
-              .pollInterval(15, TimeUnit.SECONDS)
-              .until(() -> {
-                  String dataJobExecutionReadUrl = String.format(
-                        "/data-jobs/for-team/%s/jobs/%s/executions/%s",
-                        teamName, jobName,
-                        executionId);
-                  MvcResult dataJobExecutionResult = mockMvc.perform(get(dataJobExecutionReadUrl)
-                        .with(user(username))
-                        .contentType(MediaType.APPLICATION_JSON))
-                        .andExpect(status().isOk())
-                        .andReturn();
+    String dataJobExecutionListUrl =
+        String.format("/data-jobs/for-team/%s/jobs/%s/executions", teamName, jobName);
+    MvcResult dataJobExecutionResult =
+        mockMvc
+            .perform(
+                get(dataJobExecutionListUrl)
+                    .with(user(username))
+                    .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn();
 
-                  dataJobExecution[0] = objectMapper
-                        .readValue(dataJobExecutionResult.getResponse().getContentAsString(), DataJobExecution.class);
+    List<DataJobExecution> dataJobExecutions =
+        objectMapper.readValue(
+            dataJobExecutionResult.getResponse().getContentAsString(), new TypeReference<>() {});
+    assertNotNull(dataJobExecutions);
+    dataJobExecutions =
+        dataJobExecutions.stream()
+            .filter(e -> e.getId().equals(executionId))
+            .collect(Collectors.toList());
+    assertEquals(1, dataJobExecutions.size());
+    assertDataJobExecutionValid(
+        executionId, executionStatus, opId, dataJobExecutions.get(0), jobName, username);
+  }
 
-                  return dataJobExecution[0] != null && executionStatus.equals(dataJobExecution[0].getStatus());
-              });
+  private void testDataJobDeploymentExecutionList(
+      String executionId,
+      DataJobExecution.StatusEnum executionStatus,
+      String opId,
+      String jobName,
+      String teamName,
+      String username)
+      throws Exception {
 
-        assertDataJobExecutionValid(executionId, executionStatus, opId, dataJobExecution[0], jobName, username);
-    }
+    String dataJobDeploymentExecutionListUrl =
+        String.format(
+            "/data-jobs/for-team/%s/jobs/%s/deployments/%s/executions",
+            teamName, jobName, "release");
+    MvcResult dataJobExecutionResult =
+        mockMvc
+            .perform(
+                get(dataJobDeploymentExecutionListUrl)
+                    .with(user(username))
+                    .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn();
 
-    private void testDataJobExecutionList(
-          String executionId,
-          DataJobExecution.StatusEnum executionStatus,
-          String opId,
-          String jobName,
-          String teamName,
-          String username) throws Exception {
+    List<DataJobExecution> dataJobExecutions =
+        objectMapper.readValue(
+            dataJobExecutionResult.getResponse().getContentAsString(), new TypeReference<>() {});
+    assertNotNull(dataJobExecutions);
+    dataJobExecutions =
+        dataJobExecutions.stream()
+            .filter(e -> e.getId().equals(executionId))
+            .collect(Collectors.toList());
+    assertEquals(1, dataJobExecutions.size());
+    assertDataJobExecutionValid(
+        executionId, executionStatus, opId, dataJobExecutions.get(0), jobName, username);
+  }
 
-        String dataJobExecutionListUrl = String.format(
-              "/data-jobs/for-team/%s/jobs/%s/executions",
-              teamName, jobName);
-        MvcResult dataJobExecutionResult = mockMvc.perform(get(dataJobExecutionListUrl)
-              .with(user(username))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk())
-              .andReturn();
+  private void testDataJobExecutionLogs(
+      String executionId, String jobName, String teamName, String username) throws Exception {
+    MvcResult dataJobExecutionLogsResult = getExecuteLogs(executionId, jobName, teamName, username);
+    assertFalse(dataJobExecutionLogsResult.getResponse().getContentAsString().isEmpty());
+  }
 
-        List<DataJobExecution> dataJobExecutions = objectMapper
-              .readValue(dataJobExecutionResult.getResponse().getContentAsString(), new TypeReference<>() {});
-        assertNotNull(dataJobExecutions);
-        dataJobExecutions = dataJobExecutions
-              .stream()
-              .filter(e -> e.getId().equals(executionId))
-              .collect(Collectors.toList());
-        assertEquals(1, dataJobExecutions.size());
-        assertDataJobExecutionValid(executionId, executionStatus, opId, dataJobExecutions.get(0), jobName, username);
-    }
+  @NotNull
+  private MvcResult getExecuteLogs(
+      String executionId, String jobName, String teamName, String username) throws Exception {
+    String dataJobExecutionListUrl =
+        String.format(
+            "/data-jobs/for-team/%s/jobs/%s/executions/%s/logs", teamName, jobName, executionId);
+    MvcResult dataJobExecutionLogsResult =
+        mockMvc
+            .perform(get(dataJobExecutionListUrl).with(user(username)))
+            .andExpect(status().isOk())
+            .andReturn();
+    return dataJobExecutionLogsResult;
+  }
 
-    private void testDataJobDeploymentExecutionList(
-          String executionId,
-          DataJobExecution.StatusEnum executionStatus,
-          String opId,
-          String jobName,
-          String teamName,
-          String username) throws Exception {
+  private void assertDataJobExecutionValid(
+      String executionId,
+      DataJobExecution.StatusEnum executionStatus,
+      String opId,
+      DataJobExecution dataJobExecution,
+      String jobName,
+      String username) {
 
-        String dataJobDeploymentExecutionListUrl = String.format(
-              "/data-jobs/for-team/%s/jobs/%s/deployments/%s/executions",
-              teamName, jobName, "release");
-        MvcResult dataJobExecutionResult = mockMvc.perform(get(dataJobDeploymentExecutionListUrl)
-              .with(user(username))
-              .contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isOk())
-              .andReturn();
-
-        List<DataJobExecution> dataJobExecutions = objectMapper
-              .readValue(dataJobExecutionResult.getResponse().getContentAsString(), new TypeReference<>() {});
-        assertNotNull(dataJobExecutions);
-        dataJobExecutions = dataJobExecutions
-              .stream()
-              .filter(e -> e.getId().equals(executionId))
-              .collect(Collectors.toList());
-        assertEquals(1, dataJobExecutions.size());
-        assertDataJobExecutionValid(executionId, executionStatus, opId, dataJobExecutions.get(0), jobName, username);
-    }
-
-    private void testDataJobExecutionLogs(String executionId, String jobName, String teamName, String username) throws Exception {
-        MvcResult dataJobExecutionLogsResult = getExecuteLogs(executionId, jobName, teamName, username);
-        assertFalse(dataJobExecutionLogsResult.getResponse().getContentAsString().isEmpty());
-    }
-
-    @NotNull
-    private MvcResult getExecuteLogs(String executionId, String jobName, String teamName, String username) throws Exception {
-        String dataJobExecutionListUrl = String.format(
-                "/data-jobs/for-team/%s/jobs/%s/executions/%s/logs",
-                teamName, jobName, executionId);
-        MvcResult dataJobExecutionLogsResult = mockMvc.perform(get(dataJobExecutionListUrl)
-                        .with(user(username)))
-                .andExpect(status().isOk())
-                .andReturn();
-        return dataJobExecutionLogsResult;
-    }
-
-    private void assertDataJobExecutionValid(
-          String executionId,
-          DataJobExecution.StatusEnum executionStatus,
-          String opId,
-          DataJobExecution dataJobExecution,
-          String jobName,
-          String username) {
-
-        assertNotNull(dataJobExecution);
-        assertEquals(executionId, dataJobExecution.getId());
-        assertEquals(jobName, dataJobExecution.getJobName());
-        assertEquals(executionStatus, dataJobExecution.getStatus());
-        assertEquals(DataJobExecution.TypeEnum.MANUAL, dataJobExecution.getType());
-        //assertEquals(username + "/" + "user", dataJobExecution.getStartedBy());
-        assertEquals(opId, dataJobExecution.getOpId());
-    }
+    assertNotNull(dataJobExecution);
+    assertEquals(executionId, dataJobExecution.getId());
+    assertEquals(jobName, dataJobExecution.getJobName());
+    assertEquals(executionStatus, dataJobExecution.getStatus());
+    assertEquals(DataJobExecution.TypeEnum.MANUAL, dataJobExecution.getType());
+    // assertEquals(username + "/" + "user", dataJobExecution.getStartedBy());
+    assertEquals(opId, dataJobExecution.getOpId());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/DataJobDeploymentExtension.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/DataJobDeploymentExtension.java
@@ -49,195 +49,213 @@ import com.vmware.taurus.service.kubernetes.DataJobsKubernetesService;
 import com.vmware.taurus.service.model.JobDeploymentStatus;
 
 /**
- * Extension that deploys Data Job before all tests. Before the test execution,
- * the extension creates Data Job and deploys it to Kubernetes Cluster.
- * Also, these properties are injected into each test as method parameters:
- * jobName, teamName, deploymentId and username. Example usage:
+ * Extension that deploys Data Job before all tests. Before the test execution, the extension
+ * creates Data Job and deploys it to Kubernetes Cluster. Also, these properties are injected into
+ * each test as method parameters: jobName, teamName, deploymentId and username. Example
+ * usage: @ExtendWith(DataJobDeploymentExtension.class) public class ExampleDataJobExecutionIT
+ * { @Test public void testExecuteDataJob_shouldExecuteDataJobSuccessfully(String jobName, String
+ * teamName, String username) { // Execute data job String opId = jobName +
+ * UUID.randomUUID().toString().toLowerCase(); DataJobExecutionRequest dataJobExecutionRequest = new
+ * DataJobExecutionRequest() .startedBy(username);
  *
- *  @ExtendWith(DataJobDeploymentExtension.class)
- *  public class ExampleDataJobExecutionIT {
+ * <p>String triggerDataJobExecutionUrl = String.format(
+ * "/data-jobs/for-team/%s/jobs/%s/deployments/%s/executions", teamName, jobName, "release");
+ * MvcResult dataJobExecutionResponse = mockMvc.perform(post(triggerDataJobExecutionUrl)
+ * .with(user(username)) .header(HEADER_X_OP_ID, opId)
+ * .content(mapper.writeValueAsString(dataJobExecutionRequest))
+ * .contentType(MediaType.APPLICATION_JSON)) .andExpect(status().is(202)) .andReturn(); } }
  *
- *      @Test
- *      public void testExecuteDataJob_shouldExecuteDataJobSuccessfully(String jobName, String teamName, String username) {
- *          // Execute data job
- *         String opId = jobName + UUID.randomUUID().toString().toLowerCase();
- *         DataJobExecutionRequest dataJobExecutionRequest = new DataJobExecutionRequest()
- *               .startedBy(username);
- *
- *         String triggerDataJobExecutionUrl = String.format(
- *               "/data-jobs/for-team/%s/jobs/%s/deployments/%s/executions",
- *               teamName,
- *               jobName,
- *               "release");
- *         MvcResult dataJobExecutionResponse = mockMvc.perform(post(triggerDataJobExecutionUrl)
- *               .with(user(username))
- *               .header(HEADER_X_OP_ID, opId)
- *               .content(mapper.writeValueAsString(dataJobExecutionRequest))
- *               .contentType(MediaType.APPLICATION_JSON))
- *               .andExpect(status().is(202))
- *               .andReturn();
- *      }
- *  }
- *
- * <b>Note the Data Job is shared between the all tests. Do not delete the job deployment since this may affect other tests.</b>
+ * <p><b>Note the Data Job is shared between the all tests. Do not delete the job deployment since
+ * this may affect other tests.</b>
  */
-public class DataJobDeploymentExtension implements BeforeEachCallback, ExtensionContext.Store.CloseableResource, ParameterResolver {
+public class DataJobDeploymentExtension
+    implements BeforeEachCallback, ExtensionContext.Store.CloseableResource, ParameterResolver {
 
-   private final static Lock LOCK = new ReentrantLock();
-   protected static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Lock LOCK = new ReentrantLock();
+  protected static final ObjectMapper MAPPER = new ObjectMapper();
 
-   public static final String JOB_NAME = "integration-test-" + UUID.randomUUID().toString().substring(0, 8);
-   public static final String JOB_NOTIFIED_EMAIL = "versatiledatakit@vmware.com";
-   public static final String JOB_SCHEDULE = "*/2 * * * *";
-   public static final String USER_NAME = "user";
-   public static final String DEPLOYMENT_ID = "NOT_USED";
-   public static final String TEAM_NAME = "test-team";
+  public static final String JOB_NAME =
+      "integration-test-" + UUID.randomUUID().toString().substring(0, 8);
+  public static final String JOB_NOTIFIED_EMAIL = "versatiledatakit@vmware.com";
+  public static final String JOB_SCHEDULE = "*/2 * * * *";
+  public static final String USER_NAME = "user";
+  public static final String DEPLOYMENT_ID = "NOT_USED";
+  public static final String TEAM_NAME = "test-team";
 
-   private static final Map<String, Object> SUPPORTED_PARAMETERS =
-         Map.of("jobName", JOB_NAME,
-               "username", USER_NAME,
-               "deploymentId", DEPLOYMENT_ID,
-               "teamName", TEAM_NAME);
+  private static final Map<String, Object> SUPPORTED_PARAMETERS =
+      Map.of(
+          "jobName",
+          JOB_NAME,
+          "username",
+          USER_NAME,
+          "deploymentId",
+          DEPLOYMENT_ID,
+          "teamName",
+          TEAM_NAME);
 
-   private ExtensionContext context;
+  private ExtensionContext context;
 
-   @Override
-   public void beforeEach(ExtensionContext context) throws Exception {
-      this.context = context;
-      MockMvc mockMvc = SpringExtension.getApplicationContext(context).getBean(MockMvc.class);
-      DataJobsKubernetesService dataJobsKubernetesService =
-            SpringExtension.getApplicationContext(context).getBean(DataJobsKubernetesService.class);
+  @Override
+  public void beforeEach(ExtensionContext context) throws Exception {
+    this.context = context;
+    MockMvc mockMvc = SpringExtension.getApplicationContext(context).getBean(MockMvc.class);
+    DataJobsKubernetesService dataJobsKubernetesService =
+        SpringExtension.getApplicationContext(context).getBean(DataJobsKubernetesService.class);
 
-      // Setup
-      String dataJobRequestBody = BaseIT.getDataJobRequestBody(TEAM_NAME, JOB_NAME);
+    // Setup
+    String dataJobRequestBody = BaseIT.getDataJobRequestBody(TEAM_NAME, JOB_NAME);
 
-      // Create the data job
-      mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs", TEAM_NAME))
-                  .with(user("user"))
-                  .content(dataJobRequestBody)
-                  .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isCreated())
-            .andExpect(header().string(HttpHeaders.LOCATION,
-                  BaseIT.lambdaMatcher(s -> s.endsWith(String.format("/data-jobs/for-team/%s/jobs/%s",
-                        TEAM_NAME,
-                        JOB_NAME)))));
+    // Create the data job
+    mockMvc
+        .perform(
+            post(String.format("/data-jobs/for-team/%s/jobs", TEAM_NAME))
+                .with(user("user"))
+                .content(dataJobRequestBody)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated())
+        .andExpect(
+            header()
+                .string(
+                    HttpHeaders.LOCATION,
+                    BaseIT.lambdaMatcher(
+                        s ->
+                            s.endsWith(
+                                String.format(
+                                    "/data-jobs/for-team/%s/jobs/%s", TEAM_NAME, JOB_NAME)))));
 
-      LOCK.lock();
-      String uniqueKey = this.getClass().getName();
-      Object value = context.getRoot().getStore(GLOBAL).get(uniqueKey);
+    LOCK.lock();
+    String uniqueKey = this.getClass().getName();
+    Object value = context.getRoot().getStore(GLOBAL).get(uniqueKey);
 
-      if (value == null) {
-         byte[] jobZipBinary = IOUtils.toByteArray(
-               getClass().getClassLoader().getResourceAsStream("simple_job.zip"));
+    if (value == null) {
+      byte[] jobZipBinary =
+          IOUtils.toByteArray(getClass().getClassLoader().getResourceAsStream("simple_job.zip"));
 
-         // Upload the data job
-         MvcResult uploadResult = mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs/%s/sources",
-                     TEAM_NAME,
-                     JOB_NAME))
-                     .with(user(USER_NAME))
-                     .content(jobZipBinary)
-                     .contentType(MediaType.APPLICATION_OCTET_STREAM))
-               .andExpect(status().isOk())
-               .andReturn();
-         DataJobVersion dataJobVersion = MAPPER.readValue(uploadResult.getResponse().getContentAsString(),
-               DataJobVersion.class);
+      // Upload the data job
+      MvcResult uploadResult =
+          mockMvc
+              .perform(
+                  post(String.format("/data-jobs/for-team/%s/jobs/%s/sources", TEAM_NAME, JOB_NAME))
+                      .with(user(USER_NAME))
+                      .content(jobZipBinary)
+                      .contentType(MediaType.APPLICATION_OCTET_STREAM))
+              .andExpect(status().isOk())
+              .andReturn();
+      DataJobVersion dataJobVersion =
+          MAPPER.readValue(uploadResult.getResponse().getContentAsString(), DataJobVersion.class);
 
-         // Update the data job configuration
-         var dataJob = new com.vmware.taurus.controlplane.model.data.DataJob()
-               .jobName(JOB_NAME)
-               .team(TEAM_NAME)
-               .config(new DataJobConfig()
-                     .enableExecutionNotifications(false)
-                     .contacts(new DataJobContacts()
-                           .addNotifiedOnJobSuccessItem(JOB_NOTIFIED_EMAIL)
-                           .addNotifiedOnJobDeployItem(JOB_NOTIFIED_EMAIL)
-                           .addNotifiedOnJobFailurePlatformErrorItem(JOB_NOTIFIED_EMAIL)
-                           .addNotifiedOnJobFailureUserErrorItem(JOB_NOTIFIED_EMAIL))
-                     .schedule(new DataJobSchedule()
-                           .scheduleCron(JOB_SCHEDULE)));
-         mockMvc.perform(put(String.format("/data-jobs/for-team/%s/jobs/%s",
-               TEAM_NAME,
-               JOB_NAME))
-               .with(user(USER_NAME))
-               .content(MAPPER.writeValueAsString(dataJob))
-               .contentType(MediaType.APPLICATION_JSON));
+      // Update the data job configuration
+      var dataJob =
+          new com.vmware.taurus.controlplane.model.data.DataJob()
+              .jobName(JOB_NAME)
+              .team(TEAM_NAME)
+              .config(
+                  new DataJobConfig()
+                      .enableExecutionNotifications(false)
+                      .contacts(
+                          new DataJobContacts()
+                              .addNotifiedOnJobSuccessItem(JOB_NOTIFIED_EMAIL)
+                              .addNotifiedOnJobDeployItem(JOB_NOTIFIED_EMAIL)
+                              .addNotifiedOnJobFailurePlatformErrorItem(JOB_NOTIFIED_EMAIL)
+                              .addNotifiedOnJobFailureUserErrorItem(JOB_NOTIFIED_EMAIL))
+                      .schedule(new DataJobSchedule().scheduleCron(JOB_SCHEDULE)));
+      mockMvc.perform(
+          put(String.format("/data-jobs/for-team/%s/jobs/%s", TEAM_NAME, JOB_NAME))
+              .with(user(USER_NAME))
+              .content(MAPPER.writeValueAsString(dataJob))
+              .contentType(MediaType.APPLICATION_JSON));
 
-         // Deploy the data job
-         var dataJobDeployment = new DataJobDeployment()
-               .jobVersion(dataJobVersion.getVersionSha())
-               .mode(DataJobMode.RELEASE)
-               .enabled(true);
-         mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs/%s/deployments", TEAM_NAME, JOB_NAME))
-                     .with(user(USER_NAME))
-                     .content(MAPPER.writeValueAsString(dataJobDeployment))
-                     .contentType(MediaType.APPLICATION_JSON))
-               .andExpect(status().isAccepted())
-               .andReturn();
-
-         // Verify that the job deployment was created
-         String jobDeploymentName = JobImageDeployer.getCronJobName(JOB_NAME);
-         Optional<JobDeploymentStatus> cronJobOptional = dataJobsKubernetesService.readCronJob(jobDeploymentName);
-         assertTrue(cronJobOptional.isPresent());
-         JobDeploymentStatus cronJob = cronJobOptional.get();
-         assertEquals(dataJobVersion.getVersionSha(), cronJob.getGitCommitSha());
-         assertEquals(DataJobMode.RELEASE.toString(), cronJob.getMode());
-         assertEquals(true, cronJob.getEnabled());
-         assertTrue(cronJob.getImageName().endsWith(dataJobVersion.getVersionSha()));
-         assertEquals(USER_NAME, cronJob.getLastDeployedBy());
-
-         context.getRoot().getStore(GLOBAL).put(uniqueKey, this);
-      }
-
-      LOCK.unlock();
-   }
-
-   @Override
-   public void close() throws Throwable {
-      MockMvc mockMvc = SpringExtension.getApplicationContext(context).getBean(MockMvc.class);
-      DataJobsKubernetesService dataJobsKubernetesService = SpringExtension.getApplicationContext(context).getBean(DataJobsKubernetesService.class);
-
-      // Execute delete deployment
-      mockMvc.perform(delete(String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s",
-                  TEAM_NAME,
-                  JOB_NAME,
-                  DEPLOYMENT_ID))
+      // Deploy the data job
+      var dataJobDeployment =
+          new DataJobDeployment()
+              .jobVersion(dataJobVersion.getVersionSha())
+              .mode(DataJobMode.RELEASE)
+              .enabled(true);
+      mockMvc
+          .perform(
+              post(String.format("/data-jobs/for-team/%s/jobs/%s/deployments", TEAM_NAME, JOB_NAME))
                   .with(user(USER_NAME))
+                  .content(MAPPER.writeValueAsString(dataJobDeployment))
                   .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isAccepted());
+          .andExpect(status().isAccepted())
+          .andReturn();
 
-      // Wait for deployment to be deleted
+      // Verify that the job deployment was created
       String jobDeploymentName = JobImageDeployer.getCronJobName(JOB_NAME);
-      await().atMost(5, TimeUnit.SECONDS).with().pollInterval(1, TimeUnit.SECONDS)
-            .until(() -> dataJobsKubernetesService.readCronJob(jobDeploymentName).isEmpty());
+      Optional<JobDeploymentStatus> cronJobOptional =
+          dataJobsKubernetesService.readCronJob(jobDeploymentName);
+      assertTrue(cronJobOptional.isPresent());
+      JobDeploymentStatus cronJob = cronJobOptional.get();
+      assertEquals(dataJobVersion.getVersionSha(), cronJob.getGitCommitSha());
+      assertEquals(DataJobMode.RELEASE.toString(), cronJob.getMode());
+      assertEquals(true, cronJob.getEnabled());
+      assertTrue(cronJob.getImageName().endsWith(dataJobVersion.getVersionSha()));
+      assertEquals(USER_NAME, cronJob.getLastDeployedBy());
 
-      mockMvc.perform(delete(String.format("/data-jobs/for-team/%s/jobs/%s/sources",
-                  TEAM_NAME,
-                  JOB_NAME))
-                  .with(user(USER_NAME))
-                  .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk());
+      context.getRoot().getStore(GLOBAL).put(uniqueKey, this);
+    }
 
-      // Finally, delete the K8s jobs to avoid them messing up subsequent runs of the same test
-      dataJobsKubernetesService.listJobs()
-            .stream()
-            .filter(jobName -> jobName.startsWith(JOB_NAME))
-            .forEach(s -> {
-               try {
-                  dataJobsKubernetesService.deleteJob(s);
-               } catch (ApiException e) {
-                  e.printStackTrace();
-               }
+    LOCK.unlock();
+  }
+
+  @Override
+  public void close() throws Throwable {
+    MockMvc mockMvc = SpringExtension.getApplicationContext(context).getBean(MockMvc.class);
+    DataJobsKubernetesService dataJobsKubernetesService =
+        SpringExtension.getApplicationContext(context).getBean(DataJobsKubernetesService.class);
+
+    // Execute delete deployment
+    mockMvc
+        .perform(
+            delete(
+                    String.format(
+                        "/data-jobs/for-team/%s/jobs/%s/deployments/%s",
+                        TEAM_NAME, JOB_NAME, DEPLOYMENT_ID))
+                .with(user(USER_NAME))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isAccepted());
+
+    // Wait for deployment to be deleted
+    String jobDeploymentName = JobImageDeployer.getCronJobName(JOB_NAME);
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .with()
+        .pollInterval(1, TimeUnit.SECONDS)
+        .until(() -> dataJobsKubernetesService.readCronJob(jobDeploymentName).isEmpty());
+
+    mockMvc
+        .perform(
+            delete(String.format("/data-jobs/for-team/%s/jobs/%s/sources", TEAM_NAME, JOB_NAME))
+                .with(user(USER_NAME))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+
+    // Finally, delete the K8s jobs to avoid them messing up subsequent runs of the same test
+    dataJobsKubernetesService.listJobs().stream()
+        .filter(jobName -> jobName.startsWith(JOB_NAME))
+        .forEach(
+            s -> {
+              try {
+                dataJobsKubernetesService.deleteJob(s);
+              } catch (ApiException e) {
+                e.printStackTrace();
+              }
             });
-   }
+  }
 
-   @Override
-   public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
-      Parameter parameter = parameterContext.getParameter();
-      return String.class.equals(parameter.getType()) && SUPPORTED_PARAMETERS.containsKey(parameter.getName());
-   }
+  @Override
+  public boolean supportsParameter(
+      ParameterContext parameterContext, ExtensionContext extensionContext)
+      throws ParameterResolutionException {
+    Parameter parameter = parameterContext.getParameter();
+    return String.class.equals(parameter.getType())
+        && SUPPORTED_PARAMETERS.containsKey(parameter.getName());
+  }
 
-   @Override
-   public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
-      return SUPPORTED_PARAMETERS.getOrDefault(parameterContext.getParameter().getName(), null);
-   }
+  @Override
+  public Object resolveParameter(
+      ParameterContext parameterContext, ExtensionContext extensionContext)
+      throws ParameterResolutionException {
+    return SUPPORTED_PARAMETERS.getOrDefault(parameterContext.getParameter().getName(), null);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/JobExecutionUtil.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/JobExecutionUtil.java
@@ -15,15 +15,16 @@ import com.vmware.taurus.service.model.ExecutionType;
 
 public class JobExecutionUtil {
 
-   public static DataJobExecution createDataJobExecution(
-         JobExecutionRepository jobExecutionRepository,
-         String executionId,
-         DataJob dataJob,
-         OffsetDateTime startTime,
-         OffsetDateTime endTime,
-         ExecutionStatus executionStatus) {
+  public static DataJobExecution createDataJobExecution(
+      JobExecutionRepository jobExecutionRepository,
+      String executionId,
+      DataJob dataJob,
+      OffsetDateTime startTime,
+      OffsetDateTime endTime,
+      ExecutionStatus executionStatus) {
 
-      var jobExecution = DataJobExecution.builder()
+    var jobExecution =
+        DataJobExecution.builder()
             .id(executionId)
             .dataJob(dataJob)
             .startTime(startTime)
@@ -43,6 +44,6 @@ public class JobExecutionUtil {
             .vdkVersion("test_vdk_version")
             .build();
 
-      return jobExecutionRepository.save(jobExecution);
-   }
+    return jobExecutionRepository.save(jobExecution);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/KerberosSecurityTestcaseJunit5.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/KerberosSecurityTestcaseJunit5.java
@@ -10,16 +10,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.security.kerberos.test.KerberosSecurityTestcase;
 
 public class KerberosSecurityTestcaseJunit5 extends KerberosSecurityTestcase {
-    //TODO we should think about moving away from MiniKDC as it's not maintained.
-    @BeforeEach
-    @Override
-    public void startMiniKdc() throws Exception {
-        super.startMiniKdc();
-    }
+  // TODO we should think about moving away from MiniKDC as it's not maintained.
+  @BeforeEach
+  @Override
+  public void startMiniKdc() throws Exception {
+    super.startMiniKdc();
+  }
 
-    @AfterEach
-    @Override
-    public void stopMiniKdc() {
-        super.stopMiniKdc();
-    }
+  @AfterEach
+  @Override
+  public void stopMiniKdc() {
+    super.stopMiniKdc();
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/MiniKdcCredentialsRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/MiniKdcCredentialsRepository.java
@@ -15,40 +15,39 @@ import java.io.File;
 import java.util.Optional;
 
 /**
- * This class can be used to replace {@link KerberosCredentialsRepository} for testing purposes.
- * It uses {@link MiniKdc} as a kerberos server.
+ * This class can be used to replace {@link KerberosCredentialsRepository} for testing purposes. It
+ * uses {@link MiniKdc} as a kerberos server.
  *
- * TODO: Figure out how to connect to a testing KDC server via kadmin
- ** For some reason I (tsvetkovt@vmware.com) was not able to connect to MiniKdc or to a
- ** dockerized KDC with kadmin.
+ * <p>TODO: Figure out how to connect to a testing KDC server via kadmin * For some reason I
+ * (tsvetkovt@vmware.com) was not able to connect to MiniKdc or to a * dockerized KDC with kadmin.
  * TODO we should think about moving away from MiniKDC as it's not maintained.
  */
 @Setter
 public class MiniKdcCredentialsRepository extends KerberosCredentialsRepository {
-   private static final Logger log = LoggerFactory.getLogger(MiniKdcCredentialsRepository.class);
+  private static final Logger log = LoggerFactory.getLogger(MiniKdcCredentialsRepository.class);
 
-   private MiniKdc miniKdc;
+  private MiniKdc miniKdc;
 
-   public MiniKdcCredentialsRepository() {
-      super("test", "test");
-   }
+  public MiniKdcCredentialsRepository() {
+    super("test", "test");
+  }
 
-   @Override
-   public void createPrincipal(String principal, Optional<File> keytabLocation) {
-      try {
-         miniKdc.createPrincipal(keytabLocation.get(), principal);
-      } catch (Exception e) {
-         log.error("Failed to create principal", e);
-      }
-   }
+  @Override
+  public void createPrincipal(String principal, Optional<File> keytabLocation) {
+    try {
+      miniKdc.createPrincipal(keytabLocation.get(), principal);
+    } catch (Exception e) {
+      log.error("Failed to create principal", e);
+    }
+  }
 
-   @Override
-   public boolean principalExists(String principal) {
-      return false;
-   }
+  @Override
+  public boolean principalExists(String principal) {
+    return false;
+  }
 
-   @Override
-   public void deletePrincipal(String principal) {
-      // Principals are deleted when MiniKdc is shut down.
-   }
+  @Override
+  public void deletePrincipal(String principal) {
+    // Principals are deleted when MiniKdc is shut down.
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/WebHookServerMockExtension.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/WebHookServerMockExtension.java
@@ -24,257 +24,281 @@ import org.mockserver.model.HttpStatusCode;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
- * Extension that initializes {@link ClientAndServer} and mocks web hook operations.
- * It is used for testing of Control Service web hooks. Example usage:
- *
- *  @ExtendWith(WebHookServerMockExtension.class)
- *  public class ExampleDataJobIT {
- *
- *      @Test
- *      public void testCreateDataJob_postCreateWebHookShouldReturnSuccess() {
- *         // Execute create job (Post Create WebHook will return success for this call)
- *         mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
- *               .with(user("user"))
- *               .content(dataJobRequestBody)
- *               .contentType(MediaType.APPLICATION_JSON))
- *               .andExpect(status().isCreated())
- *               .andExpect(header().string(HttpHeaders.LOCATION,
- *                     lambdaMatcher(s -> s.endsWith(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME,
- *                             TEST_JOB_NAME)))));
- *      }
- *  }
+ * Extension that initializes {@link ClientAndServer} and mocks web hook operations. It is used for
+ * testing of Control Service web hooks. Example
+ * usage: @ExtendWith(WebHookServerMockExtension.class) public class ExampleDataJobIT { @Test public
+ * void testCreateDataJob_postCreateWebHookShouldReturnSuccess() { // Execute create job (Post
+ * Create WebHook will return success for this call)
+ * mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
+ * .with(user("user")) .content(dataJobRequestBody) .contentType(MediaType.APPLICATION_JSON))
+ * .andExpect(status().isCreated()) .andExpect(header().string(HttpHeaders.LOCATION, lambdaMatcher(s
+ * -> s.endsWith(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME, TEST_JOB_NAME)))));
+ * } }
  */
-public class WebHookServerMockExtension implements BeforeAllCallback, ExtensionContext.Store.CloseableResource {
+public class WebHookServerMockExtension
+    implements BeforeAllCallback, ExtensionContext.Store.CloseableResource {
 
-   private static final Lock LOCK = new ReentrantLock();
-   private static final int TEST_INTERNAL_ERROR_RETRIES = 2;
+  private static final Lock LOCK = new ReentrantLock();
+  private static final int TEST_INTERNAL_ERROR_RETRIES = 2;
 
-   public static final String TEST_TEAM_NAME = "test-team";
-   public static final String TEST_TEAM_WRONG_NAME = "test-example-team";
-   public static final String NEW_TEST_TEAM_NAME = "new-test-team";
-   public static final String TEST_JOB_NAME = "test-job";
-   public static final String TEST_CLIENT_ERROR_TEAM = "test-client-error-team";
-   public static final String TEST_CLIENT_ERROR_JOB_NAME = "test-client-error-job";
-   public static final String TEST_INTERNAL_ERROR_TEAM = "test-internal-error-team";
-   public static final String TEST_INTERNAL_ERROR_JOB_NAME = "test-internal-error-job";
-   public static final String TEST_INTERNAL_ERROR_RETRIED_TEAM = "test-internal-error-retried-team";
-   public static final String TEST_INTERNAL_ERROR_RETRIED_JOB_NAME = "test-internal-error-retried-job";
-   public static final String TEST_JOB_1 = "test-job-1";
-   public static final String TEST_JOB_2 = "test-job-2";
-   public static final String TEST_JOB_3 = "test-job-3";
-   public static final String TEST_JOB_4 = "test-job-4";
-   public static final String TEST_JOB_5 = "test-job-5";
-   public static final String TEST_JOB_6 = "test-job-6";
+  public static final String TEST_TEAM_NAME = "test-team";
+  public static final String TEST_TEAM_WRONG_NAME = "test-example-team";
+  public static final String NEW_TEST_TEAM_NAME = "new-test-team";
+  public static final String TEST_JOB_NAME = "test-job";
+  public static final String TEST_CLIENT_ERROR_TEAM = "test-client-error-team";
+  public static final String TEST_CLIENT_ERROR_JOB_NAME = "test-client-error-job";
+  public static final String TEST_INTERNAL_ERROR_TEAM = "test-internal-error-team";
+  public static final String TEST_INTERNAL_ERROR_JOB_NAME = "test-internal-error-job";
+  public static final String TEST_INTERNAL_ERROR_RETRIED_TEAM = "test-internal-error-retried-team";
+  public static final String TEST_INTERNAL_ERROR_RETRIED_JOB_NAME =
+      "test-internal-error-retried-job";
+  public static final String TEST_JOB_1 = "test-job-1";
+  public static final String TEST_JOB_2 = "test-job-2";
+  public static final String TEST_JOB_3 = "test-job-3";
+  public static final String TEST_JOB_4 = "test-job-4";
+  public static final String TEST_JOB_5 = "test-job-5";
+  public static final String TEST_JOB_6 = "test-job-6";
 
-   private ClientAndServer mockWebHookServer;
-   private MockServerClient mockWebHookServerClient;
+  private ClientAndServer mockWebHookServer;
+  private MockServerClient mockWebHookServerClient;
 
-   @Override
-   public void beforeAll(ExtensionContext context) {
-      LOCK.lock();
-      String uniqueKey = this.getClass().getName();
-      Object value = context.getRoot().getStore(GLOBAL).get(uniqueKey);
+  @Override
+  public void beforeAll(ExtensionContext context) {
+    LOCK.lock();
+    String uniqueKey = this.getClass().getName();
+    Object value = context.getRoot().getStore(GLOBAL).get(uniqueKey);
 
-      if (value == null) {
-         String mockedWebHookServerHost = SpringExtension.getApplicationContext(context)
-               .getEnvironment()
-               .getProperty("integrationTest.mockedWebHookServerHost");
+    if (value == null) {
+      String mockedWebHookServerHost =
+          SpringExtension.getApplicationContext(context)
+              .getEnvironment()
+              .getProperty("integrationTest.mockedWebHookServerHost");
 
-         int mockedWebHookServerPort = Integer.parseInt(
-               SpringExtension.getApplicationContext(context)
-                     .getEnvironment()
-                     .getProperty("integrationTest.mockedWebHookServerPort"));
+      int mockedWebHookServerPort =
+          Integer.parseInt(
+              SpringExtension.getApplicationContext(context)
+                  .getEnvironment()
+                  .getProperty("integrationTest.mockedWebHookServerPort"));
 
-         prepareWebHookServerMock(mockedWebHookServerHost, mockedWebHookServerPort);
-         context.getRoot().getStore(GLOBAL).put(uniqueKey, this);
-      }
+      prepareWebHookServerMock(mockedWebHookServerHost, mockedWebHookServerPort);
+      context.getRoot().getStore(GLOBAL).put(uniqueKey, this);
+    }
 
-      LOCK.unlock();
-   }
+    LOCK.unlock();
+  }
 
-   @Override
-   public void close() throws Throwable {
-      mockWebHookServer.close();
-      mockWebHookServerClient.close();
-   }
+  @Override
+  public void close() throws Throwable {
+    mockWebHookServer.close();
+    mockWebHookServerClient.close();
+  }
 
-   private void prepareWebHookServerMock(String mockedWebHookServerHost, int mockedWebHookServerPort) {
-      this.mockWebHookServer = ClientAndServer.startClientAndServer(mockedWebHookServerPort);
-      this.mockWebHookServerClient = new MockServerClient(mockedWebHookServerHost, mockedWebHookServerPort);
+  private void prepareWebHookServerMock(
+      String mockedWebHookServerHost, int mockedWebHookServerPort) {
+    this.mockWebHookServer = ClientAndServer.startClientAndServer(mockedWebHookServerPort);
+    this.mockWebHookServerClient =
+        new MockServerClient(mockedWebHookServerHost, mockedWebHookServerPort);
 
-      mockSuccessfulPostCreateWebHook();
-      mockFailingPostCreateWebHook();
-      mockSuccessfulPostDeleteWebHook();
-      mockFailingPostDeleteWebHook();
-   }
+    mockSuccessfulPostCreateWebHook();
+    mockFailingPostCreateWebHook();
+    mockSuccessfulPostDeleteWebHook();
+    mockFailingPostDeleteWebHook();
+  }
 
-   private void mockFailingPostDeleteWebHook() {
-      mockWebHookServerClient.when(
-                  request()
-                        .withMethod(HttpMethod.POST.name())
-                        .withHeader("'Content-type', 'application/json'")
-                        .withPath(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_CLIENT_ERROR_TEAM,
-                              TEST_CLIENT_ERROR_JOB_NAME)))
-            .respond(getClientErrorResponse());
+  private void mockFailingPostDeleteWebHook() {
+    mockWebHookServerClient
+        .when(
+            request()
+                .withMethod(HttpMethod.POST.name())
+                .withHeader("'Content-type', 'application/json'")
+                .withPath(
+                    String.format(
+                        "/data-jobs/for-team/%s/jobs/%s",
+                        TEST_CLIENT_ERROR_TEAM, TEST_CLIENT_ERROR_JOB_NAME)))
+        .respond(getClientErrorResponse());
 
-      mockWebHookServerClient.when(
-                  request()
-                        .withMethod(HttpMethod.POST.name())
-                        .withHeader("'Content-type', 'application/json'")
-                        .withPath(String.format("/data-jobs/for-team/%s/jobs/%s",
-                              TEST_INTERNAL_ERROR_TEAM, TEST_INTERNAL_ERROR_JOB_NAME)))
-            .respond(getInternalServerErrorResponse());
+    mockWebHookServerClient
+        .when(
+            request()
+                .withMethod(HttpMethod.POST.name())
+                .withHeader("'Content-type', 'application/json'")
+                .withPath(
+                    String.format(
+                        "/data-jobs/for-team/%s/jobs/%s",
+                        TEST_INTERNAL_ERROR_TEAM, TEST_INTERNAL_ERROR_JOB_NAME)))
+        .respond(getInternalServerErrorResponse());
 
-      //Retry 2 times - will return Error 500 range
-      mockWebHookServerClient.when(
-                  request()
-                        .withMethod(HttpMethod.POST.name())
-                        .withHeader("'Content-type', 'application/json'")
-                        .withPath(String.format("/data-jobs/for-team/%s/jobs/%s",
-                              TEST_INTERNAL_ERROR_RETRIED_TEAM, TEST_INTERNAL_ERROR_RETRIED_JOB_NAME)),
-                  exactly(TEST_INTERNAL_ERROR_RETRIES))
-            .respond(getInternalServerErrorResponse());
+    // Retry 2 times - will return Error 500 range
+    mockWebHookServerClient
+        .when(
+            request()
+                .withMethod(HttpMethod.POST.name())
+                .withHeader("'Content-type', 'application/json'")
+                .withPath(
+                    String.format(
+                        "/data-jobs/for-team/%s/jobs/%s",
+                        TEST_INTERNAL_ERROR_RETRIED_TEAM, TEST_INTERNAL_ERROR_RETRIED_JOB_NAME)),
+            exactly(TEST_INTERNAL_ERROR_RETRIES))
+        .respond(getInternalServerErrorResponse());
 
-      //3-rd retry - will return 200 OK range
-      mockWebHookServerClient.when(
-                  request()
-                        .withMethod(HttpMethod.POST.name())
-                        .withHeader("'Content-type', 'application/json'")
-                        .withPath(String.format("/data-jobs/for-team/%s/jobs/%s",
-                              TEST_INTERNAL_ERROR_RETRIED_TEAM, TEST_INTERNAL_ERROR_RETRIED_JOB_NAME)),
-                  exactly(TEST_INTERNAL_ERROR_RETRIES + 1))
-            .respond(getOkResponse());
-   }
+    // 3-rd retry - will return 200 OK range
+    mockWebHookServerClient
+        .when(
+            request()
+                .withMethod(HttpMethod.POST.name())
+                .withHeader("'Content-type', 'application/json'")
+                .withPath(
+                    String.format(
+                        "/data-jobs/for-team/%s/jobs/%s",
+                        TEST_INTERNAL_ERROR_RETRIED_TEAM, TEST_INTERNAL_ERROR_RETRIED_JOB_NAME)),
+            exactly(TEST_INTERNAL_ERROR_RETRIES + 1))
+        .respond(getOkResponse());
+  }
 
-   private void mockSuccessfulPostDeleteWebHook() {
-      mockWebHookServerClient.when(
-                  request()
-                        .withMethod(HttpMethod.POST.name())
-                        .withHeader("'Content-type', 'application/json'")
-                        .withPath(String.format("/data-jobs/for-team/%s/jobs/%s",
-                              TEST_TEAM_NAME, TEST_JOB_NAME)))
-            .respond(getOkResponse());
+  private void mockSuccessfulPostDeleteWebHook() {
+    mockWebHookServerClient
+        .when(
+            request()
+                .withMethod(HttpMethod.POST.name())
+                .withHeader("'Content-type', 'application/json'")
+                .withPath(
+                    String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME, TEST_JOB_NAME)))
+        .respond(getOkResponse());
 
-      mockWebHookServerClient.when(
-                  request()
-                        .withMethod(HttpMethod.POST.name())
-                        .withHeader("'Content-type', 'application/json'")
-                        .withPath(String.format("/data-jobs/for-team/%s/jobs/%s",
-                              TEST_TEAM_NAME, TEST_JOB_1)))
-            .respond(getOkResponse());
+    mockWebHookServerClient
+        .when(
+            request()
+                .withMethod(HttpMethod.POST.name())
+                .withHeader("'Content-type', 'application/json'")
+                .withPath(
+                    String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME, TEST_JOB_1)))
+        .respond(getOkResponse());
 
-      mockWebHookServerClient.when(
-                  request()
-                        .withMethod(HttpMethod.POST.name())
-                        .withHeader("'Content-type', 'application/json'")
-                        .withPath(String.format("/data-jobs/for-team/%s/jobs/%s",
-                              TEST_TEAM_NAME, TEST_JOB_2)))
-            .respond(getOkResponse());
+    mockWebHookServerClient
+        .when(
+            request()
+                .withMethod(HttpMethod.POST.name())
+                .withHeader("'Content-type', 'application/json'")
+                .withPath(
+                    String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME, TEST_JOB_2)))
+        .respond(getOkResponse());
 
-      mockWebHookServerClient.when(
-                  request()
-                        .withMethod(HttpMethod.POST.name())
-                        .withHeader("'Content-type', 'application/json'")
-                        .withPath(String.format("/data-jobs/for-team/%s/jobs/%s",
-                              NEW_TEST_TEAM_NAME, TEST_JOB_3)))
-            .respond(getOkResponse());
+    mockWebHookServerClient
+        .when(
+            request()
+                .withMethod(HttpMethod.POST.name())
+                .withHeader("'Content-type', 'application/json'")
+                .withPath(
+                    String.format(
+                        "/data-jobs/for-team/%s/jobs/%s", NEW_TEST_TEAM_NAME, TEST_JOB_3)))
+        .respond(getOkResponse());
 
-      mockWebHookServerClient.when(
-                  request()
-                        .withMethod(HttpMethod.POST.name())
-                        .withHeader("'Content-type', 'application/json'")
-                        .withPath(String.format("/data-jobs/for-team/%s/jobs/%s",
-                              NEW_TEST_TEAM_NAME, TEST_JOB_4)))
-            .respond(getOkResponse());
+    mockWebHookServerClient
+        .when(
+            request()
+                .withMethod(HttpMethod.POST.name())
+                .withHeader("'Content-type', 'application/json'")
+                .withPath(
+                    String.format(
+                        "/data-jobs/for-team/%s/jobs/%s", NEW_TEST_TEAM_NAME, TEST_JOB_4)))
+        .respond(getOkResponse());
 
-      mockWebHookServerClient.when(
-                  request()
-                        .withMethod(HttpMethod.POST.name())
-                        .withHeader("'Content-type', 'application/json'")
-                        .withPath(String.format("/data-jobs/for-team/%s/jobs/%s",
-                              NEW_TEST_TEAM_NAME, TEST_JOB_5)))
-            .respond(getOkResponse());
+    mockWebHookServerClient
+        .when(
+            request()
+                .withMethod(HttpMethod.POST.name())
+                .withHeader("'Content-type', 'application/json'")
+                .withPath(
+                    String.format(
+                        "/data-jobs/for-team/%s/jobs/%s", NEW_TEST_TEAM_NAME, TEST_JOB_5)))
+        .respond(getOkResponse());
 
-      mockWebHookServerClient.when(
-                  request()
-                        .withMethod(HttpMethod.POST.name())
-                        .withHeader("'Content-type', 'application/json'")
-                        .withPath(String.format("/data-jobs/for-team/%s/jobs/%s",
-                              TEST_TEAM_NAME, TEST_JOB_6)))
-            .respond(getOkResponse());
-   }
+    mockWebHookServerClient
+        .when(
+            request()
+                .withMethod(HttpMethod.POST.name())
+                .withHeader("'Content-type', 'application/json'")
+                .withPath(
+                    String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME, TEST_JOB_6)))
+        .respond(getOkResponse());
+  }
 
-   private void mockFailingPostCreateWebHook() {
-      mockWebHookServerClient.when(
-                  request()
-                        .withMethod(HttpMethod.POST.name())
-                        .withHeader("'Content-type', 'application/json'")
-                        .withPath(String.format("/data-jobs/for-team/%s/jobs", TEST_CLIENT_ERROR_TEAM)))
-            .respond(getClientErrorResponse());
+  private void mockFailingPostCreateWebHook() {
+    mockWebHookServerClient
+        .when(
+            request()
+                .withMethod(HttpMethod.POST.name())
+                .withHeader("'Content-type', 'application/json'")
+                .withPath(String.format("/data-jobs/for-team/%s/jobs", TEST_CLIENT_ERROR_TEAM)))
+        .respond(getClientErrorResponse());
 
-      mockWebHookServerClient.when(
-                  request()
-                        .withMethod(HttpMethod.POST.name())
-                        .withHeader("'Content-type', 'application/json'")
-                        .withPath(String.format("/data-jobs/for-team/%s/jobs", TEST_INTERNAL_ERROR_TEAM)))
-            .respond(getInternalServerErrorResponse());
+    mockWebHookServerClient
+        .when(
+            request()
+                .withMethod(HttpMethod.POST.name())
+                .withHeader("'Content-type', 'application/json'")
+                .withPath(String.format("/data-jobs/for-team/%s/jobs", TEST_INTERNAL_ERROR_TEAM)))
+        .respond(getInternalServerErrorResponse());
 
-      //Retry 2 times - will return Error 500 range
-      mockWebHookServerClient.when(
-                  request()
-                        .withMethod(HttpMethod.POST.name())
-                        .withHeader("'Content-type', 'application/json'")
-                        .withPath(String.format("/data-jobs/for-team/%s/jobs", TEST_INTERNAL_ERROR_RETRIED_TEAM)),
-                  exactly(TEST_INTERNAL_ERROR_RETRIES))
-            .respond(getInternalServerErrorResponse());
+    // Retry 2 times - will return Error 500 range
+    mockWebHookServerClient
+        .when(
+            request()
+                .withMethod(HttpMethod.POST.name())
+                .withHeader("'Content-type', 'application/json'")
+                .withPath(
+                    String.format("/data-jobs/for-team/%s/jobs", TEST_INTERNAL_ERROR_RETRIED_TEAM)),
+            exactly(TEST_INTERNAL_ERROR_RETRIES))
+        .respond(getInternalServerErrorResponse());
 
-      //3-rd retry - will return 200 OK range
-      mockWebHookServerClient.when(
-                  request()
-                        .withMethod(HttpMethod.POST.name())
-                        .withHeader("'Content-type', 'application/json'")
-                        .withPath(String.format("/data-jobs/for-team/%s/jobs", TEST_INTERNAL_ERROR_RETRIED_TEAM)),
-                  exactly(TEST_INTERNAL_ERROR_RETRIES + 1))
-            .respond(getOkResponse());
-   }
+    // 3-rd retry - will return 200 OK range
+    mockWebHookServerClient
+        .when(
+            request()
+                .withMethod(HttpMethod.POST.name())
+                .withHeader("'Content-type', 'application/json'")
+                .withPath(
+                    String.format("/data-jobs/for-team/%s/jobs", TEST_INTERNAL_ERROR_RETRIED_TEAM)),
+            exactly(TEST_INTERNAL_ERROR_RETRIES + 1))
+        .respond(getOkResponse());
+  }
 
-   private void mockSuccessfulPostCreateWebHook() {
-      mockWebHookServerClient.when(
-                  request()
-                        .withMethod(HttpMethod.POST.name())
-                        .withHeader("'Content-type', 'application/json'")
-                        .withPath(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME)))
-            .respond(getOkResponse());
+  private void mockSuccessfulPostCreateWebHook() {
+    mockWebHookServerClient
+        .when(
+            request()
+                .withMethod(HttpMethod.POST.name())
+                .withHeader("'Content-type', 'application/json'")
+                .withPath(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME)))
+        .respond(getOkResponse());
 
-      mockWebHookServerClient.when(
-                  request()
-                        .withMethod(HttpMethod.POST.name())
-                        .withHeader("'Content-type', 'application/json'")
-                        .withPath(String.format("/data-jobs/for-team/%s/jobs", NEW_TEST_TEAM_NAME)))
-            .respond(getOkResponse());
-   }
+    mockWebHookServerClient
+        .when(
+            request()
+                .withMethod(HttpMethod.POST.name())
+                .withHeader("'Content-type', 'application/json'")
+                .withPath(String.format("/data-jobs/for-team/%s/jobs", NEW_TEST_TEAM_NAME)))
+        .respond(getOkResponse());
+  }
 
-   private HttpResponse getOkResponse() {
-      return response()
-            .withStatusCode(HttpStatusCode.OK_200.code())
-            .withHeaders(
-                  new Header("Content-Type", "application/json; charset=utf-8"))
-            .withBody("{ \"message\": \"Success\" }");
-   }
+  private HttpResponse getOkResponse() {
+    return response()
+        .withStatusCode(HttpStatusCode.OK_200.code())
+        .withHeaders(new Header("Content-Type", "application/json; charset=utf-8"))
+        .withBody("{ \"message\": \"Success\" }");
+  }
 
-   private HttpResponse getClientErrorResponse() {
-      return response()
-            .withStatusCode(HttpStatusCode.BAD_REQUEST_400.code())
-            .withHeaders(
-                  new Header("Content-Type", "application/json; charset=utf-8"))
-            .withBody("{ \"message\": \"Client error\" }");
-   }
+  private HttpResponse getClientErrorResponse() {
+    return response()
+        .withStatusCode(HttpStatusCode.BAD_REQUEST_400.code())
+        .withHeaders(new Header("Content-Type", "application/json; charset=utf-8"))
+        .withBody("{ \"message\": \"Client error\" }");
+  }
 
-   private HttpResponse getInternalServerErrorResponse() {
-      return response()
-            .withStatusCode(HttpStatusCode.BAD_GATEWAY_502.code())
-            .withHeaders(
-                  new Header("Content-Type", "application/json; charset=utf-8"))
-            .withBody("{ \"message\": \"Internal Server Error\" }");
-   }
+  private HttpResponse getInternalServerErrorResponse() {
+    return response()
+        .withStatusCode(HttpStatusCode.BAD_GATEWAY_502.code())
+        .withHeaders(new Header("Content-Type", "application/json; charset=utf-8"))
+        .withBody("{ \"message\": \"Internal Server Error\" }");
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLDataJobsFieldsIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLDataJobsFieldsIT.java
@@ -24,68 +24,68 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 public class GraphQLDataJobsFieldsIT extends BaseDataJobDeploymentIT {
 
-    private static final String DEFAULT_QUERY_WITH_DEPLOYMENTS =
-            "query($filter: [Predicate], $executionOrder: DataJobExecutionOrder, $search: String, $pageNumber: Int, $pageSize: Int) {" +
-                    "  jobs(pageNumber: $pageNumber, pageSize: $pageSize, filter: $filter, search: $search) {" +
-                    "    content {" +
-                    "      jobName" +
-                    "      deployments {" +
-                    "        id" +
-                    "        enabled" +
-                    "        lastExecutionStatus" +
-                    "        lastExecutionTime" +
-                    "        lastExecutionDuration" +
-                    "        executions(pageNumber: 1, pageSize: 5, order: $executionOrder) {" +
-                    "          id" +
-                    "          status" +
-                    "        }" +
-                    "      }" +
-                    "      config {" +
-                    "        team" +
-                    "        description" +
-                    "        schedule {" +
-                    "          scheduleCron" +
-                    "          nextRunEpochSeconds" +
-                    "        }" +
-                    "      }" +
-                    "    }" +
-                    "    totalPages" +
-                    "    totalItems" +
-                    "  }" +
-                    "}";
+  private static final String DEFAULT_QUERY_WITH_DEPLOYMENTS =
+      "query($filter: [Predicate], $executionOrder: DataJobExecutionOrder, $search: String,"
+          + " $pageNumber: Int, $pageSize: Int) {  jobs(pageNumber: $pageNumber, pageSize:"
+          + " $pageSize, filter: $filter, search: $search) {    content {      jobName     "
+          + " deployments {        id        enabled        lastExecutionStatus       "
+          + " lastExecutionTime        lastExecutionDuration        executions(pageNumber: 1,"
+          + " pageSize: 5, order: $executionOrder) {          id          status        }      }   "
+          + "   config {        team        description        schedule {          scheduleCron    "
+          + "      nextRunEpochSeconds        }      }    }    totalPages    totalItems  }}";
 
-    @Autowired
-    private JobsRepository jobsRepository;
+  @Autowired private JobsRepository jobsRepository;
 
-    @Test
-    void testFields(String jobName, String teamName, String username) throws Exception {
-        var dataJob = jobsRepository.findById(jobName).get();
-        dataJob.setLastExecutionStatus(ExecutionStatus.SUCCEEDED);
-        dataJob.setLastExecutionEndTime(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
-        dataJob.setLastExecutionDuration(1000);
-        dataJob = jobsRepository.save(dataJob);
+  @Test
+  void testFields(String jobName, String teamName, String username) throws Exception {
+    var dataJob = jobsRepository.findById(jobName).get();
+    dataJob.setLastExecutionStatus(ExecutionStatus.SUCCEEDED);
+    dataJob.setLastExecutionEndTime(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
+    dataJob.setLastExecutionDuration(1000);
+    dataJob = jobsRepository.save(dataJob);
 
-        // Test requesting of fields that are computed
-        mockMvc.perform(get(JOBS_URI)
-                        .with(user(username))
-                        .param("query", DEFAULT_QUERY_WITH_DEPLOYMENTS)
-                        .param("variables", "{" +
-                                "\"search\": \"" + jobName + "\"," +
-                                "\"pageNumber\": 1," +
-                                "\"pageSize\": 10," +
-                                "\"executionOrder\": {" +
-                                "    \"direction\": \"DESC\"," +
-                                "    \"property\": \"status\"" +
-                                "  }" +
-                                "}")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.content[0].config.team", is(teamName)))
-                .andExpect(jsonPath("$.data.content[0].config.schedule.scheduleCron", is(dataJob.getJobConfig().getSchedule())))
-                .andExpect(jsonPath("$.data.content[0].config.schedule.nextRunEpochSeconds", greaterThan(1)))
-                .andExpect(jsonPath("$.data.content[0].deployments[0].lastExecutionStatus", is(dataJob.getLastExecutionStatus().name())))
-                .andExpect(jsonPath("$.data.content[0].deployments[0].lastExecutionTime", isDate(dataJob.getLastExecutionEndTime())))
-                .andExpect(jsonPath("$.data.content[0].deployments[0].lastExecutionDuration", is(dataJob.getLastExecutionDuration())))
-                .andReturn().getResponse().getContentAsString();
-    }
+    // Test requesting of fields that are computed
+    mockMvc
+        .perform(
+            get(JOBS_URI)
+                .with(user(username))
+                .param("query", DEFAULT_QUERY_WITH_DEPLOYMENTS)
+                .param(
+                    "variables",
+                    "{"
+                        + "\"search\": \""
+                        + jobName
+                        + "\","
+                        + "\"pageNumber\": 1,"
+                        + "\"pageSize\": 10,"
+                        + "\"executionOrder\": {"
+                        + "    \"direction\": \"DESC\","
+                        + "    \"property\": \"status\""
+                        + "  }"
+                        + "}")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.content[0].config.team", is(teamName)))
+        .andExpect(
+            jsonPath(
+                "$.data.content[0].config.schedule.scheduleCron",
+                is(dataJob.getJobConfig().getSchedule())))
+        .andExpect(
+            jsonPath("$.data.content[0].config.schedule.nextRunEpochSeconds", greaterThan(1)))
+        .andExpect(
+            jsonPath(
+                "$.data.content[0].deployments[0].lastExecutionStatus",
+                is(dataJob.getLastExecutionStatus().name())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[0].deployments[0].lastExecutionTime",
+                isDate(dataJob.getLastExecutionEndTime())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[0].deployments[0].lastExecutionDuration",
+                is(dataJob.getLastExecutionDuration())))
+        .andReturn()
+        .getResponse()
+        .getContentAsString();
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLDataJobsSortContactsIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLDataJobsSortContactsIT.java
@@ -23,151 +23,168 @@ import java.util.List;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = ControlplaneApplication.class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = ControlplaneApplication.class)
 public class GraphQLDataJobsSortContactsIT extends BaseIT {
 
-   @Autowired
-   private JobsRepository jobsRepository;
+  @Autowired private JobsRepository jobsRepository;
 
-   @AfterEach
-   public void cleanup() {
-      jobsRepository.deleteAll();
-   }
+  @AfterEach
+  public void cleanup() {
+    jobsRepository.deleteAll();
+  }
 
-   private String getQuery(String sortOrder) {
-      return "{\n" +
-            "  jobs(\n" +
-            "    pageNumber: 1\n" +
-            "    pageSize: 5\n" +
-            "    filter: [{ property: \"config.contacts.present\", sort:" + sortOrder + "}]\n" +
-            "  ) {\n" +
-            "    content {\n" +
-            "      jobName\n" +
-            "      config {\n" +
-            "        contacts{" +
-            "           notifiedOnJobFailureUserError " +
-            "           notifiedOnJobSuccess" +
-            "        }\n" +
-            "      }\n" +
-            "    }\n" +
-            "  }\n" +
-            "}";
-   }
+  private String getQuery(String sortOrder) {
+    return "{\n"
+        + "  jobs(\n"
+        + "    pageNumber: 1\n"
+        + "    pageSize: 5\n"
+        + "    filter: [{ property: \"config.contacts.present\", sort:"
+        + sortOrder
+        + "}]\n"
+        + "  ) {\n"
+        + "    content {\n"
+        + "      jobName\n"
+        + "      config {\n"
+        + "        contacts{"
+        + "           notifiedOnJobFailureUserError "
+        + "           notifiedOnJobSuccess"
+        + "        }\n"
+        + "      }\n"
+        + "    }\n"
+        + "  }\n"
+        + "}";
+  }
 
-   @Test
-   public void testEmptyCall_shouldBeEmpty() throws Exception {
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery("DESC"))
-                  .with(user(TEST_USERNAME)))
-            .andExpect(jsonPath("$.data.content").isEmpty());
-   }
+  @Test
+  public void testEmptyCall_shouldBeEmpty() throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery("DESC"))
+                .with(user(TEST_USERNAME)))
+        .andExpect(jsonPath("$.data.content").isEmpty());
+  }
 
-   @Test
-   public void testSingleJob_shouldReturnOne() throws Exception {
-      var contacts = new DataJobContacts();
-      contacts.setNotifiedOnJobFailureUserError(List.of("test-notified"));
-      var job = createDummyJob(contacts, "test-job");
-      jobsRepository.save(job);
+  @Test
+  public void testSingleJob_shouldReturnOne() throws Exception {
+    var contacts = new DataJobContacts();
+    contacts.setNotifiedOnJobFailureUserError(List.of("test-notified"));
+    var job = createDummyJob(contacts, "test-job");
+    jobsRepository.save(job);
 
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery("DESC"))
-                  .with(user(TEST_USERNAME)))
-            .andExpect(jsonPath("$.data.content[0].config.contacts.notifiedOnJobFailureUserError")
-                  .value("test-notified"));
-   }
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery("DESC"))
+                .with(user(TEST_USERNAME)))
+        .andExpect(
+            jsonPath("$.data.content[0].config.contacts.notifiedOnJobFailureUserError")
+                .value("test-notified"));
+  }
 
-   @Test
-   public void testSortingTwoJobs_shouldReturnDescOrder() throws Exception {
-      var contacts = new DataJobContacts();
-      contacts.setNotifiedOnJobFailureUserError(List.of("test-notified"));
-      var job = createDummyJob(contacts, "test-job");
+  @Test
+  public void testSortingTwoJobs_shouldReturnDescOrder() throws Exception {
+    var contacts = new DataJobContacts();
+    contacts.setNotifiedOnJobFailureUserError(List.of("test-notified"));
+    var job = createDummyJob(contacts, "test-job");
 
-      var contacts2 = new DataJobContacts();
-      var job2 = createDummyJob(contacts2, "test-job2");
+    var contacts2 = new DataJobContacts();
+    var job2 = createDummyJob(contacts2, "test-job2");
 
-      jobsRepository.save(job);
-      jobsRepository.save(job2);
+    jobsRepository.save(job);
+    jobsRepository.save(job2);
 
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery("DESC"))
-                  .with(user(TEST_USERNAME)))
-            .andExpect(jsonPath("$.data.content[0].config.contacts.notifiedOnJobFailureUserError")
-                  .value("test-notified"))
-            .andExpect(jsonPath("$.data.content[1].config.contacts.notifiedOnJobFailureUserError")
-                  .isEmpty());
-   }
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery("DESC"))
+                .with(user(TEST_USERNAME)))
+        .andExpect(
+            jsonPath("$.data.content[0].config.contacts.notifiedOnJobFailureUserError")
+                .value("test-notified"))
+        .andExpect(
+            jsonPath("$.data.content[1].config.contacts.notifiedOnJobFailureUserError").isEmpty());
+  }
 
-   @Test
-   public void testSortingTwoJobs_shouldReturnAscOrder() throws Exception {
-      var contacts = new DataJobContacts();
-      contacts.setNotifiedOnJobSuccess(List.of("test-notified"));
-      var job = createDummyJob(contacts, "test-job");
+  @Test
+  public void testSortingTwoJobs_shouldReturnAscOrder() throws Exception {
+    var contacts = new DataJobContacts();
+    contacts.setNotifiedOnJobSuccess(List.of("test-notified"));
+    var job = createDummyJob(contacts, "test-job");
 
-      var contacts2 = new DataJobContacts();
-      var job2 = createDummyJob(contacts2, "test-job2");
+    var contacts2 = new DataJobContacts();
+    var job2 = createDummyJob(contacts2, "test-job2");
 
-      jobsRepository.save(job);
-      jobsRepository.save(job2);
+    jobsRepository.save(job);
+    jobsRepository.save(job2);
 
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery("ASC"))
-                  .with(user(TEST_USERNAME)))
-            .andExpect(jsonPath("$.data.content[1].config.contacts.notifiedOnJobSuccess")
-                  .value("test-notified"))
-            .andExpect(jsonPath("$.data.content[0].config.contacts.notifiedOnJobSuccess")
-                  .isEmpty());
-   }
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery("ASC"))
+                .with(user(TEST_USERNAME)))
+        .andExpect(
+            jsonPath("$.data.content[1].config.contacts.notifiedOnJobSuccess")
+                .value("test-notified"))
+        .andExpect(jsonPath("$.data.content[0].config.contacts.notifiedOnJobSuccess").isEmpty());
+  }
 
-   @Test
-   public void testSortingTwoJobsNoContacts_shouldReturnTwo() throws Exception {
-      var contacts = new DataJobContacts();
-      var job = createDummyJob(contacts, "test-job");
+  @Test
+  public void testSortingTwoJobsNoContacts_shouldReturnTwo() throws Exception {
+    var contacts = new DataJobContacts();
+    var job = createDummyJob(contacts, "test-job");
 
-      var contacts2 = new DataJobContacts();
-      var job2 = createDummyJob(contacts2, "test-job2");
+    var contacts2 = new DataJobContacts();
+    var job2 = createDummyJob(contacts2, "test-job2");
 
-      jobsRepository.save(job);
-      jobsRepository.save(job2);
+    jobsRepository.save(job);
+    jobsRepository.save(job2);
 
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery("ASC"))
-                  .with(user(TEST_USERNAME)))
-            .andExpect(jsonPath("$.data.content.length()")
-                  .value(2))
-            .andExpect(jsonPath("$.data.content[*].jobName", Matchers.contains("test-job", "test-job2")));
-   }
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery("ASC"))
+                .with(user(TEST_USERNAME)))
+        .andExpect(jsonPath("$.data.content.length()").value(2))
+        .andExpect(
+            jsonPath("$.data.content[*].jobName", Matchers.contains("test-job", "test-job2")));
+  }
 
-   @Test
-   public void testSortingTwoJobsWithContacts_shouldReturnTwo() throws Exception {
-      var contacts = new DataJobContacts();
-      contacts.setNotifiedOnJobDeploy(List.of("test"));
-      var job = createDummyJob(contacts, "test-job");
+  @Test
+  public void testSortingTwoJobsWithContacts_shouldReturnTwo() throws Exception {
+    var contacts = new DataJobContacts();
+    contacts.setNotifiedOnJobDeploy(List.of("test"));
+    var job = createDummyJob(contacts, "test-job");
 
-      var contacts2 = new DataJobContacts();
-      contacts2.setNotifiedOnJobFailurePlatformError(List.of("test"));
-      var job2 = createDummyJob(contacts2, "test-job2");
+    var contacts2 = new DataJobContacts();
+    contacts2.setNotifiedOnJobFailurePlatformError(List.of("test"));
+    var job2 = createDummyJob(contacts2, "test-job2");
 
-      jobsRepository.save(job);
-      jobsRepository.save(job2);
+    jobsRepository.save(job);
+    jobsRepository.save(job2);
 
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery("ASC"))
-                  .with(user(TEST_USERNAME)))
-            .andExpect(jsonPath("$.data.content.length()")
-                  .value(2))
-            .andExpect(jsonPath("$.data.content[*].jobName", Matchers.contains("test-job", "test-job2")));
-   }
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery("ASC"))
+                .with(user(TEST_USERNAME)))
+        .andExpect(jsonPath("$.data.content.length()").value(2))
+        .andExpect(
+            jsonPath("$.data.content[*].jobName", Matchers.contains("test-job", "test-job2")));
+  }
 
-   private DataJob createDummyJob(DataJobContacts contacts, String id) {
-      DataJob job = new DataJob();
-      job.setName(id);
-      JobConfig config = new JobConfig();
-      config.setSchedule("test-schedule");
-      config.setNotifiedOnJobFailureUserError(contacts.getNotifiedOnJobFailureUserError());
-      config.setNotifiedOnJobDeploy(contacts.getNotifiedOnJobDeploy());
-      config.setNotifiedOnJobSuccess(contacts.getNotifiedOnJobSuccess());
-      config.setNotifiedOnJobFailurePlatformError(contacts.getNotifiedOnJobFailurePlatformError());
-      job.setJobConfig(config);
-      return job;
-   }
+  private DataJob createDummyJob(DataJobContacts contacts, String id) {
+    DataJob job = new DataJob();
+    job.setName(id);
+    JobConfig config = new JobConfig();
+    config.setSchedule("test-schedule");
+    config.setNotifiedOnJobFailureUserError(contacts.getNotifiedOnJobFailureUserError());
+    config.setNotifiedOnJobDeploy(contacts.getNotifiedOnJobDeploy());
+    config.setNotifiedOnJobSuccess(contacts.getNotifiedOnJobSuccess());
+    config.setNotifiedOnJobFailurePlatformError(contacts.getNotifiedOnJobFailurePlatformError());
+    job.setJobConfig(config);
+    return job;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLExecutionsIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLExecutionsIT.java
@@ -29,308 +29,402 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = ControlplaneApplication.class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = ControlplaneApplication.class)
 public class GraphQLExecutionsIT extends BaseIT {
 
-   @Autowired
-   JobExecutionRepository jobExecutionRepository;
+  @Autowired JobExecutionRepository jobExecutionRepository;
 
-   @Autowired
-   JobsRepository jobsRepository;
+  @Autowired JobsRepository jobsRepository;
 
-   private static final String TEST_JOB_NAME_1 = "TEST-JOB-NAME-1";
-   private static final String TEST_JOB_NAME_2 = "TEST-JOB-NAME-2";
-   private static final String TEST_JOB_NAME_3 = "TEST-JOB-NAME-3";
+  private static final String TEST_JOB_NAME_1 = "TEST-JOB-NAME-1";
+  private static final String TEST_JOB_NAME_2 = "TEST-JOB-NAME-2";
+  private static final String TEST_JOB_NAME_3 = "TEST-JOB-NAME-3";
 
-   private DataJob dataJob1;
-   private DataJob dataJob2;
-   private DataJob dataJob3;
+  private DataJob dataJob1;
+  private DataJob dataJob2;
+  private DataJob dataJob3;
 
-   private DataJobExecution dataJobExecution1;
-   private DataJobExecution dataJobExecution2;
-   private DataJobExecution dataJobExecution3;
+  private DataJobExecution dataJobExecution1;
+  private DataJobExecution dataJobExecution2;
+  private DataJobExecution dataJobExecution3;
 
-   @BeforeEach
-   public void setup() {
-      cleanup();
+  @BeforeEach
+  public void setup() {
+    cleanup();
 
-      var config1 = new JobConfig();
-      config1.setTeam("test-team1");
+    var config1 = new JobConfig();
+    config1.setTeam("test-team1");
 
-      var config2 = new JobConfig();
-      config2.setTeam("test-team2");
+    var config2 = new JobConfig();
+    config2.setTeam("test-team2");
 
-      var config3 = new JobConfig();
-      config3.setTeam("test-team3");
+    var config3 = new JobConfig();
+    config3.setTeam("test-team3");
 
-      this.dataJob1 = jobsRepository.save(new DataJob(TEST_JOB_NAME_1, config1));
-      this.dataJob2 = jobsRepository.save(new DataJob(TEST_JOB_NAME_2, config2));
-      this.dataJob3 = jobsRepository.save(new DataJob(TEST_JOB_NAME_3, config3));
+    this.dataJob1 = jobsRepository.save(new DataJob(TEST_JOB_NAME_1, config1));
+    this.dataJob2 = jobsRepository.save(new DataJob(TEST_JOB_NAME_2, config2));
+    this.dataJob3 = jobsRepository.save(new DataJob(TEST_JOB_NAME_3, config3));
 
-      OffsetDateTime now = OffsetDateTime.now();
-      this.dataJobExecution1 = JobExecutionUtil.createDataJobExecution(
+    OffsetDateTime now = OffsetDateTime.now();
+    this.dataJobExecution1 =
+        JobExecutionUtil.createDataJobExecution(
             jobExecutionRepository, "testId1", dataJob1, now, now, ExecutionStatus.SUCCEEDED);
-      this.dataJobExecution2 = JobExecutionUtil.createDataJobExecution(
-            jobExecutionRepository,"testId2", dataJob2, now.minusSeconds(1), now.minusSeconds(1), ExecutionStatus.USER_ERROR);
-      this.dataJobExecution3 = JobExecutionUtil.createDataJobExecution(
-            jobExecutionRepository,"testId3", dataJob3, now.minusSeconds(10), now.minusSeconds(10), ExecutionStatus.SUBMITTED);
-   }
+    this.dataJobExecution2 =
+        JobExecutionUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "testId2",
+            dataJob2,
+            now.minusSeconds(1),
+            now.minusSeconds(1),
+            ExecutionStatus.USER_ERROR);
+    this.dataJobExecution3 =
+        JobExecutionUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "testId3",
+            dataJob3,
+            now.minusSeconds(10),
+            now.minusSeconds(10),
+            ExecutionStatus.SUBMITTED);
+  }
 
-   private static String getQuery() {
-      return "query($filter: DataJobExecutionFilter, $order: DataJobExecutionOrder, $pageNumber: Int, $pageSize: Int) {" +
-            "  executions(pageNumber: $pageNumber, pageSize: $pageSize, filter: $filter, order: $order) {" +
-            "    content {" +
-            "      id" +
-            "      jobName" +
-            "      startTime" +
-            "      endTime" +
-            "      status" +
-            "      deployment {" +
-            "        id" +
-            "        enabled" +
-            "        jobVersion" +
-            "        deployedDate" +
-            "        deployedBy" +
-            "        resources {" +
-            "           cpuLimit" +
-            "           cpuRequest" +
-            "           memoryLimit" +
-            "           memoryRequest" +
-            "        }" +
-            "        schedule {" +
-            "           scheduleCron" +
-            "        }" +
-            "        vdkVersion" +
-            "      }" +
-            "    }" +
-            "    totalPages" +
-            "    totalItems" +
-            "  }" +
-            "}";
-   }
+  private static String getQuery() {
+    return "query($filter: DataJobExecutionFilter, $order: DataJobExecutionOrder, $pageNumber: Int,"
+               + " $pageSize: Int) {  executions(pageNumber: $pageNumber, pageSize: $pageSize,"
+               + " filter: $filter, order: $order) {    content {      id      jobName     "
+               + " startTime      endTime      status      deployment {        id        enabled   "
+               + "     jobVersion        deployedDate        deployedBy        resources {         "
+               + "  cpuLimit           cpuRequest           memoryLimit           memoryRequest    "
+               + "    }        schedule {           scheduleCron        }        vdkVersion      } "
+               + "   }    totalPages    totalItems  }}";
+  }
 
-   private void cleanup() {
-      jobsRepository.findAllById(List.of(TEST_JOB_NAME_1, TEST_JOB_NAME_2, TEST_JOB_NAME_3))
-            .forEach(dataJob -> jobsRepository.delete(dataJob));
-   }
+  private void cleanup() {
+    jobsRepository
+        .findAllById(List.of(TEST_JOB_NAME_1, TEST_JOB_NAME_2, TEST_JOB_NAME_3))
+        .forEach(dataJob -> jobsRepository.delete(dataJob));
+  }
 
-   @Test
-   public void testExecutions_filterByStartTimeGte_shouldReturnAllProperties() throws Exception {
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-            .queryParam("query", getQuery())
-            .param("variables", "{" +
-                  "\"filter\": {" +
-                  "      \"startTimeGte\": \"" + dataJobExecution2.getStartTime() + "\"" +
-                  "    }," +
-                  "\"pageNumber\": 1," +
-                  "\"pageSize\": 10" +
-                  "}")
-            .with(user(TEST_USERNAME)))
-            .andExpect(status().is(200))
-            .andExpect(content().contentType("application/json"))
-            .andExpect(jsonPath(
-                  "$.data.content[*].id",
-                  Matchers.contains(dataJobExecution1.getId(), dataJobExecution2.getId())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].jobName",
-                  Matchers.contains(dataJob1.getName(), dataJob2.getName())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].status",
-                  Matchers.contains(dataJobExecution1.getStatus().toString(), dataJobExecution2.getStatus().toString())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].deployment.jobVersion",
-                  Matchers.contains(dataJobExecution1.getJobVersion(), dataJobExecution2.getJobVersion())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].deployment.deployedDate",
-                  Matchers.contains(dataJobExecution1.getLastDeployedDate().toString(), dataJobExecution2.getLastDeployedDate().toString())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].deployment.deployedBy",
-                  Matchers.contains(dataJobExecution1.getLastDeployedBy(), dataJobExecution2.getLastDeployedBy())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].deployment.vdkVersion",
-                  Matchers.contains(dataJobExecution1.getVdkVersion(), dataJobExecution2.getVdkVersion())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].deployment.resources.cpuRequest",
-                  Matchers.contains(dataJobExecution1.getResourcesCpuRequest().doubleValue(), dataJobExecution2.getResourcesCpuRequest().doubleValue())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].deployment.resources.cpuLimit",
-                  Matchers.contains(dataJobExecution1.getResourcesCpuLimit().doubleValue(), dataJobExecution2.getResourcesCpuLimit().doubleValue())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].deployment.resources.memoryRequest",
-                  Matchers.contains(dataJobExecution1.getResourcesMemoryRequest(), dataJobExecution2.getResourcesMemoryRequest())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].deployment.resources.memoryLimit",
-                  Matchers.contains(dataJobExecution1.getResourcesMemoryLimit(), dataJobExecution2.getResourcesMemoryLimit())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].deployment.schedule.scheduleCron",
-                  Matchers.contains(dataJobExecution1.getJobSchedule(), dataJobExecution2.getJobSchedule())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].id",
-                  Matchers.not(Matchers.contains(dataJobExecution3.getId()))));
-   }
+  @Test
+  public void testExecutions_filterByStartTimeGte_shouldReturnAllProperties() throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery())
+                .param(
+                    "variables",
+                    "{"
+                        + "\"filter\": {"
+                        + "      \"startTimeGte\": \""
+                        + dataJobExecution2.getStartTime()
+                        + "\""
+                        + "    },"
+                        + "\"pageNumber\": 1,"
+                        + "\"pageSize\": 10"
+                        + "}")
+                .with(user(TEST_USERNAME)))
+        .andExpect(status().is(200))
+        .andExpect(content().contentType("application/json"))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].id",
+                Matchers.contains(dataJobExecution1.getId(), dataJobExecution2.getId())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].jobName",
+                Matchers.contains(dataJob1.getName(), dataJob2.getName())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].status",
+                Matchers.contains(
+                    dataJobExecution1.getStatus().toString(),
+                    dataJobExecution2.getStatus().toString())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].deployment.jobVersion",
+                Matchers.contains(
+                    dataJobExecution1.getJobVersion(), dataJobExecution2.getJobVersion())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].deployment.deployedDate",
+                Matchers.contains(
+                    dataJobExecution1.getLastDeployedDate().toString(),
+                    dataJobExecution2.getLastDeployedDate().toString())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].deployment.deployedBy",
+                Matchers.contains(
+                    dataJobExecution1.getLastDeployedBy(), dataJobExecution2.getLastDeployedBy())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].deployment.vdkVersion",
+                Matchers.contains(
+                    dataJobExecution1.getVdkVersion(), dataJobExecution2.getVdkVersion())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].deployment.resources.cpuRequest",
+                Matchers.contains(
+                    dataJobExecution1.getResourcesCpuRequest().doubleValue(),
+                    dataJobExecution2.getResourcesCpuRequest().doubleValue())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].deployment.resources.cpuLimit",
+                Matchers.contains(
+                    dataJobExecution1.getResourcesCpuLimit().doubleValue(),
+                    dataJobExecution2.getResourcesCpuLimit().doubleValue())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].deployment.resources.memoryRequest",
+                Matchers.contains(
+                    dataJobExecution1.getResourcesMemoryRequest(),
+                    dataJobExecution2.getResourcesMemoryRequest())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].deployment.resources.memoryLimit",
+                Matchers.contains(
+                    dataJobExecution1.getResourcesMemoryLimit(),
+                    dataJobExecution2.getResourcesMemoryLimit())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].deployment.schedule.scheduleCron",
+                Matchers.contains(
+                    dataJobExecution1.getJobSchedule(), dataJobExecution2.getJobSchedule())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].id",
+                Matchers.not(Matchers.contains(dataJobExecution3.getId()))));
+  }
 
-   @Test
-   public void testExecutions_filterByStartTimeLte() throws Exception {
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery())
-                  .param("variables", "{" +
-                        "\"filter\": {" +
-                        "      \"startTimeLte\": \"" + dataJobExecution2.getStartTime() + "\"" +
-                        "    }," +
-                        "\"pageNumber\": 1," +
-                        "\"pageSize\": 10" +
-                        "}")
-                  .with(user(TEST_USERNAME)))
-            .andExpect(status().is(200))
-            .andExpect(content().contentType("application/json"))
-            .andExpect(jsonPath(
-                  "$.data.content[*].id",
-                  Matchers.contains(dataJobExecution2.getId(), dataJobExecution3.getId())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].jobName",
-                  Matchers.contains(dataJob2.getName(), dataJob3.getName())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].status",
-                  Matchers.contains(dataJobExecution2.getStatus().toString(), dataJobExecution3.getStatus().toString())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].id",
-                  Matchers.not(Matchers.contains(dataJobExecution1.getId()))));
-   }
+  @Test
+  public void testExecutions_filterByStartTimeLte() throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery())
+                .param(
+                    "variables",
+                    "{"
+                        + "\"filter\": {"
+                        + "      \"startTimeLte\": \""
+                        + dataJobExecution2.getStartTime()
+                        + "\""
+                        + "    },"
+                        + "\"pageNumber\": 1,"
+                        + "\"pageSize\": 10"
+                        + "}")
+                .with(user(TEST_USERNAME)))
+        .andExpect(status().is(200))
+        .andExpect(content().contentType("application/json"))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].id",
+                Matchers.contains(dataJobExecution2.getId(), dataJobExecution3.getId())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].jobName",
+                Matchers.contains(dataJob2.getName(), dataJob3.getName())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].status",
+                Matchers.contains(
+                    dataJobExecution2.getStatus().toString(),
+                    dataJobExecution3.getStatus().toString())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].id",
+                Matchers.not(Matchers.contains(dataJobExecution1.getId()))));
+  }
 
-   @Test
-   public void testExecutions_filterByEndTimeGte() throws Exception {
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery())
-                  .param("variables", "{" +
-                        "\"filter\": {" +
-                        "      \"endTimeGte\": \"" + dataJobExecution2.getEndTime() + "\"" +
-                        "    }," +
-                        "\"pageNumber\": 1," +
-                        "\"pageSize\": 10" +
-                        "}")
-                  .with(user("user")))
-            .andExpect(status().is(200))
-            .andExpect(content().contentType("application/json"))
-            .andExpect(jsonPath(
-                  "$.data.content[*].id",
-                  Matchers.contains(dataJobExecution1.getId(), dataJobExecution2.getId())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].jobName",
-                  Matchers.contains(dataJob1.getName(), dataJob2.getName())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].status",
-                  Matchers.contains(dataJobExecution1.getStatus().toString(), dataJobExecution2.getStatus().toString())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].id",
-                  Matchers.not(Matchers.contains(dataJobExecution3.getId()))));
-   }
+  @Test
+  public void testExecutions_filterByEndTimeGte() throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery())
+                .param(
+                    "variables",
+                    "{"
+                        + "\"filter\": {"
+                        + "      \"endTimeGte\": \""
+                        + dataJobExecution2.getEndTime()
+                        + "\""
+                        + "    },"
+                        + "\"pageNumber\": 1,"
+                        + "\"pageSize\": 10"
+                        + "}")
+                .with(user("user")))
+        .andExpect(status().is(200))
+        .andExpect(content().contentType("application/json"))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].id",
+                Matchers.contains(dataJobExecution1.getId(), dataJobExecution2.getId())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].jobName",
+                Matchers.contains(dataJob1.getName(), dataJob2.getName())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].status",
+                Matchers.contains(
+                    dataJobExecution1.getStatus().toString(),
+                    dataJobExecution2.getStatus().toString())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].id",
+                Matchers.not(Matchers.contains(dataJobExecution3.getId()))));
+  }
 
-   @Test
-   public void testExecutions_filterByEndTimeLte() throws Exception {
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery())
-                  .param("variables", "{" +
-                        "\"filter\": {" +
-                        "      \"endTimeLte\": \"" + dataJobExecution2.getEndTime() + "\"" +
-                        "    }," +
-                        "\"pageNumber\": 1," +
-                        "\"pageSize\": 10" +
-                        "}")
-                  .with(user("user")))
-            .andExpect(status().is(200))
-            .andExpect(content().contentType("application/json"))
-            .andExpect(jsonPath(
-                  "$.data.content[*].id",
-                  Matchers.contains(dataJobExecution2.getId(), dataJobExecution3.getId())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].jobName",
-                  Matchers.contains(dataJob2.getName(), dataJob3.getName())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].status",
-                  Matchers.contains(dataJobExecution2.getStatus().toString(), dataJobExecution3.getStatus().toString())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].id",
-                  Matchers.not(Matchers.contains(dataJobExecution1.getId()))));
-   }
+  @Test
+  public void testExecutions_filterByEndTimeLte() throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery())
+                .param(
+                    "variables",
+                    "{"
+                        + "\"filter\": {"
+                        + "      \"endTimeLte\": \""
+                        + dataJobExecution2.getEndTime()
+                        + "\""
+                        + "    },"
+                        + "\"pageNumber\": 1,"
+                        + "\"pageSize\": 10"
+                        + "}")
+                .with(user("user")))
+        .andExpect(status().is(200))
+        .andExpect(content().contentType("application/json"))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].id",
+                Matchers.contains(dataJobExecution2.getId(), dataJobExecution3.getId())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].jobName",
+                Matchers.contains(dataJob2.getName(), dataJob3.getName())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].status",
+                Matchers.contains(
+                    dataJobExecution2.getStatus().toString(),
+                    dataJobExecution3.getStatus().toString())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].id",
+                Matchers.not(Matchers.contains(dataJobExecution1.getId()))));
+  }
 
-   @Test
-   public void testExecutions_filterByStatusIn() throws Exception {
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery())
-                  .param("variables", "{" +
-                        "\"filter\": {" +
-                        "      \"statusIn\": [\"" + dataJobExecution1.getStatus().toString() + "\", \"" + dataJobExecution2.getStatus().toString() + "\"]" +
-                        "    }," +
-                        "\"pageNumber\": 1," +
-                        "\"pageSize\": 10" +
-                        "}")
-                  .with(user("user")))
-            .andExpect(status().is(200))
-            .andExpect(content().contentType("application/json"))
-            .andExpect(jsonPath(
-                  "$.data.content[*].id",
-                  Matchers.contains(dataJobExecution1.getId(), dataJobExecution2.getId())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].jobName",
-                  Matchers.contains(dataJob1.getName(), dataJob2.getName())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].status",
-                  Matchers.contains(dataJobExecution1.getStatus().toString(), dataJobExecution2.getStatus().toString())))
-            .andExpect(jsonPath("$.data.content[*].id", Matchers.not(Matchers.contains(dataJobExecution3.getId()))));
-   }
+  @Test
+  public void testExecutions_filterByStatusIn() throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery())
+                .param(
+                    "variables",
+                    "{"
+                        + "\"filter\": {"
+                        + "      \"statusIn\": [\""
+                        + dataJobExecution1.getStatus().toString()
+                        + "\", \""
+                        + dataJobExecution2.getStatus().toString()
+                        + "\"]"
+                        + "    },"
+                        + "\"pageNumber\": 1,"
+                        + "\"pageSize\": 10"
+                        + "}")
+                .with(user("user")))
+        .andExpect(status().is(200))
+        .andExpect(content().contentType("application/json"))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].id",
+                Matchers.contains(dataJobExecution1.getId(), dataJobExecution2.getId())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].jobName",
+                Matchers.contains(dataJob1.getName(), dataJob2.getName())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].status",
+                Matchers.contains(
+                    dataJobExecution1.getStatus().toString(),
+                    dataJobExecution2.getStatus().toString())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].id",
+                Matchers.not(Matchers.contains(dataJobExecution3.getId()))));
+  }
 
-   @Test
-   public void testExecutions_filterByJobNameIn() throws Exception {
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery())
-                  .param("variables", "{" +
-                        "\"filter\": {" +
-                        "      \"jobNameIn\": [\"" + dataJobExecution1.getDataJob().getName() + "\"]" +
-                        "    }," +
-                        "\"pageNumber\": 1," +
-                        "\"pageSize\": 10" +
-                        "}")
-                  .with(user("user")))
-            .andExpect(status().is(200))
-            .andExpect(content().contentType("application/json"))
-            .andExpect(jsonPath(
-                  "$.data.content[*].id",
-                  Matchers.contains(dataJobExecution1.getId())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].jobName",
-                  Matchers.contains(dataJob1.getName())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].status",
-                  Matchers.contains(dataJobExecution1.getStatus().toString())))
-            .andExpect(jsonPath("$.data.content[*].id", Matchers.not(Matchers.contains(dataJobExecution3.getId()))))
-            .andExpect(jsonPath("$.data.content[*].id", Matchers.not(Matchers.contains(dataJobExecution2.getId()))));
-   }
+  @Test
+  public void testExecutions_filterByJobNameIn() throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery())
+                .param(
+                    "variables",
+                    "{"
+                        + "\"filter\": {"
+                        + "      \"jobNameIn\": [\""
+                        + dataJobExecution1.getDataJob().getName()
+                        + "\"]"
+                        + "    },"
+                        + "\"pageNumber\": 1,"
+                        + "\"pageSize\": 10"
+                        + "}")
+                .with(user("user")))
+        .andExpect(status().is(200))
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.data.content[*].id", Matchers.contains(dataJobExecution1.getId())))
+        .andExpect(jsonPath("$.data.content[*].jobName", Matchers.contains(dataJob1.getName())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].status",
+                Matchers.contains(dataJobExecution1.getStatus().toString())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].id", Matchers.not(Matchers.contains(dataJobExecution3.getId()))))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].id",
+                Matchers.not(Matchers.contains(dataJobExecution2.getId()))));
+  }
 
-   @Test
-   public void testExecutions_filterByTeamNameIn() throws Exception {
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery())
-                  .param("variables", "{" +
-                        "\"filter\": {" +
-                        "      \"teamNameIn\": [\"" + dataJobExecution1.getDataJob().getJobConfig().getTeam() + "\"]" +
-                        "    }," +
-                        "\"pageNumber\": 1," +
-                        "\"pageSize\": 10" +
-                        "}")
-                  .with(user("user")))
-            .andExpect(status().is(200))
-            .andExpect(content().contentType("application/json"))
-            .andExpect(jsonPath(
-                  "$.data.content[*].id",
-                  Matchers.contains(dataJobExecution1.getId())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].jobName",
-                  Matchers.contains(dataJob1.getName())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].status",
-                  Matchers.contains(dataJobExecution1.getStatus().toString())))
-            .andExpect(jsonPath("$.data.content[*].id", Matchers.not(Matchers.contains(dataJobExecution3.getId()))))
-            .andExpect(jsonPath("$.data.content[*].id", Matchers.not(Matchers.contains(dataJobExecution2.getId()))));
-   }
-
+  @Test
+  public void testExecutions_filterByTeamNameIn() throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery())
+                .param(
+                    "variables",
+                    "{"
+                        + "\"filter\": {"
+                        + "      \"teamNameIn\": [\""
+                        + dataJobExecution1.getDataJob().getJobConfig().getTeam()
+                        + "\"]"
+                        + "    },"
+                        + "\"pageNumber\": 1,"
+                        + "\"pageSize\": 10"
+                        + "}")
+                .with(user("user")))
+        .andExpect(status().is(200))
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.data.content[*].id", Matchers.contains(dataJobExecution1.getId())))
+        .andExpect(jsonPath("$.data.content[*].jobName", Matchers.contains(dataJob1.getName())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].status",
+                Matchers.contains(dataJobExecution1.getStatus().toString())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].id", Matchers.not(Matchers.contains(dataJobExecution3.getId()))))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].id",
+                Matchers.not(Matchers.contains(dataJobExecution2.getId()))));
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLExecutionsIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLExecutionsIT.java
@@ -91,13 +91,13 @@ public class GraphQLExecutionsIT extends BaseIT {
 
   private static String getQuery() {
     return "query($filter: DataJobExecutionFilter, $order: DataJobExecutionOrder, $pageNumber: Int,"
-               + " $pageSize: Int) {  executions(pageNumber: $pageNumber, pageSize: $pageSize,"
-               + " filter: $filter, order: $order) {    content {      id      jobName     "
-               + " startTime      endTime      status      deployment {        id        enabled   "
-               + "     jobVersion        deployedDate        deployedBy        resources {         "
-               + "  cpuLimit           cpuRequest           memoryLimit           memoryRequest    "
-               + "    }        schedule {           scheduleCron        }        vdkVersion      } "
-               + "   }    totalPages    totalItems  }}";
+        + " $pageSize: Int) {  executions(pageNumber: $pageNumber, pageSize: $pageSize,"
+        + " filter: $filter, order: $order) {    content {      id      jobName     "
+        + " startTime      endTime      status      deployment {        id        enabled   "
+        + "     jobVersion        deployedDate        deployedBy        resources {         "
+        + "  cpuLimit           cpuRequest           memoryLimit           memoryRequest    "
+        + "    }        schedule {           scheduleCron        }        vdkVersion      } "
+        + "   }    totalPages    totalItems  }}";
   }
 
   private void cleanup() {

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLExecutionsLogsUrlIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLExecutionsLogsUrlIT.java
@@ -33,111 +33,147 @@ import com.vmware.taurus.service.model.DataJobExecution;
 import com.vmware.taurus.service.model.ExecutionStatus;
 import com.vmware.taurus.service.model.JobConfig;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = ControlplaneApplication.class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = ControlplaneApplication.class)
 public class GraphQLExecutionsLogsUrlIT extends BaseIT {
 
-   @Autowired
-   JobExecutionRepository jobExecutionRepository;
+  @Autowired JobExecutionRepository jobExecutionRepository;
 
-   @Autowired
-   JobsRepository jobsRepository;
+  @Autowired JobsRepository jobsRepository;
 
-   private static final String LOGS_URL_TEMPLATE =
-         "https://log-insight-base-url/li/query/stream?query=%C2%A7%C2%A7%C2%A7AND%C" +
-               "2%A7%C2%A7%C2%A7%C2%A7{0}%C2%A7{1}%C2%A7true%C2%A7COUNT%C2%A7*%C2%A7" +
-               "timestamp%C2%A7pageSortPreference:%7B%22sortBy%22%3A%22-{2}-{3}-" +
-               "ingest_timestamp%22%2C%22sortOrder%22%3A%22DESC%22%7D%C2%A7" +
-               "alertDefList:%5B%5D%C2%A7partitions:%C2%A7%C2%A7text:CONTAINS:{4}*";
+  private static final String LOGS_URL_TEMPLATE =
+      "https://log-insight-base-url/li/query/stream?query=%C2%A7%C2%A7%C2%A7AND%C"
+          + "2%A7%C2%A7%C2%A7%C2%A7{0}%C2%A7{1}%C2%A7true%C2%A7COUNT%C2%A7*%C2%A7"
+          + "timestamp%C2%A7pageSortPreference:%7B%22sortBy%22%3A%22-{2}-{3}-"
+          + "ingest_timestamp%22%2C%22sortOrder%22%3A%22DESC%22%7D%C2%A7"
+          + "alertDefList:%5B%5D%C2%A7partitions:%C2%A7%C2%A7text:CONTAINS:{4}*";
 
-   private static final String TEST_JOB_NAME_1 = "TEST-JOB-NAME-1";
-   private static final String TEST_JOB_NAME_2 = "TEST-JOB-NAME-2";
-   private static final String TEST_JOB_NAME_3 = "TEST-JOB-NAME-3";
+  private static final String TEST_JOB_NAME_1 = "TEST-JOB-NAME-1";
+  private static final String TEST_JOB_NAME_2 = "TEST-JOB-NAME-2";
+  private static final String TEST_JOB_NAME_3 = "TEST-JOB-NAME-3";
 
-   private static final long TEST_START_TIME_OFFSET_SECONDS = 1000;
-   private static final long TEST_END_TIME_OFFSET_SECONDS = -1000;
+  private static final long TEST_START_TIME_OFFSET_SECONDS = 1000;
+  private static final long TEST_END_TIME_OFFSET_SECONDS = -1000;
 
-   private DataJobExecution dataJobExecution1;
-   private DataJobExecution dataJobExecution2;
-   private DataJobExecution dataJobExecution3;
+  private DataJobExecution dataJobExecution1;
+  private DataJobExecution dataJobExecution2;
+  private DataJobExecution dataJobExecution3;
 
-   @DynamicPropertySource
-   static void dynamicProperties(DynamicPropertyRegistry registry) {
-      String logsUrlTemplate = MessageFormat.format(
+  @DynamicPropertySource
+  static void dynamicProperties(DynamicPropertyRegistry registry) {
+    String logsUrlTemplate =
+        MessageFormat.format(
             LOGS_URL_TEMPLATE,
             "{{start_time}}",
             "{{end_time}}",
             "{{job_name}}",
             "{{op_id}}",
             "{{execution_id}}");
-      registry.add("datajobs.executions.logsUrl.template", () -> logsUrlTemplate);
-      registry.add("datajobs.executions.logsUrl.dateFormat", () -> "unix");
-      registry.add("datajobs.executions.logsUrl.startTimeOffsetSeconds", () -> TEST_START_TIME_OFFSET_SECONDS);
-      registry.add("datajobs.executions.logsUrl.endTimeOffsetSeconds", () -> TEST_END_TIME_OFFSET_SECONDS);
-   }
+    registry.add("datajobs.executions.logsUrl.template", () -> logsUrlTemplate);
+    registry.add("datajobs.executions.logsUrl.dateFormat", () -> "unix");
+    registry.add(
+        "datajobs.executions.logsUrl.startTimeOffsetSeconds", () -> TEST_START_TIME_OFFSET_SECONDS);
+    registry.add(
+        "datajobs.executions.logsUrl.endTimeOffsetSeconds", () -> TEST_END_TIME_OFFSET_SECONDS);
+  }
 
-   @BeforeEach
-   public void setup() {
-      cleanup();
+  @BeforeEach
+  public void setup() {
+    cleanup();
 
-      DataJob dataJob1 = jobsRepository.save(new DataJob(TEST_JOB_NAME_1, new JobConfig()));
-      DataJob dataJob2 = jobsRepository.save(new DataJob(TEST_JOB_NAME_2, new JobConfig()));
-      DataJob dataJob3 = jobsRepository.save(new DataJob(TEST_JOB_NAME_3, new JobConfig()));
+    DataJob dataJob1 = jobsRepository.save(new DataJob(TEST_JOB_NAME_1, new JobConfig()));
+    DataJob dataJob2 = jobsRepository.save(new DataJob(TEST_JOB_NAME_2, new JobConfig()));
+    DataJob dataJob3 = jobsRepository.save(new DataJob(TEST_JOB_NAME_3, new JobConfig()));
 
-      OffsetDateTime now = OffsetDateTime.now();
-      this.dataJobExecution1 = JobExecutionUtil.createDataJobExecution(
+    OffsetDateTime now = OffsetDateTime.now();
+    this.dataJobExecution1 =
+        JobExecutionUtil.createDataJobExecution(
             jobExecutionRepository, "testId1", dataJob1, now, now, ExecutionStatus.SUCCEEDED);
-      this.dataJobExecution2 = JobExecutionUtil.createDataJobExecution(
-            jobExecutionRepository, "testId2", dataJob2, now.minusSeconds(1), now.minusSeconds(1), ExecutionStatus.RUNNING);
-      this.dataJobExecution3 = JobExecutionUtil.createDataJobExecution(
-            jobExecutionRepository, "testId3", dataJob3, now.minusSeconds(10), now.minusSeconds(10), ExecutionStatus.SUBMITTED);
-   }
+    this.dataJobExecution2 =
+        JobExecutionUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "testId2",
+            dataJob2,
+            now.minusSeconds(1),
+            now.minusSeconds(1),
+            ExecutionStatus.RUNNING);
+    this.dataJobExecution3 =
+        JobExecutionUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "testId3",
+            dataJob3,
+            now.minusSeconds(10),
+            now.minusSeconds(10),
+            ExecutionStatus.SUBMITTED);
+  }
 
-   private static String getQuery() {
-      return "query($filter: DataJobExecutionFilter, $order: DataJobExecutionOrder, $pageNumber: Int, $pageSize: Int) {" +
-            "  executions(pageNumber: $pageNumber, pageSize: $pageSize, filter: $filter, order: $order) {" +
-            "    content {" +
-            "      id" +
-            "      logsUrl" +
-            "    }" +
-            "    totalPages" +
-            "    totalItems" +
-            "  }" +
-            "}";
-   }
+  private static String getQuery() {
+    return "query($filter: DataJobExecutionFilter, $order: DataJobExecutionOrder, $pageNumber: Int,"
+               + " $pageSize: Int) {  executions(pageNumber: $pageNumber, pageSize: $pageSize,"
+               + " filter: $filter, order: $order) {    content {      id      logsUrl    }   "
+               + " totalPages    totalItems  }}";
+  }
 
-   private void cleanup() {
-      jobsRepository.findAllById(List.of(TEST_JOB_NAME_1, TEST_JOB_NAME_2, TEST_JOB_NAME_3))
-                  .forEach(dataJob -> jobsRepository.delete(dataJob));
-   }
+  private void cleanup() {
+    jobsRepository
+        .findAllById(List.of(TEST_JOB_NAME_1, TEST_JOB_NAME_2, TEST_JOB_NAME_3))
+        .forEach(dataJob -> jobsRepository.delete(dataJob));
+  }
 
-   @Test
-   public void testExecutions_filterByStartTimeGte() throws Exception {
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery())
-                  .param("variables", "{" +
-                        "\"filter\": {" +
-                        "      \"startTimeGte\": \"" + dataJobExecution3.getStartTime() + "\"" +
-                        "    }," +
-                        "\"pageNumber\": 1," +
-                        "\"pageSize\": 10" +
-                        "}")
-                  .with(user(TEST_USERNAME)))
-            .andExpect(status().is(200))
-            .andExpect(content().contentType("application/json"))
-            .andExpect(jsonPath(
-                  "$.data.content[*].id",
-                  Matchers.contains(dataJobExecution1.getId(), dataJobExecution2.getId(), dataJobExecution3.getId())))
-            .andExpect(jsonPath(
-                  "$.data.content[*].logsUrl",
-                  Matchers.contains(buildLogsUrl(dataJobExecution1), buildLogsUrl(dataJobExecution2), buildLogsUrl(dataJobExecution3))));
-   }
+  @Test
+  public void testExecutions_filterByStartTimeGte() throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery())
+                .param(
+                    "variables",
+                    "{"
+                        + "\"filter\": {"
+                        + "      \"startTimeGte\": \""
+                        + dataJobExecution3.getStartTime()
+                        + "\""
+                        + "    },"
+                        + "\"pageNumber\": 1,"
+                        + "\"pageSize\": 10"
+                        + "}")
+                .with(user(TEST_USERNAME)))
+        .andExpect(status().is(200))
+        .andExpect(content().contentType("application/json"))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].id",
+                Matchers.contains(
+                    dataJobExecution1.getId(),
+                    dataJobExecution2.getId(),
+                    dataJobExecution3.getId())))
+        .andExpect(
+            jsonPath(
+                "$.data.content[*].logsUrl",
+                Matchers.contains(
+                    buildLogsUrl(dataJobExecution1),
+                    buildLogsUrl(dataJobExecution2),
+                    buildLogsUrl(dataJobExecution3))));
+  }
 
-   private static String buildLogsUrl(DataJobExecution dataJobExecution) {
-      return MessageFormat.format(LOGS_URL_TEMPLATE,
-            String.valueOf(dataJobExecution.getStartTime().toInstant().plusSeconds(TEST_START_TIME_OFFSET_SECONDS).toEpochMilli()),
-            String.valueOf(dataJobExecution.getEndTime().toInstant().plusSeconds(TEST_END_TIME_OFFSET_SECONDS).toEpochMilli()),
-            dataJobExecution.getDataJob().getName(),
-            dataJobExecution.getOpId(),
-            dataJobExecution.getId());
-   }
+  private static String buildLogsUrl(DataJobExecution dataJobExecution) {
+    return MessageFormat.format(
+        LOGS_URL_TEMPLATE,
+        String.valueOf(
+            dataJobExecution
+                .getStartTime()
+                .toInstant()
+                .plusSeconds(TEST_START_TIME_OFFSET_SECONDS)
+                .toEpochMilli()),
+        String.valueOf(
+            dataJobExecution
+                .getEndTime()
+                .toInstant()
+                .plusSeconds(TEST_END_TIME_OFFSET_SECONDS)
+                .toEpochMilli()),
+        dataJobExecution.getDataJob().getName(),
+        dataJobExecution.getOpId(),
+        dataJobExecution.getId());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLExecutionsLogsUrlIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLExecutionsLogsUrlIT.java
@@ -110,9 +110,9 @@ public class GraphQLExecutionsLogsUrlIT extends BaseIT {
 
   private static String getQuery() {
     return "query($filter: DataJobExecutionFilter, $order: DataJobExecutionOrder, $pageNumber: Int,"
-               + " $pageSize: Int) {  executions(pageNumber: $pageNumber, pageSize: $pageSize,"
-               + " filter: $filter, order: $order) {    content {      id      logsUrl    }   "
-               + " totalPages    totalItems  }}";
+        + " $pageSize: Int) {  executions(pageNumber: $pageNumber, pageSize: $pageSize,"
+        + " filter: $filter, order: $order) {    content {      id      logsUrl    }   "
+        + " totalPages    totalItems  }}";
   }
 
   private void cleanup() {

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLExecutionsNextRunIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLExecutionsNextRunIT.java
@@ -38,8 +38,8 @@ public class GraphQLExecutionsNextRunIT extends BaseIT {
 
   private String getQuery(String sortOrder) {
     return "{\n"
-               + "  jobs(pageNumber: 1, pageSize: 100, filter: [{property:"
-               + " \"config.schedule.nextRunEpochSeconds\", sort:"
+        + "  jobs(pageNumber: 1, pageSize: 100, filter: [{property:"
+        + " \"config.schedule.nextRunEpochSeconds\", sort:"
         + sortOrder
         + "}]) {\n"
         + "    content {\n"
@@ -57,8 +57,8 @@ public class GraphQLExecutionsNextRunIT extends BaseIT {
 
   private String getQueryWithFilter(String filter) {
     return "{\n"
-               + "  jobs(pageNumber: 1, pageSize: 100, filter: [{property:"
-               + " \"config.schedule.nextRunEpochSeconds\", pattern:"
+        + "  jobs(pageNumber: 1, pageSize: 100, filter: [{property:"
+        + " \"config.schedule.nextRunEpochSeconds\", pattern:"
         + filter
         + "}]) {\n"
         + "    content {\n"

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLExecutionsNextRunIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLExecutionsNextRunIT.java
@@ -5,7 +5,6 @@
 
 package com.vmware.taurus.graphql.it;
 
-
 import com.vmware.taurus.ControlplaneApplication;
 import com.vmware.taurus.datajobs.it.common.BaseIT;
 import com.vmware.taurus.service.JobsRepository;
@@ -25,145 +24,167 @@ import java.time.ZoneId;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = ControlplaneApplication.class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = ControlplaneApplication.class)
 public class GraphQLExecutionsNextRunIT extends BaseIT {
 
-   @Autowired
-   JobsRepository jobsRepository;
+  @Autowired JobsRepository jobsRepository;
 
-   @BeforeEach
-   public void cleanup() {
-      jobsRepository.deleteAll();
-   }
+  @BeforeEach
+  public void cleanup() {
+    jobsRepository.deleteAll();
+  }
 
-   private String getQuery(String sortOrder) {
-      return "{\n" +
-            "  jobs(pageNumber: 1, pageSize: 100, filter: [{property: \"config.schedule.nextRunEpochSeconds\", sort:" + sortOrder + "}]) {\n" +
-            "    content {\n" +
-            "      jobName \n" +
-            "      config {\n" +
-            "        schedule {\n" +
-            "          scheduleCron\n" +
-            "          nextRunEpochSeconds\n" +
-            "        }" +
-            "      }" +
-            "    }\n" +
-            "  }\n" +
-            "}";
-   }
+  private String getQuery(String sortOrder) {
+    return "{\n"
+               + "  jobs(pageNumber: 1, pageSize: 100, filter: [{property:"
+               + " \"config.schedule.nextRunEpochSeconds\", sort:"
+        + sortOrder
+        + "}]) {\n"
+        + "    content {\n"
+        + "      jobName \n"
+        + "      config {\n"
+        + "        schedule {\n"
+        + "          scheduleCron\n"
+        + "          nextRunEpochSeconds\n"
+        + "        }"
+        + "      }"
+        + "    }\n"
+        + "  }\n"
+        + "}";
+  }
 
-   private String getQueryWithFilter(String filter) {
-      return "{\n" +
-            "  jobs(pageNumber: 1, pageSize: 100, filter: [{property: \"config.schedule.nextRunEpochSeconds\", pattern:" + filter + "}]) {\n" +
-            "    content {\n" +
-            "      jobName \n" +
-            "      config {\n" +
-            "        schedule {\n" +
-            "          scheduleCron\n" +
-            "          nextRunEpochSeconds\n" +
-            "        }" +
-            "      }" +
-            "    }\n" +
-            "  }\n" +
-            "}";
-   }
+  private String getQueryWithFilter(String filter) {
+    return "{\n"
+               + "  jobs(pageNumber: 1, pageSize: 100, filter: [{property:"
+               + " \"config.schedule.nextRunEpochSeconds\", pattern:"
+        + filter
+        + "}]) {\n"
+        + "    content {\n"
+        + "      jobName \n"
+        + "      config {\n"
+        + "        schedule {\n"
+        + "          scheduleCron\n"
+        + "          nextRunEpochSeconds\n"
+        + "        }"
+        + "      }"
+        + "    }\n"
+        + "  }\n"
+        + "}";
+  }
 
-   @Test
-   public void testNextRunCall_noJobs() throws Exception {
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery("DESC"))
-                  .with(user(TEST_USERNAME)))
-            .andExpect(jsonPath("$.data.content").isEmpty());
-   }
+  @Test
+  public void testNextRunCall_noJobs() throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery("DESC"))
+                .with(user(TEST_USERNAME)))
+        .andExpect(jsonPath("$.data.content").isEmpty());
+  }
 
-   @Test
-   public void testNextRunCall_oneJob() throws Exception {
-      var now = OffsetDateTime.now();
-      addJob("jobA", toCron(now));
+  @Test
+  public void testNextRunCall_oneJob() throws Exception {
+    var now = OffsetDateTime.now();
+    addJob("jobA", toCron(now));
 
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery("DESC"))
-                  .with(user(TEST_USERNAME)))
-            .andExpect(jsonPath("$.data.content[0].jobName").value("jobA"))
-            .andExpect(jsonPath("$.data.content[0].config.schedule.scheduleCron").value(toCron(now)));
-   }
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery("DESC"))
+                .with(user(TEST_USERNAME)))
+        .andExpect(jsonPath("$.data.content[0].jobName").value("jobA"))
+        .andExpect(jsonPath("$.data.content[0].config.schedule.scheduleCron").value(toCron(now)));
+  }
 
-   @Test
-   public void testNextRunCall_twoJobs_DESC() throws Exception {
-      var now = OffsetDateTime.now(ZoneId.of("UTC")).plusMinutes(2);
-      var later = now.plusDays(1);
+  @Test
+  public void testNextRunCall_twoJobs_DESC() throws Exception {
+    var now = OffsetDateTime.now(ZoneId.of("UTC")).plusMinutes(2);
+    var later = now.plusDays(1);
 
-      addJob("jobA", toCron(now));
-      addJob("jobB", toCron(later));
-      //check correct sort is applied
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery("DESC"))
-                  .with(user(TEST_USERNAME)))
-            .andExpect(jsonPath("$.data.content[0].jobName").value("jobB"))
-            .andExpect(jsonPath("$.data.content[1].jobName").value("jobA"))
-            .andExpect(jsonPath("$.data.content[0].config.schedule.scheduleCron").value(toCron(later)))
-            .andExpect(jsonPath("$.data.content[1].config.schedule.scheduleCron").value(toCron(now)));
-   }
+    addJob("jobA", toCron(now));
+    addJob("jobB", toCron(later));
+    // check correct sort is applied
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery("DESC"))
+                .with(user(TEST_USERNAME)))
+        .andExpect(jsonPath("$.data.content[0].jobName").value("jobB"))
+        .andExpect(jsonPath("$.data.content[1].jobName").value("jobA"))
+        .andExpect(jsonPath("$.data.content[0].config.schedule.scheduleCron").value(toCron(later)))
+        .andExpect(jsonPath("$.data.content[1].config.schedule.scheduleCron").value(toCron(now)));
+  }
 
-   @Test
-   public void testNextRunCall_twoJobs_ASC() throws Exception {
-      var now = OffsetDateTime.now(ZoneId.of("UTC")).plusMinutes(2);
-      var later = now.plusMinutes(60);
+  @Test
+  public void testNextRunCall_twoJobs_ASC() throws Exception {
+    var now = OffsetDateTime.now(ZoneId.of("UTC")).plusMinutes(2);
+    var later = now.plusMinutes(60);
 
-      addJob("jobA", toCron(now));
-      addJob("jobB", toCron(later));
-      //check correct sort is applied
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery("ASC"))
-                  .with(user(TEST_USERNAME)))
-            .andExpect(jsonPath("$.data.content[0].jobName").value("jobA"))
-            .andExpect(jsonPath("$.data.content[1].jobName").value("jobB"))
-            .andExpect(jsonPath("$.data.content[0].config.schedule.scheduleCron").value(toCron(now)))
-            .andExpect(jsonPath("$.data.content[1].config.schedule.scheduleCron").value(toCron(later)));
-   }
+    addJob("jobA", toCron(now));
+    addJob("jobB", toCron(later));
+    // check correct sort is applied
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery("ASC"))
+                .with(user(TEST_USERNAME)))
+        .andExpect(jsonPath("$.data.content[0].jobName").value("jobA"))
+        .andExpect(jsonPath("$.data.content[1].jobName").value("jobB"))
+        .andExpect(jsonPath("$.data.content[0].config.schedule.scheduleCron").value(toCron(now)))
+        .andExpect(jsonPath("$.data.content[1].config.schedule.scheduleCron").value(toCron(later)));
+  }
 
-   @Test
-   public void testNextRunCall_filter_noJobs() throws Exception {
-      var now = OffsetDateTime.now();
-      var before = now.minusDays(2);
+  @Test
+  public void testNextRunCall_filter_noJobs() throws Exception {
+    var now = OffsetDateTime.now();
+    var before = now.minusDays(2);
 
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQueryWithFilter(getFilterPattern(before, now)))
-                  .with(user(TEST_USERNAME)))
-            .andExpect(jsonPath("$.data.content").isEmpty());
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQueryWithFilter(getFilterPattern(before, now)))
+                .with(user(TEST_USERNAME)))
+        .andExpect(jsonPath("$.data.content").isEmpty());
+  }
 
-   }
+  @Test
+  public void testNextRunCall_filter_twoJobs() throws Exception {
+    var now = OffsetDateTime.now(ZoneId.of("UTC"));
+    var after = now.plusMinutes(120);
 
-   @Test
-   public void testNextRunCall_filter_twoJobs() throws Exception {
-      var now = OffsetDateTime.now(ZoneId.of("UTC"));
-      var after = now.plusMinutes(120);
+    addJob("jobA", toCron(now.minusMinutes(240)));
+    addJob("jobB", toCron(now.plusMinutes(30)));
 
-      addJob("jobA", toCron(now.minusMinutes(240)));
-      addJob("jobB", toCron(now.plusMinutes(30)));
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQueryWithFilter(getFilterPattern(now, after)))
+                .with(user(TEST_USERNAME)))
+        .andExpect(jsonPath("$.data.content[0].jobName").value("jobB"))
+        .andExpect(jsonPath("$.data.content[*].jobName", Matchers.not(Matchers.contains("jobA"))));
+  }
 
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQueryWithFilter(getFilterPattern(now, after)))
-                  .with(user(TEST_USERNAME)))
-            .andExpect(jsonPath("$.data.content[0].jobName").value("jobB"))
-            .andExpect(jsonPath("$.data.content[*].jobName", Matchers.not(Matchers.contains("jobA"))));
-   }
+  private void addJob(String jobName, String jobSchedule) {
+    JobConfig config = new JobConfig();
+    config.setSchedule(jobSchedule);
+    var job = new DataJob(jobName, config);
+    job.setLatestJobDeploymentStatus(DeploymentStatus.SUCCESS);
+    jobsRepository.save(job);
+  }
 
-   private void addJob(String jobName, String jobSchedule) {
-      JobConfig config = new JobConfig();
-      config.setSchedule(jobSchedule);
-      var job = new DataJob(jobName, config);
-      job.setLatestJobDeploymentStatus(DeploymentStatus.SUCCESS);
-      jobsRepository.save(job);
-   }
+  private String toCron(OffsetDateTime dateTime) {
+    return String.format(
+        "%d %d %d %d %d",
+        dateTime.getMinute(),
+        dateTime.getHour(),
+        dateTime.getDayOfMonth(),
+        dateTime.getMonth().getValue(),
+        dateTime.getDayOfWeek().getValue());
+  }
 
-   private String toCron(OffsetDateTime dateTime) {
-      return String.format("%d %d %d %d %d", dateTime.getMinute(), dateTime.getHour(), dateTime.getDayOfMonth(),
-            dateTime.getMonth().getValue(), dateTime.getDayOfWeek().getValue());
-   }
-
-   private String getFilterPattern(OffsetDateTime start, OffsetDateTime finish) {
-      return String.format("\"%d-%d\"", start.toEpochSecond(), finish.toEpochSecond());
-   }
-
+  private String getFilterPattern(OffsetDateTime start, OffsetDateTime finish) {
+    return String.format("\"%d-%d\"", start.toEpochSecond(), finish.toEpochSecond());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLJobExecutionsSortByEndTimeIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLJobExecutionsSortByEndTimeIT.java
@@ -5,7 +5,6 @@
 
 package com.vmware.taurus.graphql.it;
 
-
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -29,135 +28,157 @@ import com.vmware.taurus.service.model.ExecutionType;
 
 public class GraphQLJobExecutionsSortByEndTimeIT extends BaseDataJobDeploymentIT {
 
-   @Autowired
-   JobExecutionRepository jobExecutionRepository;
+  @Autowired JobExecutionRepository jobExecutionRepository;
 
-   @Autowired
-   JobsRepository jobsRepository;
+  @Autowired JobsRepository jobsRepository;
 
-   @BeforeEach
-   public void cleanup() {
-      jobExecutionRepository.deleteAll();
-   }
+  @BeforeEach
+  public void cleanup() {
+    jobExecutionRepository.deleteAll();
+  }
 
-   private static String getQuery(String jobName, String executionsSortOrder) {
-      return "{\n" +
-            "  jobs(pageNumber: 1, pageSize: 100, filter: [{property: \"jobName\", pattern: \"" + jobName + "\", sort: ASC}]) {\n" +
-            "    content {\n" +
-            "      jobName\n" +
-            "      deployments {\n" +
-            "        executions(pageNumber: 1, pageSize: 10, order: {property: \"endTime\", direction: " + executionsSortOrder + "}) {\n" +
-            "          id\n" +
-            "          endTime\n" +
-            "        }\n" +
-            "      }\n" +
-            "    }\n" +
-            "  }\n" +
-            "}";
-   }
+  private static String getQuery(String jobName, String executionsSortOrder) {
+    return "{\n"
+        + "  jobs(pageNumber: 1, pageSize: 100, filter: [{property: \"jobName\", pattern: \""
+        + jobName
+        + "\", sort: ASC}]) {\n"
+        + "    content {\n"
+        + "      jobName\n"
+        + "      deployments {\n"
+        + "        executions(pageNumber: 1, pageSize: 10, order: {property: \"endTime\","
+        + " direction: "
+        + executionsSortOrder
+        + "}) {\n"
+        + "          id\n"
+        + "          endTime\n"
+        + "        }\n"
+        + "      }\n"
+        + "    }\n"
+        + "  }\n"
+        + "}";
+  }
 
-   @Test
-   public void testEmptyCallAsc(String jobName, String username) throws Exception {
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery(jobName, "ASC"))
-                  .with(user(username)))
-            .andExpect(status().is(200));
-   }
+  @Test
+  public void testEmptyCallAsc(String jobName, String username) throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery(jobName, "ASC"))
+                .with(user(username)))
+        .andExpect(status().is(200));
+  }
 
-   @Test
-   public void testEmptyCallDesc(String jobName, String username) throws Exception {
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery(jobName, "DESC"))
-                  .with(user(username)))
-            .andExpect(status().is(200));
-   }
+  @Test
+  public void testEmptyCallDesc(String jobName, String username) throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery(jobName, "DESC"))
+                .with(user(username)))
+        .andExpect(status().is(200));
+  }
 
-   @Test
-   public void testCallWithSingleExecution(String jobName, String username) throws Exception {
-      var expectedId = "testId1";
-      var expectedEndTime = OffsetDateTime.now();
+  @Test
+  public void testCallWithSingleExecution(String jobName, String username) throws Exception {
+    var expectedId = "testId1";
+    var expectedEndTime = OffsetDateTime.now();
 
-      createDataJobExecution(expectedId, jobName, expectedEndTime);
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery(jobName, "DESC"))
-                  .with(user(username)))
-            .andExpect(status().is(200))
-            .andExpect(content().contentType("application/json"))
-            .andExpect(jsonPath("$.data.content[0].deployments[0].executions").exists())
-            .andExpect(jsonPath("$.data.content[0].deployments[0].executions[0].id").value(expectedId))
-            .andExpect(jsonPath("$.data.content[0].deployments[0].executions[0].endTime").value(expectedEndTime.toString()));
-   }
+    createDataJobExecution(expectedId, jobName, expectedEndTime);
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery(jobName, "DESC"))
+                .with(user(username)))
+        .andExpect(status().is(200))
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.data.content[0].deployments[0].executions").exists())
+        .andExpect(jsonPath("$.data.content[0].deployments[0].executions[0].id").value(expectedId))
+        .andExpect(
+            jsonPath("$.data.content[0].deployments[0].executions[0].endTime")
+                .value(expectedEndTime.toString()));
+  }
 
-   @Test
-   public void testCallTwoExecutionsSortAsc(String jobName, String username) throws Exception {
-      var expectedId1 = "testId1";
-      var expectedId2 = "testId2";
-      var expectedEndTimeLarger = OffsetDateTime.now();
-      var expectedEndTimeSmaller = OffsetDateTime.now().minusDays(1);
+  @Test
+  public void testCallTwoExecutionsSortAsc(String jobName, String username) throws Exception {
+    var expectedId1 = "testId1";
+    var expectedId2 = "testId2";
+    var expectedEndTimeLarger = OffsetDateTime.now();
+    var expectedEndTimeSmaller = OffsetDateTime.now().minusDays(1);
 
-      createDataJobExecution(expectedId1, jobName, expectedEndTimeLarger);
-      createDataJobExecution(expectedId2, jobName, expectedEndTimeSmaller);
+    createDataJobExecution(expectedId1, jobName, expectedEndTimeLarger);
+    createDataJobExecution(expectedId2, jobName, expectedEndTimeSmaller);
 
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery(jobName, "ASC"))
-                  .with(user(username)))
-            .andExpect(status().is(200))
-            .andExpect(content().contentType("application/json"))
-            .andExpect(jsonPath("$.data.content[0].deployments[0].executions[0]").exists())
-            .andExpect(jsonPath("$.data.content[0].deployments[0].executions[1]").exists())
-            .andExpect(jsonPath("$.data.content[0].deployments[0].executions[0].id").value(expectedId2))
-            .andExpect(jsonPath("$.data.content[0].deployments[0].executions[0].endTime").value(expectedEndTimeSmaller.toString()))
-            .andExpect(jsonPath("$.data.content[0].deployments[0].executions[1].id").value(expectedId1))
-            .andExpect(jsonPath("$.data.content[0].deployments[0].executions[1].endTime").value(expectedEndTimeLarger.toString()));
-   }
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery(jobName, "ASC"))
+                .with(user(username)))
+        .andExpect(status().is(200))
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.data.content[0].deployments[0].executions[0]").exists())
+        .andExpect(jsonPath("$.data.content[0].deployments[0].executions[1]").exists())
+        .andExpect(jsonPath("$.data.content[0].deployments[0].executions[0].id").value(expectedId2))
+        .andExpect(
+            jsonPath("$.data.content[0].deployments[0].executions[0].endTime")
+                .value(expectedEndTimeSmaller.toString()))
+        .andExpect(jsonPath("$.data.content[0].deployments[0].executions[1].id").value(expectedId1))
+        .andExpect(
+            jsonPath("$.data.content[0].deployments[0].executions[1].endTime")
+                .value(expectedEndTimeLarger.toString()));
+  }
 
-   @Test
-   public void testCallTwoExecutionsSortDesc(String jobName, String username) throws Exception {
-      var expectedId1 = "testId1";
-      var expectedId2 = "testId2";
-      var expectedEndTimeLarger = OffsetDateTime.now();
-      var expectedEndTimeSmaller = OffsetDateTime.now().minusDays(1);
+  @Test
+  public void testCallTwoExecutionsSortDesc(String jobName, String username) throws Exception {
+    var expectedId1 = "testId1";
+    var expectedId2 = "testId2";
+    var expectedEndTimeLarger = OffsetDateTime.now();
+    var expectedEndTimeSmaller = OffsetDateTime.now().minusDays(1);
 
-      createDataJobExecution(expectedId1, jobName, expectedEndTimeLarger);
-      createDataJobExecution(expectedId2, jobName, expectedEndTimeSmaller);
+    createDataJobExecution(expectedId1, jobName, expectedEndTimeLarger);
+    createDataJobExecution(expectedId2, jobName, expectedEndTimeSmaller);
 
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery(jobName, "DESC"))
-                  .with(user(username)))
-            .andExpect(status().is(200))
-            .andExpect(content().contentType("application/json"))
-            .andExpect(jsonPath("$.data.content[0].deployments[0].executions[0]").exists())
-            .andExpect(jsonPath("$.data.content[0].deployments[0].executions[1]").exists())
-            .andExpect(jsonPath("$.data.content[0].deployments[0].executions[0].id").value(expectedId1))
-            .andExpect(jsonPath("$.data.content[0].deployments[0].executions[0].endTime").value(expectedEndTimeLarger.toString()))
-            .andExpect(jsonPath("$.data.content[0].deployments[0].executions[1].id").value(expectedId2))
-            .andExpect(jsonPath("$.data.content[0].deployments[0].executions[1].endTime").value(expectedEndTimeSmaller.toString()));
-   }
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery(jobName, "DESC"))
+                .with(user(username)))
+        .andExpect(status().is(200))
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.data.content[0].deployments[0].executions[0]").exists())
+        .andExpect(jsonPath("$.data.content[0].deployments[0].executions[1]").exists())
+        .andExpect(jsonPath("$.data.content[0].deployments[0].executions[0].id").value(expectedId1))
+        .andExpect(
+            jsonPath("$.data.content[0].deployments[0].executions[0].endTime")
+                .value(expectedEndTimeLarger.toString()))
+        .andExpect(jsonPath("$.data.content[0].deployments[0].executions[1].id").value(expectedId2))
+        .andExpect(
+            jsonPath("$.data.content[0].deployments[0].executions[1].endTime")
+                .value(expectedEndTimeSmaller.toString()));
+  }
 
-   @Test
-   public void testCallPagination(String jobName, String username) throws Exception {
-      for (int i = 0; i < 15; i++) {
-         createDataJobExecution(UUID.randomUUID().toString(), jobName, OffsetDateTime.now());
-      }
-      // Query pagination is set to 10 items per page.
-      mockMvc.perform(MockMvcRequestBuilders.get(JOBS_URI)
-                  .queryParam("query", getQuery(jobName, "DESC"))
-                  .with(user(username)))
-            .andExpect(status().is(200))
-            .andExpect(content().contentType("application/json"))
-            .andExpect(jsonPath("$.data.content[0].deployments[0].executions[0]").exists())
-            .andExpect(jsonPath("$.data.content[0].deployments[0].executions[9]").exists())
-            .andExpect(jsonPath("$.data.content[0].deployments[0].executions[10]").doesNotExist());
+  @Test
+  public void testCallPagination(String jobName, String username) throws Exception {
+    for (int i = 0; i < 15; i++) {
+      createDataJobExecution(UUID.randomUUID().toString(), jobName, OffsetDateTime.now());
+    }
+    // Query pagination is set to 10 items per page.
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(JOBS_URI)
+                .queryParam("query", getQuery(jobName, "DESC"))
+                .with(user(username)))
+        .andExpect(status().is(200))
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.data.content[0].deployments[0].executions[0]").exists())
+        .andExpect(jsonPath("$.data.content[0].deployments[0].executions[9]").exists())
+        .andExpect(jsonPath("$.data.content[0].deployments[0].executions[10]").doesNotExist());
+  }
 
-   }
+  private void createDataJobExecution(String executionId, String jobName, OffsetDateTime endTime) {
 
-   private void createDataJobExecution(
-         String executionId,
-         String jobName,
-         OffsetDateTime endTime) {
-
-      DataJob dataJob = jobsRepository.findById(jobName).get();
-      var jobExecution = DataJobExecution.builder()
+    DataJob dataJob = jobsRepository.findById(jobName).get();
+    var jobExecution =
+        DataJobExecution.builder()
             .id(executionId)
             .dataJob(dataJob)
             .startTime(OffsetDateTime.now())
@@ -177,6 +198,6 @@ public class GraphQLJobExecutionsSortByEndTimeIT extends BaseDataJobDeploymentIT
             .vdkVersion("test_vdk_version")
             .build();
 
-      jobExecutionRepository.save(jobExecution);
-   }
+    jobExecutionRepository.save(jobExecution);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/ServiceApp.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/ServiceApp.java
@@ -10,19 +10,17 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.web.client.RestTemplate;
 
-/**
- * Utility class for easier application startup from Intellij Idea
- */
+/** Utility class for easier application startup from Intellij Idea */
 @EnableAsync
 @SpringBootApplication
 public class ServiceApp {
 
-   @Bean
-   public RestTemplate restTemplate() {
-      return new RestTemplate();
-   }
+  @Bean
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
 
-   public static void main(String[] args) {
-      ControlplaneApplication.main(args);
-   }
+  public static void main(String[] args) {
+    ControlplaneApplication.main(args);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/ServiceAppPropNames.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/ServiceAppPropNames.java
@@ -6,5 +6,5 @@
 package com.vmware.taurus;
 
 public class ServiceAppPropNames {
-    public static final String CREDENTIALS_REPOSITORY_TYPE = "credentials.repository";
+  public static final String CREDENTIALS_REPOSITORY_TYPE = "credentials.repository";
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/AuthorizationInterceptor.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/AuthorizationInterceptor.java
@@ -23,61 +23,62 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-
 /**
  * Intercept before any method invocation.
- * <p>
- * If a service does not need authorization it can be disabled with feature flag:
- * featureflag.authorization.disabled=true
- * </p>
- * 1. If the HTTP method is GET - allowed if the user is authenticated
- * 2. Other methods create {@link AuthorizationBody} and delegate authorization decision to {@link AuthorizationWebHookProvider}
+ *
+ * <p>If a service does not need authorization it can be disabled with feature flag:
+ * featureflag.authorization.disabled=true 1. If the HTTP method is GET - allowed if the user is
+ * authenticated 2. Other methods create {@link AuthorizationBody} and delegate authorization
+ * decision to {@link AuthorizationWebHookProvider}
  */
 @Component
 @RequiredArgsConstructor
 public class AuthorizationInterceptor implements HandlerInterceptor {
 
-    private static Logger log = LoggerFactory.getLogger(AuthorizationInterceptor.class);
+  private static Logger log = LoggerFactory.getLogger(AuthorizationInterceptor.class);
 
-    private final FeatureFlags featureFlags;
+  private final FeatureFlags featureFlags;
 
-    private final AuthorizationWebHookProvider webhookProvider;
+  private final AuthorizationWebHookProvider webhookProvider;
 
-    private final AuthorizationProvider authorizationProvider;
+  private final AuthorizationProvider authorizationProvider;
 
-    private final OperationContext opCtx;
+  private final OperationContext opCtx;
 
-    @Override
-    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) throws IOException {
-        if (featureFlags.isSecurityEnabled()) {
-            Authentication authentication =
-                    SecurityContextHolder
-                            .getContext()
-                            .getAuthentication();
-            if (authentication != null && authentication.isAuthenticated()) {
-                AuthorizationBody body = authorizationProvider.createAuthorizationBody(request, authentication);
-                updateOperationContext(body);
-                if (featureFlags.isAuthorizationEnabled()) {
-                    return isRequestAuthorized(request, response, body);
-                }
-            }
-            // If we are at this stage - either we are authenticated or authentication is disabled for that endpoint
-            return true;
+  @Override
+  public boolean preHandle(
+      final HttpServletRequest request, final HttpServletResponse response, final Object handler)
+      throws IOException {
+    if (featureFlags.isSecurityEnabled()) {
+      Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+      if (authentication != null && authentication.isAuthenticated()) {
+        AuthorizationBody body =
+            authorizationProvider.createAuthorizationBody(request, authentication);
+        updateOperationContext(body);
+        if (featureFlags.isAuthorizationEnabled()) {
+          return isRequestAuthorized(request, response, body);
         }
-        return true;
+      }
+      // If we are at this stage - either we are authenticated or authentication is disabled for
+      // that endpoint
+      return true;
     }
+    return true;
+  }
 
-    private boolean isRequestAuthorized(HttpServletRequest request, HttpServletResponse response, AuthorizationBody body) throws IOException {
-        WebHookResult decision = this.webhookProvider.invokeWebHook(body).get();
-        response.setStatus(decision.getStatus().value());
-        if (!decision.getMessage().isBlank()) {
-            response.getWriter().write(decision.getMessage());
-        }
-        return decision.isSuccess();
+  private boolean isRequestAuthorized(
+      HttpServletRequest request, HttpServletResponse response, AuthorizationBody body)
+      throws IOException {
+    WebHookResult decision = this.webhookProvider.invokeWebHook(body).get();
+    response.setStatus(decision.getStatus().value());
+    if (!decision.getMessage().isBlank()) {
+      response.getWriter().write(decision.getMessage());
     }
+    return decision.isSuccess();
+  }
 
-    private void updateOperationContext(AuthorizationBody body) {
-        opCtx.setUser(body.getRequesterUserId());
-        opCtx.setTeam(body.getRequestedResourceTeam());
-    }
+  private void updateOperationContext(AuthorizationBody body) {
+    opCtx.setUser(body.getRequesterUserId());
+    opCtx.setTeam(body.getRequestedResourceTeam());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/config/InterceptorConfig.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/config/InterceptorConfig.java
@@ -15,18 +15,14 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class InterceptorConfig implements WebMvcConfigurer {
 
-    @Autowired
-    private RequestInterceptor requestInterceptor;
+  @Autowired private RequestInterceptor requestInterceptor;
 
-    @Autowired
-    private AuthorizationInterceptor authorizationInterceptor;
+  @Autowired private AuthorizationInterceptor authorizationInterceptor;
 
-    @Override
-    public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(requestInterceptor)
-                .addPathPatterns("/**/");
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(requestInterceptor).addPathPatterns("/**/");
 
-        registry.addInterceptor(authorizationInterceptor)
-                .addPathPatterns("/**/");
-    }
+    registry.addInterceptor(authorizationInterceptor).addPathPatterns("/**/");
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/provider/AuthorizationProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/provider/AuthorizationProvider.java
@@ -21,104 +21,109 @@ import javax.servlet.http.HttpServletRequest;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
 
-
 /**
- * AuthorizationProvider class used in {@link AuthorizationInterceptor} responsible for handling
- * of the creation of {@link AuthorizationBody} for the {@link AuthorizationWebHookProvider}
+ * AuthorizationProvider class used in {@link AuthorizationInterceptor} responsible for handling of
+ * the creation of {@link AuthorizationBody} for the {@link AuthorizationWebHookProvider}
  */
 @Component
 public class AuthorizationProvider {
 
-    // TODO: instead of using those indexes to split path, introduce regex utility class
-    private static final int JOB_NAME_INDEX = 5;
+  // TODO: instead of using those indexes to split path, introduce regex utility class
+  private static final int JOB_NAME_INDEX = 5;
 
-    private static final int NEW_TEAM_NAME_INDEX = 7;
+  private static final int NEW_TEAM_NAME_INDEX = 7;
 
-    private static final int TEAM_NAME_INDEX = 3;
+  private static final int TEAM_NAME_INDEX = 3;
 
-    @Value("${datajobs.authorization.jwt.claim.username}")
-    private String usernameField;
+  @Value("${datajobs.authorization.jwt.claim.username}")
+  private String usernameField;
 
-    private static final String TEAM_PARAMETER_NAME = "team";
+  private static final String TEAM_PARAMETER_NAME = "team";
 
-    private static final String JOB_NAME_PARAMETER = "name";
+  private static final String JOB_NAME_PARAMETER = "name";
 
-    private final JobsRepository jobsRepository;
+  private final JobsRepository jobsRepository;
 
-    @Autowired
-    public AuthorizationProvider(JobsRepository jobsRepository){
-        this.jobsRepository = jobsRepository;
+  @Autowired
+  public AuthorizationProvider(JobsRepository jobsRepository) {
+    this.jobsRepository = jobsRepository;
+  }
+
+  /**
+   * Extracts necessary information out of HTTP Request and currently authenticated users and return
+   * AuthorizationBody which can be used to make Authorization decisions.
+   */
+  public AuthorizationBody createAuthorizationBody(
+      HttpServletRequest request, Authentication authentication) {
+    AuthorizationBody body = new AuthorizationBody();
+    var jobTeam = getJobTeam(request);
+    var jobNewTeam = getJobNewTeam(request, jobTeam);
+    body.setRequesterUserId(getUserId(authentication));
+    body.setRequestedResourceTeam(jobTeam);
+    body.setRequestedResourceName("data-job");
+    body.setRequestedResourceId(getJobName(request));
+    body.setRequestedPermission(request.getMethod().equalsIgnoreCase("GET") ? "read" : "write");
+    body.setRequestedHttpPath(request.getRequestURI());
+    body.setRequestedHttpVerb(request.getMethod().toUpperCase());
+    body.setRequestedResourceNewTeam(jobNewTeam);
+
+    return body;
+  }
+
+  public String getUserId(Authentication authentication) {
+    if (authentication instanceof JwtAuthenticationToken) {
+      JwtAuthenticationToken oauthToken = (JwtAuthenticationToken) authentication;
+      return oauthToken.getTokenAttributes().get(usernameField).toString();
+    } else {
+      var principal = authentication.getPrincipal();
+      if (principal instanceof UserDetails) {
+        return ((UserDetails) principal).getUsername();
+      } else {
+        return principal.toString();
+      }
     }
+  }
 
-    /**
-     * Extracts necessary information out of HTTP Request and currently authenticated users and return
-     * AuthorizationBody which can be used to make Authorization decisions.
-     */
-    public AuthorizationBody createAuthorizationBody(HttpServletRequest request, Authentication authentication){
-        AuthorizationBody body = new AuthorizationBody();
-        var jobTeam = getJobTeam(request);
-        var jobNewTeam = getJobNewTeam(request, jobTeam);
-        body.setRequesterUserId(getUserId(authentication));
-        body.setRequestedResourceTeam(jobTeam);
-        body.setRequestedResourceName("data-job");
-        body.setRequestedResourceId(getJobName(request));
-        body.setRequestedPermission(request.getMethod().equalsIgnoreCase("GET") ? "read" : "write");
-        body.setRequestedHttpPath(request.getRequestURI());
-        body.setRequestedHttpVerb(request.getMethod().toUpperCase());
-        body.setRequestedResourceNewTeam(jobNewTeam);
-
-        return body;
+  String parsePropertyFromURI(String contextPath, String fullPath, int index) {
+    String uri = URLDecoder.decode(fullPath, Charset.defaultCharset());
+    if (!StringUtils.isBlank(contextPath)) {
+      uri = fullPath.replaceFirst("^" + contextPath, "");
     }
-
-    public String getUserId(Authentication authentication) {
-        if (authentication instanceof JwtAuthenticationToken) {
-            JwtAuthenticationToken oauthToken = (JwtAuthenticationToken) authentication;
-            return oauthToken.getTokenAttributes().get(usernameField).toString();
-        } else {
-            var principal = authentication.getPrincipal();
-            if (principal instanceof UserDetails) {
-                return ((UserDetails)principal).getUsername();
-            } else {
-                return principal.toString();
-            }
-        }
+    var paths = uri.split("/");
+    try {
+      var newTeamName = paths[index];
+      return newTeamName;
+    } catch (ArrayIndexOutOfBoundsException e) {
+      return "";
     }
+  }
 
-    String parsePropertyFromURI(String contextPath, String fullPath, int index) {
-        String uri = URLDecoder.decode(fullPath, Charset.defaultCharset());
-        if (!StringUtils.isBlank(contextPath)) {
-            uri = fullPath.replaceFirst("^" + contextPath,"");
-        }
-        var paths = uri.split("/");
-        try {
-            var newTeamName = paths[index];
-            return newTeamName;
-        } catch (ArrayIndexOutOfBoundsException e) {
-            return "";
-        }
-    }
+  String getJobTeam(HttpServletRequest request) {
+    return this.parsePropertyFromURI(
+        request.getContextPath(), request.getRequestURI(), TEAM_NAME_INDEX);
+  }
 
-    String getJobTeam(HttpServletRequest request) {
-        return this.parsePropertyFromURI(request.getContextPath(), request.getRequestURI(), TEAM_NAME_INDEX);
+  String getJobNewTeam(HttpServletRequest request, String existingTeam) {
+    String jobNewTeam =
+        this.parsePropertyFromURI(
+            request.getContextPath(), request.getRequestURI(), NEW_TEAM_NAME_INDEX);
+    if (jobNewTeam.isBlank()) {
+      return existingTeam;
     }
+    return jobNewTeam;
+  }
 
-    String getJobNewTeam(HttpServletRequest request, String existingTeam) {
-        String jobNewTeam = this.parsePropertyFromURI(request.getContextPath(), request.getRequestURI(), NEW_TEAM_NAME_INDEX);
-        if (jobNewTeam.isBlank()){
-            return existingTeam;
-        }
-        return jobNewTeam;
+  String getJobName(HttpServletRequest request) {
+    var jobName = request.getParameter(JOB_NAME_PARAMETER);
+    if (jobName != null) {
+      return jobName;
     }
-
-    String getJobName(HttpServletRequest request){
-        var jobName = request.getParameter(JOB_NAME_PARAMETER);
-        if (jobName != null){
-            return jobName;
-        }
-        jobName = this.parsePropertyFromURI(request.getContextPath(), request.getRequestURI(), JOB_NAME_INDEX);
-        if (!jobName.isBlank()){
-            return jobName;
-        }
-        return "";
+    jobName =
+        this.parsePropertyFromURI(
+            request.getContextPath(), request.getRequestURI(), JOB_NAME_INDEX);
+    if (!jobName.isBlank()) {
+      return jobName;
     }
+    return "";
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/webhook/AuthorizationBody.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/webhook/AuthorizationBody.java
@@ -12,22 +12,20 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.SneakyThrows;
 
-/**
- * AuthorizationBody class which defines the request body for the authorization webhook
- */
+/** AuthorizationBody class which defines the request body for the authorization webhook */
 @Data
-@EqualsAndHashCode(callSuper=true)
+@EqualsAndHashCode(callSuper = true)
 public class AuthorizationBody extends WebHookRequestBody {
 
-    @JsonProperty(REQUESTED_PERMISSION)
-    private String requestedPermission;
+  @JsonProperty(REQUESTED_PERMISSION)
+  private String requestedPermission;
 
-    private static final String REQUESTED_PERMISSION = "requested_permission";
+  private static final String REQUESTED_PERMISSION = "requested_permission";
 
-    @SneakyThrows
-    public String toString(){
-        ObjectMapper mapper = new ObjectMapper();
-        String jsonBody = mapper.writeValueAsString(this);
-        return jsonBody;
-    }
+  @SneakyThrows
+  public String toString() {
+    ObjectMapper mapper = new ObjectMapper();
+    String jsonBody = mapper.writeValueAsString(this);
+    return jsonBody;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/webhook/AuthorizationWebHookProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/webhook/AuthorizationWebHookProvider.java
@@ -19,42 +19,40 @@ import org.springframework.stereotype.Service;
 /**
  * AuthorizationWebhookProvider class which delegates authorization request to a third party webhook
  * authorization server.
- * <p>
- * Uses a single method {@link WebHookService#invokeWebHook(WebHookRequestBody)}
- * which triggers a webhook to the actual authorization server to determine whether a user is authorized
- * or not by creating {@link WebHookResult} which is then provided to {@link AuthorizationInterceptor}
- * </p>
+ *
+ * <p>Uses a single method {@link WebHookService#invokeWebHook(WebHookRequestBody)} which triggers a
+ * webhook to the actual authorization server to determine whether a user is authorized or not by
+ * creating {@link WebHookResult} which is then provided to {@link AuthorizationInterceptor}
  */
 @Service
 @Slf4j
-public class AuthorizationWebHookProvider extends WebHookService<AuthorizationBody>  {
+public class AuthorizationWebHookProvider extends WebHookService<AuthorizationBody> {
 
-    public AuthorizationWebHookProvider(@Value("${datajobs.authorization.webhook.endpoint}")
-                                                String webHookEndpoint,
-                                        @Value("${datajobs.authorization.webhook.internal.errors.retries:1}")
-                                                int retriesOn5xxErrors) {
-        super(webHookEndpoint, retriesOn5xxErrors, log);
-    }
+  public AuthorizationWebHookProvider(
+      @Value("${datajobs.authorization.webhook.endpoint}") String webHookEndpoint,
+      @Value("${datajobs.authorization.webhook.internal.errors.retries:1}")
+          int retriesOn5xxErrors) {
+    super(webHookEndpoint, retriesOn5xxErrors, log);
+  }
 
-    @Override
-    public void ensureConfigured() {
-        if (StringUtils.isBlank(getWebHookEndpoint())) {
-            throw new AuthorizationError(
-                    "Authorization webhook endpoint is not configured",
-                    "Cannot determine whether a user is authorized to do this request",
-                    "Configure the authorization webhook property or disable the feature altogether",
-                    null
-            );
-        }
+  @Override
+  public void ensureConfigured() {
+    if (StringUtils.isBlank(getWebHookEndpoint())) {
+      throw new AuthorizationError(
+          "Authorization webhook endpoint is not configured",
+          "Cannot determine whether a user is authorized to do this request",
+          "Configure the authorization webhook property or disable the feature altogether",
+          null);
     }
+  }
 
-    @Override
-    protected String getWebHookRequestURL(AuthorizationBody webHookRequestBody) {
-        return getWebHookEndpoint();
-    }
+  @Override
+  protected String getWebHookRequestURL(AuthorizationBody webHookRequestBody) {
+    return getWebHookEndpoint();
+  }
 
-    @Override
-    public ExternalSystemError.MainExternalSystem getExternalSystemType() {
-        return ExternalSystemError.MainExternalSystem.AUTHORIZATION_SERVER;
-    }
+  @Override
+  public ExternalSystemError.MainExternalSystem getExternalSystemType() {
+    return ExternalSystemError.MainExternalSystem.AUTHORIZATION_SERVER;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsController.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsController.java
@@ -5,7 +5,6 @@
 
 package com.vmware.taurus.datajobs;
 
-
 import com.vmware.taurus.controlplane.model.api.DataJobsApi;
 import com.vmware.taurus.controlplane.model.data.DataJob;
 import com.vmware.taurus.controlplane.model.data.DataJobQueryResponse;
@@ -40,222 +39,234 @@ import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-
 /**
  * REST controller for operations on data jobs
  *
- * <p>
- * The controller may throw exception which will be handled by
- * {@link com.vmware.taurus.exception.ExceptionControllerAdvice}. The advice class logs error so no need to log them here.
+ * <p>The controller may throw exception which will be handled by {@link
+ * com.vmware.taurus.exception.ExceptionControllerAdvice}. The advice class logs error so no need to
+ * log them here.
  *
- * <p>
- * Wrap {@link org.springframework.dao.DataAccessException} from JobsService in {@link ExternalSystemError} either here
- * or in the service itself.
- *
+ * <p>Wrap {@link org.springframework.dao.DataAccessException} from JobsService in {@link
+ * ExternalSystemError} either here or in the service itself.
  */
 @RestController
 @AllArgsConstructor
 @NoArgsConstructor
 @Api(tags = {"Data Jobs"})
 public class DataJobsController implements DataJobsApi {
-   static Logger log = LoggerFactory.getLogger(DataJobsController.class);
+  static Logger log = LoggerFactory.getLogger(DataJobsController.class);
 
-   @Autowired
-   private JobsService jobsService;
+  @Autowired private JobsService jobsService;
 
-   @Autowired
-   private JobCredentialsService jobCredentialsService;
+  @Autowired private JobCredentialsService jobCredentialsService;
 
-   @Autowired
-   private JobUpload jobUpload;
+  @Autowired private JobUpload jobUpload;
 
-   @Autowired
-   private GraphQLJobsQueryService graphQLService;
+  @Autowired private GraphQLJobsQueryService graphQLService;
 
-   // modified in unit tests
-   private Supplier<UriBuilder> currentContextPathBuilderSupplier = ServletUriComponentsBuilder::fromCurrentContextPath;
+  // modified in unit tests
+  private Supplier<UriBuilder> currentContextPathBuilderSupplier =
+      ServletUriComponentsBuilder::fromCurrentContextPath;
 
-   @Override
-   public ResponseEntity<Void> dataJobCreate(String teamName, DataJob dataJob, String jobName) {
-      if (dataJob.getJobName() == null) {
-         throw new ApiConstraintError("dataJob.jobName",
-                 "missing or malformed data job name", dataJob.getJobName());
-      } else if (!dataJob.getJobName().matches("^[a-z][a-z0-9-]{5,49}$")) {
-         throw new ApiConstraintError("dataJob.jobName",
-                 "starting with lowercase letter, only lowercase alphanumeric characters or dash and between 6 and 50 characters",
-                 dataJob.getJobName());
-      }
+  @Override
+  public ResponseEntity<Void> dataJobCreate(String teamName, DataJob dataJob, String jobName) {
+    if (dataJob.getJobName() == null) {
+      throw new ApiConstraintError(
+          "dataJob.jobName", "missing or malformed data job name", dataJob.getJobName());
+    } else if (!dataJob.getJobName().matches("^[a-z][a-z0-9-]{5,49}$")) {
+      throw new ApiConstraintError(
+          "dataJob.jobName",
+          "starting with lowercase letter, only lowercase alphanumeric characters or dash and"
+              + " between 6 and 50 characters",
+          dataJob.getJobName());
+    }
 
-      if (StringUtils.isNotBlank(jobName) && !jobName.equals(dataJob.getJobName())) {
-         throw new ApiConstraintError("dataJob.jobName",
-                 "the same as the name in the request URL query parameter", dataJob.getJobName());
-      }
+    if (StringUtils.isNotBlank(jobName) && !jobName.equals(dataJob.getJobName())) {
+      throw new ApiConstraintError(
+          "dataJob.jobName",
+          "the same as the name in the request URL query parameter",
+          dataJob.getJobName());
+    }
 
-      if (StringUtils.isBlank(teamName)) {
-         throw new ApiConstraintError("team",
-                 "in path should not be blank", dataJob.getTeam());
-      } else if (StringUtils.isNotBlank(teamName) && dataJob.getTeam() == null) {
-         dataJob.setTeam(teamName);
-      }else if (StringUtils.isNotBlank(teamName) && !teamName.equals(dataJob.getTeam())) {
-         throw new ApiConstraintError("dataJob.team",
-                 "the same as the team name in the request URL query parameter", dataJob.getTeam());
-      }
+    if (StringUtils.isBlank(teamName)) {
+      throw new ApiConstraintError("team", "in path should not be blank", dataJob.getTeam());
+    } else if (StringUtils.isNotBlank(teamName) && dataJob.getTeam() == null) {
+      dataJob.setTeam(teamName);
+    } else if (StringUtils.isNotBlank(teamName) && !teamName.equals(dataJob.getTeam())) {
+      throw new ApiConstraintError(
+          "dataJob.team",
+          "the same as the team name in the request URL query parameter",
+          dataJob.getTeam());
+    }
 
-      var apiJob = ToModelApiConverter.toDataJob(dataJob);
-      var operationResult = jobsService.createJob(apiJob);
+    var apiJob = ToModelApiConverter.toDataJob(dataJob);
+    var operationResult = jobsService.createJob(apiJob);
+    if (webHookResultExists(operationResult)) {
+      propagateWebHookResult("Create", operationResult);
+    }
+    if (operationResult.isCompleted()) {
+      String contextPath =
+          String.format("/data-jobs/for-team/%s/jobs/%s", dataJob.getTeam(), dataJob.getJobName());
+      URI location = currentContextPathBuilderSupplier.get().path(contextPath).build();
+      return ResponseEntity.created(location).build();
+    } else {
+      // Mob consensus is for responding 409 Conflict when creating with existing ID:
+      // https://stackoverflow.com/questions/3825990/http-response-code-for-post-when-resource-already-exists
+      return ResponseEntity.status(HttpStatus.CONFLICT).build();
+    }
+  }
+
+  @Override
+  public ResponseEntity<Void> dataJobDelete(String teamName, String jobName) {
+    if (jobsService.jobWithTeamExists(jobName, teamName)) {
+      var operationResult = jobsService.deleteJob(jobName);
+      jobUpload.deleteDataJob(
+          jobName,
+          String.format("Source deleted automatically upon a data job: %s deletion", jobName));
       if (webHookResultExists(operationResult)) {
-         propagateWebHookResult("Create", operationResult);
+        return propagateWebHookResult("Delete", operationResult);
       }
       if (operationResult.isCompleted()) {
-         String contextPath = String.format("/data-jobs/for-team/%s/jobs/%s", dataJob.getTeam(), dataJob.getJobName());
-         URI location = currentContextPathBuilderSupplier.get().path(contextPath).build();
-         return ResponseEntity.created(location).build();
+        return ResponseEntity.ok().build();
+      }
+      return ResponseEntity.notFound().build();
+    }
+    return ResponseEntity.notFound().build();
+  }
+
+  @Override
+  public ResponseEntity<Resource> dataJobKeytabDownload(String teamName, String jobName) {
+    if (jobsService.jobWithTeamExists(jobName, teamName)) {
+      byte[] keytab = jobCredentialsService.readJobCredential(jobName);
+      if (keytab != null) {
+        return ResponseEntity.ok(new ByteArrayResource(keytab));
+      }
+    }
+    return ResponseEntity.notFound().build();
+  }
+
+  @Override
+  public ResponseEntity<DataJob> dataJobRead(String teamName, String jobName) {
+    if (jobsService.jobWithTeamExists(jobName, teamName)) {
+      var job = jobsService.getByName(jobName.toLowerCase());
+      if (job.isPresent()) {
+        return ResponseEntity.ok(ToApiModelConverter.toDataJob(job.get()));
+      }
+    }
+    return ResponseEntity.notFound().build();
+  }
+
+  @Override
+  public ResponseEntity<Void> dataJobTeamUpdate(
+      String teamName, String newTeamName, String jobName) {
+    if (jobsService.jobWithTeamExists(jobName, teamName)) {
+      if (StringUtils.isNotBlank(newTeamName)) {
+        var job = jobsService.getByName(jobName.toLowerCase());
+        if (job.isPresent()) {
+          job.get().getJobConfig().setTeam(newTeamName);
+          jobsService.updateJob(job.get());
+          return ResponseEntity.ok().build();
+        } else {
+          return ResponseEntity.notFound().build();
+        }
+      }
+    }
+    return ResponseEntity.notFound().build();
+  }
+
+  @Override
+  public ResponseEntity<Void> dataJobUpdate(String teamName, String jobName, DataJob dataJob) {
+    if (jobsService.jobWithTeamExists(jobName, teamName)) {
+      // TODO: maybe we can remove job name form PUT request body (thus eliminating the chance of an
+      // error).
+      if (!jobName.equals(dataJob.getJobName())) {
+        throw new ApiConstraintError(
+            "dataJob.jobName", "the same as the name in the PUT request URL", dataJob.getJobName());
+      }
+      var existingJob = jobsService.getByName(jobName.toLowerCase());
+      if (existingJob.isPresent()) {
+        if (dataJob.getTeam() != null) {
+          if (!existingJob.get().getJobConfig().getTeam().equals(dataJob.getTeam())) {
+            throw new ApiConstraintError(
+                "dataJob.team",
+                " '"
+                    + existingJob.get().getJobConfig().getTeam()
+                    + "' as the team of an existing job cannot be changed through this API",
+                dataJob.getTeam(),
+                "set the team to the correct value, "
+                    + "or if you want to change the job's team, use the UpdateJobTeam API.");
+          }
+        }
+        dataJob.setTeam(teamName);
+        jobsService.updateJob(ToModelApiConverter.toDataJob(dataJob));
+        return ResponseEntity.ok().build();
       } else {
-         // Mob consensus is for responding 409 Conflict when creating with existing ID:
-         // https://stackoverflow.com/questions/3825990/http-response-code-for-post-when-resource-already-exists
-         return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        return ResponseEntity.notFound().build();
       }
-   }
+    }
+    return ResponseEntity.notFound().build();
+  }
 
-   @Override
-   public ResponseEntity<Void> dataJobDelete(String teamName, String jobName) {
-      if (jobsService.jobWithTeamExists(jobName, teamName)) {
-         var operationResult = jobsService.deleteJob(jobName);
-         jobUpload.deleteDataJob(jobName,
-                 String.format("Source deleted automatically upon a data job: %s deletion", jobName));
-         if (webHookResultExists(operationResult)) {
-            return propagateWebHookResult("Delete", operationResult);
-         }
-         if (operationResult.isCompleted()) {
-            return ResponseEntity.ok().build();
-         }
-         return ResponseEntity.notFound().build();
-      }
-      return ResponseEntity.notFound().build();
-   }
+  @Override
+  @Deprecated
+  public ResponseEntity<List<DataJobSummary>> jobsList(
+      String teamName, Boolean includeAllTeams, Integer pageNumber, Integer pageSize) {
+    if (pageSize < 1 || pageSize > 100) {
+      throw new ApiConstraintError("page_size", "between 0 and 100 inclusive", pageSize);
+    }
 
-   @Override
-   public ResponseEntity<Resource> dataJobKeytabDownload(String teamName, String jobName) {
-      if (jobsService.jobWithTeamExists(jobName, teamName)) {
-         byte[] keytab = jobCredentialsService.readJobCredential(jobName);
-         if (keytab != null) {
-            return ResponseEntity.ok(new ByteArrayResource(keytab));
-         }
-      }
-      return ResponseEntity.notFound().build();
-   }
+    if (pageNumber < 0) {
+      throw new ApiConstraintError("page_number", "0 or larger", pageNumber);
+    }
 
-   @Override
-   public ResponseEntity<DataJob> dataJobRead(String teamName, String jobName) {
-      if (jobsService.jobWithTeamExists(jobName, teamName)) {
-         var job = jobsService.getByName(jobName.toLowerCase());
-         if (job.isPresent()) {
-            return ResponseEntity.ok(ToApiModelConverter.toDataJob(job.get()));
-         }
-      }
-      return ResponseEntity.notFound().build();
-   }
+    List<DataJobSummary> result = new ArrayList<>();
 
-   @Override
-   public ResponseEntity<Void> dataJobTeamUpdate(String teamName, String newTeamName, String jobName) {
-      if (jobsService.jobWithTeamExists(jobName, teamName)) {
-         if (StringUtils.isNotBlank(newTeamName)) {
-            var job = jobsService.getByName(jobName.toLowerCase());
-            if (job.isPresent()) {
-               job.get().getJobConfig().setTeam(newTeamName);
-               jobsService.updateJob(job.get());
-               return ResponseEntity.ok().build();
-            } else {
-               return ResponseEntity.notFound().build();
-            }
-         }
-      }
-      return ResponseEntity.notFound().build();
-   }
+    if (Boolean.TRUE.equals(includeAllTeams)) {
+      var jobStream = jobsService.getAllJobs(pageNumber, pageSize).stream();
+      result = jobStream.map(ToApiModelConverter::toDataJobSummary).collect(Collectors.toList());
+    } else if (StringUtils.isNotBlank(teamName)) {
+      var jobStream = jobsService.getTeamJobs(pageNumber, pageSize, teamName).stream();
+      result = jobStream.map(ToApiModelConverter::toDataJobSummary).collect(Collectors.toList());
+    }
 
-   @Override
-   public ResponseEntity<Void> dataJobUpdate(String teamName, String jobName, DataJob dataJob) {
-      if (jobsService.jobWithTeamExists(jobName, teamName)) {
-         // TODO: maybe we can remove job name form PUT request body (thus eliminating the chance of an error).
-         if (!jobName.equals(dataJob.getJobName())) {
-            throw new ApiConstraintError("dataJob.jobName", "the same as the name in the PUT request URL", dataJob.getJobName());
-         }
-         var existingJob = jobsService.getByName(jobName.toLowerCase());
-         if (existingJob.isPresent()) {
-            if (dataJob.getTeam() != null) {
-               if (!existingJob.get().getJobConfig().getTeam().equals(dataJob.getTeam())) {
-                  throw new ApiConstraintError("dataJob.team",
-                          " '" + existingJob.get().getJobConfig().getTeam()
-                                  + "' as the team of an existing job cannot be changed through this API", dataJob.getTeam(),
-                          "set the team to the correct value, " +
-                                  "or if you want to change the job's team, use the UpdateJobTeam API.");
-               }
-            }
-            dataJob.setTeam(teamName);
-            jobsService.updateJob(ToModelApiConverter.toDataJob(dataJob));
-            return ResponseEntity.ok().build();
-         } else {
-            return ResponseEntity.notFound().build();
-         }
-      }
-      return ResponseEntity.notFound().build();
-   }
+    return ResponseEntity.ok(result);
+  }
 
-   @Override
-   @Deprecated
-   public ResponseEntity<List<DataJobSummary>> jobsList(String teamName, Boolean includeAllTeams, Integer pageNumber, Integer pageSize) {
-      if (pageSize < 1 || pageSize > 100) {
-         throw new ApiConstraintError("page_size", "between 0 and 100 inclusive", pageSize);
-      }
+  @Override
+  public ResponseEntity<DataJobQueryResponse> jobsQuery(
+      String teamName, String query, String operationName, String variables) {
+    if (query == null) {
+      query = GraphQLJobsQueryService.DEFAULT_QUERY;
+    }
 
-      if (pageNumber < 0) {
-         throw new ApiConstraintError("page_number", "0 or larger", pageNumber);
-      }
-
-      List<DataJobSummary> result = new ArrayList<>();
-
-      if (Boolean.TRUE.equals(includeAllTeams)) {
-         var jobStream = jobsService.getAllJobs(pageNumber, pageSize).stream();
-         result = jobStream.map(ToApiModelConverter::toDataJobSummary).collect(Collectors.toList());
-      } else if (StringUtils.isNotBlank(teamName)) {
-         var jobStream = jobsService.getTeamJobs(pageNumber, pageSize, teamName).stream();
-         result = jobStream.map(ToApiModelConverter::toDataJobSummary).collect(Collectors.toList());
-      }
-
-      return ResponseEntity.ok(result);
-   }
-
-   @Override
-   public ResponseEntity<DataJobQueryResponse> jobsQuery(String teamName, String query, String operationName, String variables) {
-      if(query == null) {
-         query = GraphQLJobsQueryService.DEFAULT_QUERY;
-      }
-
-      var executionResult = graphQLService.executeRequest(
+    var executionResult =
+        graphQLService.executeRequest(
             query, operationName, graphQLService.convertVariablesJson(variables));
-      var dataJobQueryResponse = ToApiModelConverter.toDataJobPage(executionResult);
+    var dataJobQueryResponse = ToApiModelConverter.toDataJobPage(executionResult);
 
-      return buildGraphQLResponseEntity(dataJobQueryResponse);
-   }
+    return buildGraphQLResponseEntity(dataJobQueryResponse);
+  }
 
-   private boolean webHookResultExists(JobOperationResult operationResult) {
-      return operationResult.getWebHookResult() != null;
-   }
+  private boolean webHookResultExists(JobOperationResult operationResult) {
+    return operationResult.getWebHookResult() != null;
+  }
 
-   private ResponseEntity<Void> propagateWebHookResult(String operationName,
-                                                       JobOperationResult operationResult) {
-      throw new WebHookRequestError(operationName,
-              operationResult.getWebHookResult().getMessage(),
-              operationResult.getWebHookResult().getStatus());
-   }
+  private ResponseEntity<Void> propagateWebHookResult(
+      String operationName, JobOperationResult operationResult) {
+    throw new WebHookRequestError(
+        operationName,
+        operationResult.getWebHookResult().getMessage(),
+        operationResult.getWebHookResult().getStatus());
+  }
 
-   private static ResponseEntity<DataJobQueryResponse> buildGraphQLResponseEntity(DataJobQueryResponse dataJobQueryResponse) {
-      if (dataJobQueryResponse == null) {
-         return ResponseEntity.badRequest().body(new DataJobQueryResponse());
-      }
-      List<Object> errors = dataJobQueryResponse.getErrors();
-      return (errors != null && errors.stream().anyMatch(GraphQLError.class::isInstance)) ?
-            ResponseEntity.badRequest().body(dataJobQueryResponse) :
-            ResponseEntity.ok(dataJobQueryResponse);
-   }
+  private static ResponseEntity<DataJobQueryResponse> buildGraphQLResponseEntity(
+      DataJobQueryResponse dataJobQueryResponse) {
+    if (dataJobQueryResponse == null) {
+      return ResponseEntity.badRequest().body(new DataJobQueryResponse());
+    }
+    List<Object> errors = dataJobQueryResponse.getErrors();
+    return (errors != null && errors.stream().anyMatch(GraphQLError.class::isInstance))
+        ? ResponseEntity.badRequest().body(dataJobQueryResponse)
+        : ResponseEntity.ok(dataJobQueryResponse);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsDeploymentController.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsDeploymentController.java
@@ -5,7 +5,6 @@
 
 package com.vmware.taurus.datajobs;
 
-
 import com.vmware.taurus.controlplane.model.api.DataJobsDeploymentApi;
 import com.vmware.taurus.controlplane.model.data.DataJobDeployment;
 import com.vmware.taurus.controlplane.model.data.DataJobDeploymentStatus;
@@ -29,102 +28,115 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-
 /**
  * REST controller for operations on data job deployments
  *
- * <p>
- * The controller may throw exception which will be handled by
- * {@link com.vmware.taurus.exception.ExceptionControllerAdvice}. The advice class logs error so no need to log them here.
+ * <p>The controller may throw exception which will be handled by {@link
+ * com.vmware.taurus.exception.ExceptionControllerAdvice}. The advice class logs error so no need to
+ * log them here.
  *
- * <p>
- * Wrap {@link org.springframework.dao.DataAccessException} from JobsService in {@link ExternalSystemError} either here
- * or in the service itself.
+ * <p>Wrap {@link org.springframework.dao.DataAccessException} from JobsService in {@link
+ * ExternalSystemError} either here or in the service itself.
  */
 @RestController
 @AllArgsConstructor
 @NoArgsConstructor
 @Api(tags = {"Data Jobs Deployment"})
 public class DataJobsDeploymentController implements DataJobsDeploymentApi {
-   static Logger log = LoggerFactory.getLogger(DataJobsDeploymentController.class);
+  static Logger log = LoggerFactory.getLogger(DataJobsDeploymentController.class);
 
-   @Autowired
-   private JobsService jobsService;
+  @Autowired private JobsService jobsService;
 
-   @Autowired
-   private DeploymentService deploymentService;
+  @Autowired private DeploymentService deploymentService;
 
-   @Autowired
-   private OperationContext operationContext;
+  @Autowired private OperationContext operationContext;
 
-   @Override
-   public ResponseEntity<Void> deploymentDelete(String teamName, String jobName, String deploymentId) {
-      if (jobsService.jobWithTeamExists(jobName, teamName)) {
-         // TODO: deploymentId not implemented
-         if (jobName != null) {
-            deploymentService.deleteDeployment(jobName);
-            return ResponseEntity.accepted().build();
-         }
-         return ResponseEntity.notFound().build();
+  @Override
+  public ResponseEntity<Void> deploymentDelete(
+      String teamName, String jobName, String deploymentId) {
+    if (jobsService.jobWithTeamExists(jobName, teamName)) {
+      // TODO: deploymentId not implemented
+      if (jobName != null) {
+        deploymentService.deleteDeployment(jobName);
+        return ResponseEntity.accepted().build();
       }
       return ResponseEntity.notFound().build();
-   }
+    }
+    return ResponseEntity.notFound().build();
+  }
 
+  @Override
+  public ResponseEntity<Void> deploymentPatch(
+      String teamName, String jobName, String deploymentId, DataJobDeployment dataJobDeployment) {
+    if (jobsService.jobWithTeamExists(jobName, teamName)) {
+      // TODO: deploymentId not implemented
+      Optional<com.vmware.taurus.service.model.DataJob> job = jobsService.getByName(jobName);
 
-   @Override
-   public ResponseEntity<Void> deploymentPatch(String teamName, String jobName, String deploymentId, DataJobDeployment dataJobDeployment) {
-      if (jobsService.jobWithTeamExists(jobName, teamName)) {
-         // TODO: deploymentId not implemented
-         Optional<com.vmware.taurus.service.model.DataJob> job = jobsService.getByName(jobName);
-
-         if (job.isPresent()) {
-            var jobDeployment = ToModelApiConverter.toJobDeployment(teamName, jobName, dataJobDeployment);
-            deploymentService.patchDeployment(job.get(), jobDeployment);
-            return ResponseEntity.accepted().build();
-         }
+      if (job.isPresent()) {
+        var jobDeployment =
+            ToModelApiConverter.toJobDeployment(teamName, jobName, dataJobDeployment);
+        deploymentService.patchDeployment(job.get(), jobDeployment);
+        return ResponseEntity.accepted().build();
       }
-      return ResponseEntity.notFound().build();
-   }
+    }
+    return ResponseEntity.notFound().build();
+  }
 
-   @Override
-   public ResponseEntity<List<DataJobDeploymentStatus>> deploymentList(String teamName, String jobName, String deploymentId, DataJobMode dataJobMode) {
-      if (jobsService.jobWithTeamExists(jobName, teamName)) {
-         // TODO: deploymentId and mode not implemented
-         List<DataJobDeploymentStatus> deployments = Collections.emptyList();
-         Optional<JobDeploymentStatus> jobDeploymentStatus = deploymentService.readDeployment(jobName.toLowerCase());
-         if (jobDeploymentStatus.isPresent()) {
-            deployments = Arrays.asList(ToApiModelConverter.toDataJobDeploymentStatus(jobDeploymentStatus.get()));
-         }
-         return ResponseEntity.ok(deployments);
+  @Override
+  public ResponseEntity<List<DataJobDeploymentStatus>> deploymentList(
+      String teamName, String jobName, String deploymentId, DataJobMode dataJobMode) {
+    if (jobsService.jobWithTeamExists(jobName, teamName)) {
+      // TODO: deploymentId and mode not implemented
+      List<DataJobDeploymentStatus> deployments = Collections.emptyList();
+      Optional<JobDeploymentStatus> jobDeploymentStatus =
+          deploymentService.readDeployment(jobName.toLowerCase());
+      if (jobDeploymentStatus.isPresent()) {
+        deployments =
+            Arrays.asList(ToApiModelConverter.toDataJobDeploymentStatus(jobDeploymentStatus.get()));
       }
-      return ResponseEntity.notFound().build();
-   }
+      return ResponseEntity.ok(deployments);
+    }
+    return ResponseEntity.notFound().build();
+  }
 
-   @Override
-   public ResponseEntity<DataJobDeploymentStatus> deploymentRead(String teamName, String jobName, String deploymentId) {
-      if (jobsService.jobWithTeamExists(jobName, teamName)) {
-         // TODO: deploymentId are not implemented.
-         Optional<JobDeploymentStatus> jobDeploymentStatus = deploymentService.readDeployment(jobName.toLowerCase());
-         if (jobDeploymentStatus.isPresent()) {
-            return ResponseEntity.ok(ToApiModelConverter.toDataJobDeploymentStatus(jobDeploymentStatus.get()));
-         }
+  @Override
+  public ResponseEntity<DataJobDeploymentStatus> deploymentRead(
+      String teamName, String jobName, String deploymentId) {
+    if (jobsService.jobWithTeamExists(jobName, teamName)) {
+      // TODO: deploymentId are not implemented.
+      Optional<JobDeploymentStatus> jobDeploymentStatus =
+          deploymentService.readDeployment(jobName.toLowerCase());
+      if (jobDeploymentStatus.isPresent()) {
+        return ResponseEntity.ok(
+            ToApiModelConverter.toDataJobDeploymentStatus(jobDeploymentStatus.get()));
       }
-      return ResponseEntity.notFound().build();
-   }
+    }
+    return ResponseEntity.notFound().build();
+  }
 
-   @Override
-   public ResponseEntity<Void> deploymentUpdate(String teamName, String jobName, Boolean sendNotification, DataJobDeployment dataJobDeployment) {
-      if (jobsService.jobWithTeamExists(jobName, teamName)) {
-         Optional<com.vmware.taurus.service.model.DataJob> job = jobsService.getByName(jobName.toLowerCase());
-         if (job.isPresent()) {
-            var jobDeployment = ToModelApiConverter.toJobDeployment(teamName, jobName.toLowerCase(), dataJobDeployment);
-            //TODO: Consider using a Task-oriented API approach
-            deploymentService.updateDeployment(job.get(), jobDeployment, sendNotification,
-                    operationContext.getUser(), operationContext.getOpId());
+  @Override
+  public ResponseEntity<Void> deploymentUpdate(
+      String teamName,
+      String jobName,
+      Boolean sendNotification,
+      DataJobDeployment dataJobDeployment) {
+    if (jobsService.jobWithTeamExists(jobName, teamName)) {
+      Optional<com.vmware.taurus.service.model.DataJob> job =
+          jobsService.getByName(jobName.toLowerCase());
+      if (job.isPresent()) {
+        var jobDeployment =
+            ToModelApiConverter.toJobDeployment(teamName, jobName.toLowerCase(), dataJobDeployment);
+        // TODO: Consider using a Task-oriented API approach
+        deploymentService.updateDeployment(
+            job.get(),
+            jobDeployment,
+            sendNotification,
+            operationContext.getUser(),
+            operationContext.getOpId());
 
-            return ResponseEntity.accepted().build();
-         }
+        return ResponseEntity.accepted().build();
       }
-      return ResponseEntity.notFound().build();
-   }
+    }
+    return ResponseEntity.notFound().build();
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsExecutionController.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsExecutionController.java
@@ -5,7 +5,6 @@
 
 package com.vmware.taurus.datajobs;
 
-
 import com.vmware.taurus.controlplane.model.api.DataJobsExecutionApi;
 import com.vmware.taurus.controlplane.model.data.DataJobExecution;
 import com.vmware.taurus.controlplane.model.data.DataJobExecutionLogs;
@@ -21,13 +20,11 @@ import org.springframework.web.util.UriBuilder;
 
 import java.net.URI;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Supplier;
 
-
 /**
- * REST controller for operations on data jobs for Execution API.
- * POC of Execution API is implemented.
+ * REST controller for operations on data jobs for Execution API. POC of Execution API is
+ * implemented.
  *
  * <p>
  *
@@ -38,63 +35,67 @@ import java.util.function.Supplier;
 @Api(tags = {"Data Jobs Execution"})
 public class DataJobsExecutionController implements DataJobsExecutionApi {
 
-   private final JobsService jobsService;
+  private final JobsService jobsService;
 
-   private final JobExecutionService executionService;
+  private final JobExecutionService executionService;
 
-   private final Supplier<UriBuilder> currentContextPathBuilderSupplier = ServletUriComponentsBuilder::fromCurrentContextPath;
+  private final Supplier<UriBuilder> currentContextPathBuilderSupplier =
+      ServletUriComponentsBuilder::fromCurrentContextPath;
 
-   @Override
-   public ResponseEntity<List<DataJobExecution>> dataJobDeploymentExecutionList(
-         String teamName,
-         String jobName,
-         String deploymentId,
-         List<String> executionStatus) {
-      // TODO: add support for deployment ID
-      return dataJobExecutionList(teamName, jobName, executionStatus);
-   }
+  @Override
+  public ResponseEntity<List<DataJobExecution>> dataJobDeploymentExecutionList(
+      String teamName, String jobName, String deploymentId, List<String> executionStatus) {
+    // TODO: add support for deployment ID
+    return dataJobExecutionList(teamName, jobName, executionStatus);
+  }
 
-   @Override
-   public ResponseEntity<List<DataJobExecution>> dataJobExecutionList(
-         String teamName,
-         String jobName,
-         List<String> executionStatus) {
+  @Override
+  public ResponseEntity<List<DataJobExecution>> dataJobExecutionList(
+      String teamName, String jobName, List<String> executionStatus) {
 
-      List<DataJobExecution> executions = executionService.listJobExecutions(teamName, jobName, executionStatus);
-      return ResponseEntity.ok(executions);
-   }
+    List<DataJobExecution> executions =
+        executionService.listJobExecutions(teamName, jobName, executionStatus);
+    return ResponseEntity.ok(executions);
+  }
 
-   @Override
-   public ResponseEntity<DataJobExecution> dataJobExecutionRead(String teamName, String jobName, String executionId) {
-      DataJobExecution dataJobExecution = executionService.readJobExecution(teamName, jobName, executionId);
-      return ResponseEntity.ok(dataJobExecution);
-   }
+  @Override
+  public ResponseEntity<DataJobExecution> dataJobExecutionRead(
+      String teamName, String jobName, String executionId) {
+    DataJobExecution dataJobExecution =
+        executionService.readJobExecution(teamName, jobName, executionId);
+    return ResponseEntity.ok(dataJobExecution);
+  }
 
-   @Override
-   public ResponseEntity<Void> dataJobExecutionCancel(String teamName, String jobName, String executionId) {
-      executionService.cancelDataJobExecution(teamName, jobName, executionId);
-      return ResponseEntity.ok().build();
-   }
+  @Override
+  public ResponseEntity<Void> dataJobExecutionCancel(
+      String teamName, String jobName, String executionId) {
+    executionService.cancelDataJobExecution(teamName, jobName, executionId);
+    return ResponseEntity.ok().build();
+  }
 
-   @Override
-   public ResponseEntity<Void> dataJobExecutionStart(
-         String teamName,
-         String jobName,
-         String deploymentId,
-         DataJobExecutionRequest jobExecutionRequest) {
+  @Override
+  public ResponseEntity<Void> dataJobExecutionStart(
+      String teamName,
+      String jobName,
+      String deploymentId,
+      DataJobExecutionRequest jobExecutionRequest) {
 
-      String executionId = executionService.startDataJobExecution(teamName, jobName, deploymentId, jobExecutionRequest);
-      String contextPath = String.format(
-            "/data-jobs/for-team/%s/jobs/%s/executions/%s",
-            teamName, jobName, executionId);
-      URI location = currentContextPathBuilderSupplier.get().path(contextPath).build();
+    String executionId =
+        executionService.startDataJobExecution(
+            teamName, jobName, deploymentId, jobExecutionRequest);
+    String contextPath =
+        String.format(
+            "/data-jobs/for-team/%s/jobs/%s/executions/%s", teamName, jobName, executionId);
+    URI location = currentContextPathBuilderSupplier.get().path(contextPath).build();
 
-      return ResponseEntity.accepted().location(location).build();
-   }
+    return ResponseEntity.accepted().location(location).build();
+  }
 
-   @Override
-   public ResponseEntity<DataJobExecutionLogs> dataJobLogsDownload(String teamName, String jobName, String executionId, Integer tailLines) {
-      DataJobExecutionLogs logs = executionService.getJobExecutionLogs(teamName, jobName, executionId, tailLines);
-      return ResponseEntity.ok(logs);
-   }
+  @Override
+  public ResponseEntity<DataJobExecutionLogs> dataJobLogsDownload(
+      String teamName, String jobName, String executionId, Integer tailLines) {
+    DataJobExecutionLogs logs =
+        executionService.getJobExecutionLogs(teamName, jobName, executionId, tailLines);
+    return ResponseEntity.ok(logs);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsServiceController.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsServiceController.java
@@ -5,7 +5,6 @@
 
 package com.vmware.taurus.datajobs;
 
-
 import com.vmware.taurus.controlplane.model.api.DataJobsServiceApi;
 import com.vmware.taurus.controlplane.model.data.DataJobApiInfo;
 import com.vmware.taurus.service.UserAgentService;
@@ -16,17 +15,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
-
 /**
  * REST controller for operations on data job
  *
- * <p>
- * REST behaviour and response codes should follow guidelines at
+ * <p>REST behaviour and response codes should follow guidelines at
  *
- * <p>
- * The controller may throw exception which will be handled by
- * {@link com.vmware.taurus.exception.ExceptionControllerAdvice}. The advice class logs error so no need to log them here.
- *
+ * <p>The controller may throw exception which will be handled by {@link
+ * com.vmware.taurus.exception.ExceptionControllerAdvice}. The advice class logs error so no need to
+ * log them here.
  */
 @RestController
 @AllArgsConstructor
@@ -34,13 +30,12 @@ import org.springframework.web.bind.annotation.RestController;
 @Api(tags = {"Data Jobs Service"})
 public class DataJobsServiceController implements DataJobsServiceApi {
 
-   @Autowired
-   UserAgentService userAgentService;
+  @Autowired UserAgentService userAgentService;
 
-   @Override
-   public ResponseEntity<DataJobApiInfo> info(String teamName) {
-      DataJobApiInfo result = new DataJobApiInfo();
-      result.setApiVersion(userAgentService.getUserAgentDetails());
-      return ResponseEntity.ok(result);
-   }
+  @Override
+  public ResponseEntity<DataJobApiInfo> info(String teamName) {
+    DataJobApiInfo result = new DataJobApiInfo();
+    result.setApiVersion(userAgentService.getUserAgentDetails());
+    return ResponseEntity.ok(result);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsSourcesController.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsSourcesController.java
@@ -5,7 +5,6 @@
 
 package com.vmware.taurus.datajobs;
 
-
 import com.vmware.taurus.controlplane.model.api.DataJobsSourcesApi;
 import com.vmware.taurus.controlplane.model.data.DataJobVersion;
 import com.vmware.taurus.exception.ExternalSystemError;
@@ -21,59 +20,54 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Optional;
 
-
 /**
  * REST controller for operations on data jobs source folders
  *
- * <p>
- * REST behaviour and response codes should follow guidelines at
+ * <p>REST behaviour and response codes should follow guidelines at
  *
- * <p>
- * The controller may throw exception which will be handled by
- * {@link com.vmware.taurus.exception.ExceptionControllerAdvice}. The advice class logs error so no need to log them here.
+ * <p>The controller may throw exception which will be handled by {@link
+ * com.vmware.taurus.exception.ExceptionControllerAdvice}. The advice class logs error so no need to
+ * log them here.
  *
- * <p>
- * Wrap {@link org.springframework.dao.DataAccessException} from JobsService in {@link ExternalSystemError} either here
- * or in the service itself.
- *
+ * <p>Wrap {@link org.springframework.dao.DataAccessException} from JobsService in {@link
+ * ExternalSystemError} either here or in the service itself.
  */
 @RestController
 @AllArgsConstructor
 @NoArgsConstructor
 @Api(tags = {"Data Jobs Sources"})
 public class DataJobsSourcesController implements DataJobsSourcesApi {
-   @Autowired
-   private JobsService jobsService;
+  @Autowired private JobsService jobsService;
 
-   @Autowired
-   private JobUpload jobUpload;
+  @Autowired private JobUpload jobUpload;
 
-   @Override
-   public ResponseEntity<Void> sourcesDelete(String teamName, String jobName, String reason) {
-      if (jobsService.jobWithTeamExists(jobName, teamName)) {
-         jobUpload.deleteDataJob(jobName, reason);
-         return ResponseEntity.ok().build();
+  @Override
+  public ResponseEntity<Void> sourcesDelete(String teamName, String jobName, String reason) {
+    if (jobsService.jobWithTeamExists(jobName, teamName)) {
+      jobUpload.deleteDataJob(jobName, reason);
+      return ResponseEntity.ok().build();
+    }
+    return ResponseEntity.notFound().build();
+  }
+
+  @Override
+  public ResponseEntity<DataJobVersion> sourcesUpload(
+      String teamName, String jobName, Resource resource, String reason) {
+    if (jobsService.jobWithTeamExists(jobName, teamName)) {
+      DataJobVersion jobVersion = new DataJobVersion();
+      jobVersion.setVersionSha(jobUpload.publishDataJob(jobName, resource, reason));
+      return ResponseEntity.ok(jobVersion);
+    }
+    return ResponseEntity.notFound().build();
+  }
+
+  public ResponseEntity<Resource> dataJobSourcesDownload(String teamName, String jobName) {
+    if (jobsService.jobWithTeamExists(jobName, teamName)) {
+      Optional<Resource> jobSource = jobUpload.getDataJob(jobName);
+      if (jobSource.isPresent()) {
+        return ResponseEntity.ok(jobSource.get());
       }
-      return ResponseEntity.notFound().build();
-   }
-
-   @Override
-   public ResponseEntity<DataJobVersion> sourcesUpload(String teamName, String jobName, Resource resource, String reason) {
-      if (jobsService.jobWithTeamExists(jobName, teamName)) {
-         DataJobVersion jobVersion = new DataJobVersion();
-         jobVersion.setVersionSha(jobUpload.publishDataJob(jobName, resource, reason));
-         return ResponseEntity.ok(jobVersion);
-      }
-      return ResponseEntity.notFound().build();
-   }
-
-   public ResponseEntity<Resource> dataJobSourcesDownload(String teamName, String jobName) {
-      if (jobsService.jobWithTeamExists(jobName, teamName)) {
-         Optional<Resource> jobSource = jobUpload.getDataJob(jobName);
-         if (jobSource.isPresent()) {
-            return ResponseEntity.ok(jobSource.get());
-         }
-      }
-      return ResponseEntity.notFound().build();
-   }
+    }
+    return ResponseEntity.notFound().build();
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
@@ -11,63 +11,96 @@ import com.vmware.taurus.service.model.JobDeploymentStatus;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
-/**
- * Utility functions that convert between different model or DTO classes
- */
+/** Utility functions that convert between different model or DTO classes */
 @Service
 @AllArgsConstructor
 public class DeploymentModelConverter {
 
-    public static JobDeployment toJobDeployment(String teamName, String jobName, JobDeploymentStatus jobDeploymentStatus) {
-        JobDeployment deployment = new JobDeployment();
-        deployment.setDataJobTeam(teamName);
-        deployment.setDataJobName(jobName);
-        deployment.setCronJobName(jobDeploymentStatus.getCronJobName());
-        deployment.setImageName(jobDeploymentStatus.getImageName());
-        deployment.setEnabled(jobDeploymentStatus.getEnabled());
-        deployment.setResources(jobDeploymentStatus.getResources());
-        deployment.setMode(jobDeploymentStatus.getMode());
-        deployment.setGitCommitSha(jobDeploymentStatus.getGitCommitSha());
-        deployment.setVdkVersion(jobDeploymentStatus.getVdkVersion());
+  public static JobDeployment toJobDeployment(
+      String teamName, String jobName, JobDeploymentStatus jobDeploymentStatus) {
+    JobDeployment deployment = new JobDeployment();
+    deployment.setDataJobTeam(teamName);
+    deployment.setDataJobName(jobName);
+    deployment.setCronJobName(jobDeploymentStatus.getCronJobName());
+    deployment.setImageName(jobDeploymentStatus.getImageName());
+    deployment.setEnabled(jobDeploymentStatus.getEnabled());
+    deployment.setResources(jobDeploymentStatus.getResources());
+    deployment.setMode(jobDeploymentStatus.getMode());
+    deployment.setGitCommitSha(jobDeploymentStatus.getGitCommitSha());
+    deployment.setVdkVersion(jobDeploymentStatus.getVdkVersion());
 
-        return deployment;
+    return deployment;
+  }
+
+  /**
+   * Merge to deployments with preference of fields from newDeployment over oldDeployment.
+   *
+   * @param oldDeployment the old deployment
+   * @param newDeployment the new deployment if a field is not null it is set other oldDeployment
+   *     field is used.
+   * @return the merge deployment
+   */
+  public static JobDeployment mergeDeployments(
+      JobDeployment oldDeployment, JobDeployment newDeployment) {
+    JobDeployment mergedDeployment = new JobDeployment();
+    if (!newDeployment.getDataJobName().equals(oldDeployment.getDataJobName())
+        || !newDeployment.getDataJobTeam().equals(oldDeployment.getDataJobTeam())) {
+      throw new IllegalArgumentException(
+          "Cannot merge 2 deployments if team or job name is different."
+              + oldDeployment
+              + " vs "
+              + newDeployment);
     }
+    mergedDeployment.setDataJobTeam(newDeployment.getDataJobTeam());
+    mergedDeployment.setDataJobName(newDeployment.getDataJobName());
+    mergedDeployment.setCronJobName(
+        newDeployment.getCronJobName() != null
+            ? newDeployment.getCronJobName()
+            : oldDeployment.getCronJobName());
+    mergedDeployment.setImageName(
+        newDeployment.getImageName() != null
+            ? newDeployment.getImageName()
+            : oldDeployment.getImageName());
+    mergedDeployment.setEnabled(
+        newDeployment.getEnabled() != null
+            ? newDeployment.getEnabled()
+            : oldDeployment.getEnabled());
 
-    /**
-     * Merge to deployments with preference of fields from newDeployment over oldDeployment.
-     * @param oldDeployment the old deployment
-     * @param newDeployment the new deployment if a field is not null it is set other oldDeployment field is used.
-     * @return the merge deployment
-     */
-    public static JobDeployment mergeDeployments(JobDeployment oldDeployment, JobDeployment newDeployment) {
-        JobDeployment mergedDeployment = new JobDeployment();
-        if (!newDeployment.getDataJobName().equals(oldDeployment.getDataJobName()) ||
-            !newDeployment.getDataJobTeam().equals(oldDeployment.getDataJobTeam())) {
-            throw new IllegalArgumentException("Cannot merge 2 deployments if team or job name is different." +
-                    oldDeployment + " vs " + newDeployment);
-        }
-        mergedDeployment.setDataJobTeam(newDeployment.getDataJobTeam());
-        mergedDeployment.setDataJobName(newDeployment.getDataJobName());
-        mergedDeployment.setCronJobName(newDeployment.getCronJobName() != null ? newDeployment.getCronJobName() : oldDeployment.getCronJobName());
-        mergedDeployment.setImageName(newDeployment.getImageName() != null ? newDeployment.getImageName() : oldDeployment.getImageName());
-        mergedDeployment.setEnabled(newDeployment.getEnabled() != null ? newDeployment.getEnabled() : oldDeployment.getEnabled());
-
-        var mergedResources = new DataJobResources();
-        var newResources = newDeployment.getResources();
-        var oldResources = oldDeployment.getResources();
-        if (newResources != null && oldResources != null) {
-            mergedResources.setCpuLimit(newResources.getCpuLimit() != null ? newResources.getCpuLimit() : oldResources.getCpuLimit());
-            mergedResources.setCpuRequest(newResources.getCpuRequest() != null ? newResources.getCpuRequest() : oldResources.getCpuRequest());
-            mergedResources.setMemoryLimit(newResources.getMemoryLimit() != null ? newResources.getMemoryLimit() : oldResources.getMemoryLimit());
-            mergedResources.setMemoryRequest(newResources.getMemoryRequest() != null ? newResources.getMemoryRequest() : oldResources.getMemoryRequest());
-        } else {
-            mergedResources = newResources != null ? newResources : oldResources;
-        }
-        mergedDeployment.setResources(mergedResources);
-
-        mergedDeployment.setMode(newDeployment.getMode() != null ? newDeployment.getMode() : oldDeployment.getMode());
-        mergedDeployment.setGitCommitSha(newDeployment.getGitCommitSha() != null ? newDeployment.getGitCommitSha() : oldDeployment.getGitCommitSha());
-        mergedDeployment.setVdkVersion(newDeployment.getVdkVersion() != null ? newDeployment.getVdkVersion() : oldDeployment.getVdkVersion());
-        return mergedDeployment;
+    var mergedResources = new DataJobResources();
+    var newResources = newDeployment.getResources();
+    var oldResources = oldDeployment.getResources();
+    if (newResources != null && oldResources != null) {
+      mergedResources.setCpuLimit(
+          newResources.getCpuLimit() != null
+              ? newResources.getCpuLimit()
+              : oldResources.getCpuLimit());
+      mergedResources.setCpuRequest(
+          newResources.getCpuRequest() != null
+              ? newResources.getCpuRequest()
+              : oldResources.getCpuRequest());
+      mergedResources.setMemoryLimit(
+          newResources.getMemoryLimit() != null
+              ? newResources.getMemoryLimit()
+              : oldResources.getMemoryLimit());
+      mergedResources.setMemoryRequest(
+          newResources.getMemoryRequest() != null
+              ? newResources.getMemoryRequest()
+              : oldResources.getMemoryRequest());
+    } else {
+      mergedResources = newResources != null ? newResources : oldResources;
     }
+    mergedDeployment.setResources(mergedResources);
+
+    mergedDeployment.setMode(
+        newDeployment.getMode() != null ? newDeployment.getMode() : oldDeployment.getMode());
+    mergedDeployment.setGitCommitSha(
+        newDeployment.getGitCommitSha() != null
+            ? newDeployment.getGitCommitSha()
+            : oldDeployment.getGitCommitSha());
+    mergedDeployment.setVdkVersion(
+        newDeployment.getVdkVersion() != null
+            ? newDeployment.getVdkVersion()
+            : oldDeployment.getVdkVersion());
+    return mergedDeployment;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/ToApiModelConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/ToApiModelConverter.java
@@ -27,223 +27,239 @@ import java.util.Objects;
 @Slf4j
 public class ToApiModelConverter {
 
-   static DataJobSummary toDataJobSummary(DataJob job) {
-      DataJobSummary summary = new DataJobSummary();
-      summary.setTeam(job.getJobConfig().getTeam());
-      summary.setJobName(job.getName());
-      summary.setDescription("");
-      return summary;
-   }
+  static DataJobSummary toDataJobSummary(DataJob job) {
+    DataJobSummary summary = new DataJobSummary();
+    summary.setTeam(job.getJobConfig().getTeam());
+    summary.setJobName(job.getName());
+    summary.setDescription("");
+    return summary;
+  }
 
-   public static V2DataJob toV2DataJob(DataJob job) {
-      V2DataJob v2Job = new V2DataJob();
-      v2Job.setJobName(job.getName());
-      v2Job.setConfig(toV2JobConfig(job.getJobConfig()));
-//      v2Job.setDeployments(toDeployments(new DataJobDeployment())); TODO
-      return v2Job;
-   }
+  public static V2DataJob toV2DataJob(DataJob job) {
+    V2DataJob v2Job = new V2DataJob();
+    v2Job.setJobName(job.getName());
+    v2Job.setConfig(toV2JobConfig(job.getJobConfig()));
+    //      v2Job.setDeployments(toDeployments(new DataJobDeployment())); TODO
+    return v2Job;
+  }
 
-   public static com.vmware.taurus.controlplane.model.data.DataJob toDataJob(DataJob dataJob) {
-      com.vmware.taurus.controlplane.model.data.DataJob job
-            = new com.vmware.taurus.controlplane.model.data.DataJob();
-      job.setConfig(toJobConfig(dataJob.getJobConfig()));
-      job.setTeam(dataJob.getJobConfig().getTeam());
-      job.setDescription(dataJob.getJobConfig() == null ? null : dataJob.getJobConfig().getDescription());
-      job.setJobName(dataJob.getName());
-      return job;
-   }
+  public static com.vmware.taurus.controlplane.model.data.DataJob toDataJob(DataJob dataJob) {
+    com.vmware.taurus.controlplane.model.data.DataJob job =
+        new com.vmware.taurus.controlplane.model.data.DataJob();
+    job.setConfig(toJobConfig(dataJob.getJobConfig()));
+    job.setTeam(dataJob.getJobConfig().getTeam());
+    job.setDescription(
+        dataJob.getJobConfig() == null ? null : dataJob.getJobConfig().getDescription());
+    job.setJobName(dataJob.getName());
+    return job;
+  }
 
-   private static DataJobConfig toJobConfig(JobConfig jobConfig) {
-      DataJobConfig dataJobConfig = new DataJobConfig();
-      dataJobConfig.setDbDefaultType(jobConfig.getDbDefaultType());
-      dataJobConfig.setSchedule(toSchedule(jobConfig.getSchedule()));
-      dataJobConfig.setEnableExecutionNotifications(jobConfig.getEnableExecutionNotifications());
-      dataJobConfig.setNotificationDelayPeriodMinutes(jobConfig.getNotificationDelayPeriodMinutes());
-      dataJobConfig.setContacts(toContacts(jobConfig));
-      dataJobConfig.setGenerateKeytab(jobConfig.isGenerateKeytab());
-      return dataJobConfig;
-   }
+  private static DataJobConfig toJobConfig(JobConfig jobConfig) {
+    DataJobConfig dataJobConfig = new DataJobConfig();
+    dataJobConfig.setDbDefaultType(jobConfig.getDbDefaultType());
+    dataJobConfig.setSchedule(toSchedule(jobConfig.getSchedule()));
+    dataJobConfig.setEnableExecutionNotifications(jobConfig.getEnableExecutionNotifications());
+    dataJobConfig.setNotificationDelayPeriodMinutes(jobConfig.getNotificationDelayPeriodMinutes());
+    dataJobConfig.setContacts(toContacts(jobConfig));
+    dataJobConfig.setGenerateKeytab(jobConfig.isGenerateKeytab());
+    return dataJobConfig;
+  }
 
-   private static V2DataJobConfig toV2JobConfig(JobConfig jobConfig) {
-      V2DataJobConfig dataJobConfig = new V2DataJobConfig();
-      dataJobConfig.setDescription(jobConfig.getDescription());
-      dataJobConfig.setTeam(jobConfig.getTeam());
-      dataJobConfig.setDbDefaultType(jobConfig.getDbDefaultType());
-      dataJobConfig.setSchedule(toScheduleV2(jobConfig.getSchedule()));
-      dataJobConfig.setContacts(toContacts(jobConfig));
-      dataJobConfig.setGenerateKeytab(jobConfig.isGenerateKeytab());
-      return dataJobConfig;
-   }
+  private static V2DataJobConfig toV2JobConfig(JobConfig jobConfig) {
+    V2DataJobConfig dataJobConfig = new V2DataJobConfig();
+    dataJobConfig.setDescription(jobConfig.getDescription());
+    dataJobConfig.setTeam(jobConfig.getTeam());
+    dataJobConfig.setDbDefaultType(jobConfig.getDbDefaultType());
+    dataJobConfig.setSchedule(toScheduleV2(jobConfig.getSchedule()));
+    dataJobConfig.setContacts(toContacts(jobConfig));
+    dataJobConfig.setGenerateKeytab(jobConfig.isGenerateKeytab());
+    return dataJobConfig;
+  }
 
-   private static DataJobContacts toContacts(JobConfig jobConfig) {
-      DataJobContacts contacts = new DataJobContacts();
-      contacts.setNotifiedOnJobDeploy(jobConfig.getNotifiedOnJobDeploy());
-      contacts.setNotifiedOnJobFailurePlatformError(jobConfig.getNotifiedOnJobFailurePlatformError());
-      contacts.setNotifiedOnJobFailureUserError(jobConfig.getNotifiedOnJobFailureUserError());
-      contacts.setNotifiedOnJobSuccess(jobConfig.getNotifiedOnJobSuccess());
-      return contacts;
-   }
+  private static DataJobContacts toContacts(JobConfig jobConfig) {
+    DataJobContacts contacts = new DataJobContacts();
+    contacts.setNotifiedOnJobDeploy(jobConfig.getNotifiedOnJobDeploy());
+    contacts.setNotifiedOnJobFailurePlatformError(jobConfig.getNotifiedOnJobFailurePlatformError());
+    contacts.setNotifiedOnJobFailureUserError(jobConfig.getNotifiedOnJobFailureUserError());
+    contacts.setNotifiedOnJobSuccess(jobConfig.getNotifiedOnJobSuccess());
+    return contacts;
+  }
 
-   private static DataJobSchedule toSchedule(String scheduleCron) {
-      DataJobSchedule sched = new DataJobSchedule();
-      sched.setScheduleCron(scheduleCron);
-      return sched;
-   }
+  private static DataJobSchedule toSchedule(String scheduleCron) {
+    DataJobSchedule sched = new DataJobSchedule();
+    sched.setScheduleCron(scheduleCron);
+    return sched;
+  }
 
-   private static V2DataJobSchedule toScheduleV2(String scheduleCron) {
-      V2DataJobSchedule schedule = new V2DataJobSchedule();
-      schedule.setScheduleCron(scheduleCron);
-      // next run is calculated only if requested
-      return schedule;
-   }
+  private static V2DataJobSchedule toScheduleV2(String scheduleCron) {
+    V2DataJobSchedule schedule = new V2DataJobSchedule();
+    schedule.setScheduleCron(scheduleCron);
+    // next run is calculated only if requested
+    return schedule;
+  }
 
-   public static DataJobDeploymentStatus toDataJobDeploymentStatus(JobDeploymentStatus jobDeploymentStatus) {
-      // TODO: Set other properties when the model is changed
-      DataJobDeploymentStatus deployment = new DataJobDeploymentStatus();
-      deployment.setEnabled(jobDeploymentStatus.getEnabled());
-      deployment.setResources(jobDeploymentStatus.getResources());
-      deployment.setMode(DataJobMode.fromValue(jobDeploymentStatus.getMode()));
-      deployment.setJobVersion(jobDeploymentStatus.getGitCommitSha());
-      deployment.setLastDeployedBy(jobDeploymentStatus.getLastDeployedBy());
-      deployment.setLastDeployedDate(jobDeploymentStatus.getLastDeployedDate());
-      deployment.setVdkVersion(jobDeploymentStatus.getVdkVersion());
+  public static DataJobDeploymentStatus toDataJobDeploymentStatus(
+      JobDeploymentStatus jobDeploymentStatus) {
+    // TODO: Set other properties when the model is changed
+    DataJobDeploymentStatus deployment = new DataJobDeploymentStatus();
+    deployment.setEnabled(jobDeploymentStatus.getEnabled());
+    deployment.setResources(jobDeploymentStatus.getResources());
+    deployment.setMode(DataJobMode.fromValue(jobDeploymentStatus.getMode()));
+    deployment.setJobVersion(jobDeploymentStatus.getGitCommitSha());
+    deployment.setLastDeployedBy(jobDeploymentStatus.getLastDeployedBy());
+    deployment.setLastDeployedDate(jobDeploymentStatus.getLastDeployedDate());
+    deployment.setVdkVersion(jobDeploymentStatus.getVdkVersion());
 
-      return deployment;
-   }
+    return deployment;
+  }
 
-   public static DataJobQueryResponse toDataJobPage(ExecutionResult executionResult) {
-      // TODO allow introspecting GraphQL schema as part of TAUR-1432
-      var dataJobQueryResponse = new DataJobQueryResponse();
-      if (executionResult == null) {
-         return dataJobQueryResponse;
-      }
+  public static DataJobQueryResponse toDataJobPage(ExecutionResult executionResult) {
+    // TODO allow introspecting GraphQL schema as part of TAUR-1432
+    var dataJobQueryResponse = new DataJobQueryResponse();
+    if (executionResult == null) {
+      return dataJobQueryResponse;
+    }
 
-      dataJobQueryResponse.setErrors(new ArrayList<>(Utilities.removeGraphQLErrorsStackTrace(executionResult.getErrors())));
+    dataJobQueryResponse.setErrors(
+        new ArrayList<>(Utilities.removeGraphQLErrorsStackTrace(executionResult.getErrors())));
 
-      LinkedHashMap<String, LinkedHashMap<String, Object>> executionResultData = executionResult.getData();
-      if (executionResultData == null) {
-         return dataJobQueryResponse;
-      }
+    LinkedHashMap<String, LinkedHashMap<String, Object>> executionResultData =
+        executionResult.getData();
+    if (executionResultData == null) {
+      return dataJobQueryResponse;
+    }
 
-      String executionResultDataKey = GraphQLUtils.QUERIES
-            .stream()
+    String executionResultDataKey =
+        GraphQLUtils.QUERIES.stream()
             .filter(query -> executionResultData.containsKey(query))
             .findFirst()
             .orElse(null);
-      LinkedHashMap<String, Object> nestedExecutionResultData = executionResultData.get(executionResultDataKey);
-      if (nestedExecutionResultData == null) {
-         return dataJobQueryResponse;
-      }
-      var dataJobPage = new DataJobPage();
-      dataJobPage.setTotalPages(nestedExecutionResultData.get("totalPages") == null ? 0 : (Integer) nestedExecutionResultData.get("totalPages"));
-      dataJobPage.setTotalItems(nestedExecutionResultData.get("totalItems") == null ? 0 : (Integer) nestedExecutionResultData.get("totalItems"));
-      dataJobPage.setContent((List<Object>) nestedExecutionResultData.get("content"));
-
-      dataJobQueryResponse.setData(dataJobPage);
-
+    LinkedHashMap<String, Object> nestedExecutionResultData =
+        executionResultData.get(executionResultDataKey);
+    if (nestedExecutionResultData == null) {
       return dataJobQueryResponse;
-   }
+    }
+    var dataJobPage = new DataJobPage();
+    dataJobPage.setTotalPages(
+        nestedExecutionResultData.get("totalPages") == null
+            ? 0
+            : (Integer) nestedExecutionResultData.get("totalPages"));
+    dataJobPage.setTotalItems(
+        nestedExecutionResultData.get("totalItems") == null
+            ? 0
+            : (Integer) nestedExecutionResultData.get("totalItems"));
+    dataJobPage.setContent((List<Object>) nestedExecutionResultData.get("content"));
 
-   public static V2DataJobDeployment toV2DataJobDeployment(JobDeploymentStatus jobDeploymentStatus, DataJob sourceDataJob) {
-      Objects.requireNonNull(jobDeploymentStatus);
-      Objects.requireNonNull(sourceDataJob);
+    dataJobQueryResponse.setData(dataJobPage);
 
-      var v2DataJobDeployment = new V2DataJobDeployment();
+    return dataJobQueryResponse;
+  }
 
-      v2DataJobDeployment.setId(jobDeploymentStatus.getCronJobName());
-      v2DataJobDeployment.setEnabled(jobDeploymentStatus.getEnabled());
-      v2DataJobDeployment.setJobVersion(jobDeploymentStatus.getGitCommitSha());
-      v2DataJobDeployment.setMode(DataJobMode.fromValue(jobDeploymentStatus.getMode()));
-      v2DataJobDeployment.setResources(jobDeploymentStatus.getResources());
-      v2DataJobDeployment.setLastDeployedBy(jobDeploymentStatus.getLastDeployedBy());
-      v2DataJobDeployment.setLastDeployedDate(jobDeploymentStatus.getLastDeployedDate());
-      // TODO: Get these from the job deployment when they are available there
-      v2DataJobDeployment.setLastExecutionStatus(convertStatusEnum(sourceDataJob.getLastExecutionStatus()));
-      v2DataJobDeployment.setLastExecutionTime(sourceDataJob.getLastExecutionEndTime());
-      v2DataJobDeployment.setLastExecutionDuration(sourceDataJob.getLastExecutionDuration());
+  public static V2DataJobDeployment toV2DataJobDeployment(
+      JobDeploymentStatus jobDeploymentStatus, DataJob sourceDataJob) {
+    Objects.requireNonNull(jobDeploymentStatus);
+    Objects.requireNonNull(sourceDataJob);
 
-      // TODO finish mapping implementation in TAUR-1535
-      v2DataJobDeployment.setContacts(new DataJobContacts());
-      v2DataJobDeployment.setSchedule(new V2DataJobSchedule());
-      v2DataJobDeployment.setVdkVersion(jobDeploymentStatus.getVdkVersion());
-      v2DataJobDeployment.setExecutions(new ArrayList<>());
+    var v2DataJobDeployment = new V2DataJobDeployment();
 
-      return v2DataJobDeployment;
-   }
+    v2DataJobDeployment.setId(jobDeploymentStatus.getCronJobName());
+    v2DataJobDeployment.setEnabled(jobDeploymentStatus.getEnabled());
+    v2DataJobDeployment.setJobVersion(jobDeploymentStatus.getGitCommitSha());
+    v2DataJobDeployment.setMode(DataJobMode.fromValue(jobDeploymentStatus.getMode()));
+    v2DataJobDeployment.setResources(jobDeploymentStatus.getResources());
+    v2DataJobDeployment.setLastDeployedBy(jobDeploymentStatus.getLastDeployedBy());
+    v2DataJobDeployment.setLastDeployedDate(jobDeploymentStatus.getLastDeployedDate());
+    // TODO: Get these from the job deployment when they are available there
+    v2DataJobDeployment.setLastExecutionStatus(
+        convertStatusEnum(sourceDataJob.getLastExecutionStatus()));
+    v2DataJobDeployment.setLastExecutionTime(sourceDataJob.getLastExecutionEndTime());
+    v2DataJobDeployment.setLastExecutionDuration(sourceDataJob.getLastExecutionDuration());
 
-   public static DataJobExecution jobExecutionToConvert(com.vmware.taurus.service.model.DataJobExecution jobExecutionToConvert, String logsUrl) {
-      return new DataJobExecution()
-            .id(jobExecutionToConvert.getId())
-            .jobName(jobExecutionToConvert.getDataJob().getName())
-            .type(convertTypeEnum(jobExecutionToConvert.getType()))
-            .status(convertStatusEnum(jobExecutionToConvert.getStatus()))
-            .message(jobExecutionToConvert.getMessage())
-            .opId(jobExecutionToConvert.getOpId())
-            .startTime(jobExecutionToConvert.getStartTime())
-            .endTime(jobExecutionToConvert.getEndTime())
-            .startedBy(jobExecutionToConvert.getStartedBy())
-            .logsUrl(logsUrl)
-            .deployment(new DataJobDeployment()
-                  .vdkVersion(jobExecutionToConvert.getVdkVersion())
-                  .jobVersion(jobExecutionToConvert.getJobVersion())
-                  .schedule(new DataJobSchedule().scheduleCron(jobExecutionToConvert.getJobSchedule()))
-                  .resources(getJobResources(jobExecutionToConvert))
-                  .deployedBy(jobExecutionToConvert.getLastDeployedBy())
-                  .deployedDate(jobExecutionToConvert.getLastDeployedDate())
-                  // TODO [miroslavi] get the following properties from the database once we introduce the deployments
-                  .id(DataJobMode.RELEASE.getValue())
-                  .mode(DataJobMode.RELEASE)
-                  .enabled(true));
+    // TODO finish mapping implementation in TAUR-1535
+    v2DataJobDeployment.setContacts(new DataJobContacts());
+    v2DataJobDeployment.setSchedule(new V2DataJobSchedule());
+    v2DataJobDeployment.setVdkVersion(jobDeploymentStatus.getVdkVersion());
+    v2DataJobDeployment.setExecutions(new ArrayList<>());
 
-   }
+    return v2DataJobDeployment;
+  }
 
-   // Public for testing purposes
-   public static DataJobExecution.TypeEnum convertTypeEnum(ExecutionType type) {
-      switch (type) {
-         case MANUAL:
-            return DataJobExecution.TypeEnum.MANUAL;
-         case SCHEDULED:
-            return DataJobExecution.TypeEnum.SCHEDULED;
-         default: // no such type
-            log.warn("Unexpected type: '" + type + "' in TypeEnum.");
-            return null;
-      }
-   }
+  public static DataJobExecution jobExecutionToConvert(
+      com.vmware.taurus.service.model.DataJobExecution jobExecutionToConvert, String logsUrl) {
+    return new DataJobExecution()
+        .id(jobExecutionToConvert.getId())
+        .jobName(jobExecutionToConvert.getDataJob().getName())
+        .type(convertTypeEnum(jobExecutionToConvert.getType()))
+        .status(convertStatusEnum(jobExecutionToConvert.getStatus()))
+        .message(jobExecutionToConvert.getMessage())
+        .opId(jobExecutionToConvert.getOpId())
+        .startTime(jobExecutionToConvert.getStartTime())
+        .endTime(jobExecutionToConvert.getEndTime())
+        .startedBy(jobExecutionToConvert.getStartedBy())
+        .logsUrl(logsUrl)
+        .deployment(
+            new DataJobDeployment()
+                .vdkVersion(jobExecutionToConvert.getVdkVersion())
+                .jobVersion(jobExecutionToConvert.getJobVersion())
+                .schedule(
+                    new DataJobSchedule().scheduleCron(jobExecutionToConvert.getJobSchedule()))
+                .resources(getJobResources(jobExecutionToConvert))
+                .deployedBy(jobExecutionToConvert.getLastDeployedBy())
+                .deployedDate(jobExecutionToConvert.getLastDeployedDate())
+                // TODO [miroslavi] get the following properties from the database once we introduce
+                // the deployments
+                .id(DataJobMode.RELEASE.getValue())
+                .mode(DataJobMode.RELEASE)
+                .enabled(true));
+  }
 
-   // Public for testing purposes
-   public static DataJobExecution.StatusEnum convertStatusEnum(ExecutionStatus status) {
-      if (status == null) {
-         return null;
-      }
-      switch (status) {
-         case SUBMITTED:
-            return DataJobExecution.StatusEnum.SUBMITTED;
-         case RUNNING:
-            return DataJobExecution.StatusEnum.RUNNING;
-         case CANCELLED:
-            return DataJobExecution.StatusEnum.CANCELLED;
-         case SUCCEEDED:
-            return DataJobExecution.StatusEnum.SUCCEEDED;
-         case SKIPPED:
-            return DataJobExecution.StatusEnum.SKIPPED;
-         case USER_ERROR:
-            return DataJobExecution.StatusEnum.USER_ERROR;
-         case PLATFORM_ERROR:
-            return DataJobExecution.StatusEnum.PLATFORM_ERROR;
-         default: // No such case
-            log.warn("Unexpected status: '" + status + "' in StatusEnum.");
-            return null;
-      }
-   }
+  // Public for testing purposes
+  public static DataJobExecution.TypeEnum convertTypeEnum(ExecutionType type) {
+    switch (type) {
+      case MANUAL:
+        return DataJobExecution.TypeEnum.MANUAL;
+      case SCHEDULED:
+        return DataJobExecution.TypeEnum.SCHEDULED;
+      default: // no such type
+        log.warn("Unexpected type: '" + type + "' in TypeEnum.");
+        return null;
+    }
+  }
 
-   private static DataJobResources getJobResources(com.vmware.taurus.service.model.DataJobExecution job){
-      DataJobResources dataJobResources = new DataJobResources();
-      dataJobResources.setCpuLimit(job.getResourcesCpuLimit());
-      dataJobResources.setCpuRequest(job.getResourcesCpuRequest());
-      dataJobResources.setMemoryLimit(job.getResourcesMemoryLimit());
-      dataJobResources.setMemoryRequest(job.getResourcesMemoryRequest());
+  // Public for testing purposes
+  public static DataJobExecution.StatusEnum convertStatusEnum(ExecutionStatus status) {
+    if (status == null) {
+      return null;
+    }
+    switch (status) {
+      case SUBMITTED:
+        return DataJobExecution.StatusEnum.SUBMITTED;
+      case RUNNING:
+        return DataJobExecution.StatusEnum.RUNNING;
+      case CANCELLED:
+        return DataJobExecution.StatusEnum.CANCELLED;
+      case SUCCEEDED:
+        return DataJobExecution.StatusEnum.SUCCEEDED;
+      case SKIPPED:
+        return DataJobExecution.StatusEnum.SKIPPED;
+      case USER_ERROR:
+        return DataJobExecution.StatusEnum.USER_ERROR;
+      case PLATFORM_ERROR:
+        return DataJobExecution.StatusEnum.PLATFORM_ERROR;
+      default: // No such case
+        log.warn("Unexpected status: '" + status + "' in StatusEnum.");
+        return null;
+    }
+  }
 
-      return dataJobResources;
-   }
+  private static DataJobResources getJobResources(
+      com.vmware.taurus.service.model.DataJobExecution job) {
+    DataJobResources dataJobResources = new DataJobResources();
+    dataJobResources.setCpuLimit(job.getResourcesCpuLimit());
+    dataJobResources.setCpuRequest(job.getResourcesCpuRequest());
+    dataJobResources.setMemoryLimit(job.getResourcesMemoryLimit());
+    dataJobResources.setMemoryRequest(job.getResourcesMemoryRequest());
 
+    return dataJobResources;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/ToModelApiConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/ToModelApiConverter.java
@@ -14,79 +14,81 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ToModelApiConverter {
 
-   public static JobDeployment toJobDeployment(String teamName, String jobName, DataJobDeployment dataJobDeployment) {
+  public static JobDeployment toJobDeployment(
+      String teamName, String jobName, DataJobDeployment dataJobDeployment) {
 
-      JobDeployment jobDeployment = new JobDeployment();
-      jobDeployment.setDataJobTeam(teamName);
-      jobDeployment.setDataJobName(jobName);
-      jobDeployment.setEnabled(dataJobDeployment.getEnabled());
-      jobDeployment.setResources(dataJobDeployment.getResources());
-      if (dataJobDeployment.getMode() != null) {
-         jobDeployment.setMode(dataJobDeployment.getMode().toString());
+    JobDeployment jobDeployment = new JobDeployment();
+    jobDeployment.setDataJobTeam(teamName);
+    jobDeployment.setDataJobName(jobName);
+    jobDeployment.setEnabled(dataJobDeployment.getEnabled());
+    jobDeployment.setResources(dataJobDeployment.getResources());
+    if (dataJobDeployment.getMode() != null) {
+      jobDeployment.setMode(dataJobDeployment.getMode().toString());
+    }
+    jobDeployment.setGitCommitSha(dataJobDeployment.getJobVersion());
+    jobDeployment.setVdkVersion(dataJobDeployment.getVdkVersion());
+
+    return jobDeployment;
+  }
+
+  public static DataJob toDataJob(com.vmware.taurus.controlplane.model.data.DataJob modelJob) {
+    JobConfig config = new JobConfig();
+    config.setJobName(modelJob.getJobName());
+    config.setDescription(modelJob.getDescription());
+    config.setTeam(modelJob.getTeam());
+    DataJobConfig modelConfig = modelJob.getConfig();
+    if (modelConfig != null) {
+      config.setDbDefaultType(modelConfig.getDbDefaultType());
+
+      if (modelConfig.getSchedule() != null) {
+        config.setSchedule(modelConfig.getSchedule().getScheduleCron());
       }
-      jobDeployment.setGitCommitSha(dataJobDeployment.getJobVersion());
-      jobDeployment.setVdkVersion(dataJobDeployment.getVdkVersion());
-
-      return jobDeployment;
-   }
-
-   public static DataJob toDataJob(com.vmware.taurus.controlplane.model.data.DataJob modelJob) {
-      JobConfig config = new JobConfig();
-      config.setJobName(modelJob.getJobName());
-      config.setDescription(modelJob.getDescription());
-      config.setTeam(modelJob.getTeam());
-      DataJobConfig modelConfig = modelJob.getConfig();
-      if (modelConfig != null) {
-         config.setDbDefaultType(modelConfig.getDbDefaultType());
-
-         if (modelConfig.getSchedule() != null) {
-            config.setSchedule(modelConfig.getSchedule().getScheduleCron());
-         }
-         config.setEnableExecutionNotifications(modelConfig.getEnableExecutionNotifications());
-         config.setNotificationDelayPeriodMinutes(modelConfig.getNotificationDelayPeriodMinutes());
-         var contacts = modelConfig.getContacts();
-         if (contacts != null) {
-            config.setNotifiedOnJobSuccess(contacts.getNotifiedOnJobSuccess());
-            config.setNotifiedOnJobDeploy(contacts.getNotifiedOnJobDeploy());
-            config.setNotifiedOnJobFailurePlatformError(contacts.getNotifiedOnJobFailurePlatformError());
-            config.setNotifiedOnJobFailureUserError(contacts.getNotifiedOnJobFailureUserError());
-         }
-         config.setGenerateKeytab(modelConfig.getGenerateKeytab());
+      config.setEnableExecutionNotifications(modelConfig.getEnableExecutionNotifications());
+      config.setNotificationDelayPeriodMinutes(modelConfig.getNotificationDelayPeriodMinutes());
+      var contacts = modelConfig.getContacts();
+      if (contacts != null) {
+        config.setNotifiedOnJobSuccess(contacts.getNotifiedOnJobSuccess());
+        config.setNotifiedOnJobDeploy(contacts.getNotifiedOnJobDeploy());
+        config.setNotifiedOnJobFailurePlatformError(
+            contacts.getNotifiedOnJobFailurePlatformError());
+        config.setNotifiedOnJobFailureUserError(contacts.getNotifiedOnJobFailureUserError());
       }
-      return new DataJob(modelJob.getJobName(), config);
-   }
+      config.setGenerateKeytab(modelConfig.getGenerateKeytab());
+    }
+    return new DataJob(modelJob.getJobName(), config);
+  }
 
-   public static ExecutionType toExecutionType(DataJobExecution.TypeEnum type) {
-      switch (type) {
-         case MANUAL:
-            return ExecutionType.MANUAL;
-         case SCHEDULED:
-            return ExecutionType.SCHEDULED;
-         default: // no such type
-            log.warn("Unexpected type: '" + type + "' in ExecutionType.");
-            return null;
-      }
-   }
+  public static ExecutionType toExecutionType(DataJobExecution.TypeEnum type) {
+    switch (type) {
+      case MANUAL:
+        return ExecutionType.MANUAL;
+      case SCHEDULED:
+        return ExecutionType.SCHEDULED;
+      default: // no such type
+        log.warn("Unexpected type: '" + type + "' in ExecutionType.");
+        return null;
+    }
+  }
 
-   public static ExecutionStatus toExecutionStatus(DataJobExecution.StatusEnum status) {
-      switch (status) {
-         case SUBMITTED:
-            return ExecutionStatus.SUBMITTED;
-         case RUNNING:
-            return ExecutionStatus.RUNNING;
-         case CANCELLED:
-            return ExecutionStatus.CANCELLED;
-         case SUCCEEDED:
-            return ExecutionStatus.SUCCEEDED;
-         case SKIPPED:
-            return ExecutionStatus.SKIPPED;
-         case USER_ERROR:
-            return ExecutionStatus.USER_ERROR;
-         case PLATFORM_ERROR:
-            return ExecutionStatus.PLATFORM_ERROR;
-         default: // No such status
-            log.warn("Unexpected status: '" + status + "' in ExecutionStatus.");
-            return null;
-      }
-   }
+  public static ExecutionStatus toExecutionStatus(DataJobExecution.StatusEnum status) {
+    switch (status) {
+      case SUBMITTED:
+        return ExecutionStatus.SUBMITTED;
+      case RUNNING:
+        return ExecutionStatus.RUNNING;
+      case CANCELLED:
+        return ExecutionStatus.CANCELLED;
+      case SUCCEEDED:
+        return ExecutionStatus.SUCCEEDED;
+      case SKIPPED:
+        return ExecutionStatus.SKIPPED;
+      case USER_ERROR:
+        return ExecutionStatus.USER_ERROR;
+      case PLATFORM_ERROR:
+        return ExecutionStatus.PLATFORM_ERROR;
+      default: // No such status
+        log.warn("Unexpected status: '" + status + "' in ExecutionStatus.");
+        return null;
+    }
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostCreateWebHookProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostCreateWebHookProvider.java
@@ -12,21 +12,19 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /**
- * PostCreateWebHookProvider class which delegates custom post data job creation operations via
- * a request to a third party webhook server.
- * <p>
- * Uses a single method {@link PostCreateWebHookProvider#invokeWebHook(WebHookRequestBody)}
- * which triggers a webhook to a server to execute various Post Create Data Jobs operations.
- * </p>
+ * PostCreateWebHookProvider class which delegates custom post data job creation operations via a
+ * request to a third party webhook server.
+ *
+ * <p>Uses a single method {@link PostCreateWebHookProvider#invokeWebHook(WebHookRequestBody)} which
+ * triggers a webhook to a server to execute various Post Create Data Jobs operations.
  */
 @Service
 @Slf4j
 public class PostCreateWebHookProvider extends WebHookService<WebHookRequestBody> {
 
-   public PostCreateWebHookProvider(@Value("${datajobs.post.create.webhook.endpoint}")
-                                            String webHookEndpoint,
-                                    @Value("${datajobs.post.create.webhook.internal.errors.retries:-1}")
-                                            int retriesOn5xxErrors) {
-      super(webHookEndpoint, retriesOn5xxErrors, log);
-   }
+  public PostCreateWebHookProvider(
+      @Value("${datajobs.post.create.webhook.endpoint}") String webHookEndpoint,
+      @Value("${datajobs.post.create.webhook.internal.errors.retries:-1}") int retriesOn5xxErrors) {
+    super(webHookEndpoint, retriesOn5xxErrors, log);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostDeleteWebHookProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostDeleteWebHookProvider.java
@@ -11,22 +11,19 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-
 /**
- * PostDeleteWebHookProvider class which delegates custom post data job delete operations via
- * a request to a third party webhook server.
- * <p>
- * Uses a single method {@link PostDeleteWebHookProvider#invokeWebHook(WebHookRequestBody)}
- * which triggers a webhook to a server to execute various Post Delete Data Jobs operations.
- * </p>
+ * PostDeleteWebHookProvider class which delegates custom post data job delete operations via a
+ * request to a third party webhook server.
+ *
+ * <p>Uses a single method {@link PostDeleteWebHookProvider#invokeWebHook(WebHookRequestBody)} which
+ * triggers a webhook to a server to execute various Post Delete Data Jobs operations.
  */
 @Service
 @Slf4j
 public class PostDeleteWebHookProvider extends WebHookService<WebHookRequestBody> {
-   public PostDeleteWebHookProvider(@Value("${datajobs.post.delete.webhook.endpoint}")
-                                            String webHookEndpoint,
-                                    @Value("${datajobs.post.delete.webhook.internal.errors.retries:-1}")
-                                            int retriesOn5xxErrors) {
-      super(webHookEndpoint, retriesOn5xxErrors, log);
-   }
+  public PostDeleteWebHookProvider(
+      @Value("${datajobs.post.delete.webhook.endpoint}") String webHookEndpoint,
+      @Value("${datajobs.post.delete.webhook.internal.errors.retries:-1}") int retriesOn5xxErrors) {
+    super(webHookEndpoint, retriesOn5xxErrors, log);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/AuthorizationError.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/AuthorizationError.java
@@ -6,11 +6,12 @@
 package com.vmware.taurus.exception;
 
 /**
- * AuthorizationError class which extends the {@link SystemError} class to follow
- * the exception handling in a proper manner
+ * AuthorizationError class which extends the {@link SystemError} class to follow the exception
+ * handling in a proper manner
  */
 public class AuthorizationError extends SystemError {
-    public AuthorizationError(String why, String consequences, String countermeasures, Throwable cause) {
-        super("Authorization failed", why, consequences, countermeasures, cause);
-    }
+  public AuthorizationError(
+      String why, String consequences, String countermeasures, Throwable cause) {
+    super("Authorization failed", why, consequences, countermeasures, cause);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/DataJobAlreadyRunningException.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/DataJobAlreadyRunningException.java
@@ -9,16 +9,17 @@ import org.springframework.http.HttpStatus;
 
 public class DataJobAlreadyRunningException extends DomainError implements UserFacingError {
 
-   public DataJobAlreadyRunningException(String jobName) {
-      super(String.format("The Data Job '%s' is currently being executed.", jobName),
-            "Simultaneous execution of the same Data Job are not allowed.",
-            "The Data Job will not be started. The ongoing Data Job execution will continue to run.",
-            "Wait for the current Data Job execution to complete or cancel it and try again.",
-            null);
-   }
+  public DataJobAlreadyRunningException(String jobName) {
+    super(
+        String.format("The Data Job '%s' is currently being executed.", jobName),
+        "Simultaneous execution of the same Data Job are not allowed.",
+        "The Data Job will not be started. The ongoing Data Job execution will continue to run.",
+        "Wait for the current Data Job execution to complete or cancel it and try again.",
+        null);
+  }
 
-   @Override
-   public HttpStatus getHttpStatus() {
-      return HttpStatus.CONFLICT;
-   }
+  @Override
+  public HttpStatus getHttpStatus() {
+    return HttpStatus.CONFLICT;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/DataJobDeploymentNotFoundException.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/DataJobDeploymentNotFoundException.java
@@ -9,16 +9,17 @@ import org.springframework.http.HttpStatus;
 
 public class DataJobDeploymentNotFoundException extends DomainError implements UserFacingError {
 
-   public DataJobDeploymentNotFoundException(String jobName) {
-      super(String.format("The Data Job '%s' is not deployed.", jobName),
-            "The Data Job must be deployed.",
-            "Operation cannot complete since it expects the data job to have a deployment.",
-            "Deploy the Data Job and try again.",
-            null);
-   }
+  public DataJobDeploymentNotFoundException(String jobName) {
+    super(
+        String.format("The Data Job '%s' is not deployed.", jobName),
+        "The Data Job must be deployed.",
+        "Operation cannot complete since it expects the data job to have a deployment.",
+        "Deploy the Data Job and try again.",
+        null);
+  }
 
-   @Override
-   public HttpStatus getHttpStatus() {
-      return HttpStatus.NOT_FOUND;
-   }
+  @Override
+  public HttpStatus getHttpStatus() {
+    return HttpStatus.NOT_FOUND;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/DataJobExecutionCannotBeCancelledException.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/DataJobExecutionCannotBeCancelledException.java
@@ -7,70 +7,77 @@ package com.vmware.taurus.exception;
 
 import org.springframework.http.HttpStatus;
 
-public class DataJobExecutionCannotBeCancelledException extends DomainError implements UserFacingError {
+public class DataJobExecutionCannotBeCancelledException extends DomainError
+    implements UserFacingError {
 
-    private ExecutionCancellationFailureReason reason;
+  private ExecutionCancellationFailureReason reason;
 
-    public DataJobExecutionCannotBeCancelledException(String executionId, ExecutionCancellationFailureReason reason) {
-        super(String.format("The Data Job execution '%s' cannot be cancelled.", executionId),
-                getWhyMessage(reason),
-                getConsequencesMessage(reason),
-                getCounterMeasuresMessage(reason),
-                null);
-        this.reason = reason;
+  public DataJobExecutionCannotBeCancelledException(
+      String executionId, ExecutionCancellationFailureReason reason) {
+    super(
+        String.format("The Data Job execution '%s' cannot be cancelled.", executionId),
+        getWhyMessage(reason),
+        getConsequencesMessage(reason),
+        getCounterMeasuresMessage(reason),
+        null);
+    this.reason = reason;
+  }
+
+  @Override
+  public HttpStatus getHttpStatus() {
+
+    if (this.reason == ExecutionCancellationFailureReason.DataJobNotFound
+        || this.reason == ExecutionCancellationFailureReason.DataJobExecutionNotFound) {
+      return HttpStatus.NOT_FOUND;
     }
 
-    @Override
-    public HttpStatus getHttpStatus() {
+    return HttpStatus.BAD_REQUEST;
+  }
 
-        if (this.reason == ExecutionCancellationFailureReason.DataJobNotFound ||
-                this.reason == ExecutionCancellationFailureReason.DataJobExecutionNotFound) {
-            return HttpStatus.NOT_FOUND;
-        }
+  private static String getWhyMessage(ExecutionCancellationFailureReason reason) {
+    String message;
 
-        return HttpStatus.BAD_REQUEST;
+    if (reason == ExecutionCancellationFailureReason.DataJobNotFound) {
+      message = "Specified Data Job for Team does not exist.";
+    } else if (reason == ExecutionCancellationFailureReason.ExecutionNotRunning) {
+      message = "Specified data job execution is not in running or submitted state.";
+    } else if (reason == ExecutionCancellationFailureReason.DataJobExecutionNotFound) {
+      message = "Specified data job execution does not exist.";
+    } else {
+      message = "Unknown cause.";
+    }
+    return message;
+  }
 
+  private static String getConsequencesMessage(ExecutionCancellationFailureReason reason) {
+    // reason is here in case we need to expand this method in the future
+    return "API request to cancel Data Job Execution failed.";
+  }
+
+  private static String getCounterMeasuresMessage(ExecutionCancellationFailureReason reason) {
+    String message;
+
+    if (reason == ExecutionCancellationFailureReason.DataJobNotFound) {
+      message =
+          "Specified Data Job for Team must exist and be deployed to cancel one of its running"
+              + " executions. List data jobs that have been created in cloud and make sure you"
+              + " specify a valid data job and team.";
+    } else if (reason == ExecutionCancellationFailureReason.ExecutionNotRunning) {
+      message =
+          "List recent and/or current executions of the Data Job. "
+              + "Make sure you specify a valid execution in running or submitted state.";
+    } else if (reason == ExecutionCancellationFailureReason.DataJobExecutionNotFound) {
+      message =
+          "The provided data job execution does not exist. Make sure the provided execution id is"
+              + " correct. List all data job executions of the data job and make sure you specify"
+              + " one that exists.";
+    } else {
+      message =
+          "Unknown failure reason. Please verify all specified parameters: data job, data job"
+              + " execution and team are correct and try again. Should the problem persist please"
+              + " contact support.";
     }
 
-    private static String getWhyMessage(ExecutionCancellationFailureReason reason) {
-        String message;
-
-        if (reason == ExecutionCancellationFailureReason.DataJobNotFound) {
-            message = "Specified Data Job for Team does not exist.";
-        } else if (reason == ExecutionCancellationFailureReason.ExecutionNotRunning) {
-            message = "Specified data job execution is not in running or submitted state.";
-        } else if (reason == ExecutionCancellationFailureReason.DataJobExecutionNotFound) {
-            message = "Specified data job execution does not exist.";
-        } else {
-            message = "Unknown cause.";
-        }
-        return message;
-    }
-
-
-    private static String getConsequencesMessage(ExecutionCancellationFailureReason reason) {
-        //reason is here in case we need to expand this method in the future
-        return "API request to cancel Data Job Execution failed.";
-    }
-
-    private static String getCounterMeasuresMessage(ExecutionCancellationFailureReason reason) {
-        String message;
-
-        if (reason == ExecutionCancellationFailureReason.DataJobNotFound) {
-            message = "Specified Data Job for Team must exist and be deployed to cancel one of its running executions. " +
-                    "List data jobs that have been created in cloud and make sure you specify a valid data job and team.";
-        } else if (reason == ExecutionCancellationFailureReason.ExecutionNotRunning) {
-            message = "List recent and/or current executions of the Data Job. " +
-                    "Make sure you specify a valid execution in running or submitted state.";
-        } else if (reason == ExecutionCancellationFailureReason.DataJobExecutionNotFound) {
-            message = "The provided data job execution does not exist. Make sure the provided execution id is correct. " +
-                    "List all data job executions of the data job and make sure you specify one that exists.";
-        } else {
-            message = "Unknown failure reason. Please verify all specified parameters: data job, data job execution and " +
-                    "team are correct and try again. Should the problem persist please contact support.";
-        }
-
-        return message;
-    }
-
+    return message;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/DataJobExecutionNotFoundException.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/DataJobExecutionNotFoundException.java
@@ -9,16 +9,17 @@ import org.springframework.http.HttpStatus;
 
 public class DataJobExecutionNotFoundException extends DomainError implements UserFacingError {
 
-   public DataJobExecutionNotFoundException(String executionId) {
-      super(String.format("The Data Job execution '%s' does not exist.", executionId),
-            "Likely the Data Job execution have not started or it has expired.",
-            "The Data Job execution will not be returned.",
-            "Provide a Data Job execution that already exists or trigger one and try again.",
-            null);
-   }
+  public DataJobExecutionNotFoundException(String executionId) {
+    super(
+        String.format("The Data Job execution '%s' does not exist.", executionId),
+        "Likely the Data Job execution have not started or it has expired.",
+        "The Data Job execution will not be returned.",
+        "Provide a Data Job execution that already exists or trigger one and try again.",
+        null);
+  }
 
-   @Override
-   public HttpStatus getHttpStatus() {
-      return HttpStatus.NOT_FOUND;
-   }
+  @Override
+  public HttpStatus getHttpStatus() {
+    return HttpStatus.NOT_FOUND;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/DataJobExecutionStatusNotValidException.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/DataJobExecutionStatusNotValidException.java
@@ -11,21 +11,23 @@ import org.springframework.http.HttpStatus;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-public class DataJobExecutionStatusNotValidException extends DomainError implements UserFacingError {
+public class DataJobExecutionStatusNotValidException extends DomainError
+    implements UserFacingError {
 
-   public DataJobExecutionStatusNotValidException(String jobName) {
-      super(String.format("The Execution Status '%s' is not valid.", jobName),
-            "The Execution Status must be valid.",
-            "The Data Job Execution(s) will not be returned.",
-            "Provide a valid Execution Status. Valid statuses are: " +
-                  Arrays.stream(DataJobExecution.StatusEnum.values())
-                  .map(statusEnum -> statusEnum.getValue())
-                        .collect(Collectors.joining(", ","[","].")),
-            null);
-   }
+  public DataJobExecutionStatusNotValidException(String jobName) {
+    super(
+        String.format("The Execution Status '%s' is not valid.", jobName),
+        "The Execution Status must be valid.",
+        "The Data Job Execution(s) will not be returned.",
+        "Provide a valid Execution Status. Valid statuses are: "
+            + Arrays.stream(DataJobExecution.StatusEnum.values())
+                .map(statusEnum -> statusEnum.getValue())
+                .collect(Collectors.joining(", ", "[", "].")),
+        null);
+  }
 
-   @Override
-   public HttpStatus getHttpStatus() {
-      return HttpStatus.NOT_FOUND;
-   }
+  @Override
+  public HttpStatus getHttpStatus() {
+    return HttpStatus.NOT_FOUND;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/DataJobNotFoundException.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/DataJobNotFoundException.java
@@ -9,16 +9,17 @@ import org.springframework.http.HttpStatus;
 
 public class DataJobNotFoundException extends DomainError implements UserFacingError {
 
-   public DataJobNotFoundException(String jobName) {
-      super(String.format("The Data Job '%s' does not exist.", jobName),
-            "The Data Job must be existing.",
-            "The Data Job will not be started.",
-            "Provide a Data Job that already exists or create a new one and try again.",
-            null);
-   }
+  public DataJobNotFoundException(String jobName) {
+    super(
+        String.format("The Data Job '%s' does not exist.", jobName),
+        "The Data Job must be existing.",
+        "The Data Job will not be started.",
+        "Provide a Data Job that already exists or create a new one and try again.",
+        null);
+  }
 
-   @Override
-   public HttpStatus getHttpStatus() {
-      return HttpStatus.NOT_FOUND;
-   }
+  @Override
+  public HttpStatus getHttpStatus() {
+    return HttpStatus.NOT_FOUND;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/ExecutionCancellationFailureReason.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/ExecutionCancellationFailureReason.java
@@ -6,5 +6,7 @@
 package com.vmware.taurus.exception;
 
 public enum ExecutionCancellationFailureReason {
-    DataJobNotFound, DataJobExecutionNotFound, ExecutionNotRunning
+  DataJobNotFound,
+  DataJobExecutionNotFound,
+  ExecutionNotRunning
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/ExternalSystemError.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/ExternalSystemError.java
@@ -10,90 +10,87 @@ import org.springframework.http.HttpStatus;
 import java.io.IOException;
 
 /**
- * User-facing error caused by systems or layers that Taurus depends upon and are provided by the team that operates the
- * deployment
+ * User-facing error caused by systems or layers that Taurus depends upon and are provided by the
+ * team that operates the deployment
  *
- * <p>
- * Common systems are documented in {@link MainExternalSystem}
+ * <p>Common systems are documented in {@link MainExternalSystem}
  */
 public class ExternalSystemError extends SystemError implements UserFacingError {
 
-   /**
-    * External systems that may fail along with the name which appears in user-facing messages
-    */
-   public enum MainExternalSystem {
+  /** External systems that may fail along with the name which appears in user-facing messages */
+  public enum MainExternalSystem {
 
-      /**
-       * The Kubernetes cluster on which jobs and/or Taurus itself are deployed.
-       *
-       * <p>
-       * Typical intermittent issues are outages of components like etcd. Typical permanent issues are bad permissions.
-       */
-      KUBERNETES("Kubernetes cluster"),
+    /**
+     * The Kubernetes cluster on which jobs and/or Taurus itself are deployed.
+     *
+     * <p>Typical intermittent issues are outages of components like etcd. Typical permanent issues
+     * are bad permissions.
+     */
+    KUBERNETES("Kubernetes cluster"),
 
-      /**
-       * The backend database of the current Taurus component e.g. CockroachDB for Versatile Data Kit.
-       */
-      DATABASE("Database"),
+    /**
+     * The backend database of the current Taurus component e.g. CockroachDB for Versatile Data Kit.
+     */
+    DATABASE("Database"),
 
-      /**
-       * The OCI or Docker container that hosts the component that failed
-       *
-       * <p>
-       * Typical intermittent issues are {@link IOException} when accessing local storage or volumes.
-       */
-      HOST_CONTAINER("Host container"),
+    /**
+     * The OCI or Docker container that hosts the component that failed
+     *
+     * <p>Typical intermittent issues are {@link IOException} when accessing local storage or
+     * volumes.
+     */
+    HOST_CONTAINER("Host container"),
 
-      /**
-       * The Kerberos KDC that manages service accounts for user workloads managed by Taurus
-       */
-      KERBEROS("Kerberos"),
+    /** The Kerberos KDC that manages service accounts for user workloads managed by Taurus */
+    KERBEROS("Kerberos"),
 
-      /**
-       * The webhook server to which we delegate authorization
-       */
-      AUTHORIZATION_SERVER("Authorization server"),
+    /** The webhook server to which we delegate authorization */
+    AUTHORIZATION_SERVER("Authorization server"),
 
-      /**
-       * The webhook server to which we delegate default operations
-       */
-      WEBHOOK_SERVER("Webhook server"),
+    /** The webhook server to which we delegate default operations */
+    WEBHOOK_SERVER("Webhook server"),
 
-      /**
-       * The Git repository that contains the data job code
-       */
-      GIT("Git");
+    /** The Git repository that contains the data job code */
+    GIT("Git");
 
-      private final String userFacingName;
+    private final String userFacingName;
 
-      MainExternalSystem(String userFacingName) {
-         this.userFacingName = userFacingName;
-      }
-   }
+    MainExternalSystem(String userFacingName) {
+      this.userFacingName = userFacingName;
+    }
+  }
 
-   public ExternalSystemError(MainExternalSystem externalSystem, Throwable cause) {
-      this(externalSystem.userFacingName, cause.toString(), cause); // cause must not be null to use this constructor
-   }
+  public ExternalSystemError(MainExternalSystem externalSystem, Throwable cause) {
+    this(
+        externalSystem.userFacingName,
+        cause.toString(),
+        cause); // cause must not be null to use this constructor
+  }
 
-   public ExternalSystemError(MainExternalSystem externalSystem, String errorDescription) {
-      this(externalSystem.userFacingName, errorDescription, null);
-   }
+  public ExternalSystemError(MainExternalSystem externalSystem, String errorDescription) {
+    this(externalSystem.userFacingName, errorDescription, null);
+  }
 
-   public ExternalSystemError(MainExternalSystem externalSystem, String errorDescription, Throwable cause) {
-      this(externalSystem.userFacingName, errorDescription, cause);
-   }
+  public ExternalSystemError(
+      MainExternalSystem externalSystem, String errorDescription, Throwable cause) {
+    this(externalSystem.userFacingName, errorDescription, cause);
+  }
 
-   public ExternalSystemError(String externalSystemName, String errorDescription, Throwable cause) {
-      super(String.format("%s encountered an error: %s.", externalSystemName, errorDescription),
-              "The external system may be experiencing intermittent issues or there might be permanent misconfiguration or outage.",
-              "The current API operation failed.",
-              "Try the operation again in a few minutes and open a ticket to the SRE team if the problem persists.",
-              cause);
-   }
+  public ExternalSystemError(String externalSystemName, String errorDescription, Throwable cause) {
+    super(
+        String.format("%s encountered an error: %s.", externalSystemName, errorDescription),
+        "The external system may be experiencing intermittent issues or there might be permanent"
+            + " misconfiguration or outage.",
+        "The current API operation failed.",
+        "Try the operation again in a few minutes and open a ticket to the SRE team if the problem"
+            + " persists.",
+        cause);
+  }
 
-   @Override
-   public HttpStatus getHttpStatus() {
-      // Discussion here makes sense https://stackoverflow.com/questions/25398364/http-status-code-for-external-dependency-error
-      return HttpStatus.SERVICE_UNAVAILABLE;
-   }
+  @Override
+  public HttpStatus getHttpStatus() {
+    // Discussion here makes sense
+    // https://stackoverflow.com/questions/25398364/http-status-code-for-external-dependency-error
+    return HttpStatus.SERVICE_UNAVAILABLE;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/JsonDissectException.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/JsonDissectException.java
@@ -8,16 +8,17 @@ package com.vmware.taurus.exception;
 import org.springframework.http.HttpStatus;
 
 public class JsonDissectException extends DomainError implements UserFacingError {
-    public JsonDissectException(Throwable cause) {
-        super("Control service failed to parse provided arguments to a valid JSON string.",
-                String.format("The internal parser threw an exception because: %s", cause.getMessage()),
-                "The requested system call will not complete.",
-                "Inspect the cause and re-try the call with arguments that can be parsed to JSON.",
-                cause);
-    }
+  public JsonDissectException(Throwable cause) {
+    super(
+        "Control service failed to parse provided arguments to a valid JSON string.",
+        String.format("The internal parser threw an exception because: %s", cause.getMessage()),
+        "The requested system call will not complete.",
+        "Inspect the cause and re-try the call with arguments that can be parsed to JSON.",
+        cause);
+  }
 
-    @Override
-    public HttpStatus getHttpStatus() {
-        return HttpStatus.BAD_REQUEST;
-    }
+  @Override
+  public HttpStatus getHttpStatus() {
+    return HttpStatus.BAD_REQUEST;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/KubernetesException.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/KubernetesException.java
@@ -7,27 +7,25 @@ package com.vmware.taurus.exception;
 
 import io.kubernetes.client.openapi.ApiException;
 
-/**
- * Wrapper over Kubernetes Exception printing more details from ApiException
- */
+/** Wrapper over Kubernetes Exception printing more details from ApiException */
 public class KubernetesException extends ExternalSystemError {
 
-   public KubernetesException(String errorDescription, Throwable cause) {
-      super(MainExternalSystem.KUBERNETES.name(), errorDescription + getDetails(cause), cause);
-   }
+  public KubernetesException(String errorDescription, Throwable cause) {
+    super(MainExternalSystem.KUBERNETES.name(), errorDescription + getDetails(cause), cause);
+  }
 
-   private static String getDetails(Throwable cause) {
-      if (cause instanceof ApiException) {
-         return getDetails((ApiException)cause);
-      }
-      return cause != null ? cause.getMessage() : "";
-   }
+  private static String getDetails(Throwable cause) {
+    if (cause instanceof ApiException) {
+      return getDetails((ApiException) cause);
+    }
+    return cause != null ? cause.getMessage() : "";
+  }
 
-   private static String getDetails(ApiException cause) {
-      StringBuilder sb = new StringBuilder();
-      sb.append("\nKubernetes API Exception Details: \n");
-      sb.append("response body: ").append(cause.getResponseBody()).append("\n");
-      sb.append("response headers: ").append(cause.getResponseHeaders());
-      return sb.toString();
-   }
+  private static String getDetails(ApiException cause) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("\nKubernetes API Exception Details: \n");
+    sb.append("response body: ").append(cause.getResponseBody()).append("\n");
+    sb.append("response headers: ").append(cause.getResponseHeaders());
+    return sb.toString();
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/KubernetesJobDefinitionException.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/KubernetesJobDefinitionException.java
@@ -8,16 +8,19 @@ package com.vmware.taurus.exception;
 import org.springframework.http.HttpStatus;
 
 public class KubernetesJobDefinitionException extends SystemError implements UserFacingError {
-    public KubernetesJobDefinitionException(String jobName) {
-        super(String.format("A configuration error with the current kubernetes job: '%s' definition was found.", jobName),
-                "Likely due to recent changes in the internal implementation.",
-                "The current call will not be processed.",
-                "Please open a new GitHub issue with the details of this error.",
-                null);
-    }
+  public KubernetesJobDefinitionException(String jobName) {
+    super(
+        String.format(
+            "A configuration error with the current kubernetes job: '%s' definition was found.",
+            jobName),
+        "Likely due to recent changes in the internal implementation.",
+        "The current call will not be processed.",
+        "Please open a new GitHub issue with the details of this error.",
+        null);
+  }
 
-    @Override
-    public HttpStatus getHttpStatus() {
-        return HttpStatus.INTERNAL_SERVER_ERROR;
-    }
+  @Override
+  public HttpStatus getHttpStatus() {
+    return HttpStatus.INTERNAL_SERVER_ERROR;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/properties/controller/DataJobsPropertiesController.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/properties/controller/DataJobsPropertiesController.java
@@ -5,7 +5,6 @@
 
 package com.vmware.taurus.properties.controller;
 
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.vmware.taurus.controlplane.model.api.DataJobsPropertiesApi;
 import com.vmware.taurus.properties.service.PropertiesService;
@@ -24,33 +23,35 @@ import java.util.Map;
 @ComponentScan(basePackages = "com.vmware.taurus.properties")
 @Api(tags = {"Data Jobs Properties"})
 public class DataJobsPropertiesController implements DataJobsPropertiesApi {
-   static Logger log = LoggerFactory.getLogger(DataJobsPropertiesController.class);
+  static Logger log = LoggerFactory.getLogger(DataJobsPropertiesController.class);
 
-   private final PropertiesService propertiesService;
+  private final PropertiesService propertiesService;
 
-   public DataJobsPropertiesController(PropertiesService propertiesService) {
-      this.propertiesService = propertiesService;
-   }
+  public DataJobsPropertiesController(PropertiesService propertiesService) {
+    this.propertiesService = propertiesService;
+  }
 
-   @Override
-   public ResponseEntity<Void> dataJobPropertiesUpdate(String teamName, String jobName, String deploymentId, Map<String, Object> requestBody) {
-      log.debug("Updating properties for job: {}", jobName);
+  @Override
+  public ResponseEntity<Void> dataJobPropertiesUpdate(
+      String teamName, String jobName, String deploymentId, Map<String, Object> requestBody) {
+    log.debug("Updating properties for job: {}", jobName);
 
-      propertiesService.updateJobProperties(jobName, requestBody);
-      return ResponseEntity.noContent().build();
-   }
+    propertiesService.updateJobProperties(jobName, requestBody);
+    return ResponseEntity.noContent().build();
+  }
 
-   @Override
-   public ResponseEntity<Map<String, Object>> dataJobPropertiesRead(String teamName, String jobName, String deploymentId) {
-      log.debug("Reading properties for job: {}", jobName);
+  @Override
+  public ResponseEntity<Map<String, Object>> dataJobPropertiesRead(
+      String teamName, String jobName, String deploymentId) {
+    log.debug("Reading properties for job: {}", jobName);
 
-      try {
-         return ResponseEntity.ok(propertiesService.readJobProperties(jobName));
-      } catch (JsonProcessingException e) {
-         log.error("Error while parsing properties for job: " + jobName, e);
+    try {
+      return ResponseEntity.ok(propertiesService.readJobProperties(jobName));
+    } catch (JsonProcessingException e) {
+      log.error("Error while parsing properties for job: " + jobName, e);
 
-         throw new ResponseStatusException(
-               HttpStatus.INTERNAL_SERVER_ERROR, "Error while parsing properties for job: " + jobName);
-      }
-   }
+      throw new ResponseStatusException(
+          HttpStatus.INTERNAL_SERVER_ERROR, "Error while parsing properties for job: " + jobName);
+    }
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/properties/service/JobProperties.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/properties/service/JobProperties.java
@@ -19,9 +19,10 @@ import javax.persistence.Id;
 @Entity
 public class JobProperties {
 
-    @Id
-    @Column(name = "job_name")
-    private String jobName;
-    @Column(name = "properties_json")
-    private String propertiesJson;
+  @Id
+  @Column(name = "job_name")
+  private String jobName;
+
+  @Column(name = "properties_json")
+  private String propertiesJson;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/properties/service/PropertiesRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/properties/service/PropertiesRepository.java
@@ -13,6 +13,5 @@ import java.util.Optional;
 @Repository
 public interface PropertiesRepository extends CrudRepository<JobProperties, String> {
 
-   Optional<JobProperties> findByJobName(String jobName);
-
+  Optional<JobProperties> findByJobName(String jobName);
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/properties/service/PropertiesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/properties/service/PropertiesService.java
@@ -20,37 +20,44 @@ import java.util.stream.Collectors;
 @Service
 public class PropertiesService {
 
-   private final PropertiesRepository propertiesRepository;
-   private final ObjectMapper objectMapper = new ObjectMapper();
+  private final PropertiesRepository propertiesRepository;
+  private final ObjectMapper objectMapper = new ObjectMapper();
 
-   @Autowired
-   public PropertiesService(PropertiesRepository propertiesRepository) {
-      this.propertiesRepository = propertiesRepository;
-   }
+  @Autowired
+  public PropertiesService(PropertiesRepository propertiesRepository) {
+    this.propertiesRepository = propertiesRepository;
+  }
 
-   public void updateJobProperties(String jobName, Map<String, Object> properties) {
-      var jobProperties = propertiesRepository.findByJobName(jobName)
-            .orElse(new JobProperties( jobName, null));
+  public void updateJobProperties(String jobName, Map<String, Object> properties) {
+    var jobProperties =
+        propertiesRepository.findByJobName(jobName).orElse(new JobProperties(jobName, null));
 
-      properties = properties.entrySet()
-            .stream()
-            .collect(Collectors.toMap(Map.Entry::getKey, entry -> {
-               if (entry.getValue() == null) {
-                  entry.setValue(JSONObject.NULL);
-               }
-               return entry.getValue();
-            }));
+    properties =
+        properties.entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    Map.Entry::getKey,
+                    entry -> {
+                      if (entry.getValue() == null) {
+                        entry.setValue(JSONObject.NULL);
+                      }
+                      return entry.getValue();
+                    }));
 
-      jobProperties.setPropertiesJson(new JSONObject(properties).toString());
+    jobProperties.setPropertiesJson(new JSONObject(properties).toString());
 
-      propertiesRepository.save(jobProperties);
-   }
+    propertiesRepository.save(jobProperties);
+  }
 
-   public Map<String, Object> readJobProperties(String jobName) throws JsonProcessingException {
-      var jobPropertiesJson = propertiesRepository.findByJobName(jobName)
+  public Map<String, Object> readJobProperties(String jobName) throws JsonProcessingException {
+    var jobPropertiesJson =
+        propertiesRepository
+            .findByJobName(jobName)
             .map(JobProperties::getPropertiesJson)
             .orElse(null);
 
-      return jobPropertiesJson == null ? Collections.emptyMap() : objectMapper.readValue(jobPropertiesJson, Map.class);
-   }
+    return jobPropertiesJson == null
+        ? Collections.emptyMap()
+        : objectMapper.readValue(jobPropertiesJson, Map.class);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/GraphQLJobsQueryService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/GraphQLJobsQueryService.java
@@ -21,44 +21,45 @@ import java.util.Map;
 @AllArgsConstructor
 public class GraphQLJobsQueryService {
 
-   public static final String DEFAULT_QUERY =
-         "{" +
-               "  jobs(pageNumber: 1, pageSize: 20, filter: []) {" +
-               "    content {" +
-               "      jobName" +
-               "      config {" +
-               "        team" +
-               "        description" +
-               "        schedule {" +
-               "          scheduleCron" +
-               "        }" +
-               "      }" +
-               "    }" +
-               "    totalPages" +
-               "    totalItems" +
-               "  }" +
-               "}";
+  public static final String DEFAULT_QUERY =
+      "{"
+          + "  jobs(pageNumber: 1, pageSize: 20, filter: []) {"
+          + "    content {"
+          + "      jobName"
+          + "      config {"
+          + "        team"
+          + "        description"
+          + "        schedule {"
+          + "          scheduleCron"
+          + "        }"
+          + "      }"
+          + "    }"
+          + "    totalPages"
+          + "    totalItems"
+          + "  }"
+          + "}";
 
-   private final GraphQL graphQL;
-   private final JsonSerializer jsonSerializer;
-   private final OperationContext operationContext;
+  private final GraphQL graphQL;
+  private final JsonSerializer jsonSerializer;
+  private final OperationContext operationContext;
 
-   @SuppressWarnings("unchecked")
-   public Map<String, Object> convertVariablesJson(String jsonMap) {
-      if (jsonMap == null) {
-         return Collections.emptyMap();
-      }
-      // find a better way instead of suppressing warnings
-      return jsonSerializer.deserialize(jsonMap, Map.class);
-   }
+  @SuppressWarnings("unchecked")
+  public Map<String, Object> convertVariablesJson(String jsonMap) {
+    if (jsonMap == null) {
+      return Collections.emptyMap();
+    }
+    // find a better way instead of suppressing warnings
+    return jsonSerializer.deserialize(jsonMap, Map.class);
+  }
 
-   public ExecutionResult executeRequest(String query, String operationName, Map<String, Object> variables) {
-      return graphQL.execute(ExecutionInput.newExecutionInput()
+  public ExecutionResult executeRequest(
+      String query, String operationName, Map<String, Object> variables) {
+    return graphQL.execute(
+        ExecutionInput.newExecutionInput()
             .variables(variables)
             .query(query)
             .executionId(ExecutionId.from(operationContext.getOpId()))
             .operationName(operationName == null ? "" : operationName.trim().replace("\"", ""))
-            .build()
-      );
-   }
+            .build());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobExecutionFilterSpec.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobExecutionFilterSpec.java
@@ -24,43 +24,56 @@ import java.util.List;
 @AllArgsConstructor
 public class JobExecutionFilterSpec implements Specification<DataJobExecution> {
 
-   private DataJobExecutionFilter filter;
+  private DataJobExecutionFilter filter;
 
-   @Override
-   public Predicate toPredicate(Root<DataJobExecution> root, CriteriaQuery<?> query, CriteriaBuilder builder) {
-      List<Predicate> predicates = new ArrayList<>();
+  @Override
+  public Predicate toPredicate(
+      Root<DataJobExecution> root, CriteriaQuery<?> query, CriteriaBuilder builder) {
+    List<Predicate> predicates = new ArrayList<>();
 
-      if (filter != null) {
-         if (filter.getStartTimeGte() != null) {
-            predicates.add(builder.greaterThanOrEqualTo(root.get(DataJobExecution_.START_TIME), filter.getStartTimeGte()));
-         }
-
-         if (filter.getStartTimeLte() != null) {
-            predicates.add(builder.lessThanOrEqualTo(root.get(DataJobExecution_.START_TIME), filter.getStartTimeLte()));
-         }
-
-         if (filter.getEndTimeGte() != null) {
-            predicates.add(builder.greaterThanOrEqualTo(root.get(DataJobExecution_.END_TIME), filter.getEndTimeGte()));
-         }
-
-         if (filter.getEndTimeLte() != null) {
-            predicates.add(builder.lessThanOrEqualTo(root.get(DataJobExecution_.END_TIME), filter.getEndTimeLte()));
-         }
-
-         if (CollectionUtils.isNotEmpty(filter.getStatusIn())) {
-            predicates.add(root.get(DataJobExecution_.STATUS).in(filter.getStatusIn()));
-         }
-
-         if (CollectionUtils.isNotEmpty(filter.getJobNameIn())) {
-            predicates.add(root.get(DataJobExecution_.DATA_JOB).get(DataJob_.NAME).in(filter.getJobNameIn()));
-         }
-
-         if (CollectionUtils.isNotEmpty(filter.getTeamNameIn())) {
-            predicates.add(root.get(DataJobExecution_.DATA_JOB).get(DataJob_.JOB_CONFIG).get(JobConfig_.TEAM).in(filter.getTeamNameIn()));
-         }
-
+    if (filter != null) {
+      if (filter.getStartTimeGte() != null) {
+        predicates.add(
+            builder.greaterThanOrEqualTo(
+                root.get(DataJobExecution_.START_TIME), filter.getStartTimeGte()));
       }
 
-      return builder.and(predicates.toArray(new Predicate[0]));
-   }
+      if (filter.getStartTimeLte() != null) {
+        predicates.add(
+            builder.lessThanOrEqualTo(
+                root.get(DataJobExecution_.START_TIME), filter.getStartTimeLte()));
+      }
+
+      if (filter.getEndTimeGte() != null) {
+        predicates.add(
+            builder.greaterThanOrEqualTo(
+                root.get(DataJobExecution_.END_TIME), filter.getEndTimeGte()));
+      }
+
+      if (filter.getEndTimeLte() != null) {
+        predicates.add(
+            builder.lessThanOrEqualTo(
+                root.get(DataJobExecution_.END_TIME), filter.getEndTimeLte()));
+      }
+
+      if (CollectionUtils.isNotEmpty(filter.getStatusIn())) {
+        predicates.add(root.get(DataJobExecution_.STATUS).in(filter.getStatusIn()));
+      }
+
+      if (CollectionUtils.isNotEmpty(filter.getJobNameIn())) {
+        predicates.add(
+            root.get(DataJobExecution_.DATA_JOB).get(DataJob_.NAME).in(filter.getJobNameIn()));
+      }
+
+      if (CollectionUtils.isNotEmpty(filter.getTeamNameIn())) {
+        predicates.add(
+            root.get(DataJobExecution_.DATA_JOB)
+                .get(DataJob_.JOB_CONFIG)
+                .get(JobConfig_.TEAM)
+                .in(filter.getTeamNameIn()));
+      }
+    }
+
+    return builder.and(predicates.toArray(new Predicate[0]));
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobExecutionRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobExecutionRepository.java
@@ -19,35 +19,38 @@ import java.util.Optional;
 /**
  * Spring Data / JPA Repository for DataJobExecution objects and their members
  *
- * <p>
- * Spring Data automatically creates an implementation of this interface at runtime, provided {@link DataJobExecution}
- * is a valid JPA entity.
+ * <p>Spring Data automatically creates an implementation of this interface at runtime, provided
+ * {@link DataJobExecution} is a valid JPA entity.
  *
- * <p>
- * Methods throw {@link org.springframework.dao.DataAccessException} in case of issues of writing to the database.
+ * <p>Methods throw {@link org.springframework.dao.DataAccessException} in case of issues of writing
+ * to the database.
  *
- * <p>
- * JobExecutionRepositoryIT validates some aspects of the behavior
+ * <p>JobExecutionRepositoryIT validates some aspects of the behavior
  */
-public interface JobExecutionRepository extends JpaRepository<DataJobExecution, String>, JpaSpecificationExecutor<DataJobExecution> {
+public interface JobExecutionRepository
+    extends JpaRepository<DataJobExecution, String>, JpaSpecificationExecutor<DataJobExecution> {
 
-   List<DataJobExecution> findDataJobExecutionsByDataJobName(String jobName);
+  List<DataJobExecution> findDataJobExecutionsByDataJobName(String jobName);
 
-   Optional<DataJobExecution> findFirstByDataJobNameOrderByStartTimeDesc(String jobName);
+  Optional<DataJobExecution> findFirstByDataJobNameOrderByStartTimeDesc(String jobName);
 
-   List<DataJobExecution> findDataJobExecutionsByDataJobName(String jobName, Pageable pageable);
+  List<DataJobExecution> findDataJobExecutionsByDataJobName(String jobName, Pageable pageable);
 
-   List<DataJobExecution> findDataJobExecutionsByDataJobNameAndStatusIn(String jobName, List<ExecutionStatus> statuses);
+  List<DataJobExecution> findDataJobExecutionsByDataJobNameAndStatusIn(
+      String jobName, List<ExecutionStatus> statuses);
 
-   List<DataJobExecutionIdAndEndTime> findByDataJobNameAndStatusNotInOrderByEndTime(String jobName, List<ExecutionStatus> statuses);
+  List<DataJobExecutionIdAndEndTime> findByDataJobNameAndStatusNotInOrderByEndTime(
+      String jobName, List<ExecutionStatus> statuses);
 
-   List<DataJobExecution> findDataJobExecutionsByStatusInAndStartTimeBefore(List<ExecutionStatus> statuses, OffsetDateTime startTime);
+  List<DataJobExecution> findDataJobExecutionsByStatusInAndStartTimeBefore(
+      List<ExecutionStatus> statuses, OffsetDateTime startTime);
 
-   @Query("SELECT dje.status AS status, dje.dataJob.name AS jobName, count(dje.status) AS statusCount " +
-          "FROM DataJobExecution dje " +
-          "WHERE dje.status IN :statuses " +
-          "AND dje.dataJob.name IN :dataJobs " +
-          "GROUP BY dje.status, dje.dataJob")
-   List<DataJobExecutionStatusCount> countDataJobExecutionStatuses(@Param("statuses") List<ExecutionStatus> statuses,
-                                                                   @Param("dataJobs") List<String> dataJobs);
+  @Query(
+      "SELECT dje.status AS status, dje.dataJob.name AS jobName, count(dje.status) AS statusCount "
+          + "FROM DataJobExecution dje "
+          + "WHERE dje.status IN :statuses "
+          + "AND dje.dataJob.name IN :dataJobs "
+          + "GROUP BY dje.status, dje.dataJob")
+  List<DataJobExecutionStatusCount> countDataJobExecutionStatuses(
+      @Param("statuses") List<ExecutionStatus> statuses, @Param("dataJobs") List<String> dataJobs);
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobOperationResult.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobOperationResult.java
@@ -12,6 +12,6 @@ import lombok.Getter;
 @Getter
 @Builder
 public class JobOperationResult {
-   private boolean completed;
-   private WebHookResult webHookResult;
+  private boolean completed;
+  private WebHookResult webHookResult;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobsRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobsRepository.java
@@ -23,53 +23,55 @@ import java.util.Optional;
 /**
  * Spring Data / JPA Repository for DataJob objects and their members
  *
- * <p>
- * Spring Data automatically creates an implementation of this interface at runtime, provided {@link DataJob}
- * is a valid JPA entity.
+ * <p>Spring Data automatically creates an implementation of this interface at runtime, provided
+ * {@link DataJob} is a valid JPA entity.
  *
- * <p>
- * Methods throw {@link org.springframework.dao.DataAccessException} in case of issues of writing to the database.
+ * <p>Methods throw {@link org.springframework.dao.DataAccessException} in case of issues of writing
+ * to the database.
  *
- * <p>
- * JobsRepositoryIT validates some aspects of the behavior
+ * <p>JobsRepositoryIT validates some aspects of the behavior
  */
 @Repository
 public interface JobsRepository extends PagingAndSortingRepository<DataJob, String> {
-   List<DataJob> findAllByJobConfigTeam(String team, Pageable pageable);
+  List<DataJob> findAllByJobConfigTeam(String team, Pageable pageable);
 
-   Optional<DataJob> findDataJobByNameAndJobConfigTeam(String jobName, String teamName);
+  Optional<DataJob> findDataJobByNameAndJobConfigTeam(String jobName, String teamName);
 
-    @Transactional
-    @Modifying(clearAutomatically = true)
-    @Query("update DataJob j set j.latestJobDeploymentStatus = :latestJobDeploymentStatus where j.name = :name")
-    int updateDataJobLatestJobDeploymentStatusByName(
-            @Param(value = "name") String name,
-            @Param(value = "latestJobDeploymentStatus") DeploymentStatus latestJobDeploymentStatus);
+  @Transactional
+  @Modifying(clearAutomatically = true)
+  @Query(
+      "update DataJob j set j.latestJobDeploymentStatus = :latestJobDeploymentStatus where j.name ="
+          + " :name")
+  int updateDataJobLatestJobDeploymentStatusByName(
+      @Param(value = "name") String name,
+      @Param(value = "latestJobDeploymentStatus") DeploymentStatus latestJobDeploymentStatus);
 
-    @Transactional
-    @Modifying(clearAutomatically = true)
-    @Query("update DataJob j set j.enabled = :enabled where j.name = :name")
-    int updateDataJobEnabledByName(
-            @Param(value = "name") String name,
-            @Param(value = "enabled") Boolean enabled);
+  @Transactional
+  @Modifying(clearAutomatically = true)
+  @Query("update DataJob j set j.enabled = :enabled where j.name = :name")
+  int updateDataJobEnabledByName(
+      @Param(value = "name") String name, @Param(value = "enabled") Boolean enabled);
 
-    @Transactional
-    @Modifying(clearAutomatically = true)
-    @Query("update DataJob j set j.lastExecutionStatus = :status, j.lastExecutionEndTime = :endTime, j.lastExecutionDuration = :duration where j.name = :name")
-    int updateDataJobLastExecutionByName(
-            @Param(value = "name") String name,
-            @Param(value = "status") ExecutionStatus status,
-            @Param(value = "endTime") OffsetDateTime endTime,
-            @Param(value = "duration") Integer duration);
+  @Transactional
+  @Modifying(clearAutomatically = true)
+  @Query(
+      "update DataJob j set j.lastExecutionStatus = :status, j.lastExecutionEndTime = :endTime,"
+          + " j.lastExecutionDuration = :duration where j.name = :name")
+  int updateDataJobLastExecutionByName(
+      @Param(value = "name") String name,
+      @Param(value = "status") ExecutionStatus status,
+      @Param(value = "endTime") OffsetDateTime endTime,
+      @Param(value = "duration") Integer duration);
 
-    @Transactional
-    @Modifying(clearAutomatically = true)
-    @Query("update DataJob j set j.latestJobTerminationStatus = :status, j.latestJobExecutionId = :id where j.name = :name")
-    int updateDataJobLatestTerminationStatusByName(
-            @Param(value = "name") String name,
-            @Param(value = "status") ExecutionStatus status,
-            @Param(value = "id") String id
-    );
+  @Transactional
+  @Modifying(clearAutomatically = true)
+  @Query(
+      "update DataJob j set j.latestJobTerminationStatus = :status, j.latestJobExecutionId = :id"
+          + " where j.name = :name")
+  int updateDataJobLatestTerminationStatusByName(
+      @Param(value = "name") String name,
+      @Param(value = "status") ExecutionStatus status,
+      @Param(value = "id") String id);
 
-   boolean existsDataJobByNameAndJobConfigTeam(String jobName, String teamName);
+  boolean existsDataJobByNameAndJobConfigTeam(String jobName, String teamName);
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -5,7 +5,6 @@
 
 package com.vmware.taurus.service;
 
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Iterables;
@@ -62,1762 +61,2428 @@ import java.util.stream.Collectors;
 
 import static java.util.function.Predicate.not;
 
-
 /**
- * A facade over Kubernetes (https://en.wikipedia.org/wiki/Facade_pattern) (not complete see JobImageDeployer)
+ * A facade over Kubernetes (https://en.wikipedia.org/wiki/Facade_pattern) (not complete see
+ * JobImageDeployer)
  *
- * This way there's clear description on what parts of Kubernetes the app depends on.
- * Or changing underlying kubernetes client can be done with changes in a single place.
+ * <p>This way there's clear description on what parts of Kubernetes the app depends on. Or changing
+ * underlying kubernetes client can be done with changes in a single place.
  *
- * TODO: Consider all methods to throw KubernetesException (instead of ApiException) because:
- *  * Better encapsulation
- *  * KubernetesException is more detailed and actually prints the cause.
- * TODO: automatically inject standard labels like OpID, Data Job Name, User.
+ * <p>TODO: Consider all methods to throw KubernetesException (instead of ApiException) because: *
+ * Better encapsulation * KubernetesException is more detailed and actually prints the cause. TODO:
+ * automatically inject standard labels like OpID, Data Job Name, User.
  *
- * We are using sub-classes for different type of connections in order to make use of class-based auto-wiring in Spring.
+ * <p>We are using sub-classes for different type of connections in order to make use of class-based
+ * auto-wiring in Spring.
+ *
  * @see com.vmware.taurus.service.kubernetes.ControlKubernetesService
  * @see com.vmware.taurus.service.kubernetes.DataJobsKubernetesService
  */
 @Service
 public abstract class KubernetesService implements InitializingBean {
 
-    public static final String LABEL_PREFIX = "com.vmware.taurus";
-    private static final int WATCH_JOBS_TIMEOUT_SECONDS = 300;
-    private static final String K8S_DATA_JOB_TEMPLATE_RESOURCE ="k8s-data-job-template.yaml";
+  public static final String LABEL_PREFIX = "com.vmware.taurus";
+  private static final int WATCH_JOBS_TIMEOUT_SECONDS = 300;
+  private static final String K8S_DATA_JOB_TEMPLATE_RESOURCE = "k8s-data-job-template.yaml";
 
-    private static int fromInteger(Integer value) {
-        return Optional.ofNullable(value)
-                .orElse(0);
+  private static int fromInteger(Integer value) {
+    return Optional.ofNullable(value).orElse(0);
+  }
+
+  private static long fromDateTime(OffsetDateTime value) {
+    return Optional.ofNullable(value)
+        .map(OffsetDateTime::toInstant)
+        .map(Instant::toEpochMilli)
+        .orElse(0L);
+  }
+
+  @Value
+  @AllArgsConstructor
+  public static class JobStatus {
+    private final int active;
+    private final int failed;
+    private final int succeeded;
+    private final long started;
+    private final long completed;
+
+    JobStatus(V1JobStatus status) {
+      this(
+          KubernetesService.fromInteger(status.getActive()),
+          KubernetesService.fromInteger(status.getFailed()),
+          KubernetesService.fromInteger(status.getSucceeded()),
+          KubernetesService.fromDateTime(status.getStartTime()),
+          KubernetesService.fromDateTime(status.getCompletionTime()));
     }
+  }
 
-    private static long fromDateTime(OffsetDateTime value) {
-        return Optional.ofNullable(value)
-                .map(OffsetDateTime::toInstant)
-                .map(Instant::toEpochMilli)
-                .orElse(0L);
-    }
+  @Value
+  public static class JobStatusCondition {
+    private final boolean success;
+    private final String type;
+    private final String reason;
+    private final String message;
+    long completionTime;
+  }
 
-    @Value
-    @AllArgsConstructor
-    public static class JobStatus {
-        private final int active;
-        private final int failed;
-        private final int succeeded;
-        private final long started;
-        private final long completed;
+  @Value
+  public static class Resources {
+    private final String cpu;
+    private final String memory;
+  }
 
-        JobStatus(V1JobStatus status) {
-            this(KubernetesService.fromInteger(status.getActive()),
-                    KubernetesService.fromInteger(status.getFailed()),
-                    KubernetesService.fromInteger(status.getSucceeded()),
-                    KubernetesService.fromDateTime(status.getStartTime()),
-                    KubernetesService.fromDateTime(status.getCompletionTime()));
-        }
-    }
+  @Value
+  public static class Probe {
+    private final int port;
+    private final String path;
+    private final int period;
+  }
 
-    @Value
-    public static class JobStatusCondition {
-        private final boolean success;
-        private final String type;
-        private final String reason;
-        private final String message;
-        long completionTime;
-    }
+  @Value
+  @Builder
+  @ToString
+  public static class JobExecution {
+    String executionId;
+    String executionType;
+    String jobName;
+    String podTerminationMessage;
+    String jobTerminationReason;
+    Boolean succeeded;
+    String opId;
+    OffsetDateTime startTime;
+    OffsetDateTime endTime;
+    String jobVersion;
+    String jobSchedule;
+    Float resourcesCpuRequest;
+    Float resourcesCpuLimit;
+    Integer resourcesMemoryRequest;
+    Integer resourcesMemoryLimit;
+    OffsetDateTime deployedDate;
+    String deployedBy;
+    String containerTerminationReason;
+  }
 
-    @Value
-    public static class Resources {
-        private final String cpu;
-        private final String memory;
-    }
+  @AllArgsConstructor
+  private enum ContainerResourceType {
+    CPU("cpu"),
+    MEMORY("memory");
 
-    @Value
-    public static class Probe {
-        private final int port;
-        private final String path;
-        private final int period;
-    }
+    @Getter private final String value;
+  }
 
-    @Value
-    @Builder
-    @ToString
-    public static class JobExecution {
-        String executionId;
-        String executionType;
-        String jobName;
-        String podTerminationMessage;
-        String jobTerminationReason;
-        Boolean succeeded;
-        String opId;
-        OffsetDateTime startTime;
-        OffsetDateTime endTime;
-        String jobVersion;
-        String jobSchedule;
-        Float resourcesCpuRequest;
-        Float resourcesCpuLimit;
-        Integer resourcesMemoryRequest;
-        Integer resourcesMemoryLimit;
-        OffsetDateTime deployedDate;
-        String deployedBy;
-        String containerTerminationReason;
-    }
+  // The 'Value' annotation from Lombok collides with the 'Value' annotation from Spring.
+  @org.springframework.beans.factory.annotation.Value(
+      "${datajobs.control.k8s.data.job.template.file}")
+  private String datajobTemplateFileLocation;
 
-    @AllArgsConstructor
-    private enum ContainerResourceType {
-        CPU("cpu"),
-        MEMORY("memory");
+  @org.springframework.beans.factory.annotation.Value(
+      "${datajobs.control.k8s.jobTTLAfterFinishedSeconds}")
+  private int jobTTLAfterFinishedSeconds;
 
-        @Getter
-        private final String value;
-    }
+  private String namespace;
+  private String kubeconfig;
+  private Logger log;
+  private boolean k8sSupportsV1CronJob;
+  private ApiClient client;
 
-    // The 'Value' annotation from Lombok collides with the 'Value' annotation from Spring.
-    @org.springframework.beans.factory.annotation.Value("${datajobs.control.k8s.data.job.template.file}")
-    private String datajobTemplateFileLocation;
+  @Autowired private UserAgentService userAgentService;
 
-    @org.springframework.beans.factory.annotation.Value("${datajobs.control.k8s.jobTTLAfterFinishedSeconds}")
-    private int jobTTLAfterFinishedSeconds;
+  @Autowired private JobCommandProvider jobCommandProvider;
 
-    private String namespace;
-    private String kubeconfig;
-    private Logger log;
-    private boolean k8sSupportsV1CronJob;
-    private ApiClient client;
+  /**
+   * @param namespace the namespace where the kubernetes operation will act on. leave empty to infer
+   *     from kubeconfig
+   * @param kubeconfig The kubeconfig configuration of the Kubernetes cluster to connect to
+   * @param k8sSupportsV1CronJob Whether the target K8s cluster supports the V1CronJob API
+   * @param log log to use - used in subclasses in order to set classname to subclass.
+   */
+  protected KubernetesService(
+      String namespace, String kubeconfig, boolean k8sSupportsV1CronJob, Logger log) {
+    this.namespace = namespace;
+    this.kubeconfig = kubeconfig;
+    this.k8sSupportsV1CronJob = k8sSupportsV1CronJob;
+    this.log = log;
+  }
 
-    @Autowired
-    private UserAgentService userAgentService;
+  protected boolean getK8sSupportsV1CronJob() {
+    return this.k8sSupportsV1CronJob;
+  }
 
-    @Autowired
-    private JobCommandProvider jobCommandProvider;
-
-    /**
-     *
-     * @param namespace the namespace where the kubernetes operation will act on. leave empty to infer from kubeconfig
-     * @param kubeconfig The kubeconfig configuration of the Kubernetes cluster to connect to
-     * @param k8sSupportsV1CronJob Whether the target K8s cluster supports the V1CronJob API
-     * @param log log to use - used in subclasses in order to set classname to subclass.
-     */
-    protected KubernetesService(String namespace, String kubeconfig, boolean k8sSupportsV1CronJob, Logger log) {
-        this.namespace = namespace;
-        this.kubeconfig = kubeconfig;
-        this.k8sSupportsV1CronJob = k8sSupportsV1CronJob;
-        this.log = log;
-    }
-
-    protected boolean getK8sSupportsV1CronJob() {
-        return this.k8sSupportsV1CronJob;
-    }
-
-    @Override
-    public void afterPropertiesSet() throws Exception {
-        log.info("Configuration used: kubeconfig: {}, namespace: {}", kubeconfig, namespace);
-        if (!StringUtils.isBlank(kubeconfig) && new File(kubeconfig).isFile()) {
-            log.info("Will use provided kubeconfig file from configuration: {}", kubeconfig);
-            KubeConfig kubeConfig = KubeConfig.loadKubeConfig(new FileReader(kubeconfig));
-            client = ClientBuilder.kubeconfig(kubeConfig).build();
-            if (StringUtils.isBlank(namespace)) {
-                this.namespace = kubeConfig.getNamespace();
-            }
-        } else {
-            log.info("Will use default client");
-            client = ClientBuilder.defaultClient();
-            if (StringUtils.isBlank(namespace)) {
-                this.namespace = getCurrentNamespace();
-            }
-        }
-        log.info("kubernetes namespace: {}", namespace);
-        if (userAgentService != null) {
-            client.setUserAgent(userAgentService.getUserAgent());
-        }
-
-        // Annoying error: Watch is incompatible with debugging mode active
-        // client.setDebugging(true);
-        client.setHttpClient(
-                client.getHttpClient().newBuilder().readTimeout(0, TimeUnit.SECONDS).build());
-        // client.getHttpClient().setReadTimeout(0, TimeUnit.SECONDS);
-
-        // Step 1 - load the internal datajob template in order to validate it.
-        try {
-            if(getK8sSupportsV1CronJob()) {
-                loadV1CronjobTemplate(new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
-            } else {
-                loadV1beta1CronjobTemplate(new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
-            }
-            log.info("The internal datajob template is valid.");
-        } catch(Exception e) {
-            // Log the error and fail fast (cannot continue).
-            log.error("Fatal error while loading the internal datajob template. Cannot continue", e);
-            throw e;
-        }
-        // Step 2 - load the configurable datajob template in order to validate it
-        // when environment variable 'K8S_DATA_JOB_TEMPLATE_FILE' is set.
-        if(!StringUtils.isEmpty(datajobTemplateFileLocation)) {
-            if(getK8sSupportsV1CronJob()) {
-                if(loadConfigurableV1CronjobTemplate() == null) {
-                    log.warn("The configurable datajob template '{}' could not be loaded.", datajobTemplateFileLocation);
-                } else {
-                    log.info("The configurable datajob template '{}' is valid.", datajobTemplateFileLocation);
-                }
-            } else {
-                if(loadConfigurableV1beta1CronjobTemplate() == null) {
-                    log.warn("The configurable datajob template '{}' could not be loaded.", datajobTemplateFileLocation);
-                } else {
-                    log.info("The configurable datajob template '{}' is valid.", datajobTemplateFileLocation);
-                }
-            }
-        }
-    }
-
-    private V1CronJob loadV1CronjobTemplate() {
-        if(StringUtils.isEmpty(datajobTemplateFileLocation)) {
-            log.debug("Datajob template file location is not set. Using internal datajob template.");
-            return loadInternalV1CronjobTemplate();
-        }
-        V1CronJob cronjobTemplate = loadConfigurableV1CronjobTemplate();
-        if(cronjobTemplate == null) {
-            return loadInternalV1CronjobTemplate();
-        }
-
-        return cronjobTemplate;
-    }
-
-    private V1beta1CronJob loadV1beta1CronjobTemplate() {
-        if(StringUtils.isEmpty(datajobTemplateFileLocation)) {
-            log.debug("Datajob template file location is not set. Using internal datajob template.");
-            return loadInternalV1beta1CronjobTemplate();
-        }
-        V1beta1CronJob cronjobTemplate = loadConfigurableV1beta1CronjobTemplate();
-        if(cronjobTemplate == null) {
-            return loadInternalV1beta1CronjobTemplate();
-        }
-
-        return cronjobTemplate;
-    }
-
-    private V1beta1CronJob loadInternalV1beta1CronjobTemplate() {
-        try {
-            return loadV1beta1CronjobTemplate(new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
-        } catch (Exception e) {
-            // This should never happen unless we are testing locally and we've messed up
-            // with the internal template resource file.
-            throw new RuntimeException("Unrecoverable error while loading the internal datajob template. Cannot continue.", e);
-        }
-    }
-
-    private V1CronJob loadInternalV1CronjobTemplate() {
-        try {
-            return loadV1CronjobTemplate(new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
-        } catch (Exception e) {
-            // This should never happen unless we are testing locally and we've messed up
-            // with the internal template resource file.
-            throw new RuntimeException("Unrecoverable error while loading the internal datajob template. Cannot continue.", e);
-        }
-    }
-
-    private V1beta1CronJob loadConfigurableV1beta1CronjobTemplate() {
-        // Check whether to use configurable datajob template at all.
-        if(StringUtils.isEmpty(datajobTemplateFileLocation)) {
-            log.debug("Datajob template file location is not set.");
-            return null;
-        }
-
-        // Check whether the configurable datajob template file exists.
-        File datajobTemplateFile = new File(datajobTemplateFileLocation);
-        if(!datajobTemplateFile.isFile()) {
-            log.warn("Datajob template location '{}' is not a file.", datajobTemplateFileLocation);
-            return null;
-        }
-
-        try {
-            // Load the configurable datajob template file.
-            return loadV1beta1CronjobTemplate(datajobTemplateFile);
-        } catch (Exception e) {
-            log.error("Error while loading the datajob template file.", e);
-            return null;
-        }
-    }
-
-    private V1CronJob loadConfigurableV1CronjobTemplate() {
-        // Check whether to use configurable datajob template at all.
-        if(StringUtils.isEmpty(datajobTemplateFileLocation)) {
-            log.debug("Datajob template file location is not set.");
-            return null;
-        }
-
-        // Check whether the configurable datajob template file exists.
-        File datajobTemplateFile = new File(datajobTemplateFileLocation);
-        if(!datajobTemplateFile.isFile()) {
-            log.warn("Datajob template location '{}' is not a file.", datajobTemplateFileLocation);
-            return null;
-        }
-
-        try {
-            // Load the configurable datajob template file.
-            return loadV1CronjobTemplate(datajobTemplateFile);
-        } catch (Exception e) {
-            log.error("Error while loading the datajob template file.", e);
-            return null;
-        }
-    }
-
-    private V1beta1CronJob loadV1beta1CronjobTemplate(File datajobTemplateFile) throws Exception {
-        String cronjobTemplateString = Files.readString(datajobTemplateFile.toPath());
-        // Check whether the string template is a valid datajob template.
-        V1beta1CronJob cronjobTemplate = Yaml.loadAs(cronjobTemplateString, V1beta1CronJob.class);
-        log.debug("Datajob template for file '{}': \n{}", datajobTemplateFile.getCanonicalPath(), cronjobTemplate);
-
-        return cronjobTemplate;
-    }
-
-    private V1CronJob loadV1CronjobTemplate(File datajobTemplateFile) throws Exception {
-        String cronjobTemplateString = Files.readString(datajobTemplateFile.toPath());
-        // Check whether the string template is a valid datajob template.
-        V1CronJob cronjobTemplate = Yaml.loadAs(cronjobTemplateString, V1CronJob.class);
-        log.debug("Datajob template for file '{}': \n{}", datajobTemplateFile.getCanonicalPath(), cronjobTemplate);
-
-        return cronjobTemplate;
-    }
-
-    private String getCurrentNamespace() {
-        return getNamespaceFileContents().stream()
-                .filter(not(String::isBlank))
-                .findFirst()
-                .map(String::strip)
-                .orElse(null);
-    }
-
-    private List<String> getNamespaceFileContents () {
-        try {
-            String namespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
-            return Files.readAllLines(Paths.get(namespaceFile));
-        } catch (IOException e) {
-            return Collections.emptyList();
-        }
-    }
-
-    public Pair<Boolean, String> health() {
-        try {
-            var info = new VersionApi(client).getCode();
-            return Pair.of(true, info.getGitVersion());
-        } catch (Exception e) {
-            return Pair.of(false, e.getMessage());
-        }
-    }
-
-    public void createNamespace(String namespaceName) throws ApiException {
-        var namespaceBody = new V1NamespaceBuilder()
-              .withMetadata(
-                    new V1ObjectMetaBuilder()
-                          .withName(namespaceName)
-                          .build())
-              .build();
-
-        new CoreV1Api(client).createNamespace(namespaceBody, null, null, null);
-    }
-
-    public void deleteNamespace(String namespaceName) throws ApiException {
-        try {
-            new CoreV1Api(client).deleteNamespace(namespaceName, null, null, null, null, null, null);
-        }
-        catch (JsonSyntaxException e) {
-            if (e.getCause() instanceof IllegalStateException) {
-                IllegalStateException ise = (IllegalStateException) e.getCause();
-                if (ise.getMessage() != null && ise.getMessage().contains("Expected a string but was BEGIN_OBJECT"))
-                    log.debug("Catching exception because of issue https://github.com/kubernetes-client/java/issues/86", e);
-                else throw e;
-            }
-            else throw e;
-        }
-    }
-
-    public Set<String> listJobs() throws ApiException {
-        log.debug("Listing k8s jobs");
-        var jobs = new BatchV1Api(client).listNamespacedJob(namespace, null, null, null, null, null, null, null, null, null, null);
-        var set = jobs.getItems().stream()
-                .map(j -> j.getMetadata().getName())
-                .collect(Collectors.toSet());
-        log.debug("K8s jobs: {}", set);
-        return set;
-    }
-
-    public Optional<JobDeploymentStatus> readCronJob(String cronJobName) {
-        return getK8sSupportsV1CronJob() ? readV1CronJob(cronJobName) : readV1beta1CronJob(cronJobName);
-    }
-
-    public Optional<JobDeploymentStatus> readV1beta1CronJob(String cronJobName) {
-        log.debug("Reading k8s cron job: {}", cronJobName);
-        V1beta1CronJob cronJob = null;
-        try {
-            cronJob = new BatchV1beta1Api(client).readNamespacedCronJob(cronJobName, namespace, null);
-        } catch (ApiException e) {
-            log.warn("Could not read cron job: {}; reason: {}", cronJobName, new KubernetesException("", e).toString());
-        }
-
-        return mapV1beta1CronJobToDeploymentStatus(cronJob, cronJobName);
-    }
-
-    public Optional<JobDeploymentStatus> readV1CronJob(String cronJobName) {
-        log.debug("Reading k8s cron job: {}", cronJobName);
-        V1CronJob cronJob = null;
-        try {
-            cronJob = new BatchV1Api(client).readNamespacedCronJob(cronJobName, namespace, null);
-        } catch (ApiException e) {
-            log.warn("Could not read cron job: {}; reason: {}", cronJobName, new KubernetesException("", e).toString());
-        }
-
-        return mapV1CronJobToDeploymentStatus(cronJob, cronJobName);
-    }
-
-    /**
-     * Fetch all deployment statuses from Kubernetes
-     * @return List of {@link JobDeploymentStatus} or empty list if there is an error while fetching data
-     */
-    public List<JobDeploymentStatus> readJobDeploymentStatuses() {
-        return getK8sSupportsV1CronJob() ? readV1CronJobDeploymentStatuses() : readV1beta1CronJobDeploymentStatuses();
-    }
-
-    public List<JobDeploymentStatus> readV1beta1CronJobDeploymentStatuses() {
-        log.debug("Reading all k8s cron jobs");
-        V1beta1CronJobList cronJobs = null;
-        try {
-            cronJobs = new BatchV1beta1Api(client).listNamespacedCronJob(namespace, null, null, null, null, null, null, null, null, null, null);
-        } catch (ApiException e) {
-            log.warn("Failed to read k8s cron jobs: ", e);
-        }
-
-        return cronJobs == null ? Collections.emptyList() : cronJobs.getItems().stream()
-                .map(cronJob -> mapV1beta1CronJobToDeploymentStatus(cronJob, null))
-                .flatMap(Optional::stream)
-                .collect(Collectors.toList());
-    }
-
-   public List<JobDeploymentStatus> readV1CronJobDeploymentStatuses() {
-      log.debug("Reading all k8s cron jobs");
-      V1CronJobList cronJobs = null;
-      try {
-         cronJobs = new BatchV1Api(client).listNamespacedCronJob(namespace, null, null, null, null, null, null, null, null, null, null);
-      } catch (ApiException e) {
-         log.warn("Failed to read k8s cron jobs: ", e);
+  @Override
+  public void afterPropertiesSet() throws Exception {
+    log.info("Configuration used: kubeconfig: {}, namespace: {}", kubeconfig, namespace);
+    if (!StringUtils.isBlank(kubeconfig) && new File(kubeconfig).isFile()) {
+      log.info("Will use provided kubeconfig file from configuration: {}", kubeconfig);
+      KubeConfig kubeConfig = KubeConfig.loadKubeConfig(new FileReader(kubeconfig));
+      client = ClientBuilder.kubeconfig(kubeConfig).build();
+      if (StringUtils.isBlank(namespace)) {
+        this.namespace = kubeConfig.getNamespace();
       }
+    } else {
+      log.info("Will use default client");
+      client = ClientBuilder.defaultClient();
+      if (StringUtils.isBlank(namespace)) {
+        this.namespace = getCurrentNamespace();
+      }
+    }
+    log.info("kubernetes namespace: {}", namespace);
+    if (userAgentService != null) {
+      client.setUserAgent(userAgentService.getUserAgent());
+    }
 
-      return cronJobs == null ? Collections.emptyList() : cronJobs.getItems().stream()
+    // Annoying error: Watch is incompatible with debugging mode active
+    // client.setDebugging(true);
+    client.setHttpClient(
+        client.getHttpClient().newBuilder().readTimeout(0, TimeUnit.SECONDS).build());
+    // client.getHttpClient().setReadTimeout(0, TimeUnit.SECONDS);
+
+    // Step 1 - load the internal datajob template in order to validate it.
+    try {
+      if (getK8sSupportsV1CronJob()) {
+        loadV1CronjobTemplate(new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
+      } else {
+        loadV1beta1CronjobTemplate(new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
+      }
+      log.info("The internal datajob template is valid.");
+    } catch (Exception e) {
+      // Log the error and fail fast (cannot continue).
+      log.error("Fatal error while loading the internal datajob template. Cannot continue", e);
+      throw e;
+    }
+    // Step 2 - load the configurable datajob template in order to validate it
+    // when environment variable 'K8S_DATA_JOB_TEMPLATE_FILE' is set.
+    if (!StringUtils.isEmpty(datajobTemplateFileLocation)) {
+      if (getK8sSupportsV1CronJob()) {
+        if (loadConfigurableV1CronjobTemplate() == null) {
+          log.warn(
+              "The configurable datajob template '{}' could not be loaded.",
+              datajobTemplateFileLocation);
+        } else {
+          log.info("The configurable datajob template '{}' is valid.", datajobTemplateFileLocation);
+        }
+      } else {
+        if (loadConfigurableV1beta1CronjobTemplate() == null) {
+          log.warn(
+              "The configurable datajob template '{}' could not be loaded.",
+              datajobTemplateFileLocation);
+        } else {
+          log.info("The configurable datajob template '{}' is valid.", datajobTemplateFileLocation);
+        }
+      }
+    }
+  }
+
+  private V1CronJob loadV1CronjobTemplate() {
+    if (StringUtils.isEmpty(datajobTemplateFileLocation)) {
+      log.debug("Datajob template file location is not set. Using internal datajob template.");
+      return loadInternalV1CronjobTemplate();
+    }
+    V1CronJob cronjobTemplate = loadConfigurableV1CronjobTemplate();
+    if (cronjobTemplate == null) {
+      return loadInternalV1CronjobTemplate();
+    }
+
+    return cronjobTemplate;
+  }
+
+  private V1beta1CronJob loadV1beta1CronjobTemplate() {
+    if (StringUtils.isEmpty(datajobTemplateFileLocation)) {
+      log.debug("Datajob template file location is not set. Using internal datajob template.");
+      return loadInternalV1beta1CronjobTemplate();
+    }
+    V1beta1CronJob cronjobTemplate = loadConfigurableV1beta1CronjobTemplate();
+    if (cronjobTemplate == null) {
+      return loadInternalV1beta1CronjobTemplate();
+    }
+
+    return cronjobTemplate;
+  }
+
+  private V1beta1CronJob loadInternalV1beta1CronjobTemplate() {
+    try {
+      return loadV1beta1CronjobTemplate(
+          new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
+    } catch (Exception e) {
+      // This should never happen unless we are testing locally and we've messed up
+      // with the internal template resource file.
+      throw new RuntimeException(
+          "Unrecoverable error while loading the internal datajob template. Cannot continue.", e);
+    }
+  }
+
+  private V1CronJob loadInternalV1CronjobTemplate() {
+    try {
+      return loadV1CronjobTemplate(new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
+    } catch (Exception e) {
+      // This should never happen unless we are testing locally and we've messed up
+      // with the internal template resource file.
+      throw new RuntimeException(
+          "Unrecoverable error while loading the internal datajob template. Cannot continue.", e);
+    }
+  }
+
+  private V1beta1CronJob loadConfigurableV1beta1CronjobTemplate() {
+    // Check whether to use configurable datajob template at all.
+    if (StringUtils.isEmpty(datajobTemplateFileLocation)) {
+      log.debug("Datajob template file location is not set.");
+      return null;
+    }
+
+    // Check whether the configurable datajob template file exists.
+    File datajobTemplateFile = new File(datajobTemplateFileLocation);
+    if (!datajobTemplateFile.isFile()) {
+      log.warn("Datajob template location '{}' is not a file.", datajobTemplateFileLocation);
+      return null;
+    }
+
+    try {
+      // Load the configurable datajob template file.
+      return loadV1beta1CronjobTemplate(datajobTemplateFile);
+    } catch (Exception e) {
+      log.error("Error while loading the datajob template file.", e);
+      return null;
+    }
+  }
+
+  private V1CronJob loadConfigurableV1CronjobTemplate() {
+    // Check whether to use configurable datajob template at all.
+    if (StringUtils.isEmpty(datajobTemplateFileLocation)) {
+      log.debug("Datajob template file location is not set.");
+      return null;
+    }
+
+    // Check whether the configurable datajob template file exists.
+    File datajobTemplateFile = new File(datajobTemplateFileLocation);
+    if (!datajobTemplateFile.isFile()) {
+      log.warn("Datajob template location '{}' is not a file.", datajobTemplateFileLocation);
+      return null;
+    }
+
+    try {
+      // Load the configurable datajob template file.
+      return loadV1CronjobTemplate(datajobTemplateFile);
+    } catch (Exception e) {
+      log.error("Error while loading the datajob template file.", e);
+      return null;
+    }
+  }
+
+  private V1beta1CronJob loadV1beta1CronjobTemplate(File datajobTemplateFile) throws Exception {
+    String cronjobTemplateString = Files.readString(datajobTemplateFile.toPath());
+    // Check whether the string template is a valid datajob template.
+    V1beta1CronJob cronjobTemplate = Yaml.loadAs(cronjobTemplateString, V1beta1CronJob.class);
+    log.debug(
+        "Datajob template for file '{}': \n{}",
+        datajobTemplateFile.getCanonicalPath(),
+        cronjobTemplate);
+
+    return cronjobTemplate;
+  }
+
+  private V1CronJob loadV1CronjobTemplate(File datajobTemplateFile) throws Exception {
+    String cronjobTemplateString = Files.readString(datajobTemplateFile.toPath());
+    // Check whether the string template is a valid datajob template.
+    V1CronJob cronjobTemplate = Yaml.loadAs(cronjobTemplateString, V1CronJob.class);
+    log.debug(
+        "Datajob template for file '{}': \n{}",
+        datajobTemplateFile.getCanonicalPath(),
+        cronjobTemplate);
+
+    return cronjobTemplate;
+  }
+
+  private String getCurrentNamespace() {
+    return getNamespaceFileContents().stream()
+        .filter(not(String::isBlank))
+        .findFirst()
+        .map(String::strip)
+        .orElse(null);
+  }
+
+  private List<String> getNamespaceFileContents() {
+    try {
+      String namespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
+      return Files.readAllLines(Paths.get(namespaceFile));
+    } catch (IOException e) {
+      return Collections.emptyList();
+    }
+  }
+
+  public Pair<Boolean, String> health() {
+    try {
+      var info = new VersionApi(client).getCode();
+      return Pair.of(true, info.getGitVersion());
+    } catch (Exception e) {
+      return Pair.of(false, e.getMessage());
+    }
+  }
+
+  public void createNamespace(String namespaceName) throws ApiException {
+    var namespaceBody =
+        new V1NamespaceBuilder()
+            .withMetadata(new V1ObjectMetaBuilder().withName(namespaceName).build())
+            .build();
+
+    new CoreV1Api(client).createNamespace(namespaceBody, null, null, null);
+  }
+
+  public void deleteNamespace(String namespaceName) throws ApiException {
+    try {
+      new CoreV1Api(client).deleteNamespace(namespaceName, null, null, null, null, null, null);
+    } catch (JsonSyntaxException e) {
+      if (e.getCause() instanceof IllegalStateException) {
+        IllegalStateException ise = (IllegalStateException) e.getCause();
+        if (ise.getMessage() != null
+            && ise.getMessage().contains("Expected a string but was BEGIN_OBJECT"))
+          log.debug(
+              "Catching exception because of issue"
+                  + " https://github.com/kubernetes-client/java/issues/86",
+              e);
+        else throw e;
+      } else throw e;
+    }
+  }
+
+  public Set<String> listJobs() throws ApiException {
+    log.debug("Listing k8s jobs");
+    var jobs =
+        new BatchV1Api(client)
+            .listNamespacedJob(
+                namespace, null, null, null, null, null, null, null, null, null, null);
+    var set =
+        jobs.getItems().stream().map(j -> j.getMetadata().getName()).collect(Collectors.toSet());
+    log.debug("K8s jobs: {}", set);
+    return set;
+  }
+
+  public Optional<JobDeploymentStatus> readCronJob(String cronJobName) {
+    return getK8sSupportsV1CronJob() ? readV1CronJob(cronJobName) : readV1beta1CronJob(cronJobName);
+  }
+
+  public Optional<JobDeploymentStatus> readV1beta1CronJob(String cronJobName) {
+    log.debug("Reading k8s cron job: {}", cronJobName);
+    V1beta1CronJob cronJob = null;
+    try {
+      cronJob = new BatchV1beta1Api(client).readNamespacedCronJob(cronJobName, namespace, null);
+    } catch (ApiException e) {
+      log.warn(
+          "Could not read cron job: {}; reason: {}",
+          cronJobName,
+          new KubernetesException("", e).toString());
+    }
+
+    return mapV1beta1CronJobToDeploymentStatus(cronJob, cronJobName);
+  }
+
+  public Optional<JobDeploymentStatus> readV1CronJob(String cronJobName) {
+    log.debug("Reading k8s cron job: {}", cronJobName);
+    V1CronJob cronJob = null;
+    try {
+      cronJob = new BatchV1Api(client).readNamespacedCronJob(cronJobName, namespace, null);
+    } catch (ApiException e) {
+      log.warn(
+          "Could not read cron job: {}; reason: {}",
+          cronJobName,
+          new KubernetesException("", e).toString());
+    }
+
+    return mapV1CronJobToDeploymentStatus(cronJob, cronJobName);
+  }
+
+  /**
+   * Fetch all deployment statuses from Kubernetes
+   *
+   * @return List of {@link JobDeploymentStatus} or empty list if there is an error while fetching
+   *     data
+   */
+  public List<JobDeploymentStatus> readJobDeploymentStatuses() {
+    return getK8sSupportsV1CronJob()
+        ? readV1CronJobDeploymentStatuses()
+        : readV1beta1CronJobDeploymentStatuses();
+  }
+
+  public List<JobDeploymentStatus> readV1beta1CronJobDeploymentStatuses() {
+    log.debug("Reading all k8s cron jobs");
+    V1beta1CronJobList cronJobs = null;
+    try {
+      cronJobs =
+          new BatchV1beta1Api(client)
+              .listNamespacedCronJob(
+                  namespace, null, null, null, null, null, null, null, null, null, null);
+    } catch (ApiException e) {
+      log.warn("Failed to read k8s cron jobs: ", e);
+    }
+
+    return cronJobs == null
+        ? Collections.emptyList()
+        : cronJobs.getItems().stream()
+            .map(cronJob -> mapV1beta1CronJobToDeploymentStatus(cronJob, null))
+            .flatMap(Optional::stream)
+            .collect(Collectors.toList());
+  }
+
+  public List<JobDeploymentStatus> readV1CronJobDeploymentStatuses() {
+    log.debug("Reading all k8s cron jobs");
+    V1CronJobList cronJobs = null;
+    try {
+      cronJobs =
+          new BatchV1Api(client)
+              .listNamespacedCronJob(
+                  namespace, null, null, null, null, null, null, null, null, null, null);
+    } catch (ApiException e) {
+      log.warn("Failed to read k8s cron jobs: ", e);
+    }
+
+    return cronJobs == null
+        ? Collections.emptyList()
+        : cronJobs.getItems().stream()
             .map(cronJob -> mapV1CronJobToDeploymentStatus(cronJob, null))
             .flatMap(Optional::stream)
             .collect(Collectors.toList());
-   }
+  }
 
-    public void startNewCronJobExecution(String cronJobName, String executionId, Map<String, String> annotations,
-                                         Map<String, String> envs, Map<String, Object> extraJobArguments, String jobName) throws ApiException {
-        if(getK8sSupportsV1CronJob()) {
-            startNewV1CronJobExecution(
-                    cronJobName,
-                    executionId,
-                    annotations,
-                    envs,
-                    extraJobArguments,
-                    jobName);
-        } else {
-            startNewV1beta1CronJobExecution(
-                    cronJobName,
-                    executionId,
-                    annotations,
-                    envs,
-                    extraJobArguments,
-                    jobName);
-        }
+  public void startNewCronJobExecution(
+      String cronJobName,
+      String executionId,
+      Map<String, String> annotations,
+      Map<String, String> envs,
+      Map<String, Object> extraJobArguments,
+      String jobName)
+      throws ApiException {
+    if (getK8sSupportsV1CronJob()) {
+      startNewV1CronJobExecution(
+          cronJobName, executionId, annotations, envs, extraJobArguments, jobName);
+    } else {
+      startNewV1beta1CronJobExecution(
+          cronJobName, executionId, annotations, envs, extraJobArguments, jobName);
     }
+  }
 
-    private void startNewV1beta1CronJobExecution(String cronJobName, String executionId, Map<String, String> annotations,
-                                         Map<String, String> envs, Map<String, Object> extraJobArguments, String jobName) throws ApiException {
-        var cron = initBatchV1beta1Api().readNamespacedCronJob(cronJobName, namespace, null);
-        Optional<V1beta1JobTemplateSpec> jobTemplateSpec = Optional.ofNullable(cron)
-                .map(V1beta1CronJob::getSpec)
-                .map(V1beta1CronJobSpec::getJobTemplate);
+  private void startNewV1beta1CronJobExecution(
+      String cronJobName,
+      String executionId,
+      Map<String, String> annotations,
+      Map<String, String> envs,
+      Map<String, Object> extraJobArguments,
+      String jobName)
+      throws ApiException {
+    var cron = initBatchV1beta1Api().readNamespacedCronJob(cronJobName, namespace, null);
+    Optional<V1beta1JobTemplateSpec> jobTemplateSpec =
+        Optional.ofNullable(cron)
+            .map(V1beta1CronJob::getSpec)
+            .map(V1beta1CronJobSpec::getJobTemplate);
 
-        Map<String, String> jobLabels = jobTemplateSpec
-                .map(V1beta1JobTemplateSpec::getMetadata)
-                .map(V1ObjectMeta::getLabels)
-                .orElse(Collections.emptyMap());
+    Map<String, String> jobLabels =
+        jobTemplateSpec
+            .map(V1beta1JobTemplateSpec::getMetadata)
+            .map(V1ObjectMeta::getLabels)
+            .orElse(Collections.emptyMap());
 
-        Map<String, String> jobAnnotations = jobTemplateSpec
-                .map(V1beta1JobTemplateSpec::getMetadata)
-                .map(V1ObjectMeta::getAnnotations)
-                .map(v1ObjectMetaAnnotations -> {
-                    v1ObjectMetaAnnotations.putAll(annotations);
-                    return v1ObjectMetaAnnotations;
-                })
-                .orElse(annotations);
-
-        V1JobSpec jobSpec = jobTemplateSpec
-                .map(V1beta1JobTemplateSpec::getSpec)
-                .orElseThrow(() -> new ApiException(String.format("K8S Cron Job '%s' does not exist or is not properly defined.", cronJobName)));
-
-        jobSpec.setTtlSecondsAfterFinished(jobTTLAfterFinishedSeconds);
-
-        V1Container v1Container = Optional.ofNullable(jobSpec.getTemplate())
-                .map(V1PodTemplateSpec::getSpec)
-                .map(V1PodSpec::getContainers)
-                .map(v1Containers -> v1Containers.get(0))
-                .orElseThrow(() -> new ApiException(String.format("K8S Cron Job '%s' is not properly defined.", cronJobName)));
-        if (!CollectionUtils.isEmpty(envs)) {
-            envs.forEach((name, value) -> v1Container.addEnvItem(new V1EnvVar().name(name).value(value)));
-        }
-
-        if (!CollectionUtils.isEmpty(extraJobArguments)) {
-            addExtraJobArgumentsToVdkContainer(v1Container, extraJobArguments, jobName);
-        }
-
-        createNewJob(executionId, jobSpec, jobLabels, jobAnnotations);
-    }
-
-    private void startNewV1CronJobExecution(String cronJobName, String executionId, Map<String, String> annotations,
-                                         Map<String, String> envs, Map<String, Object> extraJobArguments, String jobName) throws ApiException {
-        var cron = initBatchV1Api().readNamespacedCronJob(cronJobName, namespace, null);
-
-        Optional<V1JobTemplateSpec> jobTemplateSpec = Optional.ofNullable(cron)
-              .map(V1CronJob::getSpec)
-              .map(V1CronJobSpec::getJobTemplate);
-
-        Map<String, String> jobLabels = jobTemplateSpec
-              .map(V1JobTemplateSpec::getMetadata)
-              .map(V1ObjectMeta::getLabels)
-              .orElse(Collections.emptyMap());
-
-        Map<String, String> jobAnnotations = jobTemplateSpec
-              .map(V1JobTemplateSpec::getMetadata)
-              .map(V1ObjectMeta::getAnnotations)
-              .map(v1ObjectMetaAnnotations -> {
+    Map<String, String> jobAnnotations =
+        jobTemplateSpec
+            .map(V1beta1JobTemplateSpec::getMetadata)
+            .map(V1ObjectMeta::getAnnotations)
+            .map(
+                v1ObjectMetaAnnotations -> {
                   v1ObjectMetaAnnotations.putAll(annotations);
                   return v1ObjectMetaAnnotations;
-              })
-              .orElse(annotations);
+                })
+            .orElse(annotations);
 
-        V1JobSpec jobSpec = jobTemplateSpec
-              .map(V1JobTemplateSpec::getSpec)
-              .orElseThrow(() -> new ApiException(String.format("K8S Cron Job '%s' does not exist or is not properly defined.", cronJobName)));
+    V1JobSpec jobSpec =
+        jobTemplateSpec
+            .map(V1beta1JobTemplateSpec::getSpec)
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        String.format(
+                            "K8S Cron Job '%s' does not exist or is not properly defined.",
+                            cronJobName)));
 
-        jobSpec.setTtlSecondsAfterFinished(jobTTLAfterFinishedSeconds);
+    jobSpec.setTtlSecondsAfterFinished(jobTTLAfterFinishedSeconds);
 
-        V1Container v1Container = Optional.ofNullable(jobSpec.getTemplate())
-              .map(V1PodTemplateSpec::getSpec)
-              .map(V1PodSpec::getContainers)
-              .map(v1Containers -> v1Containers.get(0))
-              .orElseThrow(() -> new ApiException(String.format("K8S Cron Job '%s' is not properly defined.", cronJobName)));
-        if (!CollectionUtils.isEmpty(envs)) {
-            envs.forEach((name, value) -> v1Container.addEnvItem(new V1EnvVar().name(name).value(value)));
-        }
-
-        if (!CollectionUtils.isEmpty(extraJobArguments)) {
-           addExtraJobArgumentsToVdkContainer(v1Container, extraJobArguments, jobName);
-        }
-
-        createNewJob(executionId, jobSpec, jobLabels, jobAnnotations);
+    V1Container v1Container =
+        Optional.ofNullable(jobSpec.getTemplate())
+            .map(V1PodTemplateSpec::getSpec)
+            .map(V1PodSpec::getContainers)
+            .map(v1Containers -> v1Containers.get(0))
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        String.format("K8S Cron Job '%s' is not properly defined.", cronJobName)));
+    if (!CollectionUtils.isEmpty(envs)) {
+      envs.forEach((name, value) -> v1Container.addEnvItem(new V1EnvVar().name(name).value(value)));
     }
 
-    private void addExtraJobArgumentsToVdkContainer(V1Container container, Map<String, Object> extraJobArguments,
-                                                    String jobName) {
-        var commandList = new ArrayList<>(container.getCommand()); // create a new List, since old might be immutable.
-
-        if (commandList.size() < 3 || !Iterables.getLast(commandList).contains("vdk run")) {
-            // If current job template definition changes we will throw an exception and will have to change this implementation.
-            log.debug("Command list: {}", commandList);
-            throw new KubernetesJobDefinitionException(jobName);
-        }
-
-        try {
-            var newCommand = jobCommandProvider.getJobCommand(jobName, extraJobArguments); // vdk run command is last in the list
-            container.setCommand(newCommand);
-        } catch (JsonProcessingException e) {
-            log.debug("JsonProcessingException", e);
-            throw new JsonDissectException(e);
-        }
+    if (!CollectionUtils.isEmpty(extraJobArguments)) {
+      addExtraJobArgumentsToVdkContainer(v1Container, extraJobArguments, jobName);
     }
 
-    public void cancelRunningCronJob(String teamName, String jobName, String executionId) throws ApiException {
-        log.info("K8S deleting job for team: {} data job name: {} execution: {}", teamName, jobName, executionId);
-        try {
-            var operationResponse = initBatchV1Api().deleteNamespacedJob(
-                  executionId,
-                  namespace,
-                  null,
-                  null,
-                  null,
-                  null,
-                  "Foreground",
-                  null);
+    createNewJob(executionId, jobSpec, jobLabels, jobAnnotations);
+  }
 
-            //Status of the operation. One of: "Success" or "Failure"
-            if (operationResponse == null || operationResponse.getStatus() == null) {
-                log.info("Execution: {} for data job: {} with team: {} not found! The data job has likely completed before it could be cancelled.", executionId, teamName, jobName);
-                throw new DataJobExecutionCannotBeCancelledException(executionId, ExecutionCancellationFailureReason.DataJobExecutionNotFound);
-            } else if (operationResponse.getStatus().equals("Failure")) {
-                log.warn("Failed to delete K8S job. Reason: {} Details: {}", operationResponse.getReason(), operationResponse.getDetails().toString());
-                throw new KubernetesException(operationResponse.getMessage(), new ApiException(operationResponse.getCode(), operationResponse.getMessage()));
-            }
-        } catch (JsonSyntaxException e) {
-            if (e.getCause() instanceof IllegalStateException) {
-                IllegalStateException ise = (IllegalStateException) e.getCause();
-                if (ise.getMessage() != null && ise.getMessage().contains("Expected a string but was BEGIN_OBJECT"))
-                    log.debug("Catching exception because of issue https://github.com/kubernetes-client/java/issues/86", e);
-                else throw e;
-            } else throw e;
+  private void startNewV1CronJobExecution(
+      String cronJobName,
+      String executionId,
+      Map<String, String> annotations,
+      Map<String, String> envs,
+      Map<String, Object> extraJobArguments,
+      String jobName)
+      throws ApiException {
+    var cron = initBatchV1Api().readNamespacedCronJob(cronJobName, namespace, null);
 
-        } catch (ApiException e) {
-            //If no response body is present this might be a transport layer failure.
-            if (e.getCode() == 404) {
-                log.debug("Job execution: {} team: {}, job: {} cannot be found. K8S response body {}. Will set its status to Cancelled in the DB.",
-                        executionId, teamName, jobName, e.getResponseBody());
-            } else throw e;
-        }
+    Optional<V1JobTemplateSpec> jobTemplateSpec =
+        Optional.ofNullable(cron).map(V1CronJob::getSpec).map(V1CronJobSpec::getJobTemplate);
+
+    Map<String, String> jobLabels =
+        jobTemplateSpec
+            .map(V1JobTemplateSpec::getMetadata)
+            .map(V1ObjectMeta::getLabels)
+            .orElse(Collections.emptyMap());
+
+    Map<String, String> jobAnnotations =
+        jobTemplateSpec
+            .map(V1JobTemplateSpec::getMetadata)
+            .map(V1ObjectMeta::getAnnotations)
+            .map(
+                v1ObjectMetaAnnotations -> {
+                  v1ObjectMetaAnnotations.putAll(annotations);
+                  return v1ObjectMetaAnnotations;
+                })
+            .orElse(annotations);
+
+    V1JobSpec jobSpec =
+        jobTemplateSpec
+            .map(V1JobTemplateSpec::getSpec)
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        String.format(
+                            "K8S Cron Job '%s' does not exist or is not properly defined.",
+                            cronJobName)));
+
+    jobSpec.setTtlSecondsAfterFinished(jobTTLAfterFinishedSeconds);
+
+    V1Container v1Container =
+        Optional.ofNullable(jobSpec.getTemplate())
+            .map(V1PodTemplateSpec::getSpec)
+            .map(V1PodSpec::getContainers)
+            .map(v1Containers -> v1Containers.get(0))
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        String.format("K8S Cron Job '%s' is not properly defined.", cronJobName)));
+    if (!CollectionUtils.isEmpty(envs)) {
+      envs.forEach((name, value) -> v1Container.addEnvItem(new V1EnvVar().name(name).value(value)));
     }
 
-    public Set<String> listCronJobs() throws ApiException {
-        log.debug("Listing k8s cron jobs");
-        var cronJobs = new BatchV1beta1Api(client).listNamespacedCronJob(namespace, null, null, null, null, null, null, null, null, null, null);
-        var set = cronJobs.getItems().stream()
-              .map(j -> j.getMetadata().getName())
-              .collect(Collectors.toSet());
-        log.debug("K8s cron jobs: {}", set);
-        return set;
+    if (!CollectionUtils.isEmpty(extraJobArguments)) {
+      addExtraJobArgumentsToVdkContainer(v1Container, extraJobArguments, jobName);
     }
 
-    public void createCronJob(String name, String image, Map<String, String> envs, String schedule,
-                              boolean enable, List<String> args, Resources request, Resources limit,
-                              V1Container jobContainer, V1Container initContainer,
-                              List<V1Volume> volumes, Map<String, String> jobDeploymentAnnotations)
-            throws ApiException {
-        if(getK8sSupportsV1CronJob()) {
-            createV1CronJob(name, image, envs, schedule, enable, args, request, limit, jobContainer, initContainer,
-                    volumes, jobDeploymentAnnotations, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), List.of(""));
-        } else {
-            createV1beta1CronJob(name, image, envs, schedule, enable, args, request, limit, jobContainer, initContainer,
-                    volumes, jobDeploymentAnnotations, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), List.of(""));
-        }
+    createNewJob(executionId, jobSpec, jobLabels, jobAnnotations);
+  }
+
+  private void addExtraJobArgumentsToVdkContainer(
+      V1Container container, Map<String, Object> extraJobArguments, String jobName) {
+    var commandList =
+        new ArrayList<>(container.getCommand()); // create a new List, since old might be immutable.
+
+    if (commandList.size() < 3 || !Iterables.getLast(commandList).contains("vdk run")) {
+      // If current job template definition changes we will throw an exception and will have to
+      // change this implementation.
+      log.debug("Command list: {}", commandList);
+      throw new KubernetesJobDefinitionException(jobName);
     }
 
-    public void createCronJob(String name, String image, Map<String, String> envs, String schedule,
-                              boolean enable, List<String> args, Resources request, Resources limit,
-                              V1Container jobContainer, V1Container initContainer,
-                              List<V1Volume> volumes, Map<String, String> jobDeploymentAnnotations,
-                              Map<String, String> jobPodLabels, Map<String, String> jobAnnotations, Map<String, String> jobLabels,
-                              List<String> imagePullSecrets)
-            throws ApiException {
-        if(getK8sSupportsV1CronJob()) {
-            createV1CronJob(name, image, envs, schedule, enable, args, request, limit, jobContainer, initContainer,
-                    volumes, jobDeploymentAnnotations, jobPodLabels, jobAnnotations, jobLabels, imagePullSecrets);
-        } else {
-            createV1beta1CronJob(name, image, envs, schedule, enable, args, request, limit, jobContainer, initContainer,
-                    volumes, jobDeploymentAnnotations, jobPodLabels, jobAnnotations, jobLabels, imagePullSecrets);
-        }
+    try {
+      var newCommand =
+          jobCommandProvider.getJobCommand(
+              jobName, extraJobArguments); // vdk run command is last in the list
+      container.setCommand(newCommand);
+    } catch (JsonProcessingException e) {
+      log.debug("JsonProcessingException", e);
+      throw new JsonDissectException(e);
     }
+  }
 
-    // TODO:  container/volume args are breaking a bit abstraction of KubernetesService by leaking impl. details
-    public void createV1beta1CronJob(String name, String image, Map<String, String> envs, String schedule,
-                              boolean enable, List<String> args, Resources request, Resources limit,
-                              V1Container jobContainer, V1Container initContainer,
-                              List<V1Volume> volumes, Map<String, String> jobDeploymentAnnotations,
-                              Map<String, String> jobPodLabels, Map<String, String> jobAnnotations,
-                              Map<String, String> jobLabels, List<String> imagePullSecrets)
-            throws ApiException {
-        log.debug("Creating k8s cron job name:{}, image:{}", name, image);
-        var cronJob = v1beta1CronJobFromTemplate(name, schedule, !enable, jobContainer, initContainer,
-                volumes, jobDeploymentAnnotations, jobPodLabels, jobAnnotations, jobLabels, imagePullSecrets);
-        V1beta1CronJob nsJob = new BatchV1beta1Api(client).createNamespacedCronJob(namespace, cronJob, null, null, null);
-        log.debug("Created k8s cron job: {}", nsJob);
-        log.debug("Created k8s cron job name: {}, uid:{}, link:{}", nsJob.getMetadata().getName(), nsJob.getMetadata().getUid(), nsJob.getMetadata().getSelfLink());
+  public void cancelRunningCronJob(String teamName, String jobName, String executionId)
+      throws ApiException {
+    log.info(
+        "K8S deleting job for team: {} data job name: {} execution: {}",
+        teamName,
+        jobName,
+        executionId);
+    try {
+      var operationResponse =
+          initBatchV1Api()
+              .deleteNamespacedJob(
+                  executionId, namespace, null, null, null, null, "Foreground", null);
+
+      // Status of the operation. One of: "Success" or "Failure"
+      if (operationResponse == null || operationResponse.getStatus() == null) {
+        log.info(
+            "Execution: {} for data job: {} with team: {} not found! The data job has likely"
+                + " completed before it could be cancelled.",
+            executionId,
+            teamName,
+            jobName);
+        throw new DataJobExecutionCannotBeCancelledException(
+            executionId, ExecutionCancellationFailureReason.DataJobExecutionNotFound);
+      } else if (operationResponse.getStatus().equals("Failure")) {
+        log.warn(
+            "Failed to delete K8S job. Reason: {} Details: {}",
+            operationResponse.getReason(),
+            operationResponse.getDetails().toString());
+        throw new KubernetesException(
+            operationResponse.getMessage(),
+            new ApiException(operationResponse.getCode(), operationResponse.getMessage()));
+      }
+    } catch (JsonSyntaxException e) {
+      if (e.getCause() instanceof IllegalStateException) {
+        IllegalStateException ise = (IllegalStateException) e.getCause();
+        if (ise.getMessage() != null
+            && ise.getMessage().contains("Expected a string but was BEGIN_OBJECT"))
+          log.debug(
+              "Catching exception because of issue"
+                  + " https://github.com/kubernetes-client/java/issues/86",
+              e);
+        else throw e;
+      } else throw e;
+
+    } catch (ApiException e) {
+      // If no response body is present this might be a transport layer failure.
+      if (e.getCode() == 404) {
+        log.debug(
+            "Job execution: {} team: {}, job: {} cannot be found. K8S response body {}. Will set"
+                + " its status to Cancelled in the DB.",
+            executionId,
+            teamName,
+            jobName,
+            e.getResponseBody());
+      } else throw e;
     }
+  }
 
-    // TODO:  container/volume args are breaking a bit abstraction of KubernetesService by leaking impl. details
-    public void createV1CronJob(String name, String image, Map<String, String> envs, String schedule,
-                              boolean enable, List<String> args, Resources request, Resources limit,
-                              V1Container jobContainer, V1Container initContainer,
-                              List<V1Volume> volumes, Map<String, String> jobDeploymentAnnotations,
-                              Map<String, String> jobPodLabels, Map<String, String> jobAnnotations,
-                              Map<String, String> jobLabels, List<String> imagePullSecrets)
-            throws ApiException {
-        log.debug("Creating k8s cron job name:{}, image:{}", name, image);
-        var cronJob = v1CronJobFromTemplate(name, schedule, !enable, jobContainer, initContainer,
-                volumes, jobDeploymentAnnotations, jobPodLabels, jobAnnotations, jobLabels, imagePullSecrets);
-        V1CronJob nsJob = new BatchV1Api(client).createNamespacedCronJob(namespace, cronJob, null, null, null);
-        log.debug("Created k8s cron job: {}", nsJob);
-        log.debug("Created k8s cron job name: {}, uid:{}, link:{}", nsJob.getMetadata().getName(), nsJob.getMetadata().getUid(), nsJob.getMetadata().getSelfLink());
+  public Set<String> listCronJobs() throws ApiException {
+    log.debug("Listing k8s cron jobs");
+    var cronJobs =
+        new BatchV1beta1Api(client)
+            .listNamespacedCronJob(
+                namespace, null, null, null, null, null, null, null, null, null, null);
+    var set =
+        cronJobs.getItems().stream()
+            .map(j -> j.getMetadata().getName())
+            .collect(Collectors.toSet());
+    log.debug("K8s cron jobs: {}", set);
+    return set;
+  }
+
+  public void createCronJob(
+      String name,
+      String image,
+      Map<String, String> envs,
+      String schedule,
+      boolean enable,
+      List<String> args,
+      Resources request,
+      Resources limit,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobDeploymentAnnotations)
+      throws ApiException {
+    if (getK8sSupportsV1CronJob()) {
+      createV1CronJob(
+          name,
+          image,
+          envs,
+          schedule,
+          enable,
+          args,
+          request,
+          limit,
+          jobContainer,
+          initContainer,
+          volumes,
+          jobDeploymentAnnotations,
+          Collections.emptyMap(),
+          Collections.emptyMap(),
+          Collections.emptyMap(),
+          List.of(""));
+    } else {
+      createV1beta1CronJob(
+          name,
+          image,
+          envs,
+          schedule,
+          enable,
+          args,
+          request,
+          limit,
+          jobContainer,
+          initContainer,
+          volumes,
+          jobDeploymentAnnotations,
+          Collections.emptyMap(),
+          Collections.emptyMap(),
+          Collections.emptyMap(),
+          List.of(""));
     }
+  }
 
-    public void updateCronJob(String name, String image,  Map<String, String> envs, String schedule,
-                              boolean enable, List<String> args, Resources request, Resources limit,
-                              V1Container jobContainer, V1Container initContainer,
-                              List<V1Volume> volumes, Map<String, String> jobDeploymentAnnotations)
-            throws ApiException {
-        if(getK8sSupportsV1CronJob()) {
-            updateV1CronJob(name, image, envs, schedule, enable, args, request, limit, jobContainer,
-                    initContainer, volumes, jobDeploymentAnnotations, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), List.of(""));
-        } else {
-            updateV1beta1CronJob(name, image, envs, schedule, enable, args, request, limit, jobContainer,
-                    initContainer, volumes, jobDeploymentAnnotations, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), List.of(""));
-        }
+  public void createCronJob(
+      String name,
+      String image,
+      Map<String, String> envs,
+      String schedule,
+      boolean enable,
+      List<String> args,
+      Resources request,
+      Resources limit,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobDeploymentAnnotations,
+      Map<String, String> jobPodLabels,
+      Map<String, String> jobAnnotations,
+      Map<String, String> jobLabels,
+      List<String> imagePullSecrets)
+      throws ApiException {
+    if (getK8sSupportsV1CronJob()) {
+      createV1CronJob(
+          name,
+          image,
+          envs,
+          schedule,
+          enable,
+          args,
+          request,
+          limit,
+          jobContainer,
+          initContainer,
+          volumes,
+          jobDeploymentAnnotations,
+          jobPodLabels,
+          jobAnnotations,
+          jobLabels,
+          imagePullSecrets);
+    } else {
+      createV1beta1CronJob(
+          name,
+          image,
+          envs,
+          schedule,
+          enable,
+          args,
+          request,
+          limit,
+          jobContainer,
+          initContainer,
+          volumes,
+          jobDeploymentAnnotations,
+          jobPodLabels,
+          jobAnnotations,
+          jobLabels,
+          imagePullSecrets);
     }
+  }
 
-    public void updateCronJob(String name, String image,  Map<String, String> envs, String schedule,
-                              boolean enable, List<String> args, Resources request, Resources limit,
-                              V1Container jobContainer, V1Container initContainer,
-                              List<V1Volume> volumes, Map<String, String> jobDeploymentAnnotations,
-                              Map<String, String> jobPodLabels, Map<String, String> jobAnnotations,
-                              Map<String, String> jobLabels, List<String> imagePullSecrets)
-            throws ApiException {
-        if(getK8sSupportsV1CronJob()) {
-            updateV1CronJob(name, image, envs, schedule, enable, args, request, limit, jobContainer,
-                    initContainer, volumes, jobDeploymentAnnotations, jobPodLabels, jobAnnotations, jobLabels, imagePullSecrets);
-        } else {
-            updateV1beta1CronJob(name, image, envs, schedule, enable, args, request, limit, jobContainer,
-                    initContainer, volumes, jobDeploymentAnnotations, jobPodLabels, jobAnnotations, jobLabels, imagePullSecrets);
-        }
+  // TODO:  container/volume args are breaking a bit abstraction of KubernetesService by leaking
+  // impl. details
+  public void createV1beta1CronJob(
+      String name,
+      String image,
+      Map<String, String> envs,
+      String schedule,
+      boolean enable,
+      List<String> args,
+      Resources request,
+      Resources limit,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobDeploymentAnnotations,
+      Map<String, String> jobPodLabels,
+      Map<String, String> jobAnnotations,
+      Map<String, String> jobLabels,
+      List<String> imagePullSecrets)
+      throws ApiException {
+    log.debug("Creating k8s cron job name:{}, image:{}", name, image);
+    var cronJob =
+        v1beta1CronJobFromTemplate(
+            name,
+            schedule,
+            !enable,
+            jobContainer,
+            initContainer,
+            volumes,
+            jobDeploymentAnnotations,
+            jobPodLabels,
+            jobAnnotations,
+            jobLabels,
+            imagePullSecrets);
+    V1beta1CronJob nsJob =
+        new BatchV1beta1Api(client).createNamespacedCronJob(namespace, cronJob, null, null, null);
+    log.debug("Created k8s cron job: {}", nsJob);
+    log.debug(
+        "Created k8s cron job name: {}, uid:{}, link:{}",
+        nsJob.getMetadata().getName(),
+        nsJob.getMetadata().getUid(),
+        nsJob.getMetadata().getSelfLink());
+  }
+
+  // TODO:  container/volume args are breaking a bit abstraction of KubernetesService by leaking
+  // impl. details
+  public void createV1CronJob(
+      String name,
+      String image,
+      Map<String, String> envs,
+      String schedule,
+      boolean enable,
+      List<String> args,
+      Resources request,
+      Resources limit,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobDeploymentAnnotations,
+      Map<String, String> jobPodLabels,
+      Map<String, String> jobAnnotations,
+      Map<String, String> jobLabels,
+      List<String> imagePullSecrets)
+      throws ApiException {
+    log.debug("Creating k8s cron job name:{}, image:{}", name, image);
+    var cronJob =
+        v1CronJobFromTemplate(
+            name,
+            schedule,
+            !enable,
+            jobContainer,
+            initContainer,
+            volumes,
+            jobDeploymentAnnotations,
+            jobPodLabels,
+            jobAnnotations,
+            jobLabels,
+            imagePullSecrets);
+    V1CronJob nsJob =
+        new BatchV1Api(client).createNamespacedCronJob(namespace, cronJob, null, null, null);
+    log.debug("Created k8s cron job: {}", nsJob);
+    log.debug(
+        "Created k8s cron job name: {}, uid:{}, link:{}",
+        nsJob.getMetadata().getName(),
+        nsJob.getMetadata().getUid(),
+        nsJob.getMetadata().getSelfLink());
+  }
+
+  public void updateCronJob(
+      String name,
+      String image,
+      Map<String, String> envs,
+      String schedule,
+      boolean enable,
+      List<String> args,
+      Resources request,
+      Resources limit,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobDeploymentAnnotations)
+      throws ApiException {
+    if (getK8sSupportsV1CronJob()) {
+      updateV1CronJob(
+          name,
+          image,
+          envs,
+          schedule,
+          enable,
+          args,
+          request,
+          limit,
+          jobContainer,
+          initContainer,
+          volumes,
+          jobDeploymentAnnotations,
+          Collections.emptyMap(),
+          Collections.emptyMap(),
+          Collections.emptyMap(),
+          List.of(""));
+    } else {
+      updateV1beta1CronJob(
+          name,
+          image,
+          envs,
+          schedule,
+          enable,
+          args,
+          request,
+          limit,
+          jobContainer,
+          initContainer,
+          volumes,
+          jobDeploymentAnnotations,
+          Collections.emptyMap(),
+          Collections.emptyMap(),
+          Collections.emptyMap(),
+          List.of(""));
     }
+  }
 
-    public void updateV1beta1CronJob(String name, String image,  Map<String, String> envs, String schedule,
-                              boolean enable, List<String> args, Resources request, Resources limit,
-                              V1Container jobContainer, V1Container initContainer,
-                              List<V1Volume> volumes, Map<String, String> jobDeploymentAnnotations,
-                              Map<String, String> jobPodLabels, Map<String, String> jobAnnotations,
-                              Map<String, String> jobLabels, List<String> imagePullSecrets)
-            throws ApiException {
-        var cronJob = v1beta1CronJobFromTemplate(name, schedule, !enable, jobContainer, initContainer,
-                volumes, jobDeploymentAnnotations, jobPodLabels, jobAnnotations, jobLabels, imagePullSecrets);
-        V1beta1CronJob nsJob = new BatchV1beta1Api(client).replaceNamespacedCronJob(name, namespace, cronJob, null, null, null);
-        log.debug("Updated k8s cron job status for name:{}, image:{}, uid:{}, link:{}", name, image, nsJob.getMetadata().getUid(), nsJob.getMetadata().getSelfLink());
+  public void updateCronJob(
+      String name,
+      String image,
+      Map<String, String> envs,
+      String schedule,
+      boolean enable,
+      List<String> args,
+      Resources request,
+      Resources limit,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobDeploymentAnnotations,
+      Map<String, String> jobPodLabels,
+      Map<String, String> jobAnnotations,
+      Map<String, String> jobLabels,
+      List<String> imagePullSecrets)
+      throws ApiException {
+    if (getK8sSupportsV1CronJob()) {
+      updateV1CronJob(
+          name,
+          image,
+          envs,
+          schedule,
+          enable,
+          args,
+          request,
+          limit,
+          jobContainer,
+          initContainer,
+          volumes,
+          jobDeploymentAnnotations,
+          jobPodLabels,
+          jobAnnotations,
+          jobLabels,
+          imagePullSecrets);
+    } else {
+      updateV1beta1CronJob(
+          name,
+          image,
+          envs,
+          schedule,
+          enable,
+          args,
+          request,
+          limit,
+          jobContainer,
+          initContainer,
+          volumes,
+          jobDeploymentAnnotations,
+          jobPodLabels,
+          jobAnnotations,
+          jobLabels,
+          imagePullSecrets);
     }
+  }
 
-    public void updateV1CronJob(String name, String image,  Map<String, String> envs, String schedule,
-                              boolean enable, List<String> args, Resources request, Resources limit,
-                              V1Container jobContainer, V1Container initContainer,
-                              List<V1Volume> volumes, Map<String, String> jobDeploymentAnnotations,
-                              Map<String, String> jobPodLabels, Map<String, String> jobAnnotations,
-                              Map<String, String> jobLabels, List<String> imagePullSecrets)
-            throws ApiException {
-        var cronJob = v1CronJobFromTemplate(name, schedule, !enable, jobContainer, initContainer,
-                volumes, jobDeploymentAnnotations, jobPodLabels, jobAnnotations, jobLabels, imagePullSecrets);
-        V1CronJob nsJob = new BatchV1Api(client).replaceNamespacedCronJob(name, namespace, cronJob, null, null, null);
-        log.debug("Updated k8s cron job status for name:{}, image:{}, uid:{}, link:{}", name, image, nsJob.getMetadata().getUid(), nsJob.getMetadata().getSelfLink());
+  public void updateV1beta1CronJob(
+      String name,
+      String image,
+      Map<String, String> envs,
+      String schedule,
+      boolean enable,
+      List<String> args,
+      Resources request,
+      Resources limit,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobDeploymentAnnotations,
+      Map<String, String> jobPodLabels,
+      Map<String, String> jobAnnotations,
+      Map<String, String> jobLabels,
+      List<String> imagePullSecrets)
+      throws ApiException {
+    var cronJob =
+        v1beta1CronJobFromTemplate(
+            name,
+            schedule,
+            !enable,
+            jobContainer,
+            initContainer,
+            volumes,
+            jobDeploymentAnnotations,
+            jobPodLabels,
+            jobAnnotations,
+            jobLabels,
+            imagePullSecrets);
+    V1beta1CronJob nsJob =
+        new BatchV1beta1Api(client)
+            .replaceNamespacedCronJob(name, namespace, cronJob, null, null, null);
+    log.debug(
+        "Updated k8s cron job status for name:{}, image:{}, uid:{}, link:{}",
+        name,
+        image,
+        nsJob.getMetadata().getUid(),
+        nsJob.getMetadata().getSelfLink());
+  }
+
+  public void updateV1CronJob(
+      String name,
+      String image,
+      Map<String, String> envs,
+      String schedule,
+      boolean enable,
+      List<String> args,
+      Resources request,
+      Resources limit,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobDeploymentAnnotations,
+      Map<String, String> jobPodLabels,
+      Map<String, String> jobAnnotations,
+      Map<String, String> jobLabels,
+      List<String> imagePullSecrets)
+      throws ApiException {
+    var cronJob =
+        v1CronJobFromTemplate(
+            name,
+            schedule,
+            !enable,
+            jobContainer,
+            initContainer,
+            volumes,
+            jobDeploymentAnnotations,
+            jobPodLabels,
+            jobAnnotations,
+            jobLabels,
+            imagePullSecrets);
+    V1CronJob nsJob =
+        new BatchV1Api(client).replaceNamespacedCronJob(name, namespace, cronJob, null, null, null);
+    log.debug(
+        "Updated k8s cron job status for name:{}, image:{}, uid:{}, link:{}",
+        name,
+        image,
+        nsJob.getMetadata().getUid(),
+        nsJob.getMetadata().getSelfLink());
+  }
+
+  public void deleteCronJob(String name) throws ApiException {
+    log.debug("Deleting k8s cron job: {}", name);
+    try {
+      new BatchV1beta1Api(client)
+          .deleteNamespacedCronJob(name, namespace, null, null, null, null, null, null);
+    } catch (JsonSyntaxException e) {
+      if (e.getCause() instanceof IllegalStateException) {
+        IllegalStateException ise = (IllegalStateException) e.getCause();
+        if (ise.getMessage() != null
+            && ise.getMessage().contains("Expected a string but was BEGIN_OBJECT"))
+          log.debug(
+              "Catching exception because of issue"
+                  + " https://github.com/kubernetes-client/java/issues/86",
+              e);
+        else throw e;
+      } else throw e;
     }
+    log.debug("Deleted k8s cron job: {}", name);
+  }
 
-    public void deleteCronJob(String name) throws ApiException {
-        log.debug("Deleting k8s cron job: {}", name);
-        try {
-            new BatchV1beta1Api(client).deleteNamespacedCronJob(name, namespace, null, null, null, null, null, null);
-        }
-        catch (JsonSyntaxException e) {
-            if (e.getCause() instanceof IllegalStateException) {
-                IllegalStateException ise = (IllegalStateException) e.getCause();
-                if (ise.getMessage() != null && ise.getMessage().contains("Expected a string but was BEGIN_OBJECT"))
-                    log.debug("Catching exception because of issue https://github.com/kubernetes-client/java/issues/86", e);
-                else throw e;
-            }
-            else throw e;
-        }
-        log.debug("Deleted k8s cron job: {}", name);
-    }
+  public void createJob(
+      String name,
+      String image,
+      boolean privileged,
+      Map<String, String> envs,
+      List<String> args,
+      List<V1Volume> volumes,
+      List<V1VolumeMount> volumeMounts,
+      String imagePullPolicy,
+      Resources request,
+      Resources limit,
+      long runAsUser,
+      long runAsGroup,
+      long fsGroup,
+      String serviceAccountName)
+      throws ApiException {
 
-    public void createJob(String name, String image, boolean privileged, Map<String, String> envs,
-                          List<String> args, List<V1Volume> volumes, List<V1VolumeMount> volumeMounts,
-                          String imagePullPolicy, Resources request, Resources limit,
-                          long runAsUser, long runAsGroup, long fsGroup, String serviceAccountName) throws ApiException {
-
-        log.debug("Creating k8s job name:{}, image:{}", name, image);
-        var podSpecBuilder = new V1PodSpecBuilder()
-              .withRestartPolicy("Never")
-              .withContainers(container(name, image, privileged, envs, args, volumeMounts, imagePullPolicy, request, limit, null))
-              .withVolumes(volumes)
-              .withSecurityContext(new V1PodSecurityContext()
+    log.debug("Creating k8s job name:{}, image:{}", name, image);
+    var podSpecBuilder =
+        new V1PodSpecBuilder()
+            .withRestartPolicy("Never")
+            .withContainers(
+                container(
+                    name,
+                    image,
+                    privileged,
+                    envs,
+                    args,
+                    volumeMounts,
+                    imagePullPolicy,
+                    request,
+                    limit,
+                    null))
+            .withVolumes(volumes)
+            .withSecurityContext(
+                new V1PodSecurityContext()
                     .runAsUser(runAsUser)
                     .runAsGroup(runAsGroup)
                     .fsGroup(fsGroup));
 
-        if (StringUtils.isNotEmpty(serviceAccountName)) {
-            podSpecBuilder.withServiceAccountName(serviceAccountName);
+    if (StringUtils.isNotEmpty(serviceAccountName)) {
+      podSpecBuilder.withServiceAccountName(serviceAccountName);
+    }
+
+    var template = new V1PodTemplateSpecBuilder().withSpec(podSpecBuilder.build()).build();
+    var spec =
+        new V1JobSpecBuilder()
+            .withBackoffLimit(3) // TODO configure
+            .withTtlSecondsAfterFinished(jobTTLAfterFinishedSeconds)
+            .withTemplate(template)
+            .build();
+    createNewJob(name, spec, Collections.emptyMap(), Collections.emptyMap());
+  }
+
+  // Default for testing purposes
+  void createNewJob(
+      String name, V1JobSpec spec, Map<String, String> labels, Map<String, String> annotations)
+      throws ApiException {
+    var job =
+        new V1JobBuilder()
+            .withMetadata(
+                new V1ObjectMetaBuilder()
+                    .withName(name)
+                    .addToLabels(labels)
+                    .addToAnnotations(annotations)
+                    .build())
+            .withSpec(spec)
+            .build();
+
+    V1Job nsJob = new BatchV1Api(client).createNamespacedJob(namespace, job, null, null, null);
+    log.debug("Created k8s job: {}", nsJob);
+    log.debug(
+        "Created k8s job name: {}, uid:{}, link:{}",
+        nsJob.getMetadata().getName(),
+        nsJob.getMetadata().getUid(),
+        nsJob.getMetadata().getSelfLink());
+  }
+
+  public Optional<V1Pod> getPod(String podName) throws ApiException {
+    List<V1Pod> allPods =
+        new CoreV1Api(client)
+            .listNamespacedPod(
+                namespace, "false", null, null, null, null, null, null, null, null, null)
+            .getItems();
+
+    return allPods.stream()
+        .filter(pod -> pod.getMetadata().getName().startsWith(podName))
+        .findFirst();
+  }
+
+  private List<V1Pod> listJobPods(V1Job job) throws ApiException {
+    var labelsToSelect = Map.of("job-name", job.getMetadata().getName());
+    log.debug("Getting pods with labels {}", labelsToSelect);
+    String labelSelector = buildLabelSelector(labelsToSelect);
+    var pods =
+        new CoreV1Api(client)
+            .listNamespacedPod(
+                namespace, null, null, null, null, labelSelector, null, null, null, null, null)
+            .getItems();
+    log.trace("K8s pods with label selector {}: {}", labelSelector, pods);
+    return pods;
+  }
+
+  public boolean isRunningJob(String dataJobName) throws ApiException {
+    var labelsToSelect = Map.of(JobLabel.NAME.getValue(), dataJobName);
+    String labelSelector = buildLabelSelector(labelsToSelect);
+    V1JobList v1JobList =
+        initBatchV1Api()
+            .listNamespacedJob(
+                namespace, null, null, null, null, labelSelector, null, null, null, null, null);
+
+    // In this case we use getConditions() instead of getActive()
+    // because if the job is in init state the active flag is zero.
+    // We want to track those jobs as submitted as well.
+    // The getConditions() returns result only if the job is completed.
+    return Optional.ofNullable(v1JobList).map(V1JobList::getItems).stream()
+        .flatMap(v1Jobs -> v1Jobs.stream())
+        .map(V1Job::getStatus)
+        .map(V1JobStatus::getConditions)
+        .anyMatch(v1JobConditions -> CollectionUtils.isEmpty(v1JobConditions));
+  }
+
+  public String getPodLogs(String podName) throws IOException, ApiException {
+    log.info("Get logs for pod {}", podName);
+    Optional<V1Pod> pod = getPod(podName);
+
+    String logs = "";
+    if (pod.isPresent()) {
+      PodLogs podLogs = new PodLogs(client);
+
+      try (BufferedReader br =
+          new BufferedReader(
+              new InputStreamReader(podLogs.streamNamespacedPodLog(pod.get()), Charsets.UTF_8))) {
+        // The builder logs are relatively small so we can afford to load it all in memory for
+        // easier processing.
+        log.info("Retrieving logs for Pod with name: {}", podName);
+        logs =
+            br.lines()
+                .peek(s -> log.debug("[{}] {}", podName, s))
+                .collect(Collectors.joining(System.lineSeparator()));
+      }
+    }
+    return logs;
+  }
+
+  public Optional<String> getJobLogs(String jobName, Integer tailLines)
+      throws ApiException, IOException {
+    var job = getJob(jobName);
+    if (job.isPresent()) {
+      var pods = listJobPods(job.get());
+      if (pods.size() > 0) {
+        var pod = pods.get(pods.size() - 1);
+        PodLogs podLogs = new PodLogs(client);
+
+        try (BufferedReader br =
+            new BufferedReader(
+                new InputStreamReader(
+                    podLogs.streamNamespacedPodLog(
+                        pod.getMetadata().getNamespace(),
+                        pod.getMetadata().getName(),
+                        pod.getSpec().getContainers().get(0).getName(),
+                        null,
+                        tailLines,
+                        true),
+                    Charsets.UTF_8))) {
+          String logs = br.lines().collect(Collectors.joining(System.lineSeparator()));
+          return Optional.of(logs);
         }
+      }
+    }
+    return Optional.empty();
+  }
 
-        var template = new V1PodTemplateSpecBuilder()
-                .withSpec(podSpecBuilder.build())
-                .build();
-        var spec = new V1JobSpecBuilder()
-                .withBackoffLimit(3) //TODO configure
-                .withTtlSecondsAfterFinished(jobTTLAfterFinishedSeconds)
-                .withTemplate(template)
-                .build();
-        createNewJob(name, spec, Collections.emptyMap(), Collections.emptyMap());
+  public JobStatusCondition watchJob(
+      String jobName, int timeoutSeconds, Consumer<JobStatus> watcher)
+      throws ApiException, IOException, InterruptedException {
+    log.debug("Watch job {}; timeoutSeconds: {}", jobName, timeoutSeconds);
+    JobStatusCondition condition = null;
+    // we may have started watching too soon
+    // TODO: set resourceVersion when watching to optimize waits or even avoid the loop here ?
+    // https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions
+    // https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes
+    int counter = timeoutSeconds;
+    while (condition == null && --counter > 0) {
+      Thread.sleep(1000);
+      condition = watchJobInternal(jobName, timeoutSeconds, watcher);
+    }
+    if (condition == null) {
+      condition = new JobStatusCondition(false, null, "Cannot determine job status", "", 0);
+    }
+    return condition;
+  }
+
+  // Default for testing purposes
+  BatchV1Api initBatchV1Api() {
+    return new BatchV1Api(client);
+  }
+
+  // Default for testing purposes
+  BatchV1beta1Api initBatchV1beta1Api() {
+    return new BatchV1beta1Api(client);
+  }
+
+  private JobStatusCondition watchJobInternal(
+      String jobName, int timeoutSeconds, Consumer<JobStatus> watcher)
+      throws IOException, ApiException {
+    String fieldSelector = String.format("metadata.name=%s", jobName);
+    try (Watch<V1Job> watch =
+        Watch.createWatch(
+            Configuration.getDefaultApiClient(),
+            new BatchV1Api(client)
+                .listNamespacedJobCall(
+                    namespace,
+                    null,
+                    null,
+                    null,
+                    fieldSelector,
+                    null,
+                    null,
+                    null,
+                    null,
+                    timeoutSeconds,
+                    true,
+                    null),
+            new TypeToken<Watch.Response<V1Job>>() {}.getType())) {
+      for (var response : watch) {
+        log.debug("watch k8s response type: {}", response.type);
+        var job = response.object;
+
+        var status = new JobStatus(job.getStatus());
+        log.debug("watch k8s status: {}", status);
+        watcher.accept(status);
+
+        return getJobCondition(job);
+      }
+    } catch (RuntimeException e) {
+      log.info(
+          "Could not get status of a job. " + " Error was: " + e.getMessage(),
+          " Will try to get status again from kubernetes if the job exists");
+      var job = getJob(jobName);
+      return getJobCondition(job.get());
+    }
+    return null;
+  }
+
+  private static String buildLabelSelector(Map<String, String> labels) {
+    if (labels == null) {
+      return null;
+    }
+    return labels.entrySet().stream()
+        .map(e -> e.getKey() + "=" + e.getValue())
+        .collect(Collectors.joining(","));
+  }
+
+  private static String getContainerName(V1Job job) {
+    Objects.requireNonNull(job, "The job cannot be null");
+
+    var containers =
+        Optional.ofNullable(job.getSpec())
+            .map(V1JobSpec::getTemplate)
+            .map(V1PodTemplateSpec::getSpec)
+            .map(V1PodSpec::getContainers)
+            .orElse(null);
+
+    return (containers != null && !containers.isEmpty()) ? containers.get(0).getName() : null;
+  }
+
+  private static Optional<V1ContainerStateTerminated> getTerminatedState(V1Pod pod) {
+    Objects.requireNonNull(pod, "The pod cannot be null");
+    var status = pod.getStatus();
+    if (status == null
+        || status.getContainerStatuses() == null
+        || status.getContainerStatuses().isEmpty()) {
+      return Optional.empty();
+    }
+    final var containerStatus = status.getContainerStatuses().get(0);
+    return getTerminatedState(containerStatus.getState())
+        .or(() -> getTerminatedState(containerStatus.getLastState()));
+  }
+
+  private static Optional<V1ContainerStateTerminated> getTerminatedState(V1ContainerState state) {
+    return (state == null || state.getTerminated() == null)
+        ? Optional.empty()
+        : Optional.ofNullable(state.getTerminated());
+  }
+
+  /**
+   * Returns the termination status of the specified job by looking at its associated pods and
+   * searching for the last terminated one.
+   *
+   * @param job The job whose status to return.
+   * @return A {@link V1ContainerStateTerminated} object representing the termination status of the
+   *     job.
+   */
+  Optional<V1ContainerStateTerminated> getTerminationStatus(V1Job job) {
+    List<V1Pod> jobPods;
+
+    try {
+      jobPods = listJobPods(job);
+    } catch (ApiException ex) {
+      log.info("Could not list pods for job {}", job.getMetadata().getName(), ex);
+      return Optional.empty();
     }
 
-    // Default for testing purposes
-    void createNewJob(String name, V1JobSpec spec, Map<String, String> labels, Map<String, String> annotations) throws ApiException {
-        var job = new V1JobBuilder()
-                .withMetadata(new V1ObjectMetaBuilder()
-                        .withName(name)
-                        .addToLabels(labels)
-                        .addToAnnotations(annotations)
-                        .build())
-                .withSpec(spec)
-                .build();
+    var lastTerminatedPodState =
+        jobPods.stream()
+            .map(KubernetesService::getTerminatedState)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .max(Comparator.comparing(V1ContainerStateTerminated::getFinishedAt));
 
-        V1Job nsJob = new BatchV1Api(client).createNamespacedJob(namespace, job, null, null, null);
-        log.debug("Created k8s job: {}", nsJob);
-        log.debug("Created k8s job name: {}, uid:{}, link:{}", nsJob.getMetadata().getName(), nsJob.getMetadata().getUid(), nsJob.getMetadata().getSelfLink());
+    if (lastTerminatedPodState.isEmpty()) {
+      log.info("Could not find a terminated pod for job {}", job.getMetadata().getName());
     }
 
-    public Optional<V1Pod> getPod(String podName) throws ApiException {
-        List<V1Pod> allPods = new CoreV1Api(client)
-              .listNamespacedPod(namespace, "false", null, null, null, null, null, null, null, null, null)
-              .getItems();
+    return lastTerminatedPodState;
+  }
 
-        return allPods.stream()
-              .filter(pod -> pod.getMetadata().getName().startsWith(podName))
-              .findFirst();
+  /**
+   * Returns the Data Job execution status of the specified job
+   *
+   * @param job The job whose status to return.
+   * @return A {@link JobExecution} object representing the Data Job execution status.
+   */
+  Optional<JobExecution> getJobExecutionStatus(V1Job job, JobStatusCondition jobStatusCondition) {
+    JobExecution.JobExecutionBuilder jobExecutionStatusBuilder = JobExecution.builder();
+    // jobCondition = null means that the K8S Job is still running
+    if (jobStatusCondition != null) {
+      // Job termination status
+      Optional<V1ContainerStateTerminated> lastTerminatedPodState = getTerminationStatus(job);
+      // If the job completed but its pod did not produce a termination message, we infer the
+      // termination
+      // status later, based on the status of the job itself.
+      lastTerminatedPodState
+          .map(
+              v1ContainerStateTerminated ->
+                  StringUtils.trim(v1ContainerStateTerminated.getMessage()))
+          .ifPresent(s -> jobExecutionStatusBuilder.podTerminationMessage(s));
+      jobExecutionStatusBuilder.jobTerminationReason(jobStatusCondition.getReason());
+
+      // Termination Reason of the data job pod container
+      lastTerminatedPodState
+          .map(
+              v1ContainerStateTerminated ->
+                  StringUtils.trim(v1ContainerStateTerminated.getReason()))
+          .ifPresent(s -> jobExecutionStatusBuilder.containerTerminationReason(s));
     }
 
-    private List<V1Pod> listJobPods(V1Job job) throws ApiException {
-        var labelsToSelect = Map.of("job-name", job.getMetadata().getName());
-        log.debug("Getting pods with labels {}", labelsToSelect);
-        String labelSelector = buildLabelSelector(labelsToSelect);
-        var pods = new CoreV1Api(client).listNamespacedPod(namespace, null, null, null, null, labelSelector, null, null, null, null, null).getItems();
-        log.trace("K8s pods with label selector {}: {}", labelSelector, pods);
-        return pods;
-    }
+    // Job resources
+    Optional<V1Container> containerOptional =
+        Optional.ofNullable(job.getSpec())
+            .map(V1JobSpec::getTemplate)
+            .map(V1PodTemplateSpec::getSpec)
+            .map(V1PodSpec::getContainers)
+            .filter(v1Containers -> !CollectionUtils.isEmpty(v1Containers))
+            .map(v1Containers -> v1Containers.get(0));
 
-    public boolean isRunningJob(String dataJobName) throws ApiException {
-        var labelsToSelect = Map.of(JobLabel.NAME.getValue(), dataJobName);
-        String labelSelector = buildLabelSelector(labelsToSelect);
-        V1JobList v1JobList = initBatchV1Api().listNamespacedJob(namespace, null, null, null, null, labelSelector, null, null, null, null, null);
+    Optional<Map<String, Quantity>> resourcesRequest =
+        containerOptional.map(V1Container::getResources).map(V1ResourceRequirements::getRequests);
+    jobExecutionStatusBuilder.resourcesCpuRequest(
+        resourcesRequest
+            .map(stringQuantityMap -> stringQuantityMap.get(ContainerResourceType.CPU.getValue()))
+            .map(Quantity::getNumber)
+            .map(Number::floatValue)
+            .orElse(null));
+    jobExecutionStatusBuilder.resourcesMemoryRequest(
+        resourcesRequest
+            .map(
+                stringQuantityMap -> stringQuantityMap.get(ContainerResourceType.MEMORY.getValue()))
+            .map(quantity -> convertMemoryToMBs(quantity))
+            .orElse(null));
 
-        // In this case we use getConditions() instead of getActive()
-        // because if the job is in init state the active flag is zero.
-        // We want to track those jobs as submitted as well.
-        // The getConditions() returns result only if the job is completed.
-        return Optional.ofNullable(v1JobList)
-              .map(V1JobList::getItems)
-              .stream()
-              .flatMap(v1Jobs -> v1Jobs.stream())
-              .map(V1Job::getStatus)
-              .map(V1JobStatus::getConditions)
-              .anyMatch(v1JobConditions -> CollectionUtils.isEmpty(v1JobConditions));
-    }
+    Optional<Map<String, Quantity>> resourcesLimit =
+        containerOptional.map(V1Container::getResources).map(V1ResourceRequirements::getLimits);
+    jobExecutionStatusBuilder.resourcesCpuLimit(
+        resourcesLimit
+            .map(stringQuantityMap -> stringQuantityMap.get(ContainerResourceType.CPU.getValue()))
+            .map(Quantity::getNumber)
+            .map(Number::floatValue)
+            .orElse(null));
+    jobExecutionStatusBuilder.resourcesMemoryLimit(
+        resourcesLimit
+            .map(
+                stringQuantityMap -> stringQuantityMap.get(ContainerResourceType.MEMORY.getValue()))
+            .map(quantity -> convertMemoryToMBs(quantity))
+            .orElse(null));
 
-    public String getPodLogs(String podName) throws IOException, ApiException {
-        log.info("Get logs for pod {}", podName);
-        Optional<V1Pod> pod = getPod(podName);
+    // Job metadata
+    Optional<V1ObjectMeta> metadata = Optional.ofNullable(job.getMetadata());
 
-        String logs = "";
-        if (pod.isPresent()) {
-            PodLogs podLogs = new PodLogs(client);
+    jobExecutionStatusBuilder.executionId(metadata.map(V1ObjectMeta::getName).orElse(null));
 
-            try (BufferedReader br = new BufferedReader(new InputStreamReader(podLogs.streamNamespacedPodLog(pod.get()), Charsets.UTF_8))) {
-                // The builder logs are relatively small so we can afford to load it all in memory for easier processing.
-                log.info("Retrieving logs for Pod with name: {}", podName);
-                logs = br.lines().peek(s -> log.debug("[{}] {}", podName, s)).collect(Collectors.joining(System.lineSeparator()));
-            }
-        }
-        return logs;
-    }
+    // Job labels
+    Optional<Map<String, String>> labels = metadata.map(V1ObjectMeta::getLabels);
 
-    public Optional<String> getJobLogs(String jobName, Integer tailLines) throws ApiException, IOException {
-       var job = getJob(jobName);
-       if (job.isPresent()) {
-           var pods = listJobPods(job.get());
-           if (pods.size() > 0) {
-               var pod = pods.get(pods.size() - 1);
-               PodLogs podLogs = new PodLogs(client);
+    jobExecutionStatusBuilder.jobVersion(
+        labels
+            .map(stringStringMap -> stringStringMap.get(JobLabel.VERSION.getValue()))
+            .orElse(
+                containerOptional
+                    .map(V1Container::getImage)
+                    .map(imageStr -> imageStr.substring(imageStr.lastIndexOf(":") + 1))
+                    .orElse(null)));
 
-               try (BufferedReader br = new BufferedReader(new InputStreamReader(podLogs.streamNamespacedPodLog(pod.getMetadata().getNamespace(),
-                       pod.getMetadata().getName(),
-                       pod.getSpec().getContainers().get(0).getName(),
-                       null, tailLines, true), Charsets.UTF_8))) {
-                    String logs = br.lines().collect(Collectors.joining(System.lineSeparator()));
-                    return Optional.of(logs);
-               }
-           }
-       }
-       return Optional.empty();
-    }
+    jobExecutionStatusBuilder.jobName(
+        labels
+            .map(stringStringMap -> stringStringMap.get(JobLabel.NAME.getValue()))
+            .orElse(getContainerName(job)));
 
-    public JobStatusCondition watchJob(String jobName, int timeoutSeconds, Consumer<JobStatus> watcher) throws ApiException, IOException, InterruptedException {
-        log.debug("Watch job {}; timeoutSeconds: {}", jobName, timeoutSeconds);
-        JobStatusCondition condition = null;
-        // we may have started watching too soon
-        // TODO: set resourceVersion when watching to optimize waits or even avoid the loop here ?
-        // https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions
-        // https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes
-        int counter =  timeoutSeconds;
-        while (condition == null && --counter > 0) {
-            Thread.sleep(1000);
-            condition = watchJobInternal(jobName, timeoutSeconds, watcher);
-        }
-        if (condition == null) {
-            condition = new JobStatusCondition(false, null, "Cannot determine job status", "", 0);
-        }
-        return condition;
-    }
+    // Job annotations
+    Optional<Map<String, String>> annotations = metadata.map(V1ObjectMeta::getAnnotations);
 
-    // Default for testing purposes
-    BatchV1Api initBatchV1Api() {
-        return new BatchV1Api(client);
-    }
+    jobExecutionStatusBuilder.deployedDate(
+        annotations
+            .map(stringStringMap -> stringStringMap.get(JobAnnotation.DEPLOYED_DATE.getValue()))
+            .filter(lastDeployedDateStr -> StringUtils.isNotBlank(lastDeployedDateStr))
+            .map(lastDeployedDateStr -> OffsetDateTime.parse(lastDeployedDateStr))
+            .orElse(null));
 
-    // Default for testing purposes
-    BatchV1beta1Api initBatchV1beta1Api() {
-        return new BatchV1beta1Api(client);
-    }
+    jobExecutionStatusBuilder.deployedBy(
+        annotations
+            .map(stringStringMap -> stringStringMap.get(JobAnnotation.DEPLOYED_BY.getValue()))
+            .orElse(null));
 
-    private JobStatusCondition watchJobInternal(String jobName, int timeoutSeconds, Consumer<JobStatus> watcher) throws IOException, ApiException {
-        String fieldSelector = String.format("metadata.name=%s", jobName);
-        try (Watch<V1Job> watch = Watch.createWatch(Configuration.getDefaultApiClient(),
-                new BatchV1Api(client).listNamespacedJobCall(namespace, null, null, null, fieldSelector, null, null, null, null, timeoutSeconds, true, null),
-                new TypeToken<Watch.Response<V1Job>>() {
-                }.getType())) {
-            for (var response : watch) {
-                log.debug("watch k8s response type: {}", response.type);
-                var job = response.object;
+    jobExecutionStatusBuilder.executionType(
+        annotations
+            .map(stringStringMap -> stringStringMap.get(JobAnnotation.EXECUTION_TYPE.getValue()))
+            .orElse(null));
 
-                var status = new JobStatus(job.getStatus());
-                log.debug("watch k8s status: {}", status);
-                watcher.accept(status);
+    jobExecutionStatusBuilder.opId(
+        annotations
+            .map(stringStringMap -> stringStringMap.get(JobAnnotation.OP_ID.getValue()))
+            .orElse(metadata.map(V1ObjectMeta::getName).orElse(null)));
 
-                return getJobCondition(job);
-            }
-        } catch (RuntimeException e) {
-            log.info("Could not get status of a job. " +
-                    " Error was: " + e.getMessage(),
-                    " Will try to get status again from kubernetes if the job exists");
-            var job = getJob(jobName);
-            return getJobCondition(job.get());
-        }
-        return null;
-    }
+    jobExecutionStatusBuilder.jobSchedule(
+        annotations
+            .map(stringStringMap -> stringStringMap.get(JobAnnotation.SCHEDULE.getValue()))
+            .orElse(null));
 
-    private static String buildLabelSelector(Map<String, String> labels) {
-        if (labels == null) {
-            return null;
-        }
-        return labels
-                .entrySet().stream().map(e -> e.getKey() + "=" + e.getValue())
-                .collect(Collectors.joining(","));
-    }
+    // Job status
+    Optional<V1JobStatus> jobStatus = Optional.ofNullable(job.getStatus());
 
-    private static String getContainerName(V1Job job) {
-        Objects.requireNonNull(job, "The job cannot be null");
+    jobExecutionStatusBuilder.startTime(
+        jobStatus
+            .map(V1JobStatus::getStartTime)
+            .map(startTime -> Instant.ofEpochMilli(startTime.toInstant().toEpochMilli()))
+            .map(startTimeInstant -> OffsetDateTime.ofInstant(startTimeInstant, ZoneOffset.UTC))
+            .orElse(null));
 
-        var containers = Optional.ofNullable(job.getSpec())
-              .map(V1JobSpec::getTemplate)
-              .map(V1PodTemplateSpec::getSpec)
-              .map(V1PodSpec::getContainers)
-              .orElse(null);
+    jobExecutionStatusBuilder.endTime(
+        Optional.ofNullable(jobStatusCondition)
+            .map(JobStatusCondition::getCompletionTime)
+            .map(endTime -> Instant.ofEpochMilli(endTime))
+            .map(endTimeInstant -> OffsetDateTime.ofInstant(endTimeInstant, ZoneOffset.UTC))
+            .orElse(null));
 
-        return (containers != null && !containers.isEmpty()) ? containers.get(0).getName() : null;
-    }
+    // jobCondition = null means that the Data Job is still running
+    jobExecutionStatusBuilder.succeeded(
+        Optional.ofNullable(jobStatusCondition).map(JobStatusCondition::isSuccess).orElse(null));
 
-    private static Optional<V1ContainerStateTerminated> getTerminatedState(V1Pod pod) {
-        Objects.requireNonNull(pod, "The pod cannot be null");
-        var status = pod.getStatus();
-        if (status == null || status.getContainerStatuses() == null || status.getContainerStatuses().isEmpty()) {
-            return Optional.empty();
-        }
-        final var containerStatus = status.getContainerStatuses().get(0);
-        return getTerminatedState(containerStatus.getState())
-                .or(() -> getTerminatedState(containerStatus.getLastState()));
-    }
+    return Optional.of(jobExecutionStatusBuilder.build());
+  }
 
-    private static Optional<V1ContainerStateTerminated> getTerminatedState(V1ContainerState state) {
-        return (state == null || state.getTerminated() == null) ? Optional.empty() : Optional.ofNullable(state.getTerminated());
-    }
+  /**
+   * Initiates a watch for the jobs with labels specified by {@code labelsToWatch}. The watch will
+   * be active for no longer than the number of seconds specified by {@code timeoutSeconds}. The
+   * specified watcher is invoked whenever a job is completed and has an associated pod with a
+   * termination message.
+   *
+   * @param labelsToWatch The labels for the jobs to watch, or null, to watch all jobs.
+   * @param watcher A {@link Consumer} to receive notifications about completed jobs.
+   * @param lastWatchTime The time of the last completed job watch, expressed in millis since Epoch.
+   * @throws ApiException
+   * @throws IOException
+   */
+  public void watchJobs(
+      Map<String, String> labelsToWatch,
+      Consumer<JobExecution> watcher,
+      Consumer<List<String>> runningJobExecutionsConsumer,
+      long lastWatchTime)
+      throws IOException, ApiException {
 
-    /**
-     * Returns the termination status of the specified job by looking at its associated pods and
-     * searching for the last terminated one.
-     *
-     * @param job The job whose status to return.
-     * @return A {@link V1ContainerStateTerminated} object representing the termination status of the job.
-     */
-    Optional<V1ContainerStateTerminated> getTerminationStatus(V1Job job) {
-        List<V1Pod> jobPods;
+    watchJobs(
+        labelsToWatch,
+        watcher,
+        runningJobExecutionsConsumer,
+        lastWatchTime,
+        WATCH_JOBS_TIMEOUT_SECONDS);
+  }
 
-        try {
-            jobPods = listJobPods(job);
-        } catch (ApiException ex) {
-            log.info("Could not list pods for job {}", job.getMetadata().getName(), ex);
-            return Optional.empty();
-        }
+  /**
+   * Initiates a watch for the jobs with labels specified by {@code labelsToWatch}. The watch will
+   * be active for no longer than the number of seconds specified by {@code timeoutSeconds}. The
+   * specified watcher is invoked whenever a job is completed and has an associated pod with a
+   * termination message.
+   *
+   * @param labelsToWatch The labels for the jobs to watch, or null, to watch all jobs.
+   * @param watcher A {@link Consumer} to receive notifications about completed jobs.
+   * @param lastWatchTime The time of the last completed job watch, expressed in millis since Epoch.
+   * @param timeoutSeconds The maximum number of seconds that the watch should be active, or null,
+   *     to watch using the default timeout configured on the server (usually 5 minutes). If this
+   *     value is changed, the {@code defaultLockAtMostFor} value of the {@link EnableSchedulerLock}
+   *     annotation (see {@link ThreadPoolConf}) should be adjusted accordingly to ensure that the
+   *     lock will be held long enough for the watch to complete.
+   * @throws ApiException
+   * @throws IOException
+   */
+  public void watchJobs(
+      Map<String, String> labelsToWatch,
+      Consumer<JobExecution> watcher,
+      Consumer<List<String>> runningJobExecutionsConsumer,
+      long lastWatchTime,
+      Integer timeoutSeconds)
+      throws ApiException, IOException {
 
-        var lastTerminatedPodState = jobPods.stream()
-              .map(KubernetesService::getTerminatedState)
-              .filter(Optional::isPresent)
-              .map(Optional::get)
-              .max(Comparator.comparing(V1ContainerStateTerminated::getFinishedAt));
+    Objects.requireNonNull(watcher, "The watcher cannot be null");
+    log.info("Start watching jobs with labels: {}", labelsToWatch);
 
-        if (lastTerminatedPodState.isEmpty()) {
-            log.info("Could not find a terminated pod for job {}", job.getMetadata().getName());
-        }
+    // Job change detection implementation:
+    // https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes
+    String labelSelector = buildLabelSelector(labelsToWatch);
+    String resourceVersion;
+    try {
+      var jobList =
+          new BatchV1Api(client)
+              .listNamespacedJob(
+                  namespace,
+                  "false",
+                  null,
+                  null,
+                  null,
+                  labelSelector,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null);
+      List<String> runningExecutionIds = new ArrayList<>();
 
-        return lastTerminatedPodState;
-    }
-
-    /**
-     * Returns the Data Job execution status of the specified job
-     *
-     * @param job The job whose status to return.
-     * @return A {@link JobExecution} object representing the Data Job execution status.
-     */
-    Optional<JobExecution> getJobExecutionStatus(V1Job job, JobStatusCondition jobStatusCondition) {
-        JobExecution.JobExecutionBuilder jobExecutionStatusBuilder = JobExecution.builder();
-        // jobCondition = null means that the K8S Job is still running
-        if (jobStatusCondition != null) {
-            // Job termination status
-            Optional<V1ContainerStateTerminated> lastTerminatedPodState = getTerminationStatus(job);
-            // If the job completed but its pod did not produce a termination message, we infer the termination
-            // status later, based on the status of the job itself.
-            lastTerminatedPodState
-                  .map(v1ContainerStateTerminated -> StringUtils.trim(v1ContainerStateTerminated.getMessage()))
-                  .ifPresent(s -> jobExecutionStatusBuilder.podTerminationMessage(s));
-            jobExecutionStatusBuilder.jobTerminationReason(jobStatusCondition.getReason());
-
-            // Termination Reason of the data job pod container
-            lastTerminatedPodState
-                    .map(v1ContainerStateTerminated -> StringUtils.trim(v1ContainerStateTerminated.getReason()))
-                    .ifPresent(s -> jobExecutionStatusBuilder.containerTerminationReason(s));
-        }
-
-        // Job resources
-        Optional<V1Container> containerOptional = Optional.ofNullable(job.getSpec())
-              .map(V1JobSpec::getTemplate)
-              .map(V1PodTemplateSpec::getSpec)
-              .map(V1PodSpec::getContainers)
-              .filter(v1Containers -> !CollectionUtils.isEmpty(v1Containers))
-              .map(v1Containers -> v1Containers.get(0));
-
-        Optional<Map<String, Quantity>> resourcesRequest = containerOptional
-              .map(V1Container::getResources)
-              .map(V1ResourceRequirements::getRequests);
-        jobExecutionStatusBuilder.resourcesCpuRequest(
-              resourcesRequest
-                    .map(stringQuantityMap -> stringQuantityMap.get(ContainerResourceType.CPU.getValue()))
-                    .map(Quantity::getNumber)
-                    .map(Number::floatValue)
-                    .orElse(null));
-        jobExecutionStatusBuilder.resourcesMemoryRequest(
-              resourcesRequest
-                    .map(stringQuantityMap -> stringQuantityMap.get(ContainerResourceType.MEMORY.getValue()))
-                    .map(quantity -> convertMemoryToMBs(quantity))
-                    .orElse(null));
-
-        Optional<Map<String, Quantity>> resourcesLimit = containerOptional
-              .map(V1Container::getResources)
-              .map(V1ResourceRequirements::getLimits);
-        jobExecutionStatusBuilder.resourcesCpuLimit(
-              resourcesLimit
-                    .map(stringQuantityMap -> stringQuantityMap.get(ContainerResourceType.CPU.getValue()))
-                    .map(Quantity::getNumber)
-                    .map(Number::floatValue)
-                    .orElse(null));
-        jobExecutionStatusBuilder.resourcesMemoryLimit(
-              resourcesLimit
-                    .map(stringQuantityMap -> stringQuantityMap.get(ContainerResourceType.MEMORY.getValue()))
-                    .map(quantity -> convertMemoryToMBs(quantity))
-                    .orElse(null));
-
-        // Job metadata
-        Optional<V1ObjectMeta> metadata = Optional.ofNullable(job.getMetadata());
-
-        jobExecutionStatusBuilder.executionId(
-              metadata.map(V1ObjectMeta::getName)
-                    .orElse(null));
-
-        // Job labels
-        Optional<Map<String, String>> labels = metadata.map(V1ObjectMeta::getLabels);
-
-        jobExecutionStatusBuilder.jobVersion(
-              labels.map(stringStringMap -> stringStringMap.get(JobLabel.VERSION.getValue()))
-                    .orElse(
-                          containerOptional
-                                .map(V1Container::getImage)
-                                .map(imageStr -> imageStr.substring(imageStr.lastIndexOf(":") + 1))
-                                .orElse(null)));
-
-        jobExecutionStatusBuilder.jobName(
-              labels.map(stringStringMap -> stringStringMap.get(JobLabel.NAME.getValue()))
-                    .orElse(getContainerName(job)));
-
-        // Job annotations
-        Optional<Map<String, String>> annotations = metadata.map(V1ObjectMeta::getAnnotations);
-
-        jobExecutionStatusBuilder.deployedDate(
-              annotations.map(stringStringMap -> stringStringMap.get(JobAnnotation.DEPLOYED_DATE.getValue()))
-                    .filter(lastDeployedDateStr -> StringUtils.isNotBlank(lastDeployedDateStr))
-                    .map(lastDeployedDateStr -> OffsetDateTime.parse(lastDeployedDateStr))
-                    .orElse(null));
-
-        jobExecutionStatusBuilder.deployedBy(
-              annotations.map(stringStringMap -> stringStringMap.get(JobAnnotation.DEPLOYED_BY.getValue()))
-                    .orElse(null));
-
-        jobExecutionStatusBuilder.executionType(
-              annotations.map(stringStringMap -> stringStringMap.get(JobAnnotation.EXECUTION_TYPE.getValue()))
-                    .orElse(null));
-
-        jobExecutionStatusBuilder.opId(
-              annotations.map(stringStringMap -> stringStringMap.get(JobAnnotation.OP_ID.getValue()))
-                    .orElse(
-                          metadata.map(V1ObjectMeta::getName)
-                                .orElse(null)));
-
-        jobExecutionStatusBuilder.jobSchedule(
-              annotations.map(stringStringMap -> stringStringMap.get(JobAnnotation.SCHEDULE.getValue()))
-                    .orElse(null));
-
-        // Job status
-        Optional<V1JobStatus> jobStatus = Optional.ofNullable(job.getStatus());
-
-        jobExecutionStatusBuilder.startTime(
-              jobStatus.map(V1JobStatus::getStartTime)
-                    .map(startTime -> Instant.ofEpochMilli(startTime.toInstant().toEpochMilli()))
-                    .map(startTimeInstant -> OffsetDateTime.ofInstant(startTimeInstant, ZoneOffset.UTC))
-                    .orElse(null));
-
-        jobExecutionStatusBuilder.endTime(
-              Optional.ofNullable(jobStatusCondition)
-                    .map(JobStatusCondition::getCompletionTime)
-                    .map(endTime -> Instant.ofEpochMilli(endTime))
-                    .map(endTimeInstant -> OffsetDateTime.ofInstant(endTimeInstant, ZoneOffset.UTC))
-                    .orElse(null));
-
-        // jobCondition = null means that the Data Job is still running
-        jobExecutionStatusBuilder.succeeded(
-              Optional.ofNullable(jobStatusCondition)
-                    .map(JobStatusCondition::isSuccess)
-                    .orElse(null));
-
-        return Optional.of(jobExecutionStatusBuilder.build());
-    }
-
-    /**
-     * Initiates a watch for the jobs with labels specified by {@code labelsToWatch}. The watch will be active
-     * for no longer than the number of seconds specified by {@code timeoutSeconds}. The specified watcher is
-     * invoked whenever a job is completed and has an associated pod with a termination message.
-     *
-     * @param labelsToWatch      The labels for the jobs to watch, or null, to watch all jobs.
-     * @param watcher            A {@link Consumer} to receive notifications about completed jobs.
-     * @param lastWatchTime      The time of the last completed job watch, expressed in millis since Epoch.
-     * @throws ApiException
-     * @throws IOException
-     */
-    public void watchJobs(
-          Map<String, String> labelsToWatch,
-          Consumer<JobExecution> watcher,
-          Consumer<List<String>> runningJobExecutionsConsumer,
-          long lastWatchTime) throws IOException, ApiException {
-
-        watchJobs(labelsToWatch, watcher, runningJobExecutionsConsumer, lastWatchTime, WATCH_JOBS_TIMEOUT_SECONDS);
-    }
-
-    /**
-     * Initiates a watch for the jobs with labels specified by {@code labelsToWatch}. The watch will be active
-     * for no longer than the number of seconds specified by {@code timeoutSeconds}. The specified watcher is
-     * invoked whenever a job is completed and has an associated pod with a termination message.
-     *
-     * @param labelsToWatch      The labels for the jobs to watch, or null, to watch all jobs.
-     * @param watcher            A {@link Consumer} to receive notifications about completed jobs.
-     * @param lastWatchTime      The time of the last completed job watch, expressed in millis since Epoch.
-     * @param timeoutSeconds     The maximum number of seconds that the watch should be active, or null,
-     *                           to watch using the default timeout configured on the server (usually 5 minutes).
-     *                           If this value is changed, the {@code defaultLockAtMostFor} value of the
-     *                           {@link EnableSchedulerLock} annotation (see {@link ThreadPoolConf})
-     *                           should be adjusted accordingly to ensure that the lock will be held long enough
-     *                           for the watch to complete.
-     * @throws ApiException
-     * @throws IOException
-     */
-    public void watchJobs(
-          Map<String, String> labelsToWatch,
-          Consumer<JobExecution> watcher,
-          Consumer<List<String>> runningJobExecutionsConsumer,
-          long lastWatchTime,
-          Integer timeoutSeconds) throws ApiException, IOException {
-
-        Objects.requireNonNull(watcher, "The watcher cannot be null");
-        log.info("Start watching jobs with labels: {}", labelsToWatch);
-
-        // Job change detection implementation:
-        // https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes
-        String labelSelector = buildLabelSelector(labelsToWatch);
-        String resourceVersion;
-        try {
-            var jobList = new BatchV1Api(client)
-                  .listNamespacedJob(namespace, "false", null, null, null, labelSelector, null, null, null, null, null);
-            List<String> runningExecutionIds = new ArrayList<>();
-
-            jobList.getItems().forEach(job -> {
+      jobList
+          .getItems()
+          .forEach(
+              job -> {
                 var condition = getJobCondition(job);
 
                 if (condition == null) {
-                    Optional.ofNullable(job.getMetadata())
-                          .map(V1ObjectMeta::getName)
-                          .ifPresent(executionId -> runningExecutionIds.add(executionId));
+                  Optional.ofNullable(job.getMetadata())
+                      .map(V1ObjectMeta::getName)
+                      .ifPresent(executionId -> runningExecutionIds.add(executionId));
                 } else if (condition.getCompletionTime() > lastWatchTime) {
-                    getJobExecutionStatus(job, condition).ifPresent(watcher);
+                  getJobExecutionStatus(job, condition).ifPresent(watcher);
                 }
-            });
+              });
 
-            runningJobExecutionsConsumer.accept(runningExecutionIds);
-            resourceVersion = jobList.getMetadata().getResourceVersion();
-        } catch (ApiException ex) {
-            log.info("Failed to list jobs for watching. Error was: {}", ex.getMessage());
-            return;
-        }
-
-        try (Watch<V1Job> watch = Watch.createWatch(Configuration.getDefaultApiClient(),
-                new BatchV1Api(client).listNamespacedJobCall(
-                        namespace, null, null, null, null, labelSelector, null, resourceVersion, null, timeoutSeconds, true, null),
-                new TypeToken<Watch.Response<V1Job>>() {
-                }.getType())) {
-            for (var response : watch) {
-                if (response.status != null) {
-                    // Watch failed, possibly due to the specified resource version no longer present
-                    log.info("Failed to watch jobs. Error was: {}", response.status.getMessage());
-                    break;
-                }
-
-                var job = response.object;
-
-                if (job == null) {
-                    log.info("Failed to watch jobs due to the missing V1Job object.");
-                    break;
-                }
-
-                log.debug("Job {} is {}", job.getMetadata().getName(), response.type);
-
-                if (!"DELETED".equals(response.type)) {
-                    // Occasionally events arrive for jobs that have completed into the past.
-                    // Ignore events that have arrived later than one hour after the job's completion time
-                    var condition = getJobCondition(job);
-                    boolean isLateEvent = false;
-                    if (condition != null && condition.getCompletionTime() != 0) {
-                        Instant jobCompletionTime = Instant.ofEpochMilli(condition.getCompletionTime());
-                        isLateEvent = Instant.now().isAfter(jobCompletionTime.plusSeconds(3600));
-                    }
-                    if (!isLateEvent) {
-                        getJobExecutionStatus(job, condition).ifPresent(watcher);
-                    } else {
-                        log.info("Ignoring a Kubernetes event received after job completion for job {}", job.getMetadata().getName());
-                        log.debug(job.toString());
-                    }
-                }
-            }
-        } catch (RuntimeException e) {
-            log.info("Failed to watch jobs. Error was: {}", e.getMessage(), e);
-        }
-
-        log.info("Finish watching jobs with labels: {}", labelsToWatch);
+      runningJobExecutionsConsumer.accept(runningExecutionIds);
+      resourceVersion = jobList.getMetadata().getResourceVersion();
+    } catch (ApiException ex) {
+      log.info("Failed to list jobs for watching. Error was: {}", ex.getMessage());
+      return;
     }
 
-    private JobStatusCondition getJobCondition(V1Job job) {
-        V1JobStatus jobStatus = job.getStatus();
-        if (jobStatus.getConditions() != null) {
-            if (jobStatus.getConditions().size() > 1) {
-                log.warn("More than one Job conditions found, returning first only. Job: {}", job);
-            }
-            for (var c : jobStatus.getConditions()) {
-                log.trace("k8s job condition type: {} reason: {} message: {}", c.getType(), c.getReason(), c.getMessage());
-                return new JobStatusCondition(c.getType().equals("Complete"), c.getType(), c.getReason(), c.getMessage(),
-                        c.getLastTransitionTime() != null ? c.getLastTransitionTime().toInstant().toEpochMilli() : 0);
-            }
+    try (Watch<V1Job> watch =
+        Watch.createWatch(
+            Configuration.getDefaultApiClient(),
+            new BatchV1Api(client)
+                .listNamespacedJobCall(
+                    namespace,
+                    null,
+                    null,
+                    null,
+                    null,
+                    labelSelector,
+                    null,
+                    resourceVersion,
+                    null,
+                    timeoutSeconds,
+                    true,
+                    null),
+            new TypeToken<Watch.Response<V1Job>>() {}.getType())) {
+      for (var response : watch) {
+        if (response.status != null) {
+          // Watch failed, possibly due to the specified resource version no longer present
+          log.info("Failed to watch jobs. Error was: {}", response.status.getMessage());
+          break;
         }
-        return null;
+
+        var job = response.object;
+
+        if (job == null) {
+          log.info("Failed to watch jobs due to the missing V1Job object.");
+          break;
+        }
+
+        log.debug("Job {} is {}", job.getMetadata().getName(), response.type);
+
+        if (!"DELETED".equals(response.type)) {
+          // Occasionally events arrive for jobs that have completed into the past.
+          // Ignore events that have arrived later than one hour after the job's completion time
+          var condition = getJobCondition(job);
+          boolean isLateEvent = false;
+          if (condition != null && condition.getCompletionTime() != 0) {
+            Instant jobCompletionTime = Instant.ofEpochMilli(condition.getCompletionTime());
+            isLateEvent = Instant.now().isAfter(jobCompletionTime.plusSeconds(3600));
+          }
+          if (!isLateEvent) {
+            getJobExecutionStatus(job, condition).ifPresent(watcher);
+          } else {
+            log.info(
+                "Ignoring a Kubernetes event received after job completion for job {}",
+                job.getMetadata().getName());
+            log.debug(job.toString());
+          }
+        }
+      }
+    } catch (RuntimeException e) {
+      log.info("Failed to watch jobs. Error was: {}", e.getMessage(), e);
     }
 
-    /**
-     * Deletes a Job in kubernets with given name if it exists.
-     * @param name the name of the job
-     * @throws ApiException
-     */
-    public void deleteJob(String name) throws ApiException {
-        log.debug("Deleting k8s job: {}", name);
-        try {
-            var status = new BatchV1Api(client).deleteNamespacedJob(name, namespace, null, null, null, null, null, null);
-            log.debug("Deleted k8s job: {}, status: {}", name, status);
-        } catch (JsonSyntaxException e) {
-            log.warn("Ignoring JsonSyntaxException during deleteNamespacedJob {}. Reason: {}", name, e.getMessage());
-        } catch (ApiException e) {
-            if (e.getCode() == 404) {
-                log.debug("Job {} already deleted or does not exists", name);
-            } else {
-                throw e;
-            }
-        }
-        log.debug("Deleting k8s pods for job: {}", name);
-        var status = new CoreV1Api(client)
-                .deleteCollectionNamespacedPod(namespace, null, null, null, null, null, "job-name=" + name, null, null, null, null, null, null, null);
-        log.debug("Deleted k8s pods for job: {}, status: {}", name, status);
+    log.info("Finish watching jobs with labels: {}", labelsToWatch);
+  }
+
+  private JobStatusCondition getJobCondition(V1Job job) {
+    V1JobStatus jobStatus = job.getStatus();
+    if (jobStatus.getConditions() != null) {
+      if (jobStatus.getConditions().size() > 1) {
+        log.warn("More than one Job conditions found, returning first only. Job: {}", job);
+      }
+      for (var c : jobStatus.getConditions()) {
+        log.trace(
+            "k8s job condition type: {} reason: {} message: {}",
+            c.getType(),
+            c.getReason(),
+            c.getMessage());
+        return new JobStatusCondition(
+            c.getType().equals("Complete"),
+            c.getType(),
+            c.getReason(),
+            c.getMessage(),
+            c.getLastTransitionTime() != null
+                ? c.getLastTransitionTime().toInstant().toEpochMilli()
+                : 0);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Deletes a Job in kubernets with given name if it exists.
+   *
+   * @param name the name of the job
+   * @throws ApiException
+   */
+  public void deleteJob(String name) throws ApiException {
+    log.debug("Deleting k8s job: {}", name);
+    try {
+      var status =
+          new BatchV1Api(client)
+              .deleteNamespacedJob(name, namespace, null, null, null, null, null, null);
+      log.debug("Deleted k8s job: {}, status: {}", name, status);
+    } catch (JsonSyntaxException e) {
+      log.warn(
+          "Ignoring JsonSyntaxException during deleteNamespacedJob {}. Reason: {}",
+          name,
+          e.getMessage());
+    } catch (ApiException e) {
+      if (e.getCode() == 404) {
+        log.debug("Job {} already deleted or does not exists", name);
+      } else {
+        throw e;
+      }
+    }
+    log.debug("Deleting k8s pods for job: {}", name);
+    var status =
+        new CoreV1Api(client)
+            .deleteCollectionNamespacedPod(
+                namespace,
+                null,
+                null,
+                null,
+                null,
+                null,
+                "job-name=" + name,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
+    log.debug("Deleted k8s pods for job: {}, status: {}", name, status);
+  }
+
+  public static V1Volume volume(String name) {
+    return new V1VolumeBuilder().withName(name).withEmptyDir(new V1EmptyDirVolumeSource()).build();
+  }
+
+  public static V1Volume volume(String name, String secretName) {
+    return new V1VolumeBuilder()
+        .withName(name)
+        .withSecret(new V1SecretVolumeSourceBuilder().withSecretName(secretName).build())
+        .build();
+  }
+
+  public static V1VolumeMount volumeMount(String name, String mountPath, boolean readOnly) {
+    return new V1VolumeMountBuilder()
+        .withName(name)
+        .withMountPath(mountPath)
+        .withReadOnly(readOnly)
+        .build();
+  }
+
+  private Optional<V1Job> getJob(String jobName) throws ApiException {
+    String fieldSelector = String.format("metadata.name=%s", jobName);
+    try {
+      var jobs =
+          new BatchV1Api(client)
+              .listNamespacedJob(
+                  namespace, null, null, null, fieldSelector, null, null, null, null, null, null);
+      if (!jobs.getItems().isEmpty()) {
+        return Optional.of(jobs.getItems().get(0));
+      }
+    } catch (ApiException e) {
+      if (e.getCode() != 404) {
+        throw e;
+      }
+    }
+    return Optional.empty();
+  }
+
+  // TODO - in the future we want to merge the (1) configurable datajob template
+  //        with the (2) default internal datajob template when something from (1)
+  //        is missing. For now we just check for missing entries in (1) and overwrite
+  //        them with the corresponding entries in (2).
+  private void v1beta1checkForMissingEntries(V1beta1CronJob cronjob) {
+    V1beta1CronJob internalCronjobTemplate = loadInternalV1beta1CronjobTemplate();
+    if (cronjob.getMetadata() == null) {
+      cronjob.setMetadata(internalCronjobTemplate.getMetadata());
+    }
+    V1ObjectMeta metadata = cronjob.getMetadata();
+    if (metadata.getAnnotations() == null) {
+      metadata.setAnnotations(new HashMap<>());
+    }
+    if (cronjob.getSpec() == null) {
+      cronjob.setSpec(internalCronjobTemplate.getSpec());
+    }
+    V1beta1CronJobSpec spec = cronjob.getSpec();
+    if (spec.getJobTemplate() == null) {
+      spec.setJobTemplate(internalCronjobTemplate.getSpec().getJobTemplate());
+    }
+    if (spec.getJobTemplate().getMetadata() == null) {
+      spec.getJobTemplate()
+          .setMetadata(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
+    }
+    if (spec.getJobTemplate().getMetadata().getLabels() == null) {
+      spec.getJobTemplate().getMetadata().setLabels(new HashMap<>());
+    }
+    if (spec.getJobTemplate().getMetadata().getAnnotations() == null) {
+      spec.getJobTemplate().getMetadata().setAnnotations(new HashMap<>());
+    }
+    if (spec.getJobTemplate().getSpec() == null) {
+      spec.getJobTemplate().setSpec(internalCronjobTemplate.getSpec().getJobTemplate().getSpec());
+    }
+    if (spec.getJobTemplate().getSpec().getTemplate() == null) {
+      spec.getJobTemplate()
+          .getSpec()
+          .setTemplate(internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate());
+    }
+    if (spec.getJobTemplate().getSpec().getTemplate().getSpec() == null) {
+      spec.getJobTemplate()
+          .getSpec()
+          .getTemplate()
+          .setSpec(
+              internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
+    }
+    if (spec.getJobTemplate().getSpec().getTemplate().getMetadata() == null) {
+      spec.getJobTemplate()
+          .getSpec()
+          .getTemplate()
+          .setMetadata(
+              internalCronjobTemplate
+                  .getSpec()
+                  .getJobTemplate()
+                  .getSpec()
+                  .getTemplate()
+                  .getMetadata());
+    }
+    if (spec.getJobTemplate().getSpec().getTemplate().getMetadata().getLabels() == null) {
+      spec.getJobTemplate().getSpec().getTemplate().getMetadata().setLabels(new HashMap<>());
+    }
+  }
+
+  private void v1checkForMissingEntries(V1CronJob cronjob) {
+    V1CronJob internalCronjobTemplate = loadInternalV1CronjobTemplate();
+    if (cronjob.getMetadata() == null) {
+      cronjob.setMetadata(internalCronjobTemplate.getMetadata());
+    }
+    V1ObjectMeta metadata = cronjob.getMetadata();
+    if (metadata.getAnnotations() == null) {
+      metadata.setAnnotations(new HashMap<>());
+    }
+    if (cronjob.getSpec() == null) {
+      cronjob.setSpec(internalCronjobTemplate.getSpec());
+    }
+    V1CronJobSpec spec = cronjob.getSpec();
+    if (spec.getJobTemplate() == null) {
+      spec.setJobTemplate(internalCronjobTemplate.getSpec().getJobTemplate());
+    }
+    if (spec.getJobTemplate().getMetadata() == null) {
+      spec.getJobTemplate()
+          .setMetadata(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
+    }
+    if (spec.getJobTemplate().getMetadata().getLabels() == null) {
+      spec.getJobTemplate().getMetadata().setLabels(new HashMap<>());
+    }
+    if (spec.getJobTemplate().getMetadata().getAnnotations() == null) {
+      spec.getJobTemplate().getMetadata().setAnnotations(new HashMap<>());
+    }
+    if (spec.getJobTemplate().getSpec() == null) {
+      spec.getJobTemplate().setSpec(internalCronjobTemplate.getSpec().getJobTemplate().getSpec());
+    }
+    if (spec.getJobTemplate().getSpec().getTemplate() == null) {
+      spec.getJobTemplate()
+          .getSpec()
+          .setTemplate(internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate());
+    }
+    if (spec.getJobTemplate().getSpec().getTemplate().getSpec() == null) {
+      spec.getJobTemplate()
+          .getSpec()
+          .getTemplate()
+          .setSpec(
+              internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
+    }
+    if (spec.getJobTemplate().getSpec().getTemplate().getMetadata() == null) {
+      spec.getJobTemplate()
+          .getSpec()
+          .getTemplate()
+          .setMetadata(
+              internalCronjobTemplate
+                  .getSpec()
+                  .getJobTemplate()
+                  .getSpec()
+                  .getTemplate()
+                  .getMetadata());
+    }
+    if (spec.getJobTemplate().getSpec().getTemplate().getMetadata().getLabels() == null) {
+      spec.getJobTemplate().getSpec().getTemplate().getMetadata().setLabels(new HashMap<>());
+    }
+  }
+
+  V1beta1CronJob v1beta1CronJobFromTemplate(
+      String name,
+      String schedule,
+      boolean suspend,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobDeploymentAnnotations,
+      Map<String, String> jobPodLabels,
+      Map<String, String> jobAnnotations,
+      Map<String, String> jobLabels,
+      List<String> imagePullSecrets) {
+    V1beta1CronJob cronjob = loadV1beta1CronjobTemplate();
+    v1beta1checkForMissingEntries(cronjob);
+    cronjob.getMetadata().setName(name);
+    cronjob.getSpec().setSchedule(schedule);
+    cronjob.getSpec().setSuspend(suspend);
+    cronjob
+        .getSpec()
+        .getJobTemplate()
+        .getSpec()
+        .getTemplate()
+        .getSpec()
+        .setContainers(Collections.singletonList(jobContainer));
+    cronjob
+        .getSpec()
+        .getJobTemplate()
+        .getSpec()
+        .getTemplate()
+        .getSpec()
+        .setInitContainers(Collections.singletonList(initContainer));
+    cronjob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().setVolumes(volumes);
+    // Merge the annotations and the labels.
+    cronjob.getMetadata().getAnnotations().putAll(jobDeploymentAnnotations);
+    cronjob
+        .getSpec()
+        .getJobTemplate()
+        .getSpec()
+        .getTemplate()
+        .getMetadata()
+        .getLabels()
+        .putAll(jobPodLabels);
+
+    cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations().putAll(jobAnnotations);
+    cronjob.getSpec().getJobTemplate().getMetadata().getLabels().putAll(jobLabels);
+
+    List<V1LocalObjectReference> imagePullSecretsObj =
+        Optional.ofNullable(imagePullSecrets).stream()
+            .flatMap(secrets -> secrets.stream())
+            .filter(secret -> StringUtils.isNotEmpty(secret))
+            .map(secret -> new V1LocalObjectReferenceBuilder().withName(secret).build())
+            .collect(Collectors.toList());
+
+    if (!CollectionUtils.isEmpty(imagePullSecretsObj)) {
+      cronjob
+          .getSpec()
+          .getJobTemplate()
+          .getSpec()
+          .getTemplate()
+          .getSpec()
+          .setImagePullSecrets(imagePullSecretsObj);
     }
 
-    public static V1Volume volume(String name) {
-        return new V1VolumeBuilder()
-                .withName(name)
-                .withEmptyDir(new V1EmptyDirVolumeSource())
-                .build();
+    return cronjob;
+  }
+
+  V1CronJob v1CronJobFromTemplate(
+      String name,
+      String schedule,
+      boolean suspend,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobDeploymentAnnotations,
+      Map<String, String> jobPodLabels,
+      Map<String, String> jobAnnotations,
+      Map<String, String> jobLabels,
+      List<String> imagePullSecrets) {
+    V1CronJob cronjob = loadV1CronjobTemplate();
+    v1checkForMissingEntries(cronjob);
+    cronjob.getMetadata().setName(name);
+    cronjob.getSpec().setSchedule(schedule);
+    cronjob.getSpec().setSuspend(suspend);
+    cronjob
+        .getSpec()
+        .getJobTemplate()
+        .getSpec()
+        .getTemplate()
+        .getSpec()
+        .setContainers(Collections.singletonList(jobContainer));
+    cronjob
+        .getSpec()
+        .getJobTemplate()
+        .getSpec()
+        .getTemplate()
+        .getSpec()
+        .setInitContainers(Collections.singletonList(initContainer));
+    cronjob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().setVolumes(volumes);
+    // Merge the annotations and the labels.
+    cronjob.getMetadata().getAnnotations().putAll(jobDeploymentAnnotations);
+    cronjob
+        .getSpec()
+        .getJobTemplate()
+        .getSpec()
+        .getTemplate()
+        .getMetadata()
+        .getLabels()
+        .putAll(jobPodLabels);
+
+    cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations().putAll(jobAnnotations);
+    cronjob.getSpec().getJobTemplate().getMetadata().getLabels().putAll(jobLabels);
+
+    List<V1LocalObjectReference> imagePullSecretsObj =
+        Optional.ofNullable(imagePullSecrets).stream()
+            .flatMap(secrets -> secrets.stream())
+            .filter(secret -> StringUtils.isNotEmpty(secret))
+            .map(secret -> new V1LocalObjectReferenceBuilder().withName(secret).build())
+            .collect(Collectors.toList());
+
+    if (!CollectionUtils.isEmpty(imagePullSecretsObj)) {
+      cronjob
+          .getSpec()
+          .getJobTemplate()
+          .getSpec()
+          .getTemplate()
+          .getSpec()
+          .setImagePullSecrets(imagePullSecretsObj);
     }
 
-    public static V1Volume volume(String name, String secretName) {
-        return new V1VolumeBuilder()
-              .withName(name)
-              .withSecret(new V1SecretVolumeSourceBuilder()
-                    .withSecretName(secretName)
-                    .build())
-              .build();
-    }
+    return cronjob;
+  }
 
-    public static V1VolumeMount volumeMount(String name, String mountPath, boolean readOnly) {
-        return new V1VolumeMountBuilder()
-              .withName(name)
-              .withMountPath(mountPath)
-              .withReadOnly(readOnly)
-              .build();
-    }
-
-
-    private Optional<V1Job> getJob(String jobName) throws ApiException {
-        String fieldSelector = String.format("metadata.name=%s", jobName);
-        try {
-            var jobs = new BatchV1Api(client).listNamespacedJob(namespace, null, null, null, fieldSelector, null, null, null, null, null, null);
-            if (!jobs.getItems().isEmpty()) {
-                return Optional.of(jobs.getItems().get(0));
-            }
-        } catch (ApiException e) {
-            if (e.getCode() != 404) {
-                throw e;
-            }
-        }
-        return Optional.empty();
-    }
-
-    // TODO - in the future we want to merge the (1) configurable datajob template
-    //        with the (2) default internal datajob template when something from (1)
-    //        is missing. For now we just check for missing entries in (1) and overwrite
-    //        them with the corresponding entries in (2).
-    private void v1beta1checkForMissingEntries(V1beta1CronJob cronjob) {
-        V1beta1CronJob internalCronjobTemplate = loadInternalV1beta1CronjobTemplate();
-        if(cronjob.getMetadata() == null) {
-            cronjob.setMetadata(internalCronjobTemplate.getMetadata());
-        }
-        V1ObjectMeta metadata = cronjob.getMetadata();
-        if(metadata.getAnnotations() == null) {
-            metadata.setAnnotations(new HashMap<>());
-        }
-        if(cronjob.getSpec() == null) {
-            cronjob.setSpec(internalCronjobTemplate.getSpec());
-        }
-        V1beta1CronJobSpec spec = cronjob.getSpec();
-        if(spec.getJobTemplate() == null) {
-            spec.setJobTemplate(internalCronjobTemplate.getSpec().getJobTemplate());
-        }
-        if(spec.getJobTemplate().getMetadata() == null){
-            spec.getJobTemplate().setMetadata(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
-        }
-        if(spec.getJobTemplate().getMetadata().getLabels() == null){
-            spec.getJobTemplate().getMetadata().setLabels(new HashMap<>());
-        }
-        if(spec.getJobTemplate().getMetadata().getAnnotations() == null){
-            spec.getJobTemplate().getMetadata().setAnnotations(new HashMap<>());
-        }
-        if(spec.getJobTemplate().getSpec() == null) {
-            spec.getJobTemplate().setSpec(internalCronjobTemplate.getSpec().getJobTemplate().getSpec());
-        }
-        if(spec.getJobTemplate().getSpec().getTemplate() == null) {
-            spec.getJobTemplate().getSpec().setTemplate(
-                    internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate());
-        }
-        if(spec.getJobTemplate().getSpec().getTemplate().getSpec() == null) {
-            spec.getJobTemplate().getSpec().getTemplate().setSpec(
-                    internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
-        }
-        if(spec.getJobTemplate().getSpec().getTemplate().getMetadata() == null) {
-            spec.getJobTemplate().getSpec().getTemplate().setMetadata(
-                    internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata());
-        }
-        if(spec.getJobTemplate().getSpec().getTemplate().getMetadata().getLabels() == null) {
-            spec.getJobTemplate().getSpec().getTemplate().getMetadata().setLabels(new HashMap<>());
-        }
-    }
-
-    private void v1checkForMissingEntries(V1CronJob cronjob) {
-        V1CronJob internalCronjobTemplate = loadInternalV1CronjobTemplate();
-        if(cronjob.getMetadata() == null) {
-            cronjob.setMetadata(internalCronjobTemplate.getMetadata());
-        }
-        V1ObjectMeta metadata = cronjob.getMetadata();
-        if(metadata.getAnnotations() == null) {
-            metadata.setAnnotations(new HashMap<>());
-        }
-        if(cronjob.getSpec() == null) {
-            cronjob.setSpec(internalCronjobTemplate.getSpec());
-        }
-        V1CronJobSpec spec = cronjob.getSpec();
-        if(spec.getJobTemplate() == null) {
-            spec.setJobTemplate(internalCronjobTemplate.getSpec().getJobTemplate());
-        }
-        if(spec.getJobTemplate().getMetadata() == null){
-            spec.getJobTemplate().setMetadata(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
-        }
-        if(spec.getJobTemplate().getMetadata().getLabels() == null){
-            spec.getJobTemplate().getMetadata().setLabels(new HashMap<>());
-        }
-        if(spec.getJobTemplate().getMetadata().getAnnotations() == null){
-            spec.getJobTemplate().getMetadata().setAnnotations(new HashMap<>());
-        }
-        if(spec.getJobTemplate().getSpec() == null) {
-            spec.getJobTemplate().setSpec(internalCronjobTemplate.getSpec().getJobTemplate().getSpec());
-        }
-        if(spec.getJobTemplate().getSpec().getTemplate() == null) {
-            spec.getJobTemplate().getSpec().setTemplate(
-                    internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate());
-        }
-        if(spec.getJobTemplate().getSpec().getTemplate().getSpec() == null) {
-            spec.getJobTemplate().getSpec().getTemplate().setSpec(
-                    internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
-        }
-        if(spec.getJobTemplate().getSpec().getTemplate().getMetadata() == null) {
-            spec.getJobTemplate().getSpec().getTemplate().setMetadata(
-                    internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata());
-        }
-        if(spec.getJobTemplate().getSpec().getTemplate().getMetadata().getLabels() == null) {
-            spec.getJobTemplate().getSpec().getTemplate().getMetadata().setLabels(new HashMap<>());
-        }
-    }
-
-    V1beta1CronJob v1beta1CronJobFromTemplate(String name, String schedule, boolean suspend, V1Container jobContainer,
-                                       V1Container initContainer, List<V1Volume> volumes,
-                                       Map<String, String> jobDeploymentAnnotations,
-                                       Map<String, String> jobPodLabels,
-                                       Map<String, String> jobAnnotations,
-                                       Map<String, String> jobLabels,
-                                       List<String> imagePullSecrets) {
-        V1beta1CronJob cronjob = loadV1beta1CronjobTemplate();
-        v1beta1checkForMissingEntries(cronjob);
-        cronjob.getMetadata().setName(name);
-        cronjob.getSpec().setSchedule(schedule);
-        cronjob.getSpec().setSuspend(suspend);
-        cronjob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().setContainers(Collections.singletonList(jobContainer));
-        cronjob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().setInitContainers(Collections.singletonList(initContainer));
-        cronjob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().setVolumes(volumes);
-        // Merge the annotations and the labels.
-        cronjob.getMetadata().getAnnotations().putAll(jobDeploymentAnnotations);
-        cronjob.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata().getLabels().putAll(jobPodLabels);
-
-        cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations().putAll(jobAnnotations);
-        cronjob.getSpec().getJobTemplate().getMetadata().getLabels().putAll(jobLabels);
-
-        List<V1LocalObjectReference> imagePullSecretsObj = Optional.ofNullable(imagePullSecrets)
-                .stream()
-                .flatMap(secrets -> secrets.stream())
-                .filter(secret -> StringUtils.isNotEmpty(secret))
-                .map(secret -> new V1LocalObjectReferenceBuilder().withName(secret).build())
-                .collect(Collectors.toList());
-
-        if (!CollectionUtils.isEmpty(imagePullSecretsObj)) {
-            cronjob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().setImagePullSecrets(imagePullSecretsObj);
-        }
-
-        return cronjob;
-    }
-
-    V1CronJob v1CronJobFromTemplate(String name, String schedule, boolean suspend, V1Container jobContainer,
-                                   V1Container initContainer, List<V1Volume> volumes,
-                                   Map<String, String> jobDeploymentAnnotations,
-                                   Map<String, String> jobPodLabels,
-                                   Map<String, String> jobAnnotations,
-                                   Map<String, String> jobLabels,
-                                   List<String> imagePullSecrets) {
-        V1CronJob cronjob = loadV1CronjobTemplate();
-        v1checkForMissingEntries(cronjob);
-        cronjob.getMetadata().setName(name);
-        cronjob.getSpec().setSchedule(schedule);
-        cronjob.getSpec().setSuspend(suspend);
-        cronjob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().setContainers(Collections.singletonList(jobContainer));
-        cronjob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().setInitContainers(Collections.singletonList(initContainer));
-        cronjob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().setVolumes(volumes);
-        // Merge the annotations and the labels.
-        cronjob.getMetadata().getAnnotations().putAll(jobDeploymentAnnotations);
-        cronjob.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata().getLabels().putAll(jobPodLabels);
-
-        cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations().putAll(jobAnnotations);
-        cronjob.getSpec().getJobTemplate().getMetadata().getLabels().putAll(jobLabels);
-
-        List<V1LocalObjectReference> imagePullSecretsObj = Optional.ofNullable(imagePullSecrets)
-              .stream()
-              .flatMap(secrets -> secrets.stream())
-              .filter(secret -> StringUtils.isNotEmpty(secret))
-              .map(secret -> new V1LocalObjectReferenceBuilder().withName(secret).build())
-              .collect(Collectors.toList());
-
-        if (!CollectionUtils.isEmpty(imagePullSecretsObj)) {
-            cronjob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().setImagePullSecrets(imagePullSecretsObj);
-        }
-
-        return cronjob;
-    }
-
-    public static V1Container container(String name, String image, boolean privileged, Map<String, String> envs,
-          List<String> args, List<V1VolumeMount> volumeMounts, String imagePullPolicy,
-          Resources request, Resources limit, Probe probe, List commands) {
-        var builder = new V1ContainerBuilder()
-              .withName(name)
-              .withImage(image)
-              .withVolumeMounts(volumeMounts)
-              .withImagePullPolicy(imagePullPolicy)
-              .withSecurityContext(new V1SecurityContextBuilder()
-                    .withPrivileged(privileged)
-                    .build())
-              .withResources(new V1ResourceRequirementsBuilder()
+  public static V1Container container(
+      String name,
+      String image,
+      boolean privileged,
+      Map<String, String> envs,
+      List<String> args,
+      List<V1VolumeMount> volumeMounts,
+      String imagePullPolicy,
+      Resources request,
+      Resources limit,
+      Probe probe,
+      List commands) {
+    var builder =
+        new V1ContainerBuilder()
+            .withName(name)
+            .withImage(image)
+            .withVolumeMounts(volumeMounts)
+            .withImagePullPolicy(imagePullPolicy)
+            .withSecurityContext(new V1SecurityContextBuilder().withPrivileged(privileged).build())
+            .withResources(
+                new V1ResourceRequirementsBuilder()
                     .withRequests(resources(request))
                     .withLimits(resources(limit))
                     .build())
-              .withEnv(envs.entrySet().stream()
+            .withEnv(
+                envs.entrySet().stream()
                     .map(KubernetesService::envVar)
                     .collect(Collectors.toList()))
-              .withArgs(args)
-              .withCommand(commands);
+            .withArgs(args)
+            .withCommand(commands);
 
-        if (probe != null) {
-            builder.withLivenessProbe(new V1ProbeBuilder()
-                  .withHttpGet(new V1HTTPGetActionBuilder()
-                        .withPort(new IntOrString(probe.port))
-                        .withPath(probe.path)
-                        .build())
-                  .withInitialDelaySeconds(probe.period)
-                  .withPeriodSeconds(probe.period)
-                  .build());
-        }
-
-        return builder.build();
+    if (probe != null) {
+      builder.withLivenessProbe(
+          new V1ProbeBuilder()
+              .withHttpGet(
+                  new V1HTTPGetActionBuilder()
+                      .withPort(new IntOrString(probe.port))
+                      .withPath(probe.path)
+                      .build())
+              .withInitialDelaySeconds(probe.period)
+              .withPeriodSeconds(probe.period)
+              .build());
     }
 
-    private static V1Container container(String name, String image, boolean privileged, Map<String, String> envs,
-                                         List<String> args, List<V1VolumeMount> volumeMounts, String imagePullPolicy,
-                                         Resources request, Resources limit, Probe probe) {
-        return container(name, image, privileged, envs, args, volumeMounts, imagePullPolicy, request, limit, probe, List.of());
+    return builder.build();
+  }
+
+  private static V1Container container(
+      String name,
+      String image,
+      boolean privileged,
+      Map<String, String> envs,
+      List<String> args,
+      List<V1VolumeMount> volumeMounts,
+      String imagePullPolicy,
+      Resources request,
+      Resources limit,
+      Probe probe) {
+    return container(
+        name,
+        image,
+        privileged,
+        envs,
+        args,
+        volumeMounts,
+        imagePullPolicy,
+        request,
+        limit,
+        probe,
+        List.of());
+  }
+
+  private static Map<String, Quantity> resources(Resources resources) {
+    return Map.of(
+        "cpu",
+        Quantity.fromString(resources.getCpu()),
+        "memory",
+        Quantity.fromString(resources.getMemory()));
+  }
+
+  private static V1EnvVar envVar(Map.Entry<String, String> entry) {
+    var b = new V1EnvVarBuilder().withName(entry.getKey());
+    if (entry.getValue().startsWith("$")) {
+      b.withValueFrom(
+          new V1EnvVarSourceBuilder()
+              .withFieldRef(
+                  new V1ObjectFieldSelectorBuilder()
+                      .withFieldPath(entry.getValue().substring(1))
+                      .build())
+              .build());
+    } else {
+      b.withValue(entry.getValue());
+    }
+    return b.build();
+  }
+
+  /** Get secret data from kubernetes secret or empty map if there's nothing saved. */
+  public Map<String, byte[]> getSecretData(String name) throws ApiException {
+    CoreV1Api api = new CoreV1Api(client);
+    try {
+      V1Secret v1Secret = api.readNamespacedSecret(name, this.namespace, null);
+      return v1Secret.getData();
+    } catch (ApiException e) {
+      if (e.getCode() == 404) {
+        return Collections.emptyMap();
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  /** Removes secret with given name if it exists. */
+  public void removeSecretData(String name) throws ApiException {
+    log.debug("Deleting k8s secret: {}", name);
+    try {
+      var status =
+          new CoreV1Api(client)
+              .deleteNamespacedSecret(name, this.namespace, null, null, null, null, null, null);
+      log.debug("Deleted k8s secret: {}, status: {}", name, status);
+    } catch (ApiException e) {
+      if (e.getCode() == 404) {
+        log.debug("Already deleted: k8s secret: {}");
+      } else {
+        log.error("Failed to remove K8S secret {}", name);
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * Saves a secret data into a Kubernetes secret. It will overwrite previous content or create new
+   * secret if it does not exists
+   *
+   * @param name the name of the secret. If the secret exists. It will be
+   * @param data the map with secrets, can be empty but not NULL
+   * @throws ApiException
+   */
+  public void saveSecretData(String name, Map<String, byte[]> data) throws ApiException {
+    log.debug("Saving k8s secret:{}", name);
+    V1Secret secret = buildV1Secret(name, data);
+    CoreV1Api api = new CoreV1Api(client);
+
+    V1Secret nsSecret;
+    try {
+      nsSecret = api.replaceNamespacedSecret(name, this.namespace, secret, null, null, null);
+    } catch (ApiException e) {
+      log.warn("Error while trying to save K8S secret", e);
+      if (e.getCode() == 404) {
+        log.debug("Secret {} does not exist. Creating ...", name);
+        nsSecret = api.createNamespacedSecret(this.namespace, secret, null, null, null);
+      } else {
+        log.error("Failed to save k8s secret: {}", name);
+        throw e;
+      }
+    }
+    log.debug("Saved k8s secret: {}", name);
+    logSecretDebugInformation(nsSecret);
+  }
+
+  /**
+   * This method logs secret information for debugging purposes. While also omitting any sensitive
+   * data. We don't want to throw any exceptions from this method, since it is only meant for
+   * logging.
+   *
+   * @param nsSecret
+   */
+  private void logSecretDebugInformation(V1Secret nsSecret) {
+    try {
+      var dataKeys =
+          Optional.ofNullable(nsSecret.getData()).map(secret -> secret.keySet()).orElse(null);
+      var metaData =
+          Optional.ofNullable(nsSecret.getMetadata()).map(secret -> secret.toString()).orElse(null);
+      var stringDataKeys =
+          Optional.ofNullable(nsSecret.getStringData()).map(secret -> secret.keySet()).orElse(null);
+      log.debug(
+          "Replaced namespaced secret. Data keys : {}, MetaData: {}, StringData keys: {}, Type: {},"
+              + " ApiVer: {}",
+          dataKeys,
+          metaData,
+          stringDataKeys,
+          nsSecret.getType(),
+          nsSecret.getApiVersion());
+    } catch (Exception e) {
+      log.debug("Could not log secret information due to: ", e);
+    }
+  }
+
+  private V1Secret buildV1Secret(String name, Map<String, byte[]> data) {
+    return new V1SecretBuilder()
+        .withNewMetadata()
+        .withName(name)
+        .withNamespace(this.namespace)
+        .endMetadata()
+        .withData(data)
+        .build();
+  }
+
+  private Optional<JobDeploymentStatus> mapV1beta1CronJobToDeploymentStatus(
+      V1beta1CronJob cronJob, String cronJobName) {
+    JobDeploymentStatus deployment = null;
+    if (cronJob != null) {
+      deployment = new JobDeploymentStatus();
+      deployment.setEnabled(!cronJob.getSpec().getSuspend());
+      deployment.setDataJobName(cronJob.getMetadata().getName());
+      deployment.setMode(
+          "release"); // TODO: Get from cron job config when we support testing environments
+      deployment.setCronJobName(
+          cronJobName == null ? cronJob.getMetadata().getName() : cronJobName);
+
+      // all fields until pod spec are required so no need to check for null
+      var annotations = cronJob.getSpec().getJobTemplate().getMetadata().getAnnotations();
+      if (annotations != null) {
+        deployment.setLastDeployedBy(annotations.get(JobAnnotation.DEPLOYED_BY.getValue()));
+        deployment.setLastDeployedDate(annotations.get(JobAnnotation.DEPLOYED_DATE.getValue()));
+      }
+
+      List<V1Container> containers =
+          cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getContainers();
+      if (!containers.isEmpty()) {
+        String image =
+            containers.get(0).getImage(); // TODO: Have 2 containers. 1 for VDK and 1 for the job.
+        deployment.setImageName(image); // TODO do we really need to return image_name?
+      }
+      var initContainers =
+          cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getInitContainers();
+      if (!CollectionUtils.isEmpty(initContainers)) {
+        String vdkImage = initContainers.get(0).getImage();
+        deployment.setVdkImageName(vdkImage);
+        deployment.setVdkVersion(DockerImageName.getTag(vdkImage));
+      } else {
+        log.warn("Missing init container for cronjob {}", cronJobName);
+      }
+
+      var labels = cronJob.getSpec().getJobTemplate().getMetadata().getLabels();
+      if (labels == null) {
+        log.warn(
+            "The cronjob of data job '{}' does not have any labels defined.",
+            deployment.getDataJobName());
+      }
+      if (labels != null && labels.containsKey(JobLabel.VERSION.getValue())) {
+        deployment.setGitCommitSha(labels.get(JobLabel.VERSION.getValue()));
+      } else {
+        // Legacy approach to get version:
+        deployment.setGitCommitSha(DockerImageName.getTag(deployment.getImageName()));
+      }
     }
 
-    private static Map<String, Quantity> resources(Resources resources) {
-        return Map.of("cpu", Quantity.fromString(resources.getCpu()),
-                "memory", Quantity.fromString(resources.getMemory()));
+    return Optional.ofNullable(deployment);
+  }
+
+  private Optional<JobDeploymentStatus> mapV1CronJobToDeploymentStatus(
+      V1CronJob cronJob, String cronJobName) {
+    JobDeploymentStatus deployment = null;
+    if (cronJob != null) {
+      deployment = new JobDeploymentStatus();
+      deployment.setEnabled(!cronJob.getSpec().getSuspend());
+      deployment.setDataJobName(cronJob.getMetadata().getName());
+      deployment.setMode(
+          "release"); // TODO: Get from cron job config when we support testing environments
+      deployment.setCronJobName(
+          cronJobName == null ? cronJob.getMetadata().getName() : cronJobName);
+
+      // all fields until pod spec are required so no need to check for null
+      var annotations = cronJob.getSpec().getJobTemplate().getMetadata().getAnnotations();
+      if (annotations != null) {
+        deployment.setLastDeployedBy(annotations.get(JobAnnotation.DEPLOYED_BY.getValue()));
+        deployment.setLastDeployedDate(annotations.get(JobAnnotation.DEPLOYED_DATE.getValue()));
+      }
+
+      List<V1Container> containers =
+          cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getContainers();
+      if (!containers.isEmpty()) {
+        String image =
+            containers.get(0).getImage(); // TODO: Have 2 containers. 1 for VDK and 1 for the job.
+        deployment.setImageName(image); // TODO do we really need to return image_name?
+      }
+      var initContainers =
+          cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getInitContainers();
+      if (!CollectionUtils.isEmpty(initContainers)) {
+        String vdkImage = initContainers.get(0).getImage();
+        deployment.setVdkImageName(vdkImage);
+        deployment.setVdkVersion(DockerImageName.getTag(vdkImage));
+      } else {
+        log.warn("Missing init container for cronjob {}", cronJobName);
+      }
+
+      var labels = cronJob.getSpec().getJobTemplate().getMetadata().getLabels();
+      if (labels == null) {
+        log.warn(
+            "The cronjob of data job '{}' does not have any labels defined.",
+            deployment.getDataJobName());
+      }
+      if (labels != null && labels.containsKey(JobLabel.VERSION.getValue())) {
+        deployment.setGitCommitSha(labels.get(JobLabel.VERSION.getValue()));
+      } else {
+        // Legacy approach to get version:
+        deployment.setGitCommitSha(DockerImageName.getTag(deployment.getImageName()));
+      }
     }
 
-    private static V1EnvVar envVar(Map.Entry<String, String> entry) {
-        var b = new V1EnvVarBuilder()
-                .withName(entry.getKey());
-        if (entry.getValue().startsWith("$")) {
-            b.withValueFrom(new V1EnvVarSourceBuilder()
-                    .withFieldRef(new V1ObjectFieldSelectorBuilder()
-                            .withFieldPath(entry.getValue().substring(1))
-                            .build())
-                    .build());
-        } else {
-            b.withValue(entry.getValue());
-        }
-        return b.build();
+    return Optional.ofNullable(deployment);
+  }
+
+  /**
+   * Default for testing purposes. This method returns the megabytes amount contained in a quantity.
+   *
+   * @param quantity the quantity to convert.
+   * @return integer MB's in the quantity
+   */
+  static int convertMemoryToMBs(Quantity quantity) {
+    var divider = BigInteger.valueOf(1024);
+    if (quantity.getFormat().getBase() == 10) {
+      divider = BigInteger.valueOf(1000);
     }
-
-    /**
-     * Get secret data from kubernetes secret or empty map if there's nothing saved.
-     */
-    public Map<String, byte[]> getSecretData(String name) throws ApiException {
-        CoreV1Api api = new CoreV1Api(client);
-        try {
-            V1Secret v1Secret = api.readNamespacedSecret(name, this.namespace, null);
-            return v1Secret.getData();
-        } catch (ApiException e) {
-            if (e.getCode() == 404) {
-                return Collections.emptyMap();
-            } else {
-                throw e;
-            }
-        }
-
-    }
-
-    /**
-     * Removes secret with given name if it exists.
-     */
-    public void removeSecretData(String name) throws ApiException {
-        log.debug("Deleting k8s secret: {}", name);
-        try {
-            var status = new CoreV1Api(client).deleteNamespacedSecret(name, this.namespace, null, null, null, null, null, null);
-            log.debug("Deleted k8s secret: {}, status: {}", name, status);
-        } catch (ApiException e) {
-            if (e.getCode() == 404) {
-                log.debug("Already deleted: k8s secret: {}");
-            } else {
-                log.error("Failed to remove K8S secret {}", name);
-                throw e;
-            }
-        }
-    }
-
-    /**
-     * Saves a secret data into a Kubernetes secret.
-     * It will overwrite previous content or create new secret if it does not exists
-     *
-     * @param name the name of the secret. If the secret exists. It will be
-     * @param data the map with secrets, can be empty but not NULL
-     * @throws ApiException
-     */
-    public void saveSecretData(String name, Map<String, byte[]> data) throws ApiException {
-        log.debug("Saving k8s secret:{}", name);
-        V1Secret secret = buildV1Secret(name, data);
-        CoreV1Api api = new CoreV1Api(client);
-
-        V1Secret nsSecret;
-        try {
-            nsSecret = api.replaceNamespacedSecret(name, this.namespace, secret, null, null, null);
-        } catch (ApiException e) {
-            log.warn("Error while trying to save K8S secret", e);
-            if (e.getCode() == 404) {
-                log.debug("Secret {} does not exist. Creating ...", name);
-                nsSecret = api.createNamespacedSecret(this.namespace, secret, null, null, null);
-            } else {
-                log.error("Failed to save k8s secret: {}" , name);
-                throw e;
-            }
-        }
-        log.debug("Saved k8s secret: {}", name);
-        logSecretDebugInformation(nsSecret);
-    }
-
-    /**
-     * This method logs secret information for debugging purposes.
-     * While also omitting any sensitive data. We don't want to throw
-     * any exceptions from this method, since it is only meant for logging.
-     *
-     * @param nsSecret
-     */
-    private void logSecretDebugInformation(V1Secret nsSecret) {
-        try {
-            var dataKeys = Optional.ofNullable(nsSecret.getData()).map(secret -> secret.keySet()).orElse(null);
-            var metaData = Optional.ofNullable(nsSecret.getMetadata()).map(secret -> secret.toString()).orElse(null);
-            var stringDataKeys = Optional.ofNullable(nsSecret.getStringData()).map(secret -> secret.keySet()).orElse(null);
-            log.debug("Replaced namespaced secret. Data keys : {}, MetaData: {}, StringData keys: {}, Type: {}, ApiVer: {}",
-                    dataKeys, metaData, stringDataKeys, nsSecret.getType(), nsSecret.getApiVersion());
-        } catch (Exception e) {
-            log.debug("Could not log secret information due to: ", e);
-        }
-    }
-
-    private V1Secret buildV1Secret(String name, Map<String, byte[]> data) {
-        return new V1SecretBuilder()
-                    .withNewMetadata()
-                    .withName(name)
-                    .withNamespace(this.namespace)
-                    .endMetadata()
-                    .withData(data).build();
-    }
-
-    private Optional<JobDeploymentStatus> mapV1beta1CronJobToDeploymentStatus(V1beta1CronJob cronJob, String cronJobName) {
-        JobDeploymentStatus deployment = null;
-        if (cronJob != null) {
-            deployment = new JobDeploymentStatus();
-            deployment.setEnabled(!cronJob.getSpec().getSuspend());
-            deployment.setDataJobName(cronJob.getMetadata().getName());
-            deployment.setMode("release"); // TODO: Get from cron job config when we support testing environments
-            deployment.setCronJobName(cronJobName == null ? cronJob.getMetadata().getName() : cronJobName);
-
-            // all fields until pod spec are required so no need to check for null
-            var annotations = cronJob.getSpec().getJobTemplate().getMetadata().getAnnotations();
-            if (annotations != null) {
-                deployment.setLastDeployedBy(annotations.get(JobAnnotation.DEPLOYED_BY.getValue()));
-                deployment.setLastDeployedDate(annotations.get(JobAnnotation.DEPLOYED_DATE.getValue()));
-            }
-
-            List<V1Container> containers = cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getContainers();
-            if (!containers.isEmpty()) {
-                String image = containers.get(0).getImage(); // TODO: Have 2 containers. 1 for VDK and 1 for the job.
-                deployment.setImageName(image); // TODO do we really need to return image_name?
-            }
-            var initContainers = cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getInitContainers();
-            if (!CollectionUtils.isEmpty(initContainers)) {
-                String vdkImage = initContainers.get(0).getImage();
-                deployment.setVdkImageName(vdkImage);
-                deployment.setVdkVersion(DockerImageName.getTag(vdkImage));
-            } else {
-                log.warn("Missing init container for cronjob {}", cronJobName);
-            }
-
-            var labels = cronJob.getSpec().getJobTemplate().getMetadata().getLabels();
-            if (labels == null) {
-                log.warn("The cronjob of data job '{}' does not have any labels defined.", deployment.getDataJobName());
-            }
-            if (labels != null && labels.containsKey(JobLabel.VERSION.getValue())) {
-                deployment.setGitCommitSha(labels.get(JobLabel.VERSION.getValue()));
-            } else {
-                // Legacy approach to get version:
-                deployment.setGitCommitSha(DockerImageName.getTag(deployment.getImageName()));
-            }
-        }
-
-        return Optional.ofNullable(deployment);
-    }
-
-   private Optional<JobDeploymentStatus> mapV1CronJobToDeploymentStatus(V1CronJob cronJob, String cronJobName) {
-      JobDeploymentStatus deployment = null;
-        if (cronJob != null) {
-            deployment = new JobDeploymentStatus();
-            deployment.setEnabled(!cronJob.getSpec().getSuspend());
-            deployment.setDataJobName(cronJob.getMetadata().getName());
-            deployment.setMode("release"); // TODO: Get from cron job config when we support testing environments
-            deployment.setCronJobName(cronJobName == null ? cronJob.getMetadata().getName() : cronJobName);
-
-            // all fields until pod spec are required so no need to check for null
-            var annotations = cronJob.getSpec().getJobTemplate().getMetadata().getAnnotations();
-            if (annotations != null) {
-                deployment.setLastDeployedBy(annotations.get(JobAnnotation.DEPLOYED_BY.getValue()));
-                deployment.setLastDeployedDate(annotations.get(JobAnnotation.DEPLOYED_DATE.getValue()));
-            }
-
-            List<V1Container> containers = cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getContainers();
-            if (!containers.isEmpty()) {
-                String image = containers.get(0).getImage(); // TODO: Have 2 containers. 1 for VDK and 1 for the job.
-                deployment.setImageName(image); // TODO do we really need to return image_name?
-            }
-            var initContainers = cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getInitContainers();
-            if (!CollectionUtils.isEmpty(initContainers)) {
-                String vdkImage = initContainers.get(0).getImage();
-                deployment.setVdkImageName(vdkImage);
-                deployment.setVdkVersion(DockerImageName.getTag(vdkImage));
-            } else {
-                log.warn("Missing init container for cronjob {}", cronJobName);
-            }
-
-            var labels = cronJob.getSpec().getJobTemplate().getMetadata().getLabels();
-            if (labels == null) {
-                log.warn("The cronjob of data job '{}' does not have any labels defined.", deployment.getDataJobName());
-            }
-            if (labels != null && labels.containsKey(JobLabel.VERSION.getValue())) {
-                deployment.setGitCommitSha(labels.get(JobLabel.VERSION.getValue()));
-            } else {
-                // Legacy approach to get version:
-                deployment.setGitCommitSha(DockerImageName.getTag(deployment.getImageName()));
-            }
-        }
-
-      return Optional.ofNullable(deployment);
-   }
-
-    /**
-     * Default for testing purposes.
-     * This method returns the megabytes amount contained in a
-     * quantity.
-     *
-     * @param quantity the quantity to convert.
-     * @return integer MB's in the quantity
-     */
-    static int convertMemoryToMBs(Quantity quantity) {
-        var divider = BigInteger.valueOf(1024);
-        if (quantity.getFormat().getBase() == 10) {
-            divider = BigInteger.valueOf(1000);
-        }
-        return quantity.getNumber().toBigInteger()
-                       .divide(divider.multiply(divider))
-                       .intValue();
-    }
+    return quantity.getNumber().toBigInteger().divide(divider.multiply(divider)).intValue();
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/UserAgentService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/UserAgentService.java
@@ -14,33 +14,35 @@ import java.net.InetAddress;
 @Service
 public class UserAgentService {
 
+  @Value("${datajobs.version:unknown-version}")
+  private String dataJobsVersion;
 
-    @Value("${datajobs.version:unknown-version}")
-    private String dataJobsVersion;
+  @Value("${datajobs.git_commit_hash:unknown-git-hash}")
+  private String dataJobsGitCommit;
 
-    @Value("${datajobs.git_commit_hash:unknown-git-hash}")
-    private String dataJobsGitCommit;
+  public String getUserAgent() {
+    return String.format("PipelinesControlService/%s", this.dataJobsVersion);
+  }
 
-    public String getUserAgent() {
-        return String.format("PipelinesControlService/%s", this.dataJobsVersion);
+  public String getUserAgentDetails() {
+    return String.format(
+        "PipelinesControlService/%s/%s (%s@%s %s)",
+        this.dataJobsVersion,
+        this.dataJobsGitCommit,
+        SystemUtils.USER_NAME,
+        getHostName(),
+        getOsDetails());
+  }
+
+  private static String getOsDetails() {
+    return String.format("%s/%s/%s", SystemUtils.OS_NAME, SystemUtils.OS_ARCH, SystemUtils.OS_ARCH);
+  }
+
+  private static String getHostName() {
+    try {
+      return InetAddress.getLocalHost().getHostName();
+    } catch (Exception e) {
+      return SystemUtils.getHostName();
     }
-
-    public String getUserAgentDetails() {
-        return String.format("PipelinesControlService/%s/%s (%s@%s %s)",
-                this.dataJobsVersion, this.dataJobsGitCommit, SystemUtils.USER_NAME, getHostName(), getOsDetails());
-    }
-
-    private static String getOsDetails() {
-        return String.format("%s/%s/%s",  SystemUtils.OS_NAME,  SystemUtils.OS_ARCH,  SystemUtils.OS_ARCH);
-    }
-
-    private static String getHostName() {
-        try {
-            return InetAddress.getLocalHost().getHostName();
-        } catch (Exception e) {
-            return SystemUtils.getHostName();
-        }
-
-    }
-
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/Utilities.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/Utilities.java
@@ -16,56 +16,62 @@ import java.util.List;
 
 public final class Utilities {
 
-    private static final String DEFAULT_DELIMITER = ";";
+  private static final String DEFAULT_DELIMITER = ";";
 
-    private Utilities() {
-    }
+  private Utilities() {}
 
-    /**
-     * Concatenates the specified values using the default delimiter, ';', in between them.
-     * @param elements The values to concatenate.
-     * @return The concatenated values, or an empty string if {@code elements} is null.
-     */
-    public static String join(Iterable<? extends CharSequence> elements) {
-        return join(elements, DEFAULT_DELIMITER);
-    }
+  /**
+   * Concatenates the specified values using the default delimiter, ';', in between them.
+   *
+   * @param elements The values to concatenate.
+   * @return The concatenated values, or an empty string if {@code elements} is null.
+   */
+  public static String join(Iterable<? extends CharSequence> elements) {
+    return join(elements, DEFAULT_DELIMITER);
+  }
 
-    /**
-     * Concatenates the specified values using the specified delimiter in between them.
-     * @param elements The values to concatenate.
-     * @param delimiter The delimiter to use.
-     * @return The concatenated values, or an empty string if {@code elements} is null.
-     */
-    public static String join(Iterable<? extends CharSequence> elements, CharSequence delimiter) {
-        return elements == null ? "" : String.join(delimiter, elements);
-    }
+  /**
+   * Concatenates the specified values using the specified delimiter in between them.
+   *
+   * @param elements The values to concatenate.
+   * @param delimiter The delimiter to use.
+   * @return The concatenated values, or an empty string if {@code elements} is null.
+   */
+  public static String join(Iterable<? extends CharSequence> elements, CharSequence delimiter) {
+    return elements == null ? "" : String.join(delimiter, elements);
+  }
 
-    /**
-     * Splits the specified string into an array using the default delimiter, ';'.
-     * @param values The string to split.
-     * @return A list of parsed strings, or an empty list, of the provided value is {@code null}.
-     */
-    public static List<String> parseList(String values) {
-        String[] parts = StringUtils.split(values, DEFAULT_DELIMITER);
-        return values == null ? Collections.emptyList() : Arrays.asList(parts);
-    }
+  /**
+   * Splits the specified string into an array using the default delimiter, ';'.
+   *
+   * @param values The string to split.
+   * @return A list of parsed strings, or an empty list, of the provided value is {@code null}.
+   */
+  public static List<String> parseList(String values) {
+    String[] parts = StringUtils.split(values, DEFAULT_DELIMITER);
+    return values == null ? Collections.emptyList() : Arrays.asList(parts);
+  }
 
-    /**
-     * Hide stacktrace of the response body. Without this it return fat stacktrace into json response body
-     * More info for future workarounds https://github.com/graphql-java/graphql-java/issues/939
-     * @param errors List of graphql errors attached to the response body
-     * @return Altered errors list with stacktrace removed
-     */
-    public static List<GraphQLError> removeGraphQLErrorsStackTrace(List<GraphQLError> errors) {
-        if(errors != null) {
-            errors.stream()
-                  .filter(ExceptionWhileDataFetching.class::isInstance)
-                  .map(ExceptionWhileDataFetching.class::cast)
-                  .filter(exceptionWhileDataFetching -> exceptionWhileDataFetching.getException() != null)
-                  .forEach(exceptionWhileDataFetching ->
-                        exceptionWhileDataFetching.getException().setStackTrace(new StackTraceElement[]{}));
-            return errors;
-        }
-        return new ArrayList<>();
+  /**
+   * Hide stacktrace of the response body. Without this it return fat stacktrace into json response
+   * body More info for future workarounds https://github.com/graphql-java/graphql-java/issues/939
+   *
+   * @param errors List of graphql errors attached to the response body
+   * @return Altered errors list with stacktrace removed
+   */
+  public static List<GraphQLError> removeGraphQLErrorsStackTrace(List<GraphQLError> errors) {
+    if (errors != null) {
+      errors.stream()
+          .filter(ExceptionWhileDataFetching.class::isInstance)
+          .map(ExceptionWhileDataFetching.class::cast)
+          .filter(exceptionWhileDataFetching -> exceptionWhileDataFetching.getException() != null)
+          .forEach(
+              exceptionWhileDataFetching ->
+                  exceptionWhileDataFetching
+                      .getException()
+                      .setStackTrace(new StackTraceElement[] {}));
+      return errors;
     }
+    return new ArrayList<>();
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/credentials/CredentialsRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/credentials/CredentialsRepository.java
@@ -9,28 +9,33 @@ import java.io.File;
 import java.util.Optional;
 
 /**
- * CRUD operations on principals and credentials which are associated with a given data job.
- * The backing service can be LDAP or Kerberos or Cloud IAM (AWS IAM), etc.
+ * CRUD operations on principals and credentials which are associated with a given data job. The
+ * backing service can be LDAP or Kerberos or Cloud IAM (AWS IAM), etc.
  */
 public interface CredentialsRepository {
-    /**
-     * Create principal with the given name and store its credentials in the file location passed
-     * @param principal the name of the principal (e.g user name in LDAP)
-     * @param keytabLocation here to export the file with credentials (password, keys) for the new principal.
-     *                       If there's already existing file, it will be deleted/overwritten with new credentials.
-     */
-    void createPrincipal(String principal, Optional<File> keytabLocation);
+  /**
+   * Create principal with the given name and store its credentials in the file location passed
+   *
+   * @param principal the name of the principal (e.g user name in LDAP)
+   * @param keytabLocation here to export the file with credentials (password, keys) for the new
+   *     principal. If there's already existing file, it will be deleted/overwritten with new
+   *     credentials.
+   */
+  void createPrincipal(String principal, Optional<File> keytabLocation);
 
-    /**
-     * Check if principle already exists
-     * @param principal the name of the principal (e.g user name in LDAP)
-     * @return
-     */
-    boolean principalExists(String principal);
+  /**
+   * Check if principle already exists
+   *
+   * @param principal the name of the principal (e.g user name in LDAP)
+   * @return
+   */
+  boolean principalExists(String principal);
 
-    /**
-     * Delete the principal with given name. This should also invalidate its credentials (password, key, etc.)
-     * @param principal the name of the principal (e.g user name in LDAP)
-     */
-    void deletePrincipal(String principal);
+  /**
+   * Delete the principal with given name. This should also invalidate its credentials (password,
+   * key, etc.)
+   *
+   * @param principal the name of the principal (e.g user name in LDAP)
+   */
+  void deletePrincipal(String principal);
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/credentials/EmptyCredentialsRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/credentials/EmptyCredentialsRepository.java
@@ -16,31 +16,34 @@ import java.io.File;
 import java.util.Optional;
 
 /**
- * Creates dummy empty princpal that does not exists. Used to basically disable credentials generation functionality.
+ * Creates dummy empty princpal that does not exists. Used to basically disable credentials
+ * generation functionality.
  */
 @Profile("!MockKerberos")
 @Component
-@ConditionalOnProperty(value = ServiceAppPropNames.CREDENTIALS_REPOSITORY_TYPE, havingValue = "EMPTY", matchIfMissing = true)
+@ConditionalOnProperty(
+    value = ServiceAppPropNames.CREDENTIALS_REPOSITORY_TYPE,
+    havingValue = "EMPTY",
+    matchIfMissing = true)
 public class EmptyCredentialsRepository implements CredentialsRepository {
-    private static final Logger log = LoggerFactory.getLogger(EmptyCredentialsRepository.class);
+  private static final Logger log = LoggerFactory.getLogger(EmptyCredentialsRepository.class);
 
-    public EmptyCredentialsRepository() {
-        log.info("Credentials repository used will be empty - no credentials.");
-    }
+  public EmptyCredentialsRepository() {
+    log.info("Credentials repository used will be empty - no credentials.");
+  }
 
-    @Override
-    public void createPrincipal(String principal, Optional<File> keytabLocation) {
-        log.trace("Create empty principal " + principal);
-    }
+  @Override
+  public void createPrincipal(String principal, Optional<File> keytabLocation) {
+    log.trace("Create empty principal " + principal);
+  }
 
-    @Override
-    public boolean principalExists(String principal) {
-        return false;
-    }
+  @Override
+  public boolean principalExists(String principal) {
+    return false;
+  }
 
-    @Override
-    public void deletePrincipal(String principal) {
-        log.trace("Delete empty principal " + principal);
-    }
-
+  @Override
+  public void deletePrincipal(String principal) {
+    log.trace("Delete empty principal " + principal);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/credentials/JobCredentialsService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/credentials/JobCredentialsService.java
@@ -25,83 +25,84 @@ import java.util.Optional;
 /**
  * Manages credentials of a job.
  *
- * <p>
- * Credentials (kerberos principal and keytab) are generated and
- * then are stored as kubernetes secret.
+ * <p>Credentials (kerberos principal and keytab) are generated and then are stored as kubernetes
+ * secret.
  *
- * <p>
- * Methods throw {@link ExternalSystemError} in case of unexpected, and likely intermittent, errors from
- * Kubernetes.
+ * <p>Methods throw {@link ExternalSystemError} in case of unexpected, and likely intermittent,
+ * errors from Kubernetes.
  */
 @Service
 @RequiredArgsConstructor
 public class JobCredentialsService {
-    public static final String K8S_KEYTAB_KEY_IN_SECRET = "keytab";
+  public static final String K8S_KEYTAB_KEY_IN_SECRET = "keytab";
 
-    // pattern for the name of the principal to be created - "%(data_job)" will be replaced with the job name
-    @Value("${credentials.principal.pattern:pa__view_%(data_job)}")
-    private String credentialsPrincipalPattern = "pa__view_%(data_job)";
+  // pattern for the name of the principal to be created - "%(data_job)" will be replaced with the
+  // job name
+  @Value("${credentials.principal.pattern:pa__view_%(data_job)}")
+  private String credentialsPrincipalPattern = "pa__view_%(data_job)";
 
-    private final DataJobsKubernetesService dataJobsKubernetesService;
-    private final CredentialsRepository credentialsRepository;
+  private final DataJobsKubernetesService dataJobsKubernetesService;
+  private final CredentialsRepository credentialsRepository;
 
-    /**
-     * Create a new job credentials and saves it as kubernetes secret possibly overwriting the older credentials (if
-     * they existed)
-     */
-    public void createJobCredentials(String jobName) {
-       Validate.notBlank(jobName, "jobName must not be blank");
+  /**
+   * Create a new job credentials and saves it as kubernetes secret possibly overwriting the older
+   * credentials (if they existed)
+   */
+  public void createJobCredentials(String jobName) {
+    Validate.notBlank(jobName, "jobName must not be blank");
 
-       String principal = getJobPrincipalName(jobName);
-       File keytabFile;
-       try {
-          keytabFile = File.createTempFile(principal, ".keytab");
-       } catch (IOException e) {
-          throw new ExternalSystemError(MainExternalSystem.HOST_CONTAINER, e);
-       }
-       try (Closeable ignored = () -> keytabFile.delete()) {
-          credentialsRepository.createPrincipal(principal, Optional.of(keytabFile));
-
-          String secretName = getJobKeytabKubernetesSecretName(jobName);
-          var keytabData = Collections.singletonMap(K8S_KEYTAB_KEY_IN_SECRET, Files.readAllBytes(keytabFile.toPath()));
-          dataJobsKubernetesService.saveSecretData(secretName, keytabData);
-       } catch (ApiException e) {
-          throw new KubernetesException("Cannot update job credentials", e);
-       } catch (IOException e) {
-          throw new ExternalSystemError(MainExternalSystem.HOST_CONTAINER, e);
-       }
+    String principal = getJobPrincipalName(jobName);
+    File keytabFile;
+    try {
+      keytabFile = File.createTempFile(principal, ".keytab");
+    } catch (IOException e) {
+      throw new ExternalSystemError(MainExternalSystem.HOST_CONTAINER, e);
     }
+    try (Closeable ignored = () -> keytabFile.delete()) {
+      credentialsRepository.createPrincipal(principal, Optional.of(keytabFile));
 
-    /**
-     * Delete job's credentials.
-     */
-    public void deleteJobCredentials(String jobName) {
-        Validate.notBlank(jobName, "jobName must not be blank");
-
-        String secretName = getJobKeytabKubernetesSecretName(jobName);
-        try {
-         dataJobsKubernetesService.removeSecretData(secretName);
-      } catch (ApiException e) {
-           throw new KubernetesException("Cannot delete job credentials", e);
-      }
-        String principal = getJobPrincipalName(jobName);
-        credentialsRepository.deletePrincipal(principal);
+      String secretName = getJobKeytabKubernetesSecretName(jobName);
+      var keytabData =
+          Collections.singletonMap(
+              K8S_KEYTAB_KEY_IN_SECRET, Files.readAllBytes(keytabFile.toPath()));
+      dataJobsKubernetesService.saveSecretData(secretName, keytabData);
+    } catch (ApiException e) {
+      throw new KubernetesException("Cannot update job credentials", e);
+    } catch (IOException e) {
+      throw new ExternalSystemError(MainExternalSystem.HOST_CONTAINER, e);
     }
+  }
 
-    public byte[] readJobCredential(String jobName) {
-       String secretName = getJobKeytabKubernetesSecretName(jobName);
-       try {
-         return dataJobsKubernetesService.getSecretData(secretName).getOrDefault(K8S_KEYTAB_KEY_IN_SECRET, null);
-      } catch (ApiException e) {
-          throw new KubernetesException("Cannot read job credentials", e);
-      }
-    }
+  /** Delete job's credentials. */
+  public void deleteJobCredentials(String jobName) {
+    Validate.notBlank(jobName, "jobName must not be blank");
 
-    public String getJobPrincipalName(String jobName) {
-        return credentialsPrincipalPattern.replace("%(data_job)", jobName);
+    String secretName = getJobKeytabKubernetesSecretName(jobName);
+    try {
+      dataJobsKubernetesService.removeSecretData(secretName);
+    } catch (ApiException e) {
+      throw new KubernetesException("Cannot delete job credentials", e);
     }
+    String principal = getJobPrincipalName(jobName);
+    credentialsRepository.deletePrincipal(principal);
+  }
 
-    public static String getJobKeytabKubernetesSecretName(String jobName) {
-        return "data-job-keytab-" + jobName;
+  public byte[] readJobCredential(String jobName) {
+    String secretName = getJobKeytabKubernetesSecretName(jobName);
+    try {
+      return dataJobsKubernetesService
+          .getSecretData(secretName)
+          .getOrDefault(K8S_KEYTAB_KEY_IN_SECRET, null);
+    } catch (ApiException e) {
+      throw new KubernetesException("Cannot read job credentials", e);
     }
+  }
+
+  public String getJobPrincipalName(String jobName) {
+    return credentialsPrincipalPattern.replace("%(data_job)", jobName);
+  }
+
+  public static String getJobKeytabKubernetesSecretName(String jobName) {
+    return "data-job-keytab-" + jobName;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/credentials/KerberosCredentialsRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/credentials/KerberosCredentialsRepository.java
@@ -26,160 +26,179 @@ import java.util.Optional;
 /**
  * CRUD operations on principals and keytab files.
  *
- * <p>
- * It requires to have kadmin installed locally and in PATH and /bin/sh .
+ * <p>It requires to have kadmin installed locally and in PATH and /bin/sh .
  *
- * <p>
- * NOTE: KerberosCredentialsServiceTestManual is currently manual test, use it when making changes to test.
+ * <p>NOTE: KerberosCredentialsServiceTestManual is currently manual test, use it when making
+ * changes to test.
  */
 @Profile("!MockKerberos")
 @Component
-@ConditionalOnProperty(value = ServiceAppPropNames.CREDENTIALS_REPOSITORY_TYPE, havingValue = "KERBEROS", matchIfMissing = false)
+@ConditionalOnProperty(
+    value = ServiceAppPropNames.CREDENTIALS_REPOSITORY_TYPE,
+    havingValue = "KERBEROS",
+    matchIfMissing = false)
 public class KerberosCredentialsRepository implements CredentialsRepository {
-    private static final Logger log = LoggerFactory.getLogger(KerberosCredentialsRepository.class);
+  private static final Logger log = LoggerFactory.getLogger(KerberosCredentialsRepository.class);
 
-    private final String kadminUser;
-    private final String kadminPassword;
+  private final String kadminUser;
+  private final String kadminPassword;
 
-    public KerberosCredentialsRepository(
-            @Value("${datajobs.kadmin_user}") String kadminUser,
-            @Value("${datajobs.kadmin_password}") String kadminPassword) {
-        this.kadminUser = kadminUser;
-        this.kadminPassword = kadminPassword;
-        log.info("Credentials repository used will be Kerberos");
-        checkDependencies();
+  public KerberosCredentialsRepository(
+      @Value("${datajobs.kadmin_user}") String kadminUser,
+      @Value("${datajobs.kadmin_password}") String kadminPassword) {
+    this.kadminUser = kadminUser;
+    this.kadminPassword = kadminPassword;
+    log.info("Credentials repository used will be Kerberos");
+    checkDependencies();
+  }
+
+  private void checkDependencies() {
+    try {
+      ProcessExecutor executor = new ProcessExecutor();
+      executor.readOutput(true);
+      ProcessResult result = executor.command("/bin/sh", "-c", "which kadmin").execute();
+      if (result.getExitValue() != 0) {
+        log.error(
+            "Missing required dependencies. "
+                + " kadmin are missing or are not found on PATH."
+                + "Possible reason: "
+                + result.getOutput().getUTF8()
+                + "Without those credential management will not work. ");
+      }
+      var krbConf = System.getenv().getOrDefault("KRB5_CONFIG", "/etc/krb5.conf");
+      if (!new File(krbConf).isFile()) {
+        log.error(
+            "Missing required dependencies. "
+                + "{} is missing. "
+                + "Without this credential management cannot work. ",
+            krbConf);
+      }
+    } catch (Exception e) {
+      log.error(
+          "Checking dependencies failed."
+              + "See exception for more information and root cause. "
+              + "It's possible that credentials management will not be working properly or at all.",
+          e);
     }
+  }
 
-    private void checkDependencies() {
-        try {
-            ProcessExecutor executor = new ProcessExecutor();
-            executor.readOutput(true);
-            ProcessResult result = executor.command("/bin/sh", "-c", "which kadmin").execute();
-            if (result.getExitValue() != 0) {
-                log.error("Missing required dependencies. " +
-                        " kadmin are missing or are not found on PATH." +
-                        "Possible reason: " + result.getOutput().getUTF8() +
-                        "Without those credential management will not work. ");
-            }
-            var krbConf = System.getenv().getOrDefault("KRB5_CONFIG", "/etc/krb5.conf");
-            if (!new File(krbConf).isFile()) {
-                log.error("Missing required dependencies. " +
-                        "{} is missing. " +
-                        "Without this credential management cannot work. ", krbConf);
-            }
-        } catch (Exception e) {
-            log.error("Checking dependencies failed." +
-                    "See exception for more information and root cause. " +
-                    "It's possible that credentials management will not be working properly or at all.", e);
-        }
+  /**
+   * Create a new Principal and keytab for the given principal. If the principal already existed,
+   * the keytab will be refreshed and previous keytab file cannot be used anymore.
+   *
+   * @param principal Kerberos principal is a unique identity in Kerberos (KDC).
+   * @param keytabLocation where to export the keytab file for the new principal. If there's already
+   *     existing file, it will be deleted/overwritten. If variable is not present keytab will not
+   *     be generated. see also https://web.mit.edu/kerberos/krb5-devel/doc/basic/keytab_def.html
+   */
+  @Override
+  public void createPrincipal(String principal, Optional<File> keytabLocation) {
+    Validate.notBlank(principal, "principal must not be blank");
+    if (!principalExists(principal)) {
+      createPrincipal(principal);
     }
-
-    /**
-     * Create a new Principal and keytab for the given principal.
-     * If the principal already existed, the keytab will be refreshed and previous keytab file cannot be used anymore.
-     *
-     * @param principal Kerberos principal is a unique identity in Kerberos (KDC).
-     * @param keytabLocation where to export the keytab file for the new principal.
-     *                       If there's already existing file, it will be deleted/overwritten.
-     *                       If variable is not present keytab will not be generated.
-     *                       see also https://web.mit.edu/kerberos/krb5-devel/doc/basic/keytab_def.html
-     */
-    @Override
-    public void createPrincipal(String principal, Optional<File> keytabLocation) {
-        Validate.notBlank(principal, "principal must not be blank");
-        if (!principalExists(principal)) {
-            createPrincipal(principal);
-        }
-        if (keytabLocation.isPresent()) {
-            exportKeytab(principal, keytabLocation.get());
-        }
+    if (keytabLocation.isPresent()) {
+      exportKeytab(principal, keytabLocation.get());
     }
+  }
 
-    private void createPrincipal(String principal) {
-        var success = execute_kadmin_command("add_principal -randkey " + principal, "created");
-        if (!success) {
-            String msg = String.format("Failed to execute add principal %s. " +
-                    "It return error code. Check logs for more details", principal);
-            log.error(msg);
-            throw new ExternalSystemError(MainExternalSystem.KERBEROS, msg);
-        }
-        log.debug("Created {} successfully", principal);
+  private void createPrincipal(String principal) {
+    var success = execute_kadmin_command("add_principal -randkey " + principal, "created");
+    if (!success) {
+      String msg =
+          String.format(
+              "Failed to execute add principal %s. "
+                  + "It return error code. Check logs for more details",
+              principal);
+      log.error(msg);
+      throw new ExternalSystemError(MainExternalSystem.KERBEROS, msg);
     }
+    log.debug("Created {} successfully", principal);
+  }
 
-    private void exportKeytab(String principal, File keytabLocation) {
-        boolean success;
-        keytabLocation.delete();
-        success = execute_kadmin_command(String.format("ktadd -k %s %s", keytabLocation.getAbsolutePath(), principal),
-                "Entry for principal");
-        if (!success) {
-            String msg = String.format("Failed to create principal keytab for principal %s. " +
-                    "It return error code. Check logs for more details", principal);
-            log.error(msg);
-            throw new ExternalSystemError(MainExternalSystem.KERBEROS, msg);
-        }
+  private void exportKeytab(String principal, File keytabLocation) {
+    boolean success;
+    keytabLocation.delete();
+    success =
+        execute_kadmin_command(
+            String.format("ktadd -k %s %s", keytabLocation.getAbsolutePath(), principal),
+            "Entry for principal");
+    if (!success) {
+      String msg =
+          String.format(
+              "Failed to create principal keytab for principal %s. "
+                  + "It return error code. Check logs for more details",
+              principal);
+      log.error(msg);
+      throw new ExternalSystemError(MainExternalSystem.KERBEROS, msg);
     }
+  }
 
-    /**
-     * Check if principal exists in KDC.
-     * @param principal Kerberos principal is a unique identity in Kerberos (KDC).
-     */
-    @Override
-    public boolean principalExists(String principal) {
-        Validate.notBlank(principal, "principal must not be blank");
-        return execute_kadmin_command("get_principal " + principal, "Expiration date");
+  /**
+   * Check if principal exists in KDC.
+   *
+   * @param principal Kerberos principal is a unique identity in Kerberos (KDC).
+   */
+  @Override
+  public boolean principalExists(String principal) {
+    Validate.notBlank(principal, "principal must not be blank");
+    return execute_kadmin_command("get_principal " + principal, "Expiration date");
+  }
+
+  /**
+   * Delete principal. It will also invalidate any keytab created for this principal. If job is
+   * already deleted, this is no op.
+   *
+   * @param principal Kerberos principal is a unique identity in Kerberos (KDC).
+   */
+  @Override
+  @SneakyThrows
+  public void deletePrincipal(String principal) {
+    Validate.notBlank(principal, "principal must not be blank");
+    if (principalExists(principal)) {
+      var success = execute_kadmin_command("delete_principal -force " + principal, "deleted");
+      if (!success) {
+        String msg =
+            String.format(
+                "Failed to delete principal %s. "
+                    + "It return error code. Check logs for more details",
+                principal);
+        log.error(msg);
+        throw new ExternalSystemError(MainExternalSystem.KERBEROS, msg);
+      }
     }
+  }
 
-    /**
-     * Delete principal.
-     * It will also invalidate any keytab created for this principal.
-     * If job is already deleted, this is no op.
-     * @param principal Kerberos principal is a unique identity in Kerberos (KDC).
-     */
-    @Override
-    @SneakyThrows
-    public void deletePrincipal(String principal) {
-        Validate.notBlank(principal, "principal must not be blank");
-        if (principalExists(principal)) {
-            var success = execute_kadmin_command("delete_principal -force " + principal, "deleted");
-            if (!success) {
-                String msg = String.format("Failed to delete principal %s. " +
-                        "It return error code. Check logs for more details", principal);
-                log.error(msg);
-                throw new ExternalSystemError(MainExternalSystem.KERBEROS, msg);
-            }
-        }
+  /**
+   * Execute (kerberos) kadmin command
+   *
+   * @param cmd the kadmin command e.g ktadd, add_principal
+   * @param expectedInOutput kadmin commands always return 0 so exit code cannot be used as usual,
+   *     so we trick it by checking if substring is found in output. TODO: That's brittle so we will
+   *     probably have some maintenance cost for this. In the future we should try some libraries.
+   *     Few that were tried and did not work are apache directory-kerby (hit issue DIRKRB-534) and
+   *     pt.tecnico.dsi:kadmin (was hard to use)
+   * @return true if command is successful otherwise false.
+   */
+  @SneakyThrows
+  private boolean execute_kadmin_command(String cmd, String expectedInOutput) {
+    String full_command =
+        String.format("kadmin -w '%s' -p %s -q '%s'", kadminPassword, kadminUser, cmd);
+    log.debug("Execute kadmin command: {}", cmd);
+    ProcessExecutor processExecutor =
+        new ProcessExecutor()
+            .command("/bin/sh", "-c", full_command)
+            .redirectOutputAlsoTo(Slf4jStream.of(log).asInfo())
+            .redirectErrorAlsoTo(Slf4jStream.of(log).asInfo())
+            .readOutput(true);
+
+    ProcessResult result = processExecutor.start().getFuture().get();
+    if (result.getExitValue() == 0) {
+      if (!expectedInOutput.isBlank()) {
+        String stdout = result.getOutput().getUTF8();
+        return stdout.contains(expectedInOutput);
+      }
     }
-
-    /**
-     * Execute (kerberos) kadmin command
-     *
-     * @param cmd the kadmin command e.g ktadd, add_principal
-     * @param expectedInOutput kadmin commands always return 0 so exit code cannot be used as usual,
-     *                        so we trick it by checking if substring is found in output.
-     *                        TODO:
-     *                        That's brittle so we will probably have some maintenance cost for this.
-     *                        In the future we should try some libraries. Few that were tried and did not work are
-     *                        apache directory-kerby (hit issue DIRKRB-534) and pt.tecnico.dsi:kadmin (was hard to use)
-     * @return true if command is successful otherwise false.
-     */
-    @SneakyThrows
-    private boolean execute_kadmin_command(String cmd, String expectedInOutput) {
-        String full_command = String.format("kadmin -w '%s' -p %s -q '%s'", kadminPassword, kadminUser, cmd);
-        log.debug("Execute kadmin command: {}", cmd);
-        ProcessExecutor processExecutor = new ProcessExecutor()
-                .command("/bin/sh", "-c", full_command)
-                .redirectOutputAlsoTo(Slf4jStream.of(log).asInfo())
-                .redirectErrorAlsoTo(Slf4jStream.of(log).asInfo())
-                .readOutput(true);
-
-        ProcessResult result = processExecutor.start().getFuture().get();
-        if (result.getExitValue() == 0) {
-            if(!expectedInOutput.isBlank()) {
-                String stdout = result.getOutput().getUTF8();
-                return stdout.contains(expectedInOutput);
-            }
-        }
-        return false;
-    }
-
+    return false;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/BuilderResources.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/BuilderResources.java
@@ -12,12 +12,15 @@ import org.springframework.stereotype.Component;
 @Component
 @Getter
 public class BuilderResources {
-    @Value("${datajob.builder.cpu.requests:250m}")
-    private String dataJobBuilderCpuRequests;
-    @Value("${datajob.builder.memory.requests:250Mi}")
-    private String dataJobBuilderMemoryRequests;
-    @Value("${datajob.builder.cpu.limits:1000m}")
-    private String dataJobBuilderCpuLimits;
-    @Value("${datajob.builder.memory.limits:1000Mi}")
-    private String dataJobBuilderMemoryLimits;
+  @Value("${datajob.builder.cpu.requests:250m}")
+  private String dataJobBuilderCpuRequests;
+
+  @Value("${datajob.builder.memory.requests:250Mi}")
+  private String dataJobBuilderMemoryRequests;
+
+  @Value("${datajob.builder.cpu.limits:1000m}")
+  private String dataJobBuilderCpuLimits;
+
+  @Value("${datajob.builder.memory.limits:1000Mi}")
+  private String dataJobBuilderMemoryLimits;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobDefaultConfigurations.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobDefaultConfigurations.java
@@ -9,24 +9,26 @@ import com.vmware.taurus.service.KubernetesService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-
 @Component
 public class DataJobDefaultConfigurations {
 
-   @Value("${datajobs.job.resources.limits.memory:1G}")
-   private String memoryLimits;
-   @Value("${datajobs.job.resources.limits.cpu:2000m}")
-   private String cpuLimits;
-   @Value("${datajobs.job.resources.requests.memory:500Mi}")
-   private String memoryRequests;
-   @Value("${datajobs.job.resources.requests.cpu:1000m}")
-   private String cpuRequests;
+  @Value("${datajobs.job.resources.limits.memory:1G}")
+  private String memoryLimits;
 
-   public KubernetesService.Resources dataJobRequests() {
-      return new KubernetesService.Resources(cpuRequests, memoryRequests);
-   }
+  @Value("${datajobs.job.resources.limits.cpu:2000m}")
+  private String cpuLimits;
 
-   public KubernetesService.Resources dataJobLimits() {
-      return new KubernetesService.Resources(cpuLimits, memoryLimits);
-   }
+  @Value("${datajobs.job.resources.requests.memory:500Mi}")
+  private String memoryRequests;
+
+  @Value("${datajobs.job.resources.requests.cpu:1000m}")
+  private String cpuRequests;
+
+  public KubernetesService.Resources dataJobRequests() {
+    return new KubernetesService.Resources(cpuRequests, memoryRequests);
+  }
+
+  public KubernetesService.Resources dataJobLimits() {
+    return new KubernetesService.Resources(cpuLimits, memoryLimits);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentNotificationHelper.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentNotificationHelper.java
@@ -22,87 +22,108 @@ import java.io.IOException;
 @Component
 @RequiredArgsConstructor
 public class DeploymentNotificationHelper {
-   private static final Logger log = LoggerFactory.getLogger(DeploymentNotificationHelper.class);
+  private static final Logger log = LoggerFactory.getLogger(DeploymentNotificationHelper.class);
 
-   private final DeploymentProgress deploymentProgress;
+  private final DeploymentProgress deploymentProgress;
 
-   public void verifyBuilderResult(String builderJobName,
-                                   DataJob dataJob,
-                                   JobDeployment jobDeployment,
-                                   KubernetesService.JobStatusCondition condition,
-                                   String logs,
-                                   Boolean sendNotification) throws IOException {
+  public void verifyBuilderResult(
+      String builderJobName,
+      DataJob dataJob,
+      JobDeployment jobDeployment,
+      KubernetesService.JobStatusCondition condition,
+      String logs,
+      Boolean sendNotification)
+      throws IOException {
 
-      if (condition.isSuccess()) {
-         log.info("Builder job {} finished successfully", builderJobName);
+    if (condition.isSuccess()) {
+      log.info("Builder job {} finished successfully", builderJobName);
+    } else {
+      log.info("Something went wrong when building job image. Job condition: {}", condition);
+      String userErrorMessage = getUserErrorMessage(logs, jobDeployment);
+      if (StringUtils.isNotBlank(userErrorMessage)) {
+        log.info(
+            String.format(
+                "An error occurred while processing the requirements file for job: %s with version:"
+                    + " %s",
+                jobDeployment.getDataJobName(), jobDeployment.getGitCommitSha()));
+
+        deploymentProgress.failed(
+            dataJob.getJobConfig(),
+            jobDeployment,
+            DeploymentStatus.USER_ERROR,
+            userErrorMessage,
+            sendNotification);
       } else {
-         log.info("Something went wrong when building job image. Job condition: {}", condition);
-         String userErrorMessage = getUserErrorMessage(logs, jobDeployment);
-         if (StringUtils.isNotBlank(userErrorMessage)) {
-            log.info(String.format("An error occurred while processing the requirements file for job: %s with version: %s",
-                  jobDeployment.getDataJobName(), jobDeployment.getGitCommitSha()));
-
-            deploymentProgress.failed(dataJob.getJobConfig(), jobDeployment, DeploymentStatus.USER_ERROR,
-                    userErrorMessage, sendNotification);
-         } else {
-            ErrorMessage message = new ErrorMessage(
-                    String.format("Could not build an image for job: %s with version: %s", jobDeployment.getDataJobName(), jobDeployment.getGitCommitSha()),
-                    "Unexpected error occurred.",
-                    "The new/updated job was not deployed." +
-                            " The job will run its latest successfully deployed version (if any) as scheduled. " +
-                            " Data Job Owner will get notification if enabled.",
-                    "Investigate. See the failed builder job if it is still present in kubernetes. " +
-                            "Or see captured logs from the job here:\n" + logs
-            );
-            log.warn(message.toString());
-            deploymentProgress.failed(dataJob.getJobConfig(), jobDeployment, DeploymentStatus.PLATFORM_ERROR,
-                    NotificationContent.getPlatformErrorBody(), sendNotification);
-         }
+        ErrorMessage message =
+            new ErrorMessage(
+                String.format(
+                    "Could not build an image for job: %s with version: %s",
+                    jobDeployment.getDataJobName(), jobDeployment.getGitCommitSha()),
+                "Unexpected error occurred.",
+                "The new/updated job was not deployed. The job will run its latest successfully"
+                    + " deployed version (if any) as scheduled.  Data Job Owner will get"
+                    + " notification if enabled.",
+                "Investigate. See the failed builder job if it is still present in kubernetes. "
+                    + "Or see captured logs from the job here:\n"
+                    + logs);
+        log.warn(message.toString());
+        deploymentProgress.failed(
+            dataJob.getJobConfig(),
+            jobDeployment,
+            DeploymentStatus.PLATFORM_ERROR,
+            NotificationContent.getPlatformErrorBody(),
+            sendNotification);
       }
-   }
+    }
+  }
 
-   private String getUserErrorMessage(String logs, JobDeployment jobDeployment) throws IOException {
-      String requirementsError = getRequirementsError(logs);
-      if (StringUtils.isNotBlank(requirementsError)) {
-         return NotificationContent.getErrorBody(
-                 "Tried to deploy a data job",
-                 "There has been an error while processing your requirements file: " + requirementsError,
-                 "Your new/updated job was not deployed. Your job will run its latest successfully deployed version (if any) as scheduled.",
-                 "Please fix the requirements file");
+  private String getUserErrorMessage(String logs, JobDeployment jobDeployment) throws IOException {
+    String requirementsError = getRequirementsError(logs);
+    if (StringUtils.isNotBlank(requirementsError)) {
+      return NotificationContent.getErrorBody(
+          "Tried to deploy a data job",
+          "There has been an error while processing your requirements file: " + requirementsError,
+          "Your new/updated job was not deployed. Your job will run its latest successfully"
+              + " deployed version (if any) as scheduled.",
+          "Please fix the requirements file");
+    }
+    String notFoundError = getDataJobNotFoundError(logs, jobDeployment);
+    if (StringUtils.isNotBlank(notFoundError)) {
+      return notFoundError;
+    }
+
+    return null;
+  }
+
+  private String getDataJobNotFoundError(String logs, JobDeployment jobDeployment) {
+    String error = null;
+
+    if (StringUtils.isNotBlank(logs) && logs.contains(">data-job-not-found<")) {
+      error =
+          NotificationContent.getErrorBody(
+              "Tried to deploy a data job and failed.",
+              "The data job source code cannot be found. Tried to deploy with git commit: "
+                  + jobDeployment.getGitCommitSha(),
+              "Your new/updated job was not deployed. Your job will run its latest successfully"
+                  + " deployed version (if any) as scheduled.",
+              "Make sure you push the job in the git repository and during deployment have"
+                  + " specified the correct commit hash.");
+    }
+    return error;
+  }
+
+  // Currently, the only way to differentiate between infra and user error
+  // when building a data job is by parsing the logs of the builder job.
+  private String getRequirementsError(String logs) throws IOException {
+    String requirements_error = null;
+
+    if (StringUtils.isNotBlank(logs) && logs.contains(">requirements_failed<")) {
+      String[] error_list = logs.split(">requirements_failed<");
+
+      if (error_list.length > 3) {
+        requirements_error = error_list[error_list.length - 2];
       }
-      String notFoundError = getDataJobNotFoundError(logs, jobDeployment);
-      if (StringUtils.isNotBlank(notFoundError)) {
-         return notFoundError;
-      }
-
-      return null;
-   }
-
-   private String getDataJobNotFoundError(String logs, JobDeployment jobDeployment) {
-      String error = null;
-
-      if (StringUtils.isNotBlank(logs) && logs.contains(">data-job-not-found<")) {
-         error = NotificationContent.getErrorBody(
-                 "Tried to deploy a data job and failed.",
-                 "The data job source code cannot be found. Tried to deploy with git commit: " + jobDeployment.getGitCommitSha() ,
-                 "Your new/updated job was not deployed. Your job will run its latest successfully deployed version (if any) as scheduled.",
-                 "Make sure you push the job in the git repository and during deployment have specified the correct commit hash.");
-      }
-      return error;
-   }
-
-   // Currently, the only way to differentiate between infra and user error
-   // when building a data job is by parsing the logs of the builder job.
-   private String getRequirementsError(String logs) throws IOException {
-      String requirements_error = null;
-
-      if (StringUtils.isNotBlank(logs) && logs.contains(">requirements_failed<")) {
-         String[] error_list = logs.split(">requirements_failed<");
-
-         if (error_list.length > 3) {
-            requirements_error = error_list[error_list.length-2];
-         }
-      }
-      return requirements_error;
-   }
+    }
+    return requirements_error;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentProgress.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentProgress.java
@@ -14,70 +14,74 @@ import com.vmware.taurus.service.notification.DataJobNotification;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.Map;
 
-/**
- * Track the progress of a deployment.
- */
+/** Track the progress of a deployment. */
 @Component
 @RequiredArgsConstructor
 public class DeploymentProgress {
 
-    private final DataJobNotification dataJobNotification;
-    private final DeploymentMonitor deploymentMonitor;
+  private final DataJobNotification dataJobNotification;
+  private final DeploymentMonitor deploymentMonitor;
 
-    /**
-     * Data Job Deployment has started.
-     * @param jobConfig the job configuration
-     * @param jobDeployment the job deployment configuration
-     */
-    @Measurable(includeArg = 1, argName = "deployment")
-    void started(JobConfig jobConfig, JobDeployment jobDeployment) {
-    }
+  /**
+   * Data Job Deployment has started.
+   *
+   * @param jobConfig the job configuration
+   * @param jobDeployment the job deployment configuration
+   */
+  @Measurable(includeArg = 1, argName = "deployment")
+  void started(JobConfig jobConfig, JobDeployment jobDeployment) {}
 
-    /**
-     * Data Job Deployment has completed successfully.
-     * @param jobConfig the job configuration
-     * @param jobDeployment the job deployment configuration
-     */
-    @Measurable(includeArg = 1, argName = "deployment")
-    void completed(JobConfig jobConfig, JobDeployment jobDeployment, boolean sendNotification) {
-        deploymentMonitor.recordDeploymentStatus(jobDeployment.getDataJobName(), DeploymentStatus.SUCCESS);
-        if (sendNotification) {
-            dataJobNotification.notifyJobDeploySuccess(jobConfig);
-        }
+  /**
+   * Data Job Deployment has completed successfully.
+   *
+   * @param jobConfig the job configuration
+   * @param jobDeployment the job deployment configuration
+   */
+  @Measurable(includeArg = 1, argName = "deployment")
+  void completed(JobConfig jobConfig, JobDeployment jobDeployment, boolean sendNotification) {
+    deploymentMonitor.recordDeploymentStatus(
+        jobDeployment.getDataJobName(), DeploymentStatus.SUCCESS);
+    if (sendNotification) {
+      dataJobNotification.notifyJobDeploySuccess(jobConfig);
     }
+  }
 
-    /**
-     * Data Job Deployment has failed.
-     * @param jobConfig the job configuration
-     * @param jobDeployment the job deployment configuration
-     * @param status Deployment status - user or platform error
-     * @param message the error message that will be sent as notificaiton
-     * @param sendNotification if true will sent notification to user
-     */
-    @Measurable(includeArg = 1, argName = "deployment")
-    @Measurable(includeArg = 2, argName = "status")
-    @Measurable(includeArg = 3, argName = "message")
-    void failed(JobConfig jobConfig, JobDeployment jobDeployment, DeploymentStatus status, String message, boolean sendNotification) {
-        deploymentMonitor.recordDeploymentStatus(jobDeployment.getDataJobName(), status);
-        if(sendNotification) {
-            dataJobNotification.notifyJobDeployError(jobConfig,"Failed to deploy the job.", message);
-        }
+  /**
+   * Data Job Deployment has failed.
+   *
+   * @param jobConfig the job configuration
+   * @param jobDeployment the job deployment configuration
+   * @param status Deployment status - user or platform error
+   * @param message the error message that will be sent as notificaiton
+   * @param sendNotification if true will sent notification to user
+   */
+  @Measurable(includeArg = 1, argName = "deployment")
+  @Measurable(includeArg = 2, argName = "status")
+  @Measurable(includeArg = 3, argName = "message")
+  void failed(
+      JobConfig jobConfig,
+      JobDeployment jobDeployment,
+      DeploymentStatus status,
+      String message,
+      boolean sendNotification) {
+    deploymentMonitor.recordDeploymentStatus(jobDeployment.getDataJobName(), status);
+    if (sendNotification) {
+      dataJobNotification.notifyJobDeployError(jobConfig, "Failed to deploy the job.", message);
     }
+  }
 
-    /**
-     * Data Job Deployment is deleted.
-     * On delete for a deployment of a data job we reset its status to 0 (success)
-     * @param dataJobName data job name
-     * TODO: param to support multiple modes
-     */
-    @Measurable(includeArg = 0, argName = "job_name")
-    public void deleted(String dataJobName) {
-        deploymentMonitor.recordDeploymentStatus(dataJobName, DeploymentStatus.SUCCESS);
-    }
+  /**
+   * Data Job Deployment is deleted. On delete for a deployment of a data job we reset its status to
+   * 0 (success)
+   *
+   * @param dataJobName data job name TODO: param to support multiple modes
+   */
+  @Measurable(includeArg = 0, argName = "job_name")
+  public void deleted(String dataJobName) {
+    deploymentMonitor.recordDeploymentStatus(dataJobName, DeploymentStatus.SUCCESS);
+  }
 
-    @Measurable(includeArg = 1, argName = "deployment")
-    public void configuration_updated(JobConfig jobConfig, JobDeployment jobDeployment) {
-    }
+  @Measurable(includeArg = 1, argName = "deployment")
+  public void configuration_updated(JobConfig jobConfig, JobDeployment jobDeployment) {}
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentProgress.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentProgress.java
@@ -14,7 +14,6 @@ import com.vmware.taurus.service.notification.DataJobNotification;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-
 /** Track the progress of a deployment. */
 @Component
 @RequiredArgsConstructor

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentService.java
@@ -29,170 +29,198 @@ import java.util.Optional;
 /**
  * CRUD operations for Versatile Data Kit deployments on kubernetes.
  *
- * This class is in a transition from operating against Kubernetes to operating against the database.
- * Currently, only the enabled flag is stored in the database. Eventually, all deployment information
- * will be stored (and retrieved) from a database from a dedicated table.
+ * <p>This class is in a transition from operating against Kubernetes to operating against the
+ * database. Currently, only the enabled flag is stored in the database. Eventually, all deployment
+ * information will be stored (and retrieved) from a database from a dedicated table.
  */
 @Service
 @RequiredArgsConstructor
 public class DeploymentService {
-   private static final Logger log = LoggerFactory.getLogger(DeploymentService.class);
+  private static final Logger log = LoggerFactory.getLogger(DeploymentService.class);
 
-   private final DockerRegistryService dockerRegistryService;
-   private final DeploymentProgress deploymentProgress;
-   private final JobImageBuilder jobImageBuilder;
-   private final JobImageDeployer jobImageDeployer;
-   private final OperationContext operationContext;
-   private final JobsRepository jobsRepository;
+  private final DockerRegistryService dockerRegistryService;
+  private final DeploymentProgress deploymentProgress;
+  private final JobImageBuilder jobImageBuilder;
+  private final JobImageDeployer jobImageDeployer;
+  private final OperationContext operationContext;
+  private final JobsRepository jobsRepository;
 
-   public Optional<JobDeploymentStatus> readDeployment(String jobName) {
-      return jobImageDeployer.readScheduledJob(jobName);
-   }
+  public Optional<JobDeploymentStatus> readDeployment(String jobName) {
+    return jobImageDeployer.readScheduledJob(jobName);
+  }
 
-   public List<JobDeploymentStatus> readDeployments() {
-      return jobImageDeployer.readScheduledJobs();
-   }
+  public List<JobDeploymentStatus> readDeployments() {
+    return jobImageDeployer.readScheduledJobs();
+  }
 
+  /**
+   * Patch existing deployment of a data job. Existing fields are overwritten from non-NULL fields
+   * in jobDeployment.
+   *
+   * @param dataJob the data job details
+   * @param jobDeployment JobDeployment that contains ony the changes necessary (all other fields
+   *     are null)
+   */
+  public void patchDeployment(DataJob dataJob, JobDeployment jobDeployment) {
+    var deploymentStatus = readDeployment(dataJob.getName());
+    if (deploymentStatus.isPresent()) {
+      var oldDeployment =
+          DeploymentModelConverter.toJobDeployment(
+              dataJob.getJobConfig().getTeam(), dataJob.getName(), deploymentStatus.get());
+      var mergedDeployment =
+          DeploymentModelConverter.mergeDeployments(oldDeployment, jobDeployment);
+      validateFieldsCanBePatched(oldDeployment, mergedDeployment);
 
-   /**
-    * Patch existing deployment of a data job. Existing fields are overwritten from non-NULL fields in jobDeployment.
-    *
-    * @param dataJob the data job details
-    * @param jobDeployment JobDeployment that contains ony the changes necessary (all other fields are null)
-    */
-   public void patchDeployment(DataJob dataJob, JobDeployment jobDeployment) {
+      // we are setting sendNotification to false since it's not necessary. If something fails we'd
+      // return HTTP error
+      // as the request is synchronous
+      jobImageDeployer.scheduleJob(dataJob, mergedDeployment, false, operationContext.getUser());
+
+      saveDeployment(dataJob, mergedDeployment);
+      deploymentProgress.configuration_updated(dataJob.getJobConfig(), jobDeployment);
+    } else {
+      throw new DataJobDeploymentNotFoundException(dataJob.getName());
+    }
+  }
+
+  /**
+   * Changing job version requires rebuilding the data job image which is async operation (happens
+   * in background after/while http request finishes) But we'd like to be able to guarantee that
+   * patch operation are synchronous (the desired job deployment configuration is applied when the
+   * http requests finishes) So we return error if job version has been changed and require POST
+   * request to be completed.
+   *
+   * @param oldDeployment the old (or existing) deployment of the data job
+   * @param mergedDeployment the new (merged with the old one) deployment of the data job
+   */
+  private void validateFieldsCanBePatched(
+      JobDeployment oldDeployment, JobDeployment mergedDeployment) {
+    if (mergedDeployment.getGitCommitSha() != null
+        && !mergedDeployment.getGitCommitSha().equals(oldDeployment.getGitCommitSha())) {
+      throw new ApiConstraintError(
+          "job_version",
+          "same as current job version when using PATCH request.",
+          mergedDeployment.getGitCommitSha(),
+          "Use PUT HTTP request to change job version.");
+    }
+  }
+
+  /**
+   * Deploys data jobs on kubernetes as cron jobs. Creates a new deployment if none is present for
+   * the data job. Updates an existing deployment if it already exists (behaves same as patch). This
+   * method is will be executed in a separate thread (it is async).
+   *
+   * @param dataJob The data job
+   * @param jobDeployment Deployment configuration
+   * @param sendNotification
+   * @param lastDeployedBy name of the user that last updated the data job
+   * @param opId Operation ID of the client request
+   * @see org.springframework.scheduling.annotation.Async
+   */
+  @Async
+  @Measurable(includeArg = 0, argName = "data_job")
+  public void updateDeployment(
+      DataJob dataJob,
+      JobDeployment jobDeployment,
+      Boolean sendNotification,
+      String lastDeployedBy,
+      String opId) {
+    // TODO: Consider introducing a generalised mechanism to propagate Operation Context properties
+    // to all ASYNC calls.
+    // Add the opId value propagated from the operation context to a thread's local operation
+    // context.
+    operationContext.setId(opId);
+
+    try {
+      log.info("Starting deployment of job {}", jobDeployment.getDataJobName());
+      deploymentProgress.started(dataJob.getJobConfig(), jobDeployment);
       var deploymentStatus = readDeployment(dataJob.getName());
       if (deploymentStatus.isPresent()) {
-         var oldDeployment = DeploymentModelConverter.toJobDeployment(
-                 dataJob.getJobConfig().getTeam(), dataJob.getName(), deploymentStatus.get());
-         var mergedDeployment = DeploymentModelConverter.mergeDeployments(oldDeployment, jobDeployment);
-         validateFieldsCanBePatched(oldDeployment, mergedDeployment);
-
-         // we are setting sendNotification to false since it's not necessary. If something fails we'd return HTTP error
-         // as the request is synchronous
-         jobImageDeployer.scheduleJob(dataJob, mergedDeployment, false, operationContext.getUser());
-
-         saveDeployment(dataJob, mergedDeployment);
-         deploymentProgress.configuration_updated(dataJob.getJobConfig(), jobDeployment);
-      } else {
-         throw new DataJobDeploymentNotFoundException(dataJob.getName());
+        var oldDeployment =
+            DeploymentModelConverter.toJobDeployment(
+                dataJob.getJobConfig().getTeam(), dataJob.getName(), deploymentStatus.get());
+        jobDeployment = DeploymentModelConverter.mergeDeployments(oldDeployment, jobDeployment);
       }
-   }
 
-   /**
-    * Changing job version requires rebuilding the data job image
-    * which is async operation (happens in background after/while http request finishes)
-    * But we'd like to be able to guarantee that patch operation are synchronous
-    * (the desired job deployment configuration is applied when the http requests finishes)
-    * So we return error if job version has been changed and require POST request to be completed.
-    *
-    * @param oldDeployment the old (or existing) deployment of the data job
-    * @param mergedDeployment the new (merged with the old one) deployment of the data job
-    */
-   private void validateFieldsCanBePatched(JobDeployment oldDeployment, JobDeployment mergedDeployment) {
-      if (mergedDeployment.getGitCommitSha() != null &&
-              !mergedDeployment.getGitCommitSha().equals(oldDeployment.getGitCommitSha())) {
-         throw new ApiConstraintError("job_version",
-                 "same as current job version when using PATCH request.",
-                 mergedDeployment.getGitCommitSha(),
-                 "Use PUT HTTP request to change job version.");
+      String imageName =
+          dockerRegistryService.dataJobImage(
+              jobDeployment.getDataJobName(), jobDeployment.getGitCommitSha());
+
+      if (jobImageBuilder.buildImage(imageName, dataJob, jobDeployment, sendNotification)) {
+        log.info(
+            "Image {} has been built. Will now schedule job {} for execution",
+            imageName,
+            dataJob.getName());
+        jobDeployment.setImageName(imageName);
+        if (jobImageDeployer.scheduleJob(
+            dataJob, jobDeployment, sendNotification, lastDeployedBy)) {
+          log.info(
+              String.format(
+                  "Successfully updated job: %s with version: %s",
+                  jobDeployment.getDataJobName(), jobDeployment.getGitCommitSha()));
+
+          saveDeployment(dataJob, jobDeployment);
+
+          deploymentProgress.completed(dataJob.getJobConfig(), jobDeployment, sendNotification);
+        }
       }
-   }
+    } catch (ApiException e) {
+      handleException(dataJob, jobDeployment, sendNotification, new KubernetesException("", e));
+    } catch (Exception e) {
+      handleException(dataJob, jobDeployment, sendNotification, e);
+    } catch (Throwable e) {
+      handleException(dataJob, jobDeployment, sendNotification, e);
+      throw e;
+    }
+  }
 
-   /**
-    * Deploys data jobs on kubernetes as cron jobs.
-    * Creates a new deployment if none is present for the data job.
-    * Updates an existing deployment if it already exists (behaves same as patch).
-    * This method is will be executed in a separate thread (it is async).
-    *
-    * @param dataJob The data job
-    * @param jobDeployment Deployment configuration
-    * @param sendNotification
-    * @param lastDeployedBy name of the user that last updated the data job
-    * @param opId Operation ID of the client request
-    * @see org.springframework.scheduling.annotation.Async
-    */
-   @Async
-   @Measurable(includeArg = 0, argName = "data_job")
-   public void updateDeployment(DataJob dataJob, JobDeployment jobDeployment,
-                                Boolean sendNotification, String lastDeployedBy, String opId) {
-      // TODO: Consider introducing a generalised mechanism to propagate Operation Context properties to all ASYNC calls.
-      // Add the opId value propagated from the operation context to a thread's local operation context.
-      operationContext.setId(opId);
+  private void saveDeployment(DataJob dataJob, JobDeployment jobDeployment) {
+    // Currently, store only 'enabled' in the database
+    if (!Objects.equals(dataJob.getEnabled(), jobDeployment.getEnabled())) {
+      dataJob.setEnabled(jobDeployment.getEnabled());
+      jobsRepository.save(dataJob);
+      log.info(
+          "The deployment of the data job {} has been {}",
+          dataJob.getName(),
+          Boolean.TRUE.equals(dataJob.getEnabled()) ? "ENABLED" : "DISABLED");
+    }
+  }
 
-      try {
-         log.info("Starting deployment of job {}", jobDeployment.getDataJobName());
-         deploymentProgress.started(dataJob.getJobConfig(), jobDeployment);
-         var deploymentStatus = readDeployment(dataJob.getName());
-         if (deploymentStatus.isPresent()) {
-            var oldDeployment = DeploymentModelConverter.toJobDeployment(dataJob.getJobConfig().getTeam(), dataJob.getName(), deploymentStatus.get());
-            jobDeployment = DeploymentModelConverter.mergeDeployments(oldDeployment, jobDeployment);
-         }
+  private void handleException(
+      DataJob dataJob, JobDeployment jobDeployment, Boolean sendNotification, Throwable e) {
+    ErrorMessage message =
+        new ErrorMessage(
+            String.format(
+                "An error occurred while trying to deploy job: %s with version: %s",
+                jobDeployment.getDataJobName(), jobDeployment.getGitCommitSha()),
+            "See exception message below for possible reason.",
+            "Most likely the deployment has failed. It is possible that deployment may have"
+                + " succeeded (or failed with User error) but there was communication issue. Since"
+                + " we do not know we assume that it was platform error and SRE team need to"
+                + " investigate. End user deploying the job would get notification for deploy"
+                + " failure due to platform error",
+            "End user may verify which version is currently deployed and re-try if necessary. "
+                + "SRE team may investigate by looking at the logs or in kubernetes.");
+    log.error(message.toString(), e);
+    deploymentProgress.failed(
+        dataJob.getJobConfig(),
+        jobDeployment,
+        DeploymentStatus.PLATFORM_ERROR,
+        NotificationContent.getPlatformErrorBody(),
+        sendNotification);
+  }
 
-         String imageName = dockerRegistryService.dataJobImage(
-                 jobDeployment.getDataJobName(), jobDeployment.getGitCommitSha());
+  public void deleteDeployment(String dataJobName) {
+    if (this.deploymentExistsOrInProgress(dataJobName)) {
+      jobImageBuilder.cancelBuildingJob(dataJobName);
+      jobImageDeployer.unScheduleJob(dataJobName);
+      jobsRepository.updateDataJobEnabledByName(dataJobName, false);
+    }
+    deploymentProgress.deleted(dataJobName);
+  }
 
-         if (jobImageBuilder.buildImage(imageName, dataJob, jobDeployment, sendNotification)) {
-            log.info("Image {} has been built. Will now schedule job {} for execution", imageName, dataJob.getName());
-            jobDeployment.setImageName(imageName);
-            if (jobImageDeployer.scheduleJob(dataJob, jobDeployment, sendNotification, lastDeployedBy)) {
-               log.info(String.format("Successfully updated job: %s with version: %s",
-                       jobDeployment.getDataJobName(), jobDeployment.getGitCommitSha()));
-
-               saveDeployment(dataJob, jobDeployment);
-
-               deploymentProgress.completed(dataJob.getJobConfig(), jobDeployment, sendNotification);
-            }
-         }
-      } catch (ApiException e) {
-         handleException(dataJob, jobDeployment, sendNotification, new KubernetesException("", e));
-      } catch (Exception e) {
-         handleException(dataJob, jobDeployment, sendNotification, e);
-      } catch (Throwable e) {
-         handleException(dataJob, jobDeployment, sendNotification, e);
-         throw e;
-      }
-   }
-
-   private void saveDeployment(DataJob dataJob, JobDeployment jobDeployment) {
-      // Currently, store only 'enabled' in the database
-      if (!Objects.equals(dataJob.getEnabled(), jobDeployment.getEnabled())) {
-         dataJob.setEnabled(jobDeployment.getEnabled());
-         jobsRepository.save(dataJob);
-         log.info("The deployment of the data job {} has been {}",
-                 dataJob.getName(), Boolean.TRUE.equals(dataJob.getEnabled()) ? "ENABLED" : "DISABLED");
-      }
-   }
-
-   private void handleException(DataJob dataJob, JobDeployment jobDeployment, Boolean sendNotification, Throwable e) {
-      ErrorMessage message = new ErrorMessage(
-              String.format("An error occurred while trying to deploy job: %s with version: %s",
-                      jobDeployment.getDataJobName(), jobDeployment.getGitCommitSha()),
-              "See exception message below for possible reason.",
-              "Most likely the deployment has failed." +
-                      " It is possible that deployment may have succeeded (or failed with User error)" +
-                      " but there was communication issue." +
-                      " Since we do not know we assume that it was platform error and SRE team need to investigate." +
-                      " End user deploying the job would get notification for deploy failure due to platform error",
-              "End user may verify which version is currently deployed and re-try if necessary. " +
-                      "SRE team may investigate by looking at the logs or in kubernetes."
-      );
-      log.error(message.toString(), e);
-      deploymentProgress.failed(dataJob.getJobConfig(), jobDeployment, DeploymentStatus.PLATFORM_ERROR,
-              NotificationContent.getPlatformErrorBody(), sendNotification);
-   }
-
-   public void deleteDeployment(String dataJobName)  {
-      if (this.deploymentExistsOrInProgress(dataJobName)) {
-         jobImageBuilder.cancelBuildingJob(dataJobName);
-         jobImageDeployer.unScheduleJob(dataJobName);
-         jobsRepository.updateDataJobEnabledByName(dataJobName, false);
-      }
-      deploymentProgress.deleted(dataJobName);
-   }
-
-   private boolean deploymentExistsOrInProgress(String dataJobName)  {
-      return jobImageBuilder.isBuildingJobInProgress(dataJobName) || readDeployment(dataJobName).isPresent();
-   }
-
+  private boolean deploymentExistsOrInProgress(String dataJobName) {
+    return jobImageBuilder.isBuildingJobInProgress(dataJobName)
+        || readDeployment(dataJobName).isPresent();
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DockerImageName.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DockerImageName.java
@@ -12,43 +12,48 @@ import java.util.regex.Pattern;
 
 public class DockerImageName {
 
-    private static final Pattern tagPattern = Pattern.compile("^(.+?)(?::([^:/]+))?$");
+  private static final Pattern tagPattern = Pattern.compile("^(.+?)(?::([^:/]+))?$");
 
-    @NotNull
-    private static Matcher matchImageName(String imageName) {
-        if(imageName.contains("@sha256")) {
-            String[] digestParts = imageName.split("@");
-            imageName = digestParts[0];
-            // digest = digestParts[1];
-        }
-
-        var matcher = tagPattern.matcher(imageName);
-        if (!matcher.matches()) {
-            throw new IllegalArgumentException("Parsing image name failed. It was not properly formatted image name: " + imageName
-            + " Image name format is usually [registryAddress/]name:tag. See docker or OCI standard documentation for more details.");
-        } return matcher;
+  @NotNull
+  private static Matcher matchImageName(String imageName) {
+    if (imageName.contains("@sha256")) {
+      String[] digestParts = imageName.split("@");
+      imageName = digestParts[0];
+      // digest = digestParts[1];
     }
 
-
-    /**
-     * See https://github.com/distribution/distribution/blob/main/reference/regexp.go#L72
-     * and https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier
-     * @param imageName the full image name.
-     * @return the tag
-     */
-    public static String getTag(String imageName) {
-        var tag = matchImageName(imageName).group(2);
-        return tag != null ? tag : "latest";
+    var matcher = tagPattern.matcher(imageName);
+    if (!matcher.matches()) {
+      throw new IllegalArgumentException(
+          "Parsing image name failed. It was not properly formatted image name: "
+              + imageName
+              + " Image name format is usually [registryAddress/]name:tag. See docker or OCI"
+              + " standard documentation for more details.");
     }
+    return matcher;
+  }
 
-    /**
-     * Updates the image name with the new tag
-     * @param imageName the update name to update
-     * @param newTag the new tag to set
-     * @return the updated image name
-     */
-    public static String updateImageWithTag(String imageName, String newTag) {
-        var matcher = matchImageName(imageName);
-        return matcher.group(1) + ":" + newTag;
-    }
+  /**
+   * See https://github.com/distribution/distribution/blob/main/reference/regexp.go#L72 and
+   * https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier
+   *
+   * @param imageName the full image name.
+   * @return the tag
+   */
+  public static String getTag(String imageName) {
+    var tag = matchImageName(imageName).group(2);
+    return tag != null ? tag : "latest";
+  }
+
+  /**
+   * Updates the image name with the new tag
+   *
+   * @param imageName the update name to update
+   * @param newTag the new tag to set
+   * @return the updated image name
+   */
+  public static String updateImageWithTag(String imageName, String newTag) {
+    var matcher = matchImageName(imageName);
+    return matcher.group(1) + ":" + newTag;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DockerRegistryService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DockerRegistryService.java
@@ -11,22 +11,22 @@ import org.springframework.stereotype.Service;
 @Service
 public class DockerRegistryService {
 
-   @Value("${datajobs.proxy.repositoryUrl}")
-   private String proxyRepositoryURL;
+  @Value("${datajobs.proxy.repositoryUrl}")
+  private String proxyRepositoryURL;
 
-   @Value("${datajobs.builder.image}")
-   private String builderImage;
+  @Value("${datajobs.builder.image}")
+  private String builderImage;
 
-   public String dataJobImage(String dataJobName, String gitCommitSha) {
-      return String.format("%s/%s:%s", proxyRepositoryURL, dataJobName, gitCommitSha);
-   }
+  public String dataJobImage(String dataJobName, String gitCommitSha) {
+    return String.format("%s/%s:%s", proxyRepositoryURL, dataJobName, gitCommitSha);
+  }
 
-   public String builderImage() {
-      return builderImage;
-   }
+  public String builderImage() {
+    return builderImage;
+  }
 
-   // TODO: Implement
-   public boolean dataJobImageExists(String imageName) {
-      return false;
-   }
+  // TODO: Implement
+  public boolean dataJobImageExists(String imageName) {
+    return false;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobCommandProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobCommandProvider.java
@@ -13,46 +13,42 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * This class provides the command list for the K8S' data job
- * container. The command list executes the data job, by calling
- * vdk run ...
+ * This class provides the command list for the K8S' data job container. The command list executes
+ * the data job, by calling vdk run ...
  */
 @Component
 public class JobCommandProvider {
-    private List<String> command;
+  private List<String> command;
 
-    public JobCommandProvider() {
+  public JobCommandProvider() {
 
-        this.command = List.of(
-                "/bin/bash",
-                "-c",
-                "export PYTHONPATH=/usr/local/lib/python3.7/site-packages:/vdk/site-packages/ && /vdk/vdk run"
-        );
-    }
+    this.command =
+        List.of(
+            "/bin/bash",
+            "-c",
+            "export PYTHONPATH=/usr/local/lib/python3.7/site-packages:/vdk/site-packages/ &&"
+                + " /vdk/vdk run");
+  }
 
-    private String getJobNameArgument(String jobName) {
-        return String.format(" ./%s", jobName);
-    }
+  private String getJobNameArgument(String jobName) {
+    return String.format(" ./%s", jobName);
+  }
 
-    private String getExtraArguments(String arguments) {
-        return String.format(" --arguments '%s'", arguments);
-    }
+  private String getExtraArguments(String arguments) {
+    return String.format(" --arguments '%s'", arguments);
+  }
 
-    public List<String> getJobCommand(String jobName) {
+  public List<String> getJobCommand(String jobName) {
 
-        return List.of(
-                command.get(0),
-                command.get(1),
-                command.get(2) + getJobNameArgument(jobName)
-        );
-    }
+    return List.of(command.get(0), command.get(1), command.get(2) + getJobNameArgument(jobName));
+  }
 
-    public List<String> getJobCommand(String jobName, Map<String, Object> extraArguments) throws JsonProcessingException {
-        var arguments = new ObjectMapper().writeValueAsString(extraArguments);
-        return List.of(
-                command.get(0),
-                command.get(1),
-                command.get(2) + getJobNameArgument(jobName) + getExtraArguments(arguments)
-        );
-    }
+  public List<String> getJobCommand(String jobName, Map<String, Object> extraArguments)
+      throws JsonProcessingException {
+    var arguments = new ObjectMapper().writeValueAsString(extraArguments);
+    return List.of(
+        command.get(0),
+        command.get(1),
+        command.get(2) + getJobNameArgument(jobName) + getExtraArguments(arguments));
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
@@ -24,123 +24,137 @@ import java.util.Map;
 import static java.util.Map.entry;
 
 /**
- * Responsible for building docker images for data jobs. The images
- * are pushed to a docker repository and then deployed on kubernetes.
+ * Responsible for building docker images for data jobs. The images are pushed to a docker
+ * repository and then deployed on kubernetes.
  */
 @Component
 public class JobImageBuilder {
-   private static final Logger log = LoggerFactory.getLogger(JobImageBuilder.class);
+  private static final Logger log = LoggerFactory.getLogger(JobImageBuilder.class);
 
-   private static final int BUILDER_TIMEOUT_SECONDS = 1800;
-   private static final String REGISTRY_TYPE_ECR = "ecr";
-   private static final String REGISTRY_TYPE_GENERIC = "generic";
+  private static final int BUILDER_TIMEOUT_SECONDS = 1800;
+  private static final String REGISTRY_TYPE_ECR = "ecr";
+  private static final String REGISTRY_TYPE_GENERIC = "generic";
 
-   @Value("${datajobs.git.url}")
-   private String gitRepo;
-   @Value("${datajobs.git.username}")
-   private String gitUsername;
-   @Value("${datajobs.git.password}")
-   private String gitPassword;
-   @Value("${datajobs.aws.region:}")
-   private String awsRegion;
-   @Value("${datajobs.aws.accessKeyId:}")
-   private String awsAccessKeyId;
-   @Value("${datajobs.aws.secretAccessKey:}")
-   private String awsSecretAccessKey;
-   @Value("${datajobs.docker.repositoryUrl}")
-   private String dockerRepositoryUrl;
-   @Value("${datajobs.docker.registryType}")
-   private String registryType;
-   @Value("${datajobs.docker.registryUsername:}")
-   private String registryUsername;
-   @Value("${datajobs.docker.registryPassword:}")
-   private String registryPassword;
-   @Value("${datajobs.deployment.dataJobBaseImage:python:3.9-slim}")
-   private String deploymentDataJobBaseImage;
-   @Value("${datajobs.deployment.builder.extraArgs:}")
-   private String builderJobExtraArgs;
-   @Value("${datajobs.deployment.builder.imagePullPolicy:IfNotPresent}")
-   private String builderJobImagePullPolicy;
-   @Value("${datajobs.git.ssl.enabled}")
-   private boolean gitDataJobsSslEnabled;
+  @Value("${datajobs.git.url}")
+  private String gitRepo;
 
-   @Value("${datajobs.deployment.builder.securitycontext.runAsUser}")
-   private long  builderSecurityContextRunAsUser;
+  @Value("${datajobs.git.username}")
+  private String gitUsername;
 
-   @Value("${datajobs.deployment.builder.securitycontext.runAsGroup}")
-   private long  builderSecurityContextRunAsGroup;
+  @Value("${datajobs.git.password}")
+  private String gitPassword;
 
-   @Value("${datajobs.deployment.builder.securitycontext.fsGroup}")
-   private long  builderSecurityContextFsGroup;
+  @Value("${datajobs.aws.region:}")
+  private String awsRegion;
 
-   @Value("${datajobs.deployment.builder.serviceAccountName}")
-   private String  builderServiceAccountName;
+  @Value("${datajobs.aws.accessKeyId:}")
+  private String awsAccessKeyId;
 
-   private final ControlKubernetesService controlKubernetesService;
-   private final DockerRegistryService dockerRegistryService;
-   private final DeploymentNotificationHelper notificationHelper;
-   private final KubernetesResources kubernetesResources;
+  @Value("${datajobs.aws.secretAccessKey:}")
+  private String awsSecretAccessKey;
 
-   public JobImageBuilder(ControlKubernetesService controlKubernetesService,
-                          DockerRegistryService dockerRegistryService,
-                          DeploymentNotificationHelper notificationHelper,
-                          KubernetesResources kubernetesResources) {
+  @Value("${datajobs.docker.repositoryUrl}")
+  private String dockerRepositoryUrl;
 
-      this.controlKubernetesService = controlKubernetesService;
-      this.dockerRegistryService = dockerRegistryService;
-      this.notificationHelper = notificationHelper;
-      this.kubernetesResources = kubernetesResources;
-   }
+  @Value("${datajobs.docker.registryType}")
+  private String registryType;
 
-   /**
-    * Builds and pushes a docker image for a data job.
-    * Runs a  job on k8s which is responsible for building and pushing the data job image.
-    * This call will block until the builder job has finished.
-    * Notifies the users on failure.
-    *
-    * @param imageName Full name of the image to build.
-    * @param dataJob Information about the data job.
-    * @param jobDeployment Information about the data job deployment.
-    * @param sendNotification
-    * @return True if build and push was successful. False otherwise.
-    * @throws ApiException
-    * @throws IOException
-    * @throws InterruptedException
-    */
-   public boolean buildImage(String imageName, DataJob dataJob, JobDeployment jobDeployment, Boolean sendNotification)
-         throws ApiException, IOException, InterruptedException {
+  @Value("${datajobs.docker.registryUsername:}")
+  private String registryUsername;
 
-      log.info("Build data job image for job {}. Image name: {}", dataJob.getName(), imageName);
-      if (!StringUtils.isBlank(registryType)) {
-         if (unsupportedRegistryType(registryType)) {
-            log.debug(String.format("Unsupported registry type: %s available options %s/%s",
-                    registryType,
-                    REGISTRY_TYPE_ECR,
-                    REGISTRY_TYPE_GENERIC
-                    ));
-            return false;
-         }
+  @Value("${datajobs.docker.registryPassword:}")
+  private String registryPassword;
+
+  @Value("${datajobs.deployment.dataJobBaseImage:python:3.9-slim}")
+  private String deploymentDataJobBaseImage;
+
+  @Value("${datajobs.deployment.builder.extraArgs:}")
+  private String builderJobExtraArgs;
+
+  @Value("${datajobs.deployment.builder.imagePullPolicy:IfNotPresent}")
+  private String builderJobImagePullPolicy;
+
+  @Value("${datajobs.git.ssl.enabled}")
+  private boolean gitDataJobsSslEnabled;
+
+  @Value("${datajobs.deployment.builder.securitycontext.runAsUser}")
+  private long builderSecurityContextRunAsUser;
+
+  @Value("${datajobs.deployment.builder.securitycontext.runAsGroup}")
+  private long builderSecurityContextRunAsGroup;
+
+  @Value("${datajobs.deployment.builder.securitycontext.fsGroup}")
+  private long builderSecurityContextFsGroup;
+
+  @Value("${datajobs.deployment.builder.serviceAccountName}")
+  private String builderServiceAccountName;
+
+  private final ControlKubernetesService controlKubernetesService;
+  private final DockerRegistryService dockerRegistryService;
+  private final DeploymentNotificationHelper notificationHelper;
+  private final KubernetesResources kubernetesResources;
+
+  public JobImageBuilder(
+      ControlKubernetesService controlKubernetesService,
+      DockerRegistryService dockerRegistryService,
+      DeploymentNotificationHelper notificationHelper,
+      KubernetesResources kubernetesResources) {
+
+    this.controlKubernetesService = controlKubernetesService;
+    this.dockerRegistryService = dockerRegistryService;
+    this.notificationHelper = notificationHelper;
+    this.kubernetesResources = kubernetesResources;
+  }
+
+  /**
+   * Builds and pushes a docker image for a data job. Runs a job on k8s which is responsible for
+   * building and pushing the data job image. This call will block until the builder job has
+   * finished. Notifies the users on failure.
+   *
+   * @param imageName Full name of the image to build.
+   * @param dataJob Information about the data job.
+   * @param jobDeployment Information about the data job deployment.
+   * @param sendNotification
+   * @return True if build and push was successful. False otherwise.
+   * @throws ApiException
+   * @throws IOException
+   * @throws InterruptedException
+   */
+  public boolean buildImage(
+      String imageName, DataJob dataJob, JobDeployment jobDeployment, Boolean sendNotification)
+      throws ApiException, IOException, InterruptedException {
+
+    log.info("Build data job image for job {}. Image name: {}", dataJob.getName(), imageName);
+    if (!StringUtils.isBlank(registryType)) {
+      if (unsupportedRegistryType(registryType)) {
+        log.debug(
+            String.format(
+                "Unsupported registry type: %s available options %s/%s",
+                registryType, REGISTRY_TYPE_ECR, REGISTRY_TYPE_GENERIC));
+        return false;
       }
+    }
 
-      if (dockerRegistryService.dataJobImageExists(imageName)) {
-         log.debug("Data Job image {} already exists and nothing else to do.", imageName);
-         return true;
+    if (dockerRegistryService.dataJobImageExists(imageName)) {
+      log.debug("Data Job image {} already exists and nothing else to do.", imageName);
+      return true;
+    }
+
+    String builderJobName = getBuilderJobName(jobDeployment.getDataJobName());
+
+    log.debug("Check if old builder job {} exists", builderJobName);
+    if (controlKubernetesService.listJobs().contains(builderJobName)) {
+      log.debug("Delete old builder job {}", builderJobName);
+      controlKubernetesService.deleteJob(builderJobName);
+
+      // Wait for the old job to be deleted to avoid conflicts
+      while (controlKubernetesService.listJobs().contains(builderJobName)) {
+        Thread.sleep(1000);
       }
+    }
 
-      String builderJobName = getBuilderJobName(jobDeployment.getDataJobName());
-
-      log.debug("Check if old builder job {} exists", builderJobName);
-      if (controlKubernetesService.listJobs().contains(builderJobName)) {
-         log.debug("Delete old builder job {}", builderJobName);
-         controlKubernetesService.deleteJob(builderJobName);
-
-         // Wait for the old job to be deleted to avoid conflicts
-         while (controlKubernetesService.listJobs().contains(builderJobName)) {
-            Thread.sleep(1000);
-         }
-      }
-
-      var args = Arrays.asList(
+    var args =
+        Arrays.asList(
             awsAccessKeyId,
             awsSecretAccessKey,
             awsRegion,
@@ -150,115 +164,126 @@ public class JobImageBuilder {
             gitRepo,
             registryType,
             registryUsername,
-            registryPassword
-      );
+            registryPassword);
 
-      var envs = getBuildParameters(dataJob, jobDeployment);
+    var envs = getBuildParameters(dataJob, jobDeployment);
 
-      log.info("Creating builder job {} for data job version {}", builderJobName, jobDeployment.getGitCommitSha());
-      controlKubernetesService.createJob(
-            builderJobName,
-            dockerRegistryService.builderImage(),
-            false,
-            envs,
-            args,
-            null,
-            null,
-            builderJobImagePullPolicy,
-            kubernetesResources.builderRequests(),
-            kubernetesResources.builderLimits(),
-            builderSecurityContextRunAsUser,
-            builderSecurityContextRunAsGroup,
-            builderSecurityContextFsGroup,
-            builderServiceAccountName);
+    log.info(
+        "Creating builder job {} for data job version {}",
+        builderJobName,
+        jobDeployment.getGitCommitSha());
+    controlKubernetesService.createJob(
+        builderJobName,
+        dockerRegistryService.builderImage(),
+        false,
+        envs,
+        args,
+        null,
+        null,
+        builderJobImagePullPolicy,
+        kubernetesResources.builderRequests(),
+        kubernetesResources.builderLimits(),
+        builderSecurityContextRunAsUser,
+        builderSecurityContextRunAsGroup,
+        builderSecurityContextFsGroup,
+        builderServiceAccountName);
 
-      log.debug("Waiting for builder job {} for data job version {}", builderJobName, jobDeployment.getGitCommitSha());
+    log.debug(
+        "Waiting for builder job {} for data job version {}",
+        builderJobName,
+        jobDeployment.getGitCommitSha());
 
-      var condition = controlKubernetesService.watchJob(builderJobName, BUILDER_TIMEOUT_SECONDS, s -> log.debug("Wait status: {}", s));
+    var condition =
+        controlKubernetesService.watchJob(
+            builderJobName, BUILDER_TIMEOUT_SECONDS, s -> log.debug("Wait status: {}", s));
 
-      log.debug("Finished watching builder job {}. Condition is: {}", builderJobName, condition);
-      String logs = null;
+    log.debug("Finished watching builder job {}. Condition is: {}", builderJobName, condition);
+    String logs = null;
+    try {
+      log.info("Get logs of builder job {}", builderJobName);
+      logs = controlKubernetesService.getPodLogs(builderJobName);
+    } catch (Exception e) {
+      // wrap in Kubernetes exception in case it's ApiException - in order to log more details.
+      String message =
+          new KubernetesException("Could not get pod " + builderJobName + " logs", e).getMessage();
+      log.warn("Could not find logs from builder job {}; reason: {}", builderJobName, message);
+    }
+    if (!condition.isSuccess()) {
+      notificationHelper.verifyBuilderResult(
+          builderJobName, dataJob, jobDeployment, condition, logs, sendNotification);
+    } else {
+      log.info("Builder job {} finished successfully. Will delete it now", builderJobName);
       try {
-         log.info("Get logs of builder job {}", builderJobName);
-         logs = controlKubernetesService.getPodLogs(builderJobName);
+        controlKubernetesService.deleteJob(builderJobName);
       } catch (Exception e) {
-         // wrap in Kubernetes exception in case it's ApiException - in order to log more details.
-         String message = new KubernetesException("Could not get pod " + builderJobName + " logs", e).getMessage();
-         log.warn("Could not find logs from builder job {}; reason: {}", builderJobName, message);
+        log.warn("Failed to delete builder job {}; reason: {}", builderJobName, e.getMessage());
       }
-      if (!condition.isSuccess()) {
-         notificationHelper.verifyBuilderResult(builderJobName, dataJob, jobDeployment, condition, logs, sendNotification);
+    }
+    // we are using Kubernetes TTL Controller with ttlSecondsAfterFinished to clean up jobs in case
+    // of failure
+    return condition.isSuccess();
+  }
+
+  /**
+   * If building new deployment of a data job has started (by buildImage), it is canceled/stopped.
+   *
+   * @param dataJobName the name of the data job
+   */
+  public void cancelBuildingJob(String dataJobName) {
+    log.info("Cancel builder job for data job {}", dataJobName);
+    deleteBuilderJob(dataJobName);
+  }
+
+  /**
+   * See if the data job is currently in progress of being built.
+   *
+   * @param dataJobName the name of the data job
+   * @return true if there's builder running for the given data job
+   */
+  public boolean isBuildingJobInProgress(String dataJobName) {
+    try {
+      return controlKubernetesService.listJobs().contains(getBuilderJobName(dataJobName));
+    } catch (ApiException e) {
+      throw new KubernetesException("Cannot determine if deployment is in progress", e);
+    }
+  }
+
+  private Map<String, String> getBuildParameters(DataJob dataJob, JobDeployment jobDeployment) {
+    String jobName = dataJob.getName();
+    String jobVersion = jobDeployment.getGitCommitSha();
+
+    return Map.ofEntries(
+        entry("JOB_NAME", jobName),
+        entry("DATA_JOB_NAME", jobName),
+        entry("GIT_COMMIT", jobVersion),
+        entry("JOB_GITHASH", jobVersion),
+        entry("IMAGE_REGISTRY_PATH", dockerRepositoryUrl),
+        entry("BASE_IMAGE", deploymentDataJobBaseImage),
+        entry("EXTRA_ARGUMENTS", builderJobExtraArgs),
+        entry("GIT_SSL_ENABLED", Boolean.toString(gitDataJobsSslEnabled)));
+  }
+
+  private boolean unsupportedRegistryType(String registry) {
+    return !registry.equalsIgnoreCase(REGISTRY_TYPE_GENERIC)
+        && !registry.equalsIgnoreCase(REGISTRY_TYPE_ECR);
+  }
+
+  private static String getBuilderJobName(String dataJobName) {
+    return String.format("builder-%s", dataJobName);
+  }
+
+  private void deleteBuilderJob(String dataJobName) {
+    String builderJobName = getBuilderJobName(dataJobName);
+    try {
+      if (controlKubernetesService.listJobs().contains(builderJobName)) {
+        controlKubernetesService.deleteJob(builderJobName);
+      }
+    } catch (ApiException e) {
+      if (e.getCode() == 404) {
+        log.info("Builder job for {} has been already deleted.", dataJobName);
       } else {
-         log.info("Builder job {} finished successfully. Will delete it now", builderJobName);
-         try {
-            controlKubernetesService.deleteJob(builderJobName);
-         } catch (Exception e) {
-            log.warn("Failed to delete builder job {}; reason: {}", builderJobName, e.getMessage());
-         }
+        throw new ExternalSystemError(ExternalSystemError.MainExternalSystem.KUBERNETES, e);
       }
-      // we are using Kubernetes TTL Controller with ttlSecondsAfterFinished to clean up jobs in case of failure
-      return condition.isSuccess();
-   }
-
-
-   /**
-    * If building new deployment of a data job has started (by buildImage), it is canceled/stopped.
-    * @param dataJobName the name of the data job
-    */
-   public void cancelBuildingJob(String dataJobName) {
-      log.info("Cancel builder job for data job {}", dataJobName);
-      deleteBuilderJob(dataJobName);
-   }
-
-   /**
-    * See if the data job is currently in progress of being built.
-    * @param dataJobName the name of the data job
-    * @return true if there's builder running for the given data job
-    */
-   public boolean isBuildingJobInProgress(String dataJobName) {
-      try {
-         return controlKubernetesService.listJobs().contains(getBuilderJobName(dataJobName));
-      } catch (ApiException e) {
-         throw new KubernetesException("Cannot determine if deployment is in progress", e);
-      }
-   }
-
-   private Map<String, String> getBuildParameters(DataJob dataJob, JobDeployment jobDeployment) {
-      String jobName = dataJob.getName();
-      String jobVersion = jobDeployment.getGitCommitSha();
-
-      return Map.ofEntries(
-            entry("JOB_NAME", jobName),
-            entry("DATA_JOB_NAME", jobName),
-            entry("GIT_COMMIT", jobVersion),
-            entry("JOB_GITHASH", jobVersion),
-            entry("IMAGE_REGISTRY_PATH", dockerRepositoryUrl),
-            entry("BASE_IMAGE", deploymentDataJobBaseImage),
-            entry("EXTRA_ARGUMENTS", builderJobExtraArgs),
-            entry("GIT_SSL_ENABLED", Boolean.toString(gitDataJobsSslEnabled))
-      );
-   }
-
-   private boolean unsupportedRegistryType(String registry){
-      return !registry.equalsIgnoreCase(REGISTRY_TYPE_GENERIC) && !registry.equalsIgnoreCase(REGISTRY_TYPE_ECR);
-   }
-
-   private static String getBuilderJobName(String dataJobName) {
-      return String.format("builder-%s", dataJobName);
-   }
-
-   private void deleteBuilderJob(String dataJobName) {
-      String builderJobName = getBuilderJobName(dataJobName);
-      try {
-         if (controlKubernetesService.listJobs().contains(builderJobName)){
-            controlKubernetesService.deleteJob(builderJobName);
-         }
-      } catch (ApiException e) {
-         if (e.getCode() == 404) {
-            log.info("Builder job for {} has been already deleted.", dataJobName);
-         } else {
-            throw new ExternalSystemError(ExternalSystemError.MainExternalSystem.KUBERNETES, e);
-         }
-      }
-   }
+    }
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
@@ -25,280 +25,353 @@ import java.time.OffsetDateTime;
 import java.util.*;
 
 /**
- * Takes care of deploying a Data Job in Kubernetes and scheduling it to run.
- * Currently this is deployed as CronJob. For more details see #updateCronJob doc.
+ * Takes care of deploying a Data Job in Kubernetes and scheduling it to run. Currently this is
+ * deployed as CronJob. For more details see #updateCronJob doc.
  */
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class JobImageDeployer {
 
-   // TODO: Out of the image we pick only the python vdk module
-   // It may make sense to just pass the module name as argument instead of an image ???
-   @Value("${datajobs.vdk.image}")
-   private String vdkImage;
+  // TODO: Out of the image we pick only the python vdk module
+  // It may make sense to just pass the module name as argument instead of an image ???
+  @Value("${datajobs.vdk.image}")
+  private String vdkImage;
 
-   @Value("${datajobs.docker.registrySecret:}")
-   private String dockerRegistrySecret = "";
+  @Value("${datajobs.docker.registrySecret:}")
+  private String dockerRegistrySecret = "";
 
-   @Value("${datajobs.vdk.docker.registrySecret:}")
-   private String vdkSdkDockerRegistrySecret = "";
+  @Value("${datajobs.vdk.docker.registrySecret:}")
+  private String vdkSdkDockerRegistrySecret = "";
 
-   private static final String VOLUME_NAME = "vdk";
-   private static final String VOLUME_MOUNT_PATH = "/vdk";
-   private static final String KEYTAB_PRINCIPAL_ENV = "VDK_KEYTAB_PRINCIPAL";
-   private static final String KEYTAB_FOLDER_ENV = "VDK_KEYTAB_FOLDER";
-   private static final String KEYTAB_FILENAME_ENV = "VDK_KEYTAB_FILENAME";
-   private static final String ATTEMPT_ID = "VDK_ATTEMPT_ID";
+  private static final String VOLUME_NAME = "vdk";
+  private static final String VOLUME_MOUNT_PATH = "/vdk";
+  private static final String KEYTAB_PRINCIPAL_ENV = "VDK_KEYTAB_PRINCIPAL";
+  private static final String KEYTAB_FOLDER_ENV = "VDK_KEYTAB_FOLDER";
+  private static final String KEYTAB_FILENAME_ENV = "VDK_KEYTAB_FILENAME";
+  private static final String ATTEMPT_ID = "VDK_ATTEMPT_ID";
 
-   private final JobCredentialsService jobCredentialsService;
-   private final DataJobsKubernetesService dataJobsKubernetesService;
-   private final VdkOptionsReader vdkOptionsReader;
-   private final DataJobDefaultConfigurations defaultConfigurations;
-   private final DeploymentProgress deploymentProgress;
-   private final KubernetesResources kubernetesResources;
-   private final JobCommandProvider jobCommandProvider;
+  private final JobCredentialsService jobCredentialsService;
+  private final DataJobsKubernetesService dataJobsKubernetesService;
+  private final VdkOptionsReader vdkOptionsReader;
+  private final DataJobDefaultConfigurations defaultConfigurations;
+  private final DeploymentProgress deploymentProgress;
+  private final KubernetesResources kubernetesResources;
+  private final JobCommandProvider jobCommandProvider;
 
-   public Optional<JobDeploymentStatus> readScheduledJob(String dataJobName) {
-      Optional<JobDeploymentStatus> jobDeployment = dataJobsKubernetesService.readCronJob(getCronJobName(dataJobName));
-      if(jobDeployment.isPresent()) {
-         jobDeployment.get().setDataJobName(dataJobName);
+  public Optional<JobDeploymentStatus> readScheduledJob(String dataJobName) {
+    Optional<JobDeploymentStatus> jobDeployment =
+        dataJobsKubernetesService.readCronJob(getCronJobName(dataJobName));
+    if (jobDeployment.isPresent()) {
+      jobDeployment.get().setDataJobName(dataJobName);
+    }
+    return jobDeployment;
+  }
+
+  public List<JobDeploymentStatus> readScheduledJobs() {
+    return dataJobsKubernetesService.readJobDeploymentStatuses();
+  }
+
+  /**
+   * Schedules for execution a data job at kubernetes cluster.
+   *
+   * @param dataJob the data job being deployed
+   * @param jobDeployment the deployment information necessary to exeucte the deployment
+   * @param sendNotification to sent or not notification (not it is sent only in case of failure,
+   *     caller is responsible for sending on success or in case of an exception)
+   * @param lastDeployedBy the name of the user that last deployed the data job
+   * @return true if it is successful and false if not.
+   */
+  public boolean scheduleJob(
+      DataJob dataJob,
+      JobDeployment jobDeployment,
+      Boolean sendNotification,
+      String lastDeployedBy) {
+    Validate.notNull(jobDeployment, "jobDeployment should not be null");
+    Validate.notNull(jobDeployment.getImageName(), "Image name is expected in jobDeployment");
+    try {
+      return updateCronJobWithNotification(
+          dataJob, jobDeployment, sendNotification, lastDeployedBy);
+    } catch (ApiException e) {
+      throw new KubernetesException("Failed to schedule job", e);
+    }
+  }
+
+  private boolean updateCronJobWithNotification(
+      DataJob dataJob, JobDeployment jobDeployment, Boolean sendNotification, String lastDeployedBy)
+      throws ApiException {
+    try {
+      log.info("Update cron job for data job {}", dataJob.getName());
+      updateCronJob(dataJob, jobDeployment, lastDeployedBy);
+    } catch (ApiException apiException) {
+      if (apiException.getCode() == 422) {
+        try {
+          Gson gson = new Gson();
+          Map<Object, Object> error = gson.fromJson(apiException.getResponseBody(), HashMap.class);
+          log.error(
+              "Failed to schedule job due to Kubernetes client error (422). Generally input"
+                  + " validation should be done earlier. If this exception happens, most likely we"
+                  + " need to do some better input validation at client library. We are assuming"
+                  + " all k8s client error when creating cron job can be only customer"
+                  + " misconfiguration sending notification and reporting as user error",
+              apiException);
+          String msg =
+              NotificationContent.getErrorBody(
+                  "Tried to deploy a data job",
+                  "There has been an error in the configuration of your data job : "
+                      + error.get("message"),
+                  "Your new/updated job was not deployed. Your job will run its latest successfully"
+                      + " deployed version (if any) as scheduled.",
+                  "Please fix the job's configuration");
+          log.error(msg);
+          deploymentProgress.failed(
+              dataJob.getJobConfig(),
+              jobDeployment,
+              DeploymentStatus.USER_ERROR,
+              msg,
+              sendNotification);
+          return false;
+        } catch (Exception ignored) {
+          log.debug("Failed to parse ApiException body, re-throwing it.: ", ignored);
+        }
       }
-      return jobDeployment;
-   }
+      throw apiException;
+    }
+    return true;
+  }
 
-   public List<JobDeploymentStatus> readScheduledJobs() {
-      return dataJobsKubernetesService.readJobDeploymentStatuses();
-   }
-
-   /**
-    * Schedules for execution a data job at kubernetes cluster.
-    * @param dataJob the data job being deployed
-    * @param jobDeployment the deployment information necessary to exeucte the deployment
-    * @param sendNotification to sent or not notification (not it is sent only in case of failure, caller is responsible for sending on success or in case of an exception)
-    * @param lastDeployedBy the name of the user that last deployed the data job
-    * @return true if it is successful and false if not.
-    */
-   public boolean scheduleJob(DataJob dataJob, JobDeployment jobDeployment,
-                              Boolean sendNotification, String lastDeployedBy) {
-      Validate.notNull(jobDeployment, "jobDeployment should not be null");
-      Validate.notNull(jobDeployment.getImageName(), "Image name is expected in jobDeployment");
-      try {
-         return updateCronJobWithNotification(dataJob, jobDeployment, sendNotification, lastDeployedBy);
-      } catch (ApiException e) {
-         throw new KubernetesException("Failed to schedule job", e);
-      }
-   }
-
-   private boolean updateCronJobWithNotification(DataJob dataJob, JobDeployment jobDeployment,
-                                                 Boolean sendNotification, String lastDeployedBy) throws ApiException {
-      try {
-         log.info("Update cron job for data job {}", dataJob.getName());
-         updateCronJob(dataJob, jobDeployment, lastDeployedBy);
-      } catch (ApiException apiException) {
-         if (apiException.getCode() == 422) {
-            try {
-               Gson gson = new Gson();
-               Map<Object, Object> error = gson.fromJson(apiException.getResponseBody(), HashMap.class);
-               log.error("Failed to schedule job due to Kubernetes client error (422)." +
-                       " Generally input validation should be done earlier. If this exception happens, " +
-                       "most likely we need to do some better input validation at client library. " +
-                       "We are assuming all k8s client error when creating cron job can be only customer misconfiguration " +
-                       "sending notification and reporting as user error", apiException);
-               String msg = NotificationContent.getErrorBody(
-                       "Tried to deploy a data job",
-                       "There has been an error in the configuration of your data job : " + error.get("message"),
-                       "Your new/updated job was not deployed. Your job will run its latest successfully deployed version (if any) as scheduled.",
-                       "Please fix the job's configuration");
-               log.error(msg);
-               deploymentProgress.failed(dataJob.getJobConfig(), jobDeployment, DeploymentStatus.USER_ERROR,
-                       msg, sendNotification);
-               return false;
-            } catch (Exception ignored) {
-               log.debug("Failed to parse ApiException body, re-throwing it.: ", ignored);
-            }
-         }
-         throw apiException;
-      }
-      return true;
-   }
-
-   /**
-    * Remove a Data Job from Kubernetes cluster.
-    * @param dataJobName the job name
-    */
-   public void unScheduleJob(@NonNull String dataJobName) {
-      String cronJobName = getCronJobName(dataJobName);
-      try {
-         if (dataJobsKubernetesService.listCronJobs().contains(cronJobName)) {
-            dataJobsKubernetesService.deleteCronJob(cronJobName);
-         }
-      } catch (ApiException e) {
-         // TODO: technically if code is 4xx, k8s errors are more of Bug exception ...
-         throw new KubernetesException("Failed to un-schedule job", e);
-      }
-   }
-
-
-      private Map<String, String> getSystemDefaults() {
-         Map<String, String> systemDefaults = new LinkedHashMap<>();
-
-         systemDefaults.put("LOG_CONFIG", "CLOUD");
-         systemDefaults.put("MONITORING_ENABLED", String.valueOf(true));
-         return systemDefaults;
-      }
-
-   /**
-    * Creates data job as CronJob against the Kubernetes API:
-    * <p>
-    * The implementation includes vdk as initContainer. The main container stores the job with
-    * its dependencies and shared emptyDir volume between the two containers.
-    * <p>
-    * Requires image with pip installed vdk so it can be found in the site-packages directory
-    * of the vdk container. This is in order for the initContainer (vdk) primitive to copy it
-    * from there into the shared folder to be used by the container which runs the job.
-    *
-    * @param dataJob
-    *       The data job
-    * @param jobDeployment
-    *       Deployment configuration
-    */
-   private void updateCronJob(DataJob dataJob,
-                              JobDeployment jobDeployment,
-                              String lastDeployedBy) throws ApiException {
-      log.debug("Deploy cron job for data job {}", dataJob);
-
-      // Schedule defaults to Feb 30 (i.e. never) if no schedule has been given.
-      String schedule = StringUtils.isEmpty(dataJob.getJobConfig().getSchedule()) ? "0 0 30 2 *" : dataJob.getJobConfig().getSchedule();
-
-      var jobName = dataJob.getName();
-      var volume = KubernetesService.volume(VOLUME_NAME);
-      var volumeMount = KubernetesService.volumeMount(VOLUME_NAME, VOLUME_MOUNT_PATH, false);
-
-      var principalName = jobCredentialsService.getJobPrincipalName(jobName);
-      var vdkEnvs = vdkOptionsReader.readVdkOptions(jobName);
-
-      var jobContainerEnvVars = new HashMap<String, String>();
-
-      String keytabFolder = "/credentials";
-      String jobKeytabKubernetesSecretName = JobCredentialsService.getJobKeytabKubernetesSecretName(jobName);
-      var secretVolume = KubernetesService.volume(jobKeytabKubernetesSecretName, jobKeytabKubernetesSecretName);
-      var secretVolumeMount = KubernetesService.volumeMount(jobKeytabKubernetesSecretName, keytabFolder, true);
-
-      jobContainerEnvVars.put(KEYTAB_PRINCIPAL_ENV, principalName);
-      jobContainerEnvVars.put(KEYTAB_FOLDER_ENV, keytabFolder);
-      jobContainerEnvVars.put(KEYTAB_FILENAME_ENV, JobCredentialsService.K8S_KEYTAB_KEY_IN_SECRET);
-      jobContainerEnvVars.put(ATTEMPT_ID, "$metadata.name");
-      jobContainerEnvVars.putAll(getSystemDefaults());
-      jobContainerEnvVars.putAll(vdkEnvs);
-      jobContainerEnvVars.putAll(jobConfigBasedEnvVars(dataJob.getJobConfig()));
-
-      var jobCommand = jobCommandProvider.getJobCommand(jobName);
-
-      // The job name is used as the container name. This is something that we rely on later,
-      // when watching for pod modifications in DataJobStatusMonitor.watchPods
-      var jobContainer = KubernetesService.container(jobName, jobDeployment.getImageName(), false,
-              jobContainerEnvVars, List.of(),
-              List.of(volumeMount, secretVolumeMount), "Always", defaultConfigurations.dataJobRequests(),
-              defaultConfigurations.dataJobLimits(), null, jobCommand);
-      var vdkCommand = List.of(
-              "/bin/bash",
-              "-c",
-              "cp -r /usr/local/lib/python3.7/site-packages /vdk/. && cp /usr/local/bin/vdk /vdk/.");
-      var jobVdkImage = getJobVdkImage(jobDeployment);
-      var jobInitContainer = KubernetesService.container("vdk", jobVdkImage, false, Map.of(), List.of(),
-              List.of(volumeMount, secretVolumeMount), "Always", kubernetesResources.dataJobInitContainerRequests(),
-              kubernetesResources.dataJobInitContainerLimits(), null, vdkCommand);
-      // TODO: changing imagePullPolicy to IfNotPresent might be necessary optimization when running thousands of jobs.
-      // At the moment Always is chosen because it's possible to have a change in image that is not detected.
-
-      Map<String, String> jobDeploymentAnnotations = new HashMap<>();
-      var jobLabels = getJobLabels(dataJob, jobDeployment);
-      var jobAnnotations = getJobAnnotations(dataJob, lastDeployedBy);
-
-      String cronJobName = getCronJobName(jobName);
-      boolean enabled = jobDeployment.getEnabled() == null || jobDeployment.getEnabled();
+  /**
+   * Remove a Data Job from Kubernetes cluster.
+   *
+   * @param dataJobName the job name
+   */
+  public void unScheduleJob(@NonNull String dataJobName) {
+    String cronJobName = getCronJobName(dataJobName);
+    try {
       if (dataJobsKubernetesService.listCronJobs().contains(cronJobName)) {
-         dataJobsKubernetesService.updateCronJob(cronJobName, jobDeployment.getImageName(), jobContainerEnvVars, schedule,
-                 enabled, List.of(), defaultConfigurations.dataJobRequests(),
-                 defaultConfigurations.dataJobLimits(), jobContainer,
-                 jobInitContainer, Arrays.asList(volume, secretVolume), jobDeploymentAnnotations, Collections.emptyMap(),
-                 jobAnnotations, jobLabels, List.of(dockerRegistrySecret, vdkSdkDockerRegistrySecret));
-      } else {
-         dataJobsKubernetesService.createCronJob(cronJobName, jobDeployment.getImageName(), jobContainerEnvVars, schedule,
-                 enabled, List.of(), defaultConfigurations.dataJobRequests(),
-                 defaultConfigurations.dataJobLimits(), jobContainer,
-                 jobInitContainer, Arrays.asList(volume, secretVolume), jobDeploymentAnnotations, Collections.emptyMap(),
-                 jobAnnotations, jobLabels, List.of(dockerRegistrySecret, vdkSdkDockerRegistrySecret));
+        dataJobsKubernetesService.deleteCronJob(cronJobName);
       }
-   }
+    } catch (ApiException e) {
+      // TODO: technically if code is 4xx, k8s errors are more of Bug exception ...
+      throw new KubernetesException("Failed to un-schedule job", e);
+    }
+  }
 
-   private String getJobVdkImage(JobDeployment jobDeployment) {
-      if (StringUtils.isNotBlank(jobDeployment.getVdkVersion())) {
-         return DockerImageName.updateImageWithTag(vdkImage, jobDeployment.getVdkVersion());
-      } else {
-         return vdkImage;
-      }
-   }
+  private Map<String, String> getSystemDefaults() {
+    Map<String, String> systemDefaults = new LinkedHashMap<>();
 
-   /**
-    * Returns the environment variables set to vdk that are based on job configuration.
-    * Those are automatically injected during cloud runs
-    */
-   private static HashMap<String, String> jobConfigBasedEnvVars(JobConfig config) {
-      HashMap<String, String> envVars = new LinkedHashMap<>();
-      if (StringUtils.isNotBlank(config.getDbDefaultType())) {
-         envVars.put("VDK_DB_DEFAULT_TYPE", config.getDbDefaultType());
-      }
-      if (StringUtils.isNotBlank(config.getTeam())) {
-         envVars.put("VDK_JOB_TEAM", config.getTeam());
-      }
-      if (config.getEnableExecutionNotifications() != null) {
-         envVars.put("VDK_ENABLE_EXECUTION_NOTIFICATIONS", config.getEnableExecutionNotifications().toString());
-      }
-      if (config.getNotifiedOnJobSuccess() != null) {
-         envVars.put("VDK_NOTIFIED_ON_JOB_SUCCESS",
-                 String.join(",", config.getNotifiedOnJobSuccess()));
-      }
-      if (config.getNotifiedOnJobFailurePlatformError() != null) {
-         envVars.put("VDK_NOTIFIED_ON_JOB_FAILURE_PLATFORM_ERROR",
-                 String.join(",", config.getNotifiedOnJobFailurePlatformError()));
-      }
-      if (config.getNotifiedOnJobFailureUserError() != null) {
-         envVars.put("VDK_NOTIFIED_ON_JOB_FAILURE_USER_ERROR",
-                 String.join(",", config.getNotifiedOnJobFailureUserError()));
-      }
-      if (config.getNotifiedOnJobDeploy() != null) {
-         envVars.put("VDK_NOTIFIED_ON_JOB_DEPLOY",
-                 String.join(",", config.getNotifiedOnJobDeploy()));
-      }
-      return envVars;
-   }
+    systemDefaults.put("LOG_CONFIG", "CLOUD");
+    systemDefaults.put("MONITORING_ENABLED", String.valueOf(true));
+    return systemDefaults;
+  }
 
-   private Map<String, String> getJobLabels(DataJob dataJob, JobDeployment jobDeployment){
-      Map<String, String> jobPodLabels = new HashMap<>();
-      // This label provides means during watching to select only Kubernetes jobs which represent data jobs.
-      // See DataJobStatusMonitor.watchJobs for how the label is used
-      jobPodLabels.put(JobLabel.TYPE.getValue(), "DataJob");
-      jobPodLabels.put(JobLabel.NAME.getValue(), dataJob.getName());
-      jobPodLabels.put(JobLabel.VERSION.getValue(), jobDeployment.getGitCommitSha());
+  /**
+   * Creates data job as CronJob against the Kubernetes API:
+   *
+   * <p>The implementation includes vdk as initContainer. The main container stores the job with its
+   * dependencies and shared emptyDir volume between the two containers.
+   *
+   * <p>Requires image with pip installed vdk so it can be found in the site-packages directory of
+   * the vdk container. This is in order for the initContainer (vdk) primitive to copy it from there
+   * into the shared folder to be used by the container which runs the job.
+   *
+   * @param dataJob The data job
+   * @param jobDeployment Deployment configuration
+   */
+  private void updateCronJob(DataJob dataJob, JobDeployment jobDeployment, String lastDeployedBy)
+      throws ApiException {
+    log.debug("Deploy cron job for data job {}", dataJob);
 
-      return jobPodLabels;
-   }
+    // Schedule defaults to Feb 30 (i.e. never) if no schedule has been given.
+    String schedule =
+        StringUtils.isEmpty(dataJob.getJobConfig().getSchedule())
+            ? "0 0 30 2 *"
+            : dataJob.getJobConfig().getSchedule();
 
-   private Map<String, String> getJobAnnotations(DataJob dataJob, String deployedBy){
-      Map<String, String> jobPodAnnotations = new HashMap<>();
-      jobPodAnnotations.put(JobAnnotation.SCHEDULE.getValue(), dataJob.getJobConfig().getSchedule());
-      jobPodAnnotations.put(JobAnnotation.EXECUTION_TYPE.getValue(), "scheduled");
-      jobPodAnnotations.put(JobAnnotation.DEPLOYED_BY.getValue(), deployedBy);
-      jobPodAnnotations.put(JobAnnotation.DEPLOYED_DATE.getValue(), OffsetDateTime.now().toString());
-      jobPodAnnotations.put(JobAnnotation.STARTED_BY.getValue(), "scheduled/runtime"); //TODO are those valid?
-      jobPodAnnotations.put(JobAnnotation.UNSCHEDULED.getValue(), (StringUtils.isEmpty(dataJob.getJobConfig().getSchedule()) ? "true" : "false"));
-      return jobPodAnnotations;
-   }
+    var jobName = dataJob.getName();
+    var volume = KubernetesService.volume(VOLUME_NAME);
+    var volumeMount = KubernetesService.volumeMount(VOLUME_NAME, VOLUME_MOUNT_PATH, false);
 
-   // Public for integration testing purposes
-   public static String getCronJobName(String jobName) {
-      return jobName;
-   }
+    var principalName = jobCredentialsService.getJobPrincipalName(jobName);
+    var vdkEnvs = vdkOptionsReader.readVdkOptions(jobName);
+
+    var jobContainerEnvVars = new HashMap<String, String>();
+
+    String keytabFolder = "/credentials";
+    String jobKeytabKubernetesSecretName =
+        JobCredentialsService.getJobKeytabKubernetesSecretName(jobName);
+    var secretVolume =
+        KubernetesService.volume(jobKeytabKubernetesSecretName, jobKeytabKubernetesSecretName);
+    var secretVolumeMount =
+        KubernetesService.volumeMount(jobKeytabKubernetesSecretName, keytabFolder, true);
+
+    jobContainerEnvVars.put(KEYTAB_PRINCIPAL_ENV, principalName);
+    jobContainerEnvVars.put(KEYTAB_FOLDER_ENV, keytabFolder);
+    jobContainerEnvVars.put(KEYTAB_FILENAME_ENV, JobCredentialsService.K8S_KEYTAB_KEY_IN_SECRET);
+    jobContainerEnvVars.put(ATTEMPT_ID, "$metadata.name");
+    jobContainerEnvVars.putAll(getSystemDefaults());
+    jobContainerEnvVars.putAll(vdkEnvs);
+    jobContainerEnvVars.putAll(jobConfigBasedEnvVars(dataJob.getJobConfig()));
+
+    var jobCommand = jobCommandProvider.getJobCommand(jobName);
+
+    // The job name is used as the container name. This is something that we rely on later,
+    // when watching for pod modifications in DataJobStatusMonitor.watchPods
+    var jobContainer =
+        KubernetesService.container(
+            jobName,
+            jobDeployment.getImageName(),
+            false,
+            jobContainerEnvVars,
+            List.of(),
+            List.of(volumeMount, secretVolumeMount),
+            "Always",
+            defaultConfigurations.dataJobRequests(),
+            defaultConfigurations.dataJobLimits(),
+            null,
+            jobCommand);
+    var vdkCommand =
+        List.of(
+            "/bin/bash",
+            "-c",
+            "cp -r /usr/local/lib/python3.7/site-packages /vdk/. && cp /usr/local/bin/vdk /vdk/.");
+    var jobVdkImage = getJobVdkImage(jobDeployment);
+    var jobInitContainer =
+        KubernetesService.container(
+            "vdk",
+            jobVdkImage,
+            false,
+            Map.of(),
+            List.of(),
+            List.of(volumeMount, secretVolumeMount),
+            "Always",
+            kubernetesResources.dataJobInitContainerRequests(),
+            kubernetesResources.dataJobInitContainerLimits(),
+            null,
+            vdkCommand);
+    // TODO: changing imagePullPolicy to IfNotPresent might be necessary optimization when running
+    // thousands of jobs.
+    // At the moment Always is chosen because it's possible to have a change in image that is not
+    // detected.
+
+    Map<String, String> jobDeploymentAnnotations = new HashMap<>();
+    var jobLabels = getJobLabels(dataJob, jobDeployment);
+    var jobAnnotations = getJobAnnotations(dataJob, lastDeployedBy);
+
+    String cronJobName = getCronJobName(jobName);
+    boolean enabled = jobDeployment.getEnabled() == null || jobDeployment.getEnabled();
+    if (dataJobsKubernetesService.listCronJobs().contains(cronJobName)) {
+      dataJobsKubernetesService.updateCronJob(
+          cronJobName,
+          jobDeployment.getImageName(),
+          jobContainerEnvVars,
+          schedule,
+          enabled,
+          List.of(),
+          defaultConfigurations.dataJobRequests(),
+          defaultConfigurations.dataJobLimits(),
+          jobContainer,
+          jobInitContainer,
+          Arrays.asList(volume, secretVolume),
+          jobDeploymentAnnotations,
+          Collections.emptyMap(),
+          jobAnnotations,
+          jobLabels,
+          List.of(dockerRegistrySecret, vdkSdkDockerRegistrySecret));
+    } else {
+      dataJobsKubernetesService.createCronJob(
+          cronJobName,
+          jobDeployment.getImageName(),
+          jobContainerEnvVars,
+          schedule,
+          enabled,
+          List.of(),
+          defaultConfigurations.dataJobRequests(),
+          defaultConfigurations.dataJobLimits(),
+          jobContainer,
+          jobInitContainer,
+          Arrays.asList(volume, secretVolume),
+          jobDeploymentAnnotations,
+          Collections.emptyMap(),
+          jobAnnotations,
+          jobLabels,
+          List.of(dockerRegistrySecret, vdkSdkDockerRegistrySecret));
+    }
+  }
+
+  private String getJobVdkImage(JobDeployment jobDeployment) {
+    if (StringUtils.isNotBlank(jobDeployment.getVdkVersion())) {
+      return DockerImageName.updateImageWithTag(vdkImage, jobDeployment.getVdkVersion());
+    } else {
+      return vdkImage;
+    }
+  }
+
+  /**
+   * Returns the environment variables set to vdk that are based on job configuration. Those are
+   * automatically injected during cloud runs
+   */
+  private static HashMap<String, String> jobConfigBasedEnvVars(JobConfig config) {
+    HashMap<String, String> envVars = new LinkedHashMap<>();
+    if (StringUtils.isNotBlank(config.getDbDefaultType())) {
+      envVars.put("VDK_DB_DEFAULT_TYPE", config.getDbDefaultType());
+    }
+    if (StringUtils.isNotBlank(config.getTeam())) {
+      envVars.put("VDK_JOB_TEAM", config.getTeam());
+    }
+    if (config.getEnableExecutionNotifications() != null) {
+      envVars.put(
+          "VDK_ENABLE_EXECUTION_NOTIFICATIONS",
+          config.getEnableExecutionNotifications().toString());
+    }
+    if (config.getNotifiedOnJobSuccess() != null) {
+      envVars.put(
+          "VDK_NOTIFIED_ON_JOB_SUCCESS", String.join(",", config.getNotifiedOnJobSuccess()));
+    }
+    if (config.getNotifiedOnJobFailurePlatformError() != null) {
+      envVars.put(
+          "VDK_NOTIFIED_ON_JOB_FAILURE_PLATFORM_ERROR",
+          String.join(",", config.getNotifiedOnJobFailurePlatformError()));
+    }
+    if (config.getNotifiedOnJobFailureUserError() != null) {
+      envVars.put(
+          "VDK_NOTIFIED_ON_JOB_FAILURE_USER_ERROR",
+          String.join(",", config.getNotifiedOnJobFailureUserError()));
+    }
+    if (config.getNotifiedOnJobDeploy() != null) {
+      envVars.put("VDK_NOTIFIED_ON_JOB_DEPLOY", String.join(",", config.getNotifiedOnJobDeploy()));
+    }
+    return envVars;
+  }
+
+  private Map<String, String> getJobLabels(DataJob dataJob, JobDeployment jobDeployment) {
+    Map<String, String> jobPodLabels = new HashMap<>();
+    // This label provides means during watching to select only Kubernetes jobs which represent data
+    // jobs.
+    // See DataJobStatusMonitor.watchJobs for how the label is used
+    jobPodLabels.put(JobLabel.TYPE.getValue(), "DataJob");
+    jobPodLabels.put(JobLabel.NAME.getValue(), dataJob.getName());
+    jobPodLabels.put(JobLabel.VERSION.getValue(), jobDeployment.getGitCommitSha());
+
+    return jobPodLabels;
+  }
+
+  private Map<String, String> getJobAnnotations(DataJob dataJob, String deployedBy) {
+    Map<String, String> jobPodAnnotations = new HashMap<>();
+    jobPodAnnotations.put(JobAnnotation.SCHEDULE.getValue(), dataJob.getJobConfig().getSchedule());
+    jobPodAnnotations.put(JobAnnotation.EXECUTION_TYPE.getValue(), "scheduled");
+    jobPodAnnotations.put(JobAnnotation.DEPLOYED_BY.getValue(), deployedBy);
+    jobPodAnnotations.put(JobAnnotation.DEPLOYED_DATE.getValue(), OffsetDateTime.now().toString());
+    jobPodAnnotations.put(
+        JobAnnotation.STARTED_BY.getValue(), "scheduled/runtime"); // TODO are those valid?
+    jobPodAnnotations.put(
+        JobAnnotation.UNSCHEDULED.getValue(),
+        (StringUtils.isEmpty(dataJob.getJobConfig().getSchedule()) ? "true" : "false"));
+    return jobPodAnnotations;
+  }
+
+  // Public for integration testing purposes
+  public static String getCronJobName(String jobName) {
+    return jobName;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/KubernetesResources.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/KubernetesResources.java
@@ -13,31 +13,36 @@ import org.springframework.stereotype.Component;
 @Component
 @AllArgsConstructor
 public class KubernetesResources {
-   // TODO: clients may need to configure those - consider making them configurable.
+  // TODO: clients may need to configure those - consider making them configurable.
 
-   // Data jobs Default resource configuration for the init container only.
-   public static final String DATA_JOB_INIT_CONTAINER_CPU_REQUESTS = "100m";
-   public static final String DATA_JOB_INIT_CONTAINER_MEMORY_REQUESTS = "100M";
+  // Data jobs Default resource configuration for the init container only.
+  public static final String DATA_JOB_INIT_CONTAINER_CPU_REQUESTS = "100m";
+  public static final String DATA_JOB_INIT_CONTAINER_MEMORY_REQUESTS = "100M";
 
-   public static final String DATA_JOB_INIT_CONTAINER_CPU_LIMITS = "100m";
-   public static final String DATA_JOB_INIT_CONTAINER_MEMORY_LIMITS = "100M";
+  public static final String DATA_JOB_INIT_CONTAINER_CPU_LIMITS = "100m";
+  public static final String DATA_JOB_INIT_CONTAINER_MEMORY_LIMITS = "100M";
 
-   @Autowired
-   private final BuilderResources builderResources;
+  @Autowired private final BuilderResources builderResources;
 
-   public KubernetesService.Resources dataJobInitContainerRequests() {
-      return new KubernetesService.Resources(DATA_JOB_INIT_CONTAINER_CPU_REQUESTS, DATA_JOB_INIT_CONTAINER_MEMORY_REQUESTS);
-   }
+  public KubernetesService.Resources dataJobInitContainerRequests() {
+    return new KubernetesService.Resources(
+        DATA_JOB_INIT_CONTAINER_CPU_REQUESTS, DATA_JOB_INIT_CONTAINER_MEMORY_REQUESTS);
+  }
 
-   public KubernetesService.Resources dataJobInitContainerLimits() {
-      return new KubernetesService.Resources(DATA_JOB_INIT_CONTAINER_CPU_LIMITS, DATA_JOB_INIT_CONTAINER_MEMORY_LIMITS);
-   }
+  public KubernetesService.Resources dataJobInitContainerLimits() {
+    return new KubernetesService.Resources(
+        DATA_JOB_INIT_CONTAINER_CPU_LIMITS, DATA_JOB_INIT_CONTAINER_MEMORY_LIMITS);
+  }
 
-   public KubernetesService.Resources builderRequests() {
-      return new KubernetesService.Resources(builderResources.getDataJobBuilderCpuRequests(), builderResources.getDataJobBuilderMemoryRequests());
-   }
+  public KubernetesService.Resources builderRequests() {
+    return new KubernetesService.Resources(
+        builderResources.getDataJobBuilderCpuRequests(),
+        builderResources.getDataJobBuilderMemoryRequests());
+  }
 
-   public KubernetesService.Resources builderLimits() {
-      return new KubernetesService.Resources(builderResources.getDataJobBuilderCpuLimits(), builderResources.getDataJobBuilderMemoryLimits());
-   }
+  public KubernetesService.Resources builderLimits() {
+    return new KubernetesService.Resources(
+        builderResources.getDataJobBuilderCpuLimits(),
+        builderResources.getDataJobBuilderMemoryLimits());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/VdkOptionsReader.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/VdkOptionsReader.java
@@ -20,59 +20,64 @@ import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 
 /**
- * VDK Options and environment variables that are passed to VDK during execution.
- * Enables administrators to apply common configuration for all Data Jobs.
- * Admins can specify global options in "default" ini section or per job in "job-name" ini section.
+ * VDK Options and environment variables that are passed to VDK during execution. Enables
+ * administrators to apply common configuration for all Data Jobs. Admins can specify global options
+ * in "default" ini section or per job in "job-name" ini section.
  */
 @Component
 @Slf4j
 public class VdkOptionsReader {
 
-   private String vdkOptionsIni;
+  private String vdkOptionsIni;
 
-   @Autowired
-   public VdkOptionsReader(@Value("${datajobs.vdk_options_ini}") String vdkOptionsIni) {
-      this.vdkOptionsIni = vdkOptionsIni;
-   }
+  @Autowired
+  public VdkOptionsReader(@Value("${datajobs.vdk_options_ini}") String vdkOptionsIni) {
+    this.vdkOptionsIni = vdkOptionsIni;
+  }
 
-   public Map<String, String> readVdkOptions(String jobName) {
-      Map<String, String> vdkOptions = new HashMap<>();
+  public Map<String, String> readVdkOptions(String jobName) {
+    Map<String, String> vdkOptions = new HashMap<>();
 
-      try {
-         var iniFile = new File(this.vdkOptionsIni);
-         if (!iniFile.isFile()) {
-            ErrorMessage message = new ErrorMessage(
-                    "VDK Options file is not specified or missing.",
-                    String.format("'%s' is missing. Most likely it is not configured during installation." , vdkOptionsIni),
-                    "This is not necessarily a problem since the defaults that come with VDK will be used for the data jobs. ",
-                    "Specify during installation vdk options file if it's necessary otherwise nothing and you can ignore this."
-            );
-            log.warn(message.toString());
-            return vdkOptions;
-         }
-
-         Preferences vdkOptionsIni = new IniPreferences(new Ini(iniFile));
-
-         var defaults = iniSectionToMap("default", "", vdkOptionsIni);
-         var perJob = iniSectionToMap(jobName, "", vdkOptionsIni);
-         vdkOptions.putAll(defaults);
-         // TODO add per team ?
-         vdkOptions.putAll(perJob);
-      } catch (Exception e) {
-         log.error("Error while reading VDK runtime options. Default options will be used.", e);
+    try {
+      var iniFile = new File(this.vdkOptionsIni);
+      if (!iniFile.isFile()) {
+        ErrorMessage message =
+            new ErrorMessage(
+                "VDK Options file is not specified or missing.",
+                String.format(
+                    "'%s' is missing. Most likely it is not configured during installation.",
+                    vdkOptionsIni),
+                "This is not necessarily a problem since the defaults that come with VDK will be"
+                    + " used for the data jobs. ",
+                "Specify during installation vdk options file if it's necessary otherwise nothing"
+                    + " and you can ignore this.");
+        log.warn(message.toString());
+        return vdkOptions;
       }
-      return vdkOptions;
-   }
 
-   public Map<String, String> iniSectionToMap(String section, String def, Preferences ini) throws BackingStoreException {
-      Map<String, String> sectionMap = new HashMap<>();
+      Preferences vdkOptionsIni = new IniPreferences(new Ini(iniFile));
 
-      if (ini.nodeExists(section)) {
-         Preferences iniSection = ini.node(section);
-         for (var key : iniSection.keys()) {
-            sectionMap.put(key, iniSection.get(key, def));
-         }
+      var defaults = iniSectionToMap("default", "", vdkOptionsIni);
+      var perJob = iniSectionToMap(jobName, "", vdkOptionsIni);
+      vdkOptions.putAll(defaults);
+      // TODO add per team ?
+      vdkOptions.putAll(perJob);
+    } catch (Exception e) {
+      log.error("Error while reading VDK runtime options. Default options will be used.", e);
+    }
+    return vdkOptions;
+  }
+
+  public Map<String, String> iniSectionToMap(String section, String def, Preferences ini)
+      throws BackingStoreException {
+    Map<String, String> sectionMap = new HashMap<>();
+
+    if (ini.nodeExists(section)) {
+      Preferences iniSection = ini.node(section);
+      for (var key : iniSection.keys()) {
+        sectionMap.put(key, iniSection.get(key, def));
       }
-      return sectionMap;
-   }
+    }
+    return sectionMap;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/doc/SwaggerConfig.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/doc/SwaggerConfig.java
@@ -32,78 +32,83 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Swagger Configuration for Versatile Data Kit Control Service.
- * It relies on OpenApiGenerator to generate both API interfaces (APIOperation annotaiton)
- * And OpenAPIDocumentationConfig which contains info part of swagger doc
+ * Swagger Configuration for Versatile Data Kit Control Service. It relies on OpenApiGenerator to
+ * generate both API interfaces (APIOperation annotaiton) And OpenAPIDocumentationConfig which
+ * contains info part of swagger doc
  */
 @Configuration
 @EnableSwagger2
 @Controller
 public class SwaggerConfig implements WebMvcConfigurer {
-    private static final String PATH = "/data-jobs";
-    private static final String AUTHORIZE_KEY_NAME = "Authorization Header (put 'Bearer access_token')";
+  private static final String PATH = "/data-jobs";
+  private static final String AUTHORIZE_KEY_NAME =
+      "Authorization Header (put 'Bearer access_token')";
 
-    @Bean
-    @Order(1)
-    public Docket swaggerSpringMvcPlugin(ServletContext context) {
-        return new OpenAPIDocumentationConfig().customImplementation(context, "")
-                .securitySchemes(Arrays.asList(apiKey()))
-                .securityContexts(Collections.singletonList(securityContext()))
-                .select()
-                .apis(RequestHandlerSelectors.withMethodAnnotation(ApiOperation.class))
-                .build()
-                .tags(new Tag("Data Jobs Execution", "(Experimental)"),
-                        new Tag("Data Jobs", "(Stable)"),
-                        new Tag("Data Jobs Deployment", "(Stable)"),
-                        new Tag("Data Jobs Service", "(Stable)"),
-                        new Tag("Data Jobs Sources", "(Stable)"));
-    }
+  @Bean
+  @Order(1)
+  public Docket swaggerSpringMvcPlugin(ServletContext context) {
+    return new OpenAPIDocumentationConfig()
+        .customImplementation(context, "")
+        .securitySchemes(Arrays.asList(apiKey()))
+        .securityContexts(Collections.singletonList(securityContext()))
+        .select()
+        .apis(RequestHandlerSelectors.withMethodAnnotation(ApiOperation.class))
+        .build()
+        .tags(
+            new Tag("Data Jobs Execution", "(Experimental)"),
+            new Tag("Data Jobs", "(Stable)"),
+            new Tag("Data Jobs Deployment", "(Stable)"),
+            new Tag("Data Jobs Service", "(Stable)"),
+            new Tag("Data Jobs Sources", "(Stable)"));
+  }
 
+  @Override
+  public void addViewControllers(ViewControllerRegistry registry) {
+    final var apiDocs = "/v2/api-docs";
+    final var configUi = "/swagger-resources/configuration/ui";
+    final var configSecurity = "/swagger-resources/configuration/security";
+    final var resources = "/swagger-resources";
 
-    @Override
-    public void addViewControllers(ViewControllerRegistry registry) {
-        final var apiDocs = "/v2/api-docs";
-        final var configUi = "/swagger-resources/configuration/ui";
-        final var configSecurity = "/swagger-resources/configuration/security";
-        final var resources = "/swagger-resources";
+    registry.addViewController(PATH + apiDocs).setViewName("forward:" + apiDocs);
+    registry.addViewController(PATH + configUi).setViewName("forward:" + configUi);
+    registry.addViewController(PATH + configSecurity).setViewName("forward:" + configSecurity);
+    registry.addViewController(PATH + resources).setViewName("forward:" + resources);
+  }
 
-        registry.addViewController(PATH + apiDocs).setViewName("forward:" + apiDocs);
-        registry.addViewController(PATH + configUi).setViewName("forward:" + configUi);
-        registry.addViewController(PATH + configSecurity).setViewName("forward:" + configSecurity);
-        registry.addViewController(PATH + resources).setViewName("forward:" + resources);
-    }
+  @Override
+  public void addResourceHandlers(ResourceHandlerRegistry registry) {
+    registry
+        .addResourceHandler(PATH + "/**")
+        .addResourceLocations("classpath:/META-INF/resources/");
+  }
 
-    @Override
-    public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        registry.addResourceHandler(PATH + "/**").addResourceLocations("classpath:/META-INF/resources/");
-    }
+  // springfox does not support Bearer Token Auth from api.yaml so we hack it manually
+  // TODO: there must be cleaner way. We may consider switch to other library also.
+  private ApiKey apiKey() {
+    return new ApiKey(AUTHORIZE_KEY_NAME, "Authorization", "header");
+  }
 
-    // springfox does not support Bearer Token Auth from api.yaml so we hack it manually
-    // TODO: there must be cleaner way. We may consider switch to other library also.
-    private ApiKey apiKey() {
-        return new ApiKey(AUTHORIZE_KEY_NAME, "Authorization", "header");
-    }
+  private List<SecurityReference> defaultAuth() {
+    AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEverything");
+    AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+    authorizationScopes[0] = authorizationScope;
+    return Collections.singletonList(
+        new SecurityReference(AUTHORIZE_KEY_NAME, authorizationScopes));
+  }
 
-    private List<SecurityReference> defaultAuth() {
-        AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEverything");
-        AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
-        authorizationScopes[0] = authorizationScope;
-        return Collections.singletonList(new SecurityReference(AUTHORIZE_KEY_NAME, authorizationScopes));
-    }
+  private SecurityContext securityContext() {
+    return SecurityContext.builder()
+        .securityReferences(defaultAuth())
+        .forPaths(PathSelectors.any())
+        .build();
+  }
 
-    private SecurityContext securityContext() {
-        return SecurityContext.builder()
-                .securityReferences(defaultAuth())
-                .forPaths(PathSelectors.any())
-                .build();
-    }
-
-    @Bean
-    public SecurityConfiguration security() {
-        return SecurityConfigurationBuilder.builder()
-                .scopeSeparator(",")
-                .additionalQueryStringParams(null)
-                .useBasicAuthenticationWithAccessCodeGrant(false)
-                .build();
-    }
+  @Bean
+  public SecurityConfiguration security() {
+    return SecurityConfigurationBuilder.builder()
+        .scopeSeparator(",")
+        .additionalQueryStringParams(null)
+        .useBasicAuthenticationWithAccessCodeGrant(false)
+        .build();
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionCleanupService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionCleanupService.java
@@ -25,93 +25,111 @@ import java.util.List;
 @Slf4j
 public class JobExecutionCleanupService {
 
-    @Value("${datajobs.executions.cleanupJob.maximumExecutionsToStore:100}") //default value is 100
-    private int maxExecutionsToKeep;
-    @Value("${datajobs.executions.cleanupJob.executionsTtlSeconds:1209600}") //default value is 14 days
-    private long secondsCutoffAmount;
-    private JobExecutionRepository jobExecutionRepository;
-    private JobsRepository jobsRepository;
-    private DataJobExecutionCleanupMonitor dataJobExecutionCleanupMonitor;
+  @Value("${datajobs.executions.cleanupJob.maximumExecutionsToStore:100}") // default value is 100
+  private int maxExecutionsToKeep;
 
-    @Autowired
-    public void setJobExecutionRepository(JobExecutionRepository jobExecutionRepository) {
-        this.jobExecutionRepository = jobExecutionRepository;
+  @Value(
+      "${datajobs.executions.cleanupJob.executionsTtlSeconds:1209600}") // default value is 14 days
+  private long secondsCutoffAmount;
+
+  private JobExecutionRepository jobExecutionRepository;
+  private JobsRepository jobsRepository;
+  private DataJobExecutionCleanupMonitor dataJobExecutionCleanupMonitor;
+
+  @Autowired
+  public void setJobExecutionRepository(JobExecutionRepository jobExecutionRepository) {
+    this.jobExecutionRepository = jobExecutionRepository;
+  }
+
+  @Autowired
+  public void setJobsRepository(JobsRepository jobsRepository) {
+    this.jobsRepository = jobsRepository;
+  }
+
+  @Autowired
+  public void setDataJobExecutionCleanupMonitor(
+      DataJobExecutionCleanupMonitor dataJobExecutionCleanupMonitor) {
+    this.dataJobExecutionCleanupMonitor = dataJobExecutionCleanupMonitor;
+  }
+
+  @SchedulerLock(name = "cleanupExecutionsTask")
+  @Scheduled(
+      cron =
+          "${datajobs.executions.cleanupJob.scheduleCron:0 0 */3 * * *}") // default value is every
+                                                                          // 3 hours
+  public void cleanupExecutions() {
+    log.info("Starting DataJobExecutionCleanup and incrementing invocations counter.");
+    dataJobExecutionCleanupMonitor.countInvocation();
+    var jobs = jobsRepository.findAll();
+    for (var job : jobs) {
+      try {
+        deleteDataJobExecutions(job);
+        dataJobExecutionCleanupMonitor.countSuccessfulDeletion();
+      } catch (Exception e) {
+        dataJobExecutionCleanupMonitor.countFailedDeletion();
+        log.warn(
+            "Failed to delete executions for job {} due to {}, message: {}",
+            job.getName(),
+            e.getClass(),
+            e.getMessage());
+        log.warn("Error:", e);
+      }
+    }
+  }
+
+  private void deleteDataJobExecutions(DataJob job) {
+
+    var statuses = List.of(ExecutionStatus.RUNNING, ExecutionStatus.SUBMITTED);
+    var jobExecutions =
+        jobExecutionRepository.findByDataJobNameAndStatusNotInOrderByEndTime(
+            job.getName(), statuses);
+    var jobsToDelete = new ArrayList<String>();
+    var cutOff = OffsetDateTime.now().minusSeconds(secondsCutoffAmount);
+
+    for (int i = 0; i < jobExecutions.size(); i++) { // first execution is the oldest
+      var execution = jobExecutions.get(i);
+      // ensure we add jobs for deletion only once
+      if (shouldDeleteJobExecution(i, jobExecutions.size(), cutOff, execution.getEndTime())) {
+        jobsToDelete.add(execution.getId());
+      }
     }
 
-    @Autowired
-    public void setJobsRepository(JobsRepository jobsRepository) {
-        this.jobsRepository = jobsRepository;
+    if (jobsToDelete.size() == 0) {
+      log.debug("Found 0 job executions to delete for DataJob:'{}'.", job.getName());
+
+    } else {
+
+      log.info(
+          "Found {} job executions to delete for DataJob:'{}'. Deleting...",
+          jobsToDelete.size(),
+          job.getName());
+      jobExecutionRepository.deleteAllByIdInBatch(jobsToDelete);
     }
+  }
 
-    @Autowired
-    public void setDataJobExecutionCleanupMonitor(DataJobExecutionCleanupMonitor dataJobExecutionCleanupMonitor) {
-        this.dataJobExecutionCleanupMonitor = dataJobExecutionCleanupMonitor;
+  /**
+   * Helper method which determines if a data job execution should be deleted. Assumes that
+   * executionPos is the position of a dataJobExecution in a sorted execution list by start time
+   * ASC.
+   *
+   * @param executionPos the position of a data job execution in a sorted list.
+   * @param executionsSize the size of the list.
+   * @param cutOff cut off date for deletion.
+   * @param executionEndTime data job execution end time.
+   * @return boolean describing if the data job should be deleted.
+   */
+  private boolean shouldDeleteJobExecution(
+      int executionPos,
+      int executionsSize,
+      OffsetDateTime cutOff,
+      OffsetDateTime executionEndTime) {
+    boolean shouldDelete = false;
+
+    if (executionPos < executionsSize - maxExecutionsToKeep) { // Delete by numbers
+      shouldDelete = true;
+    } else if (executionEndTime != null && executionEndTime.isBefore(cutOff)) { // Delete by date
+      shouldDelete = true;
     }
-
-    @SchedulerLock(name = "cleanupExecutionsTask")
-    @Scheduled(cron = "${datajobs.executions.cleanupJob.scheduleCron:0 0 */3 * * *}") //default value is every 3 hours
-    public void cleanupExecutions() {
-        log.info("Starting DataJobExecutionCleanup and incrementing invocations counter.");
-        dataJobExecutionCleanupMonitor.countInvocation();
-        var jobs = jobsRepository.findAll();
-        for (var job : jobs) {
-            try {
-                deleteDataJobExecutions(job);
-                dataJobExecutionCleanupMonitor.countSuccessfulDeletion();
-            } catch (Exception e) {
-                dataJobExecutionCleanupMonitor.countFailedDeletion();
-                log.warn("Failed to delete executions for job {} due to {}, message: {}", job.getName(), e.getClass(), e.getMessage());
-                log.warn("Error:", e);
-            }
-        }
-    }
-
-    private void deleteDataJobExecutions(DataJob job) {
-
-        var statuses = List.of(ExecutionStatus.RUNNING, ExecutionStatus.SUBMITTED);
-        var jobExecutions = jobExecutionRepository.findByDataJobNameAndStatusNotInOrderByEndTime(job.getName(), statuses);
-        var jobsToDelete = new ArrayList<String>();
-        var cutOff = OffsetDateTime.now().minusSeconds(secondsCutoffAmount);
-
-        for (int i = 0; i < jobExecutions.size(); i++) { //first execution is the oldest
-            var execution = jobExecutions.get(i);
-            //ensure we add jobs for deletion only once
-            if (shouldDeleteJobExecution(i, jobExecutions.size(), cutOff, execution.getEndTime())) {
-                jobsToDelete.add(execution.getId());
-            }
-        }
-
-        if (jobsToDelete.size() == 0) {
-            log.debug("Found 0 job executions to delete for DataJob:'{}'.", job.getName());
-
-        } else {
-
-            log.info("Found {} job executions to delete for DataJob:'{}'. Deleting...", jobsToDelete.size(), job.getName());
-            jobExecutionRepository.deleteAllByIdInBatch(jobsToDelete);
-        }
-    }
-
-    /**
-     * Helper method which determines if a data job execution should be deleted.
-     * Assumes that executionPos is the position of a dataJobExecution in a sorted
-     * execution list by start time ASC.
-     *
-     * @param executionPos     the position of a data job execution in a sorted list.
-     * @param executionsSize   the size of the list.
-     * @param cutOff           cut off date for deletion.
-     * @param executionEndTime data job execution end time.
-     * @return boolean describing if the data job should be deleted.
-     */
-    private boolean shouldDeleteJobExecution(int executionPos, int executionsSize,
-                                             OffsetDateTime cutOff, OffsetDateTime executionEndTime) {
-        boolean shouldDelete = false;
-
-        if (executionPos < executionsSize - maxExecutionsToKeep) { //Delete by numbers
-            shouldDelete = true;
-        } else if (executionEndTime != null && executionEndTime.isBefore(cutOff)) { // Delete by date
-            shouldDelete = true;
-        }
-        return shouldDelete;
-    }
-
+    return shouldDelete;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionCleanupService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionCleanupService.java
@@ -56,7 +56,7 @@ public class JobExecutionCleanupService {
   @Scheduled(
       cron =
           "${datajobs.executions.cleanupJob.scheduleCron:0 0 */3 * * *}") // default value is every
-                                                                          // 3 hours
+  // 3 hours
   public void cleanupExecutions() {
     log.info("Starting DataJobExecutionCleanup and incrementing invocations counter.");
     dataJobExecutionCleanupMonitor.countInvocation();

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionLogsUrlBuilder.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionLogsUrlBuilder.java
@@ -24,109 +24,113 @@ import com.vmware.taurus.service.model.DataJobExecution;
  * Builds logs URL for each data job execution by specified template
  * (datajobs.executions.logsUrl.template).
  *
- * Supported variables which will be replaced in the template
- * with the particular execution values:
+ * <p>Supported variables which will be replaced in the template with the particular execution
+ * values:
  *
  * <ul>
- *    <li>{@value VAR_PREFIX}{@value EXECUTION_ID_VAR}{@value VAR_SUFFIX}</li>
- *    <li>{@value VAR_PREFIX}{@value OP_ID_VAR}{@value VAR_SUFFIX}</li>
- *    <li>{@value VAR_PREFIX}{@value JOB_NAME_VAR}{@value VAR_SUFFIX}</li>
- *    <li>{@value VAR_PREFIX}{@value START_TIME_VAR}{@value VAR_SUFFIX}</li>
- *    <li>{@value VAR_PREFIX}{@value END_TIME_VAR}{@value VAR_SUFFIX}</li>
+ *   <li>{@value VAR_PREFIX}{@value EXECUTION_ID_VAR}{@value VAR_SUFFIX}
+ *   <li>{@value VAR_PREFIX}{@value OP_ID_VAR}{@value VAR_SUFFIX}
+ *   <li>{@value VAR_PREFIX}{@value JOB_NAME_VAR}{@value VAR_SUFFIX}
+ *   <li>{@value VAR_PREFIX}{@value START_TIME_VAR}{@value VAR_SUFFIX}
+ *   <li>{@value VAR_PREFIX}{@value END_TIME_VAR}{@value VAR_SUFFIX}
  * </ul>
  *
- * Example: "https://log-insight-url/li/query/stream?query=%C2%A7%C2%A7%C2%A7AND%C2%A7%C2%A7%C2%A7%C2%
+ * Example:
+ * "https://log-insight-url/li/query/stream?query=%C2%A7%C2%A7%C2%A7AND%C2%A7%C2%A7%C2%A7%C2%
  * A7{{start_time}}%C2%A7{{end_time}}%C2%A7true%C2%A7COUNT%C2%A7text:CONTAINS:{{execution_id}}*"
  */
 @Slf4j
 @Component
 public class JobExecutionLogsUrlBuilder {
 
-   // Default for testing purposes
-   static final String VAR_PREFIX = "{{";
-   static final String VAR_SUFFIX = "}}";
+  // Default for testing purposes
+  static final String VAR_PREFIX = "{{";
+  static final String VAR_SUFFIX = "}}";
 
-   static final String EXECUTION_ID_VAR = "execution_id";
-   static final String OP_ID_VAR = "op_id";
-   static final String JOB_NAME_VAR = "job_name";
-   static final String START_TIME_VAR = "start_time";
-   static final String END_TIME_VAR = "end_time";
+  static final String EXECUTION_ID_VAR = "execution_id";
+  static final String OP_ID_VAR = "op_id";
+  static final String JOB_NAME_VAR = "job_name";
+  static final String START_TIME_VAR = "start_time";
+  static final String END_TIME_VAR = "end_time";
 
-   static final String ISO_DATE_FORMAT = "iso";
-   static final String UNIX_DATE_FORMAT = "unix";
+  static final String ISO_DATE_FORMAT = "iso";
+  static final String UNIX_DATE_FORMAT = "unix";
 
-   @Value("${datajobs.executions.logsUrl.template}")
-   private String template;
+  @Value("${datajobs.executions.logsUrl.template}")
+  private String template;
 
-   @Value("${datajobs.executions.logsUrl.dateFormat}")
-   private String dateFormat;
+  @Value("${datajobs.executions.logsUrl.dateFormat}")
+  private String dateFormat;
 
-   @Value("${datajobs.executions.logsUrl.startTimeOffsetSeconds}")
-   private long startTimeOffsetSeconds = 0;
+  @Value("${datajobs.executions.logsUrl.startTimeOffsetSeconds}")
+  private long startTimeOffsetSeconds = 0;
 
-   @Value("${datajobs.executions.logsUrl.endTimeOffsetSeconds}")
-   private long endTimeOffsetSeconds = 0;
+  @Value("${datajobs.executions.logsUrl.endTimeOffsetSeconds}")
+  private long endTimeOffsetSeconds = 0;
 
-   Clock clock = Clock.systemDefaultZone();
+  Clock clock = Clock.systemDefaultZone();
 
-   public String build(DataJobExecution dataJobExecution) {
-      if (StringUtils.isEmpty(template)) {
-         log.warn("The property 'datajobs.executions.logsUrl.template' is empty!");
-         return "";
-      }
+  public String build(DataJobExecution dataJobExecution) {
+    if (StringUtils.isEmpty(template)) {
+      log.warn("The property 'datajobs.executions.logsUrl.template' is empty!");
+      return "";
+    }
 
-      return StringSubstitutor.replace(
-            template,
-            buildVars(dataJobExecution),
-            VAR_PREFIX,
-            VAR_SUFFIX);
-   }
+    return StringSubstitutor.replace(template, buildVars(dataJobExecution), VAR_PREFIX, VAR_SUFFIX);
+  }
 
-   private Map<String, String> buildVars(DataJobExecution dataJobExecution) {
-      Map<String, String> params = new HashMap<>();
+  private Map<String, String> buildVars(DataJobExecution dataJobExecution) {
+    Map<String, String> params = new HashMap<>();
 
-      if (dataJobExecution != null) {
-         params.put(EXECUTION_ID_VAR, dataJobExecution.getId());
-         params.put(OP_ID_VAR, dataJobExecution.getOpId());
-         params.put(
-               JOB_NAME_VAR,
-               Optional.ofNullable(dataJobExecution.getDataJob())
-                     .map(dataJob -> dataJob.getName())
-                     .orElse(""));
-         params.put(START_TIME_VAR, convertDate(dataJobExecution.getStartTime(), startTimeOffsetSeconds));
-         params.put(END_TIME_VAR, convertDate(dataJobExecution.getEndTime(), endTimeOffsetSeconds));
-      }
+    if (dataJobExecution != null) {
+      params.put(EXECUTION_ID_VAR, dataJobExecution.getId());
+      params.put(OP_ID_VAR, dataJobExecution.getOpId());
+      params.put(
+          JOB_NAME_VAR,
+          Optional.ofNullable(dataJobExecution.getDataJob())
+              .map(dataJob -> dataJob.getName())
+              .orElse(""));
+      params.put(
+          START_TIME_VAR, convertDate(dataJobExecution.getStartTime(), startTimeOffsetSeconds));
+      params.put(END_TIME_VAR, convertDate(dataJobExecution.getEndTime(), endTimeOffsetSeconds));
+    }
 
-      return params;
-   }
+    return params;
+  }
 
-   private String convertDate(OffsetDateTime dateTime, Long offset) {
-      String format = dateFormat;
+  private String convertDate(OffsetDateTime dateTime, Long offset) {
+    String format = dateFormat;
 
-      if (dateTime == null) {
-         // if not set it to current time
-         dateTime = OffsetDateTime.now(clock);
-      }
+    if (dateTime == null) {
+      // if not set it to current time
+      dateTime = OffsetDateTime.now(clock);
+    }
 
-      Instant offsetDateTime = dateTime.toInstant().plusSeconds(offset);
+    Instant offsetDateTime = dateTime.toInstant().plusSeconds(offset);
 
-      if (StringUtils.isEmpty(format)) {
-         log.warn("The property 'datajobs.executions.logsUrl.dateFormat' is empty, defaults to '{}'", UNIX_DATE_FORMAT);
-         format = UNIX_DATE_FORMAT;
-      }
+    if (StringUtils.isEmpty(format)) {
+      log.warn(
+          "The property 'datajobs.executions.logsUrl.dateFormat' is empty, defaults to '{}'",
+          UNIX_DATE_FORMAT);
+      format = UNIX_DATE_FORMAT;
+    }
 
-      switch (format) {
-         case ISO_DATE_FORMAT:
-            return offsetDateTime.toString();
-         case UNIX_DATE_FORMAT:
-            return getDateTimeUnix(offsetDateTime);
-         default:
-            log.warn("The property 'datajobs.executions.logsUrl.dateFormat' is not correct '{}', defaults to '{}'", dateFormat, UNIX_DATE_FORMAT);
-            return getDateTimeUnix(offsetDateTime);
-      }
-   }
+    switch (format) {
+      case ISO_DATE_FORMAT:
+        return offsetDateTime.toString();
+      case UNIX_DATE_FORMAT:
+        return getDateTimeUnix(offsetDateTime);
+      default:
+        log.warn(
+            "The property 'datajobs.executions.logsUrl.dateFormat' is not correct '{}', defaults to"
+                + " '{}'",
+            dateFormat,
+            UNIX_DATE_FORMAT);
+        return getDateTimeUnix(offsetDateTime);
+    }
+  }
 
-   private static String getDateTimeUnix(Instant offsetDateTime) {
-      return String.valueOf(offsetDateTime.toEpochMilli());
-   }
+  private static String getDateTimeUnix(Instant offsetDateTime) {
+    return String.valueOf(offsetDateTime.toEpochMilli());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionResultManager.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionResultManager.java
@@ -20,142 +20,147 @@ import com.vmware.taurus.service.model.ExecutionResult;
 import com.vmware.taurus.service.model.ExecutionStatus;
 
 /**
- * This class helps to determine Execution Status
- * as it is difficult to be determined and depend on many components.
- * It extracts, determines and combines the data as {@link ExecutionResult}.
+ * This class helps to determine Execution Status as it is difficult to be determined and depend on
+ * many components. It extracts, determines and combines the data as {@link ExecutionResult}.
  */
 @Slf4j
 public class JobExecutionResultManager {
 
-   static final String TERMINATION_MESSAGE_ATTRIBUTE_STATUS = "status";
-   static final String TERMINATION_MESSAGE_ATTRIBUTE_VDK_VERSION = "vdk_version";
-   static final String TERMINATION_REASON_DEADLINE_EXCEEDED = "DeadlineExceeded";
-   static final String TERMINATION_REASON_OUT_OF_MEMORY = "OOMKilled";
+  static final String TERMINATION_MESSAGE_ATTRIBUTE_STATUS = "status";
+  static final String TERMINATION_MESSAGE_ATTRIBUTE_VDK_VERSION = "vdk_version";
+  static final String TERMINATION_REASON_DEADLINE_EXCEEDED = "DeadlineExceeded";
+  static final String TERMINATION_REASON_OUT_OF_MEMORY = "OOMKilled";
 
-   @Data
-   @Builder
-   private static class PodTerminationMessage {
-      private String status;
-      private String vdkVersion;
-   }
+  @Data
+  @Builder
+  private static class PodTerminationMessage {
+    private String status;
+    private String vdkVersion;
+  }
 
-   /**
-    * Extracts and determines the execution status and vdk version
-    * based on K8S Job status and K8S Pod termination message.
-    *
-    * @param jobExecution
-    *       current job execution
-    * @return returns the execution result that contains execution status, termination status and vdk version
-    */
-   public static ExecutionResult getResult(KubernetesService.JobExecution jobExecution) {
-      PodTerminationMessage podTerminationMessage = parsePodTerminationMessage(jobExecution.getPodTerminationMessage());
-      ExecutionStatus executionStatus = getExecutionStatus(
+  /**
+   * Extracts and determines the execution status and vdk version based on K8S Job status and K8S
+   * Pod termination message.
+   *
+   * @param jobExecution current job execution
+   * @return returns the execution result that contains execution status, termination status and vdk
+   *     version
+   */
+  public static ExecutionResult getResult(KubernetesService.JobExecution jobExecution) {
+    PodTerminationMessage podTerminationMessage =
+        parsePodTerminationMessage(jobExecution.getPodTerminationMessage());
+    ExecutionStatus executionStatus =
+        getExecutionStatus(
             jobExecution.getSucceeded(),
             podTerminationMessage.getStatus(),
             jobExecution.getJobTerminationReason(),
             jobExecution.getContainerTerminationReason(),
             jobExecution.getStartTime());
 
-      return ExecutionResult.builder()
-            .executionStatus(executionStatus)
-            .vdkVersion(podTerminationMessage.getVdkVersion())
-            .build();
-   }
+    return ExecutionResult.builder()
+        .executionStatus(executionStatus)
+        .vdkVersion(podTerminationMessage.getVdkVersion())
+        .build();
+  }
 
-   /**
-    * Determines the execution status based on K8S Job status as follows:
-    * <ul>
-    *   <li>If K8S Job succeeded is null (which means there is no K8S Job condition
-    *   because the job is already running), then the execution status will be either SUBMITTED or RUNNING</li>
-    *   <li>If the K8S Job succeeded is true, then the execution status will be either SUCCEEDED or
-    *   the one that comes from K8S Pod termination message (e.g. SUCCESS, USER_ERROR, PLATFORM_ERROR, etc.)</li>
-    *   <li>If K8S Job succeeded is false, then the execution status will be either USER_ERROR or PLATFORM_ERROR.
-    *   In case of missing termination status due to the missing K8S Pod
-    *   it sets an appropriate execution status based on the K8S Job termination reason.</li>
-    * </ul>
-    *
-    * @param executionSucceeded K8s Job status (true - succeeded, false - failed, null - running)
-    * @param podTerminationStatus termination status returned from K8S Pod (e.g. "Success", "User error", etc.)
-    * @param jobTerminationReason condition reason as reported by K8s Job (e.g. "DeadlineExceeded", "BackoffLimitExceeded", etc.)
-    * @param containerTerminationReason termination reason for pod container as returned by K8s pod container (e.g., "OOMKilled", etc.)
-    * @param executionStarTime K8S Job execution start time
-    * @return if there is no termination message due to the missing K8S Pod
-     * returns execution status based on K8S Job status otherwise returns
-     * execution status based on the K8S Pod termination status.
-    */
-   private static ExecutionStatus getExecutionStatus(
-         Boolean executionSucceeded,
-         String podTerminationStatus,
-         String jobTerminationReason,
-         String containerTerminationReason,
-         OffsetDateTime executionStarTime) {
+  /**
+   * Determines the execution status based on K8S Job status as follows:
+   *
+   * <ul>
+   *   <li>If K8S Job succeeded is null (which means there is no K8S Job condition because the job
+   *       is already running), then the execution status will be either SUBMITTED or RUNNING
+   *   <li>If the K8S Job succeeded is true, then the execution status will be either SUCCEEDED or
+   *       the one that comes from K8S Pod termination message (e.g. SUCCESS, USER_ERROR,
+   *       PLATFORM_ERROR, etc.)
+   *   <li>If K8S Job succeeded is false, then the execution status will be either USER_ERROR or
+   *       PLATFORM_ERROR. In case of missing termination status due to the missing K8S Pod it sets
+   *       an appropriate execution status based on the K8S Job termination reason.
+   * </ul>
+   *
+   * @param executionSucceeded K8s Job status (true - succeeded, false - failed, null - running)
+   * @param podTerminationStatus termination status returned from K8S Pod (e.g. "Success", "User
+   *     error", etc.)
+   * @param jobTerminationReason condition reason as reported by K8s Job (e.g. "DeadlineExceeded",
+   *     "BackoffLimitExceeded", etc.)
+   * @param containerTerminationReason termination reason for pod container as returned by K8s pod
+   *     container (e.g., "OOMKilled", etc.)
+   * @param executionStarTime K8S Job execution start time
+   * @return if there is no termination message due to the missing K8S Pod returns execution status
+   *     based on K8S Job status otherwise returns execution status based on the K8S Pod termination
+   *     status.
+   */
+  private static ExecutionStatus getExecutionStatus(
+      Boolean executionSucceeded,
+      String podTerminationStatus,
+      String jobTerminationReason,
+      String containerTerminationReason,
+      OffsetDateTime executionStarTime) {
 
-      ExecutionStatus executionStatus;
+    ExecutionStatus executionStatus;
 
-      if (executionSucceeded == null) {
-         executionStatus = executionStarTime == null ?
-               ExecutionStatus.SUBMITTED :
-               ExecutionStatus.RUNNING;
-      } else if (executionSucceeded && StringUtils.isEmpty(podTerminationStatus)) {
-         executionStatus = ExecutionStatus.SUCCEEDED;
-      } else if (!executionSucceeded && StringUtils.isEmpty(podTerminationStatus)) {
-         executionStatus = inferError(jobTerminationReason, containerTerminationReason);
-      } else {
-         executionStatus = Arrays.stream(ExecutionStatus.values())
-               .filter(status -> status.getPodStatus().equals(podTerminationStatus))
-               .findAny()
-               .orElse(ExecutionStatus.PLATFORM_ERROR);
+    if (executionSucceeded == null) {
+      executionStatus =
+          executionStarTime == null ? ExecutionStatus.SUBMITTED : ExecutionStatus.RUNNING;
+    } else if (executionSucceeded && StringUtils.isEmpty(podTerminationStatus)) {
+      executionStatus = ExecutionStatus.SUCCEEDED;
+    } else if (!executionSucceeded && StringUtils.isEmpty(podTerminationStatus)) {
+      executionStatus = inferError(jobTerminationReason, containerTerminationReason);
+    } else {
+      executionStatus =
+          Arrays.stream(ExecutionStatus.values())
+              .filter(status -> status.getPodStatus().equals(podTerminationStatus))
+              .findAny()
+              .orElse(ExecutionStatus.PLATFORM_ERROR);
+    }
+
+    return executionStatus;
+  }
+
+  /**
+   * Returns execution status based on K8S Job status.
+   *
+   * @param jobTerminationReason condition reason as reported by K8s Job (e.g. "DeadlineExceeded",
+   *     "BackoffLimitExceeded", etc.)
+   * @param containerTerminationReason termination reason for pod container as reported by K8s Job
+   *     (e.g., "OOMKilled", etc.)
+   * @return returns execution status based on K8S Job status.
+   */
+  private static ExecutionStatus inferError(
+      String jobTerminationReason, String containerTerminationReason) {
+    ExecutionStatus executionStatus;
+
+    if (StringUtils.equalsIgnoreCase(jobTerminationReason, TERMINATION_REASON_DEADLINE_EXCEEDED)
+        || StringUtils.equalsIgnoreCase(
+            containerTerminationReason, TERMINATION_REASON_OUT_OF_MEMORY)) {
+      executionStatus = ExecutionStatus.USER_ERROR;
+    } else {
+      executionStatus = ExecutionStatus.PLATFORM_ERROR;
+    }
+
+    return executionStatus;
+  }
+
+  /**
+   * Extracts attributes from K8S Pod termination message (e.g. status, vdk_version)
+   *
+   * @param podTerminationMessage K8S Pod termination message in JSON or Plain Text format
+   * @return returns parsed termination message
+   */
+  private static PodTerminationMessage parsePodTerminationMessage(String podTerminationMessage) {
+    String status = "";
+    String vdkVersion = "";
+
+    if (!StringUtils.isEmpty(podTerminationMessage)) {
+      try {
+        Map<String, String> obj = new Gson().fromJson(podTerminationMessage, Map.class);
+        status = obj.get(TERMINATION_MESSAGE_ATTRIBUTE_STATUS);
+        vdkVersion = obj.getOrDefault(TERMINATION_MESSAGE_ATTRIBUTE_VDK_VERSION, "");
+      } catch (com.google.gson.JsonSyntaxException ex) {
+        // Fallback to the old plain text format
+        status = podTerminationMessage;
       }
+    }
 
-      return executionStatus;
-   }
-
-   /**
-    * Returns execution status based on K8S Job status.
-    *
-    * @param jobTerminationReason condition reason as reported by K8s Job (e.g. "DeadlineExceeded", "BackoffLimitExceeded", etc.)
-    * @param containerTerminationReason termination reason for pod container as reported by K8s Job (e.g., "OOMKilled", etc.)
-    * @return returns execution status based on K8S Job status.
-    */
-   private static ExecutionStatus inferError(String jobTerminationReason, String containerTerminationReason) {
-      ExecutionStatus executionStatus;
-
-      if (StringUtils.equalsIgnoreCase(jobTerminationReason, TERMINATION_REASON_DEADLINE_EXCEEDED) ||
-            StringUtils.equalsIgnoreCase(containerTerminationReason, TERMINATION_REASON_OUT_OF_MEMORY)) {
-         executionStatus = ExecutionStatus.USER_ERROR;
-      } else {
-         executionStatus = ExecutionStatus.PLATFORM_ERROR;
-      }
-
-      return executionStatus;
-   }
-
-   /**
-    * Extracts attributes from K8S Pod termination message (e.g. status, vdk_version)
-    *
-    * @param podTerminationMessage
-    *       K8S Pod termination message in JSON or Plain Text format
-    * @return returns parsed termination message
-    */
-   private static PodTerminationMessage parsePodTerminationMessage(String podTerminationMessage) {
-      String status = "";
-      String vdkVersion = "";
-
-      if (!StringUtils.isEmpty(podTerminationMessage)) {
-         try {
-            Map<String, String> obj = new Gson().fromJson(podTerminationMessage, Map.class);
-            status = obj.get(TERMINATION_MESSAGE_ATTRIBUTE_STATUS);
-            vdkVersion = obj.getOrDefault(TERMINATION_MESSAGE_ATTRIBUTE_VDK_VERSION, "");
-         } catch (com.google.gson.JsonSyntaxException ex) {
-            // Fallback to the old plain text format
-            status = podTerminationMessage;
-         }
-      }
-
-      return PodTerminationMessage
-            .builder()
-            .status(status)
-            .vdkVersion(vdkVersion)
-            .build();
-   }
+    return PodTerminationMessage.builder().status(status).vdkVersion(vdkVersion).build();
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/ExecutionDataFetcher.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/ExecutionDataFetcher.java
@@ -58,264 +58,313 @@ import static com.vmware.taurus.service.graphql.model.DataJobExecutionQueryVaria
 
 /**
  * Data fetcher class for Data Job Executions
- * <p>
- * Data fetchers are classes that provides to graphql api the needed data while it modify the source data:
- * By providing list of data jobs it alter each job and attach its execution while reading requested
- * information from graphql query to specify how many executions, are they sorted by specific field, etc.
+ *
+ * <p>Data fetchers are classes that provides to graphql api the needed data while it modify the
+ * source data: By providing list of data jobs it alter each job and attach its execution while
+ * reading requested information from graphql query to specify how many executions, are they sorted
+ * by specific field, etc.
  */
 @Component
 @RequiredArgsConstructor
 public class ExecutionDataFetcher {
 
-   private final JobExecutionRepository jobsExecutionRepository;
+  private final JobExecutionRepository jobsExecutionRepository;
 
-   private final JobExecutionService jobExecutionService;
+  private final JobExecutionService jobExecutionService;
 
-   private final JobExecutionLogsUrlBuilder jobExecutionLogsUrlBuilder;
+  private final JobExecutionLogsUrlBuilder jobExecutionLogsUrlBuilder;
 
-   /**
-    * Populates the executions of the specified data jobs, that match the specified criteria.
-    */
-   List<V2DataJob> populateExecutions(List<V2DataJob> allDataJob, DataFetchingEnvironment dataFetchingEnvironment) {
-      final Map<String, Object> arguments = dataFetchingEnvironment.getSelectionSet().getField(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()).getArguments();
-      final DataJobExecutionQueryVariables dataJobExecutionQueryVariables = fetchDataJobExecutionQueryVariables(arguments);
-      allDataJob.forEach(dataJob -> {
-         if (dataJob.getDeployments() != null) {
-            dataJob.getDeployments()
-                    .stream()
-                    .findFirst()
-                    .ifPresent(deployment -> deployment.setExecutions(
+  /** Populates the executions of the specified data jobs, that match the specified criteria. */
+  List<V2DataJob> populateExecutions(
+      List<V2DataJob> allDataJob, DataFetchingEnvironment dataFetchingEnvironment) {
+    final Map<String, Object> arguments =
+        dataFetchingEnvironment
+            .getSelectionSet()
+            .getField(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath())
+            .getArguments();
+    final DataJobExecutionQueryVariables dataJobExecutionQueryVariables =
+        fetchDataJobExecutionQueryVariables(arguments);
+    allDataJob.forEach(
+        dataJob -> {
+          if (dataJob.getDeployments() != null) {
+            dataJob.getDeployments().stream()
+                .findFirst()
+                .ifPresent(
+                    deployment ->
+                        deployment.setExecutions(
                             findAllExecutions(dataJobExecutionQueryVariables, dataJob.getJobName())
-                                    .getContent()
-                                    .stream()
-                                    .map(dataJobExecution -> ToApiModelConverter.jobExecutionToConvert(dataJobExecution, jobExecutionLogsUrlBuilder.build(dataJobExecution)))
-                                    .collect(Collectors.toList())));
-         }
-      });
-      return allDataJob;
-   }
+                                .getContent()
+                                .stream()
+                                .map(
+                                    dataJobExecution ->
+                                        ToApiModelConverter.jobExecutionToConvert(
+                                            dataJobExecution,
+                                            jobExecutionLogsUrlBuilder.build(dataJobExecution)))
+                                .collect(Collectors.toList())));
+          }
+        });
+    return allDataJob;
+  }
 
-   public DataFetcher<Object> findAllAndBuildResponse() {
-      return environment -> {
-         DataJobExecutionQueryVariables dataJobExecutionQueryVariables = fetchDataJobExecutionQueryVariables(environment.getArguments());
+  public DataFetcher<Object> findAllAndBuildResponse() {
+    return environment -> {
+      DataJobExecutionQueryVariables dataJobExecutionQueryVariables =
+          fetchDataJobExecutionQueryVariables(environment.getArguments());
 
-         Page<DataJobExecution> dataJobExecutionsResult = findAllExecutions(dataJobExecutionQueryVariables, null);
-         List<com.vmware.taurus.controlplane.model.data.DataJobExecution> dataJobExecutions = dataJobExecutionsResult
-               .getContent()
-               .stream()
-               .map(dataJobExecution -> ToApiModelConverter.jobExecutionToConvert(dataJobExecution, jobExecutionLogsUrlBuilder.build(dataJobExecution)))
-               .collect(Collectors.toList());
+      Page<DataJobExecution> dataJobExecutionsResult =
+          findAllExecutions(dataJobExecutionQueryVariables, null);
+      List<com.vmware.taurus.controlplane.model.data.DataJobExecution> dataJobExecutions =
+          dataJobExecutionsResult.getContent().stream()
+              .map(
+                  dataJobExecution ->
+                      ToApiModelConverter.jobExecutionToConvert(
+                          dataJobExecution, jobExecutionLogsUrlBuilder.build(dataJobExecution)))
+              .collect(Collectors.toList());
 
-         return buildResponse(
-               dataJobExecutionsResult.getTotalPages(),
-               (int) dataJobExecutionsResult.getTotalElements(),
-               dataJobExecutions);
-      };
-   }
+      return buildResponse(
+          dataJobExecutionsResult.getTotalPages(),
+          (int) dataJobExecutionsResult.getTotalElements(),
+          dataJobExecutions);
+    };
+  }
 
-   private Page<DataJobExecution> findAllExecutions(DataJobExecutionQueryVariables dataJobExecutionQueryVariables, String dataJobName) {
-      DataJobExecutionFilter filter = dataJobExecutionQueryVariables.getFilter() != null ?
-            dataJobExecutionQueryVariables.getFilter() :
-            DataJobExecutionFilter.builder().build();
+  private Page<DataJobExecution> findAllExecutions(
+      DataJobExecutionQueryVariables dataJobExecutionQueryVariables, String dataJobName) {
+    DataJobExecutionFilter filter =
+        dataJobExecutionQueryVariables.getFilter() != null
+            ? dataJobExecutionQueryVariables.getFilter()
+            : DataJobExecutionFilter.builder().build();
 
-      if (dataJobName != null && filter.getJobNameIn() != null) {
-         throw new GraphQLException("The jobNameIn filter is not supported for nested executions");
-      }
+    if (dataJobName != null && filter.getJobNameIn() != null) {
+      throw new GraphQLException("The jobNameIn filter is not supported for nested executions");
+    }
 
-      if (dataJobName != null) {
-         filter.setJobNameIn(List.of(dataJobName));
-      }
+    if (dataJobName != null) {
+      filter.setJobNameIn(List.of(dataJobName));
+    }
 
-      Specification<DataJobExecution> filterSpec = new JobExecutionFilterSpec(filter);
-      Page<DataJobExecution> result;
-      DataJobExecutionOrder order = dataJobExecutionQueryVariables.getOrder();
-      Sort sort = order != null ? Sort.by(order.getDirection(), order.getProperty()) : null;
+    Specification<DataJobExecution> filterSpec = new JobExecutionFilterSpec(filter);
+    Page<DataJobExecution> result;
+    DataJobExecutionOrder order = dataJobExecutionQueryVariables.getOrder();
+    Sort sort = order != null ? Sort.by(order.getDirection(), order.getProperty()) : null;
 
-      if (dataJobExecutionQueryVariables.getPageNumber() != null && dataJobExecutionQueryVariables.getPageSize() != null) {
-         PageRequest pageRequest = PageRequest.of(
-               dataJobExecutionQueryVariables.getPageNumber() - 1,
-               dataJobExecutionQueryVariables.getPageSize());
-         pageRequest = sort != null ? pageRequest.withSort(sort) : pageRequest;
+    if (dataJobExecutionQueryVariables.getPageNumber() != null
+        && dataJobExecutionQueryVariables.getPageSize() != null) {
+      PageRequest pageRequest =
+          PageRequest.of(
+              dataJobExecutionQueryVariables.getPageNumber() - 1,
+              dataJobExecutionQueryVariables.getPageSize());
+      pageRequest = sort != null ? pageRequest.withSort(sort) : pageRequest;
 
-         result = jobsExecutionRepository.findAll(filterSpec, pageRequest);
-      } else {
-         List<DataJobExecution> elements = sort == null ?
-               jobsExecutionRepository.findAll(filterSpec) :
-               jobsExecutionRepository.findAll(filterSpec, sort);
+      result = jobsExecutionRepository.findAll(filterSpec, pageRequest);
+    } else {
+      List<DataJobExecution> elements =
+          sort == null
+              ? jobsExecutionRepository.findAll(filterSpec)
+              : jobsExecutionRepository.findAll(filterSpec, sort);
 
-         result = new PageImpl(elements);
-      }
+      result = new PageImpl(elements);
+    }
 
-      return result;
-   }
+    return result;
+  }
 
-   private static DataJobExecutionQueryVariables fetchDataJobExecutionQueryVariables(Map<String, Object> arguments) {
-      DataJobExecutionQueryVariables queryVariables = new DataJobExecutionQueryVariables();
+  private static DataJobExecutionQueryVariables fetchDataJobExecutionQueryVariables(
+      Map<String, Object> arguments) {
+    DataJobExecutionQueryVariables queryVariables = new DataJobExecutionQueryVariables();
 
-      Optional<ImmutablePair<Integer, Integer>> page = extractDataJobExecutionPage(
-              arguments.get(PAGE_NUMBER_FIELD),
-              arguments.get(PAGE_SIZE_FIELD));
+    Optional<ImmutablePair<Integer, Integer>> page =
+        extractDataJobExecutionPage(
+            arguments.get(PAGE_NUMBER_FIELD), arguments.get(PAGE_SIZE_FIELD));
 
-      page.ifPresent(pair -> {
-         queryVariables.setPageNumber(pair.getLeft());
-         queryVariables.setPageSize(pair.getRight());
-      });
+    page.ifPresent(
+        pair -> {
+          queryVariables.setPageNumber(pair.getLeft());
+          queryVariables.setPageSize(pair.getRight());
+        });
 
-      extractDataJobExecutionFilter((Map<String, Object>)arguments.get(FILTER_FIELD))
-              .ifPresent(filter -> queryVariables.setFilter(filter));
+    extractDataJobExecutionFilter((Map<String, Object>) arguments.get(FILTER_FIELD))
+        .ifPresent(filter -> queryVariables.setFilter(filter));
 
-      extractDataJobExecutionOrder((Map<String, Object>)arguments.get(ORDER_FIELD))
-              .ifPresent(order -> queryVariables.setOrder(order));
+    extractDataJobExecutionOrder((Map<String, Object>) arguments.get(ORDER_FIELD))
+        .ifPresent(order -> queryVariables.setOrder(order));
 
-      return queryVariables;
-   }
+    return queryVariables;
+  }
 
-   private static Optional<ImmutablePair<Integer, Integer>> extractDataJobExecutionPage(Object pageNumberRaw, Object pageSizeRaw) {
-      Optional<ImmutablePair<Integer, Integer>> result = Optional.empty();
+  private static Optional<ImmutablePair<Integer, Integer>> extractDataJobExecutionPage(
+      Object pageNumberRaw, Object pageSizeRaw) {
+    Optional<ImmutablePair<Integer, Integer>> result = Optional.empty();
 
-      if (pageNumberRaw != null && pageSizeRaw == null) {
-         throw new GraphQLException(String.format("Executions field must contain %s", PAGE_SIZE_FIELD));
-      }
+    if (pageNumberRaw != null && pageSizeRaw == null) {
+      throw new GraphQLException(
+          String.format("Executions field must contain %s", PAGE_SIZE_FIELD));
+    }
 
-      if (pageNumberRaw == null && pageSizeRaw != null) {
-         throw new GraphQLException(String.format("Executions field must contain %s", PAGE_NUMBER_FIELD));
-      }
+    if (pageNumberRaw == null && pageSizeRaw != null) {
+      throw new GraphQLException(
+          String.format("Executions field must contain %s", PAGE_NUMBER_FIELD));
+    }
 
-      if (pageNumberRaw != null && pageSizeRaw != null) {
-         Integer pageNumber = (Integer)pageNumberRaw;
-         Integer pageSize = (Integer)pageSizeRaw;
-         GraphQLUtils.validatePageInput(pageSize, pageNumber);
-         result = Optional.of(ImmutablePair.of(pageNumber, pageSize));
-      }
+    if (pageNumberRaw != null && pageSizeRaw != null) {
+      Integer pageNumber = (Integer) pageNumberRaw;
+      Integer pageSize = (Integer) pageSizeRaw;
+      GraphQLUtils.validatePageInput(pageSize, pageNumber);
+      result = Optional.of(ImmutablePair.of(pageNumber, pageSize));
+    }
 
-      return result;
-   }
+    return result;
+  }
 
-   private static Optional<DataJobExecutionFilter> extractDataJobExecutionFilter(Map<String, Object> filterRaw) {
-      Optional<DataJobExecutionFilter> filter = Optional.empty();
+  private static Optional<DataJobExecutionFilter> extractDataJobExecutionFilter(
+      Map<String, Object> filterRaw) {
+    Optional<DataJobExecutionFilter> filter = Optional.empty();
 
-      if (filterRaw != null) {
-         DataJobExecutionFilter.DataJobExecutionFilterBuilder builder = DataJobExecutionFilter.builder();
+    if (filterRaw != null) {
+      DataJobExecutionFilter.DataJobExecutionFilterBuilder builder =
+          DataJobExecutionFilter.builder();
 
-         builder.statusIn(
-               Optional.ofNullable(filterRaw.get(DataJobExecutionFilter.STATUS_IN_FIELD))
-                     .map(statusInRaw -> ((List<String>) statusInRaw))
-                     .stream()
-                     .flatMap(v1Jobs -> v1Jobs.stream())
-                     .filter(Objects::nonNull)
-                     .map(status -> com.vmware.taurus.controlplane.model.data.DataJobExecution.StatusEnum.fromValue(status.toLowerCase()))
-                     .map(statusEnum -> ToModelApiConverter.toExecutionStatus(statusEnum))
-                     .collect(Collectors.toList())
-         );
+      builder.statusIn(
+          Optional.ofNullable(filterRaw.get(DataJobExecutionFilter.STATUS_IN_FIELD))
+              .map(statusInRaw -> ((List<String>) statusInRaw))
+              .stream()
+              .flatMap(v1Jobs -> v1Jobs.stream())
+              .filter(Objects::nonNull)
+              .map(
+                  status ->
+                      com.vmware.taurus.controlplane.model.data.DataJobExecution.StatusEnum
+                          .fromValue(status.toLowerCase()))
+              .map(statusEnum -> ToModelApiConverter.toExecutionStatus(statusEnum))
+              .collect(Collectors.toList()));
 
-         filter = Optional.of(
-               builder
-                     .startTimeGte((OffsetDateTime) filterRaw.get(DataJobExecutionFilter.START_TIME_GTE_FIELD))
-                     .endTimeGte((OffsetDateTime) filterRaw.get(DataJobExecutionFilter.END_TIME_GTE_FIELD))
-                     .startTimeLte((OffsetDateTime) filterRaw.get(DataJobExecutionFilter.START_TIME_LTE_FIELD))
-                     .endTimeLte((OffsetDateTime) filterRaw.get(DataJobExecutionFilter.END_TIME_LTE_FIELD))
-                     .jobNameIn((List<String>) filterRaw.get(DataJobExecutionFilter.JOB_NAME_IN_FIELD))
-                     .teamNameIn((List<String>) filterRaw.get(DataJobExecutionFilter.TEAM_NAME_IN_FIELD))
-                     .build()
-         );
-      }
+      filter =
+          Optional.of(
+              builder
+                  .startTimeGte(
+                      (OffsetDateTime) filterRaw.get(DataJobExecutionFilter.START_TIME_GTE_FIELD))
+                  .endTimeGte(
+                      (OffsetDateTime) filterRaw.get(DataJobExecutionFilter.END_TIME_GTE_FIELD))
+                  .startTimeLte(
+                      (OffsetDateTime) filterRaw.get(DataJobExecutionFilter.START_TIME_LTE_FIELD))
+                  .endTimeLte(
+                      (OffsetDateTime) filterRaw.get(DataJobExecutionFilter.END_TIME_LTE_FIELD))
+                  .jobNameIn((List<String>) filterRaw.get(DataJobExecutionFilter.JOB_NAME_IN_FIELD))
+                  .teamNameIn(
+                      (List<String>) filterRaw.get(DataJobExecutionFilter.TEAM_NAME_IN_FIELD))
+                  .build());
+    }
 
-      return filter;
-   }
+    return filter;
+  }
 
-   private static Optional<DataJobExecutionOrder> extractDataJobExecutionOrder(Map<String, Object> orderRaw) {
-      Optional<DataJobExecutionOrder> order = Optional.empty();
+  private static Optional<DataJobExecutionOrder> extractDataJobExecutionOrder(
+      Map<String, Object> orderRaw) {
+    Optional<DataJobExecutionOrder> order = Optional.empty();
 
-      if (orderRaw != null) {
-         DataJobExecutionOrder.DataJobExecutionOrderBuilder builder = DataJobExecutionOrder.builder();
+    if (orderRaw != null) {
+      DataJobExecutionOrder.DataJobExecutionOrderBuilder builder = DataJobExecutionOrder.builder();
 
-         builder.property(
-               Optional.ofNullable(orderRaw.get(PROPERTY_FIELD))
-                     .map(o -> (String) o)
-                     .filter(p -> AVAILABLE_PROPERTIES.contains(p))
-                     .map(p -> PUBLIC_NAME_TO_DB_ENTITY_MAP.getOrDefault(p, p)) // If no mapping present use user provided property name
-                     .orElseThrow(() -> new GraphQLException(String.format(
-                           "%s.%s must be in [%s]",
-                           ORDER_FIELD,
-                           PROPERTY_FIELD,
-                           StringUtils.join(AVAILABLE_PROPERTIES, ","))))
-         );
+      builder.property(
+          Optional.ofNullable(orderRaw.get(PROPERTY_FIELD))
+              .map(o -> (String) o)
+              .filter(p -> AVAILABLE_PROPERTIES.contains(p))
+              .map(
+                  p ->
+                      PUBLIC_NAME_TO_DB_ENTITY_MAP.getOrDefault(
+                          p, p)) // If no mapping present use user provided property name
+              .orElseThrow(
+                  () ->
+                      new GraphQLException(
+                          String.format(
+                              "%s.%s must be in [%s]",
+                              ORDER_FIELD,
+                              PROPERTY_FIELD,
+                              StringUtils.join(AVAILABLE_PROPERTIES, ",")))));
 
-         builder.direction(
-               Optional.ofNullable(orderRaw.get(DIRECTION_FIELD))
-                     .map(o -> Sort.Direction.fromString((String)o))
-                     .orElseThrow(() -> new GraphQLException(String.format(
-                           "Executions field must contain %s.%s",
-                           ORDER_FIELD,
-                           DIRECTION_FIELD)))
-         );
+      builder.direction(
+          Optional.ofNullable(orderRaw.get(DIRECTION_FIELD))
+              .map(o -> Sort.Direction.fromString((String) o))
+              .orElseThrow(
+                  () ->
+                      new GraphQLException(
+                          String.format(
+                              "Executions field must contain %s.%s",
+                              ORDER_FIELD, DIRECTION_FIELD))));
 
-         order = Optional.of(builder.build());
-      }
+      order = Optional.of(builder.build());
+    }
 
-      return order;
-   }
+    return order;
+  }
 
-   private static DataJobPage buildResponse(
-         int pageSize,
-         int count,
-         List pageList) {
+  private static DataJobPage buildResponse(int pageSize, int count, List pageList) {
 
-      return DataJobPage.builder()
-            .content(new ArrayList<>(pageList))
-            .totalPages(pageSize)
-            .totalItems(count).build();
-   }
+    return DataJobPage.builder()
+        .content(new ArrayList<>(pageList))
+        .totalPages(pageSize)
+        .totalItems(count)
+        .build();
+  }
 
-   List<V2DataJob> populateStatusCounts(List<V2DataJob> dataJobs, DataFetchingEnvironment dataFetchingEnvironment) {
+  List<V2DataJob> populateStatusCounts(
+      List<V2DataJob> dataJobs, DataFetchingEnvironment dataFetchingEnvironment) {
 
-      List<ExecutionStatus> statusesToCount = determineStatusesToCount(dataFetchingEnvironment);
-      List<String> jobsList = dataJobs.stream().map(V2DataJob::getJobName).collect(Collectors.toList());
-      Map<String, Map<ExecutionStatus, Integer>> statusCountMap = jobExecutionService.countExecutionStatuses(jobsList,
-              statusesToCount);
+    List<ExecutionStatus> statusesToCount = determineStatusesToCount(dataFetchingEnvironment);
+    List<String> jobsList =
+        dataJobs.stream().map(V2DataJob::getJobName).collect(Collectors.toList());
+    Map<String, Map<ExecutionStatus, Integer>> statusCountMap =
+        jobExecutionService.countExecutionStatuses(jobsList, statusesToCount);
 
-      dataJobs.stream()
-              .forEach(job -> {
-                 if (job.getDeployments() != null) {
-                    job.getDeployments()
-                            .stream()
-                            .findFirst()
-                            .ifPresent(deployment -> {
-                               setStatusCounts(statusCountMap, job, dataFetchingEnvironment, deployment);
-                            });
-                 }
-              });
-      return dataJobs;
-   }
+    dataJobs.stream()
+        .forEach(
+            job -> {
+              if (job.getDeployments() != null) {
+                job.getDeployments().stream()
+                    .findFirst()
+                    .ifPresent(
+                        deployment -> {
+                          setStatusCounts(statusCountMap, job, dataFetchingEnvironment, deployment);
+                        });
+              }
+            });
+    return dataJobs;
+  }
 
-   private void setStatusCounts(Map<String, Map<ExecutionStatus, Integer>> response, V2DataJob job,
-                                DataFetchingEnvironment dataFetchingEnvironment, V2DataJobDeployment v2DataJobDeployment) {
+  private void setStatusCounts(
+      Map<String, Map<ExecutionStatus, Integer>> response,
+      V2DataJob job,
+      DataFetchingEnvironment dataFetchingEnvironment,
+      V2DataJobDeployment v2DataJobDeployment) {
 
-      DataFetchingFieldSelectionSet selectionSet = dataFetchingEnvironment.getSelectionSet();
-      Map<ExecutionStatus, Integer> statusCountsPerJob = response.getOrDefault(job.getJobName(), Map.of());
+    DataFetchingFieldSelectionSet selectionSet = dataFetchingEnvironment.getSelectionSet();
+    Map<ExecutionStatus, Integer> statusCountsPerJob =
+        response.getOrDefault(job.getJobName(), Map.of());
 
-      if (selectionSet.contains(JobFieldStrategyBy.DEPLOYMENT_FAILED_EXECUTIONS.getPath())) {
-         int failedExecutions = statusCountsPerJob.getOrDefault(ExecutionStatus.USER_ERROR, 0) +
-               statusCountsPerJob.getOrDefault(ExecutionStatus.PLATFORM_ERROR, 0);
-         v2DataJobDeployment.setFailedExecutions(failedExecutions);
-      }
-      if (selectionSet.contains(JobFieldStrategyBy.DEPLOYMENT_SUCCESSFUL_EXECUTIONS.getPath())) {
-         v2DataJobDeployment.setSuccessfulExecutions(statusCountsPerJob.getOrDefault(ExecutionStatus.SUCCEEDED, 0));
-      }
-   }
+    if (selectionSet.contains(JobFieldStrategyBy.DEPLOYMENT_FAILED_EXECUTIONS.getPath())) {
+      int failedExecutions =
+          statusCountsPerJob.getOrDefault(ExecutionStatus.USER_ERROR, 0)
+              + statusCountsPerJob.getOrDefault(ExecutionStatus.PLATFORM_ERROR, 0);
+      v2DataJobDeployment.setFailedExecutions(failedExecutions);
+    }
+    if (selectionSet.contains(JobFieldStrategyBy.DEPLOYMENT_SUCCESSFUL_EXECUTIONS.getPath())) {
+      v2DataJobDeployment.setSuccessfulExecutions(
+          statusCountsPerJob.getOrDefault(ExecutionStatus.SUCCEEDED, 0));
+    }
+  }
 
-   private List<ExecutionStatus> determineStatusesToCount(DataFetchingEnvironment dataFetchingEnvironment) {
-      DataFetchingFieldSelectionSet selectionSet = dataFetchingEnvironment.getSelectionSet();
-      List<ExecutionStatus> statusesToCount = new ArrayList<>();
+  private List<ExecutionStatus> determineStatusesToCount(
+      DataFetchingEnvironment dataFetchingEnvironment) {
+    DataFetchingFieldSelectionSet selectionSet = dataFetchingEnvironment.getSelectionSet();
+    List<ExecutionStatus> statusesToCount = new ArrayList<>();
 
-      if (selectionSet.contains(JobFieldStrategyBy.DEPLOYMENT_FAILED_EXECUTIONS.getPath())) {
-         statusesToCount.add(ExecutionStatus.USER_ERROR);
-         statusesToCount.add(ExecutionStatus.PLATFORM_ERROR);
-      }
-      if (selectionSet.contains(JobFieldStrategyBy.DEPLOYMENT_SUCCESSFUL_EXECUTIONS.getPath())) {
-         statusesToCount.add(ExecutionStatus.SUCCEEDED);
-      }
+    if (selectionSet.contains(JobFieldStrategyBy.DEPLOYMENT_FAILED_EXECUTIONS.getPath())) {
+      statusesToCount.add(ExecutionStatus.USER_ERROR);
+      statusesToCount.add(ExecutionStatus.PLATFORM_ERROR);
+    }
+    if (selectionSet.contains(JobFieldStrategyBy.DEPLOYMENT_SUCCESSFUL_EXECUTIONS.getPath())) {
+      statusesToCount.add(ExecutionStatus.SUCCEEDED);
+    }
 
-      return statusesToCount;
-   }
+    return statusesToCount;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLDataFetchers.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLDataFetchers.java
@@ -43,161 +43,196 @@ import java.util.stream.StreamSupport;
 @AllArgsConstructor
 public class GraphQLDataFetchers {
 
-   private static final Criteria<V2DataJob> JOB_CRITERIA_DEFAULT =
-         new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
+  private static final Criteria<V2DataJob> JOB_CRITERIA_DEFAULT =
+      new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
 
-   private final JobFieldStrategyFactory strategyFactory;
-   private final JobsRepository jobsRepository;
-   private final DeploymentService deploymentService;
-   private final ExecutionDataFetcher executionDataFetcher;
+  private final JobFieldStrategyFactory strategyFactory;
+  private final JobsRepository jobsRepository;
+  private final DeploymentService deploymentService;
+  private final ExecutionDataFetcher executionDataFetcher;
 
-   public DataFetcher<Object> findAllAndBuildDataJobPage() {
-      return dataFetchingEnvironment -> {
-         DataJobQueryVariables queryVar = fetchDataJobQueryVariables(dataFetchingEnvironment);
-         var dataJobs = StreamSupport.stream(jobsRepository.findAll().spliterator(), false)
-                 .collect(Collectors.toMap(
-                         DataJob::getName,
-                         job -> job
-                 ));
-         List<V2DataJob> allDataJob = dataJobs.values().stream()
-               .map(ToApiModelConverter::toV2DataJob)
-               .collect(Collectors.toList());
+  public DataFetcher<Object> findAllAndBuildDataJobPage() {
+    return dataFetchingEnvironment -> {
+      DataJobQueryVariables queryVar = fetchDataJobQueryVariables(dataFetchingEnvironment);
+      var dataJobs =
+          StreamSupport.stream(jobsRepository.findAll().spliterator(), false)
+              .collect(Collectors.toMap(DataJob::getName, job -> job));
+      List<V2DataJob> allDataJob =
+          dataJobs.values().stream()
+              .map(ToApiModelConverter::toV2DataJob)
+              .collect(Collectors.toList());
 
-         final Criteria<V2DataJob> filterCriteria = populateCriteria(queryVar.getFilters());
-         List<V2DataJob> dataJobsFiltered = populateDataJobsByRequestedFields(dataFetchingEnvironment, allDataJob, dataJobs).stream()
-               .filter(filterCriteria.getPredicate())
-               .filter(computeSearch(dataFetchingEnvironment.getSelectionSet(), queryVar.getSearch()))
-               .sorted(filterCriteria.getComparator())
-               .collect(Collectors.toList());
+      final Criteria<V2DataJob> filterCriteria = populateCriteria(queryVar.getFilters());
+      List<V2DataJob> dataJobsFiltered =
+          populateDataJobsByRequestedFields(dataFetchingEnvironment, allDataJob, dataJobs).stream()
+              .filter(filterCriteria.getPredicate())
+              .filter(
+                  computeSearch(dataFetchingEnvironment.getSelectionSet(), queryVar.getSearch()))
+              .sorted(filterCriteria.getComparator())
+              .collect(Collectors.toList());
 
-         int count = dataJobsFiltered.size();
+      int count = dataJobsFiltered.size();
 
-         List<V2DataJob> dataJobList = dataJobsFiltered.stream()
-               .skip((long) (queryVar.getPageNumber() - 1) * queryVar.getPageSize())
-               .limit(queryVar.getPageSize())
-               .collect(Collectors.toList());
+      List<V2DataJob> dataJobList =
+          dataJobsFiltered.stream()
+              .skip((long) (queryVar.getPageNumber() - 1) * queryVar.getPageSize())
+              .limit(queryVar.getPageSize())
+              .collect(Collectors.toList());
 
-         List<V2DataJob> resultList = populateDataJobsPostPagination(dataJobList, dataFetchingEnvironment);
+      List<V2DataJob> resultList =
+          populateDataJobsPostPagination(dataJobList, dataFetchingEnvironment);
 
-         return buildResponse(queryVar.getPageSize(), count, resultList);
-      };
-   }
+      return buildResponse(queryVar.getPageSize(), count, resultList);
+    };
+  }
 
-   private List<V2DataJob> populateDataJobsPostPagination(List<V2DataJob> allDataJob, DataFetchingEnvironment dataFetchingEnvironment) {
-      if (dataFetchingEnvironment.getSelectionSet().contains(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath())) {
-         executionDataFetcher.populateExecutions(allDataJob, dataFetchingEnvironment);
-      }
+  private List<V2DataJob> populateDataJobsPostPagination(
+      List<V2DataJob> allDataJob, DataFetchingEnvironment dataFetchingEnvironment) {
+    if (dataFetchingEnvironment
+        .getSelectionSet()
+        .contains(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath())) {
+      executionDataFetcher.populateExecutions(allDataJob, dataFetchingEnvironment);
+    }
 
-      if (dataFetchingEnvironment.getSelectionSet().contains(JobFieldStrategyBy.DEPLOYMENT_FAILED_EXECUTIONS.getPath())
-              || dataFetchingEnvironment.getSelectionSet().contains(JobFieldStrategyBy.DEPLOYMENT_SUCCESSFUL_EXECUTIONS.getPath())) {
-         executionDataFetcher.populateStatusCounts(allDataJob, dataFetchingEnvironment);
-      }
+    if (dataFetchingEnvironment
+            .getSelectionSet()
+            .contains(JobFieldStrategyBy.DEPLOYMENT_FAILED_EXECUTIONS.getPath())
+        || dataFetchingEnvironment
+            .getSelectionSet()
+            .contains(JobFieldStrategyBy.DEPLOYMENT_SUCCESSFUL_EXECUTIONS.getPath())) {
+      executionDataFetcher.populateStatusCounts(allDataJob, dataFetchingEnvironment);
+    }
 
-      return allDataJob;
-   }
+    return allDataJob;
+  }
 
-   private DataJobQueryVariables fetchDataJobQueryVariables(DataFetchingEnvironment dataFetchingEnvironment) {
-      DataJobQueryVariables queryVariables = new DataJobQueryVariables();
+  private DataJobQueryVariables fetchDataJobQueryVariables(
+      DataFetchingEnvironment dataFetchingEnvironment) {
+    DataJobQueryVariables queryVariables = new DataJobQueryVariables();
 
-      queryVariables.setPageNumber(dataFetchingEnvironment.getArgument("pageNumber"));
-      queryVariables.setPageSize(dataFetchingEnvironment.getArgument("pageSize"));
-      GraphQLUtils.validatePageInput(queryVariables.getPageSize(), queryVariables.getPageNumber());
-      queryVariables.setSearch(dataFetchingEnvironment.getArgument("search"));
-      queryVariables.setFilters(GraphQLUtils.convertFilters(dataFetchingEnvironment.getArgument("filter")));
+    queryVariables.setPageNumber(dataFetchingEnvironment.getArgument("pageNumber"));
+    queryVariables.setPageSize(dataFetchingEnvironment.getArgument("pageSize"));
+    GraphQLUtils.validatePageInput(queryVariables.getPageSize(), queryVariables.getPageNumber());
+    queryVariables.setSearch(dataFetchingEnvironment.getArgument("search"));
+    queryVariables.setFilters(
+        GraphQLUtils.convertFilters(dataFetchingEnvironment.getArgument("filter")));
 
-      return queryVariables;
-   }
+    return queryVariables;
+  }
 
-   /**
-    * Alter each data job in order to populate fields that are requested from the GraphQL body
-    * @param dataFetchingEnvironment Environment holder of the graphql requests
-    * @param allDataJob      List of the data jobs which will be altered
-    * @return Altered data job list
-    */
-   private List<V2DataJob> populateDataJobsByRequestedFields(DataFetchingEnvironment dataFetchingEnvironment,
-                                                             List<V2DataJob> allDataJob,
-                                                             Map<String, DataJob> dataJobs) {
-      DataFetchingFieldSelectionSet requestedFields = dataFetchingEnvironment.getSelectionSet();
-      if (requestedFields.contains(JobFieldStrategyBy.DEPLOYMENT.getPath())) {
-         populateDeployments(allDataJob, dataJobs);
-      }
+  /**
+   * Alter each data job in order to populate fields that are requested from the GraphQL body
+   *
+   * @param dataFetchingEnvironment Environment holder of the graphql requests
+   * @param allDataJob List of the data jobs which will be altered
+   * @return Altered data job list
+   */
+  private List<V2DataJob> populateDataJobsByRequestedFields(
+      DataFetchingEnvironment dataFetchingEnvironment,
+      List<V2DataJob> allDataJob,
+      Map<String, DataJob> dataJobs) {
+    DataFetchingFieldSelectionSet requestedFields = dataFetchingEnvironment.getSelectionSet();
+    if (requestedFields.contains(JobFieldStrategyBy.DEPLOYMENT.getPath())) {
+      populateDeployments(allDataJob, dataJobs);
+    }
 
-      allDataJob.forEach(dataJob -> strategyFactory.getStrategies().entrySet().stream()
-            .filter(strategy -> requestedFields.contains(strategy.getKey().getPath()))
-            .forEach(strategy -> strategy.getValue().alterFieldData(dataJob)));
+    allDataJob.forEach(
+        dataJob ->
+            strategyFactory.getStrategies().entrySet().stream()
+                .filter(strategy -> requestedFields.contains(strategy.getKey().getPath()))
+                .forEach(strategy -> strategy.getValue().alterFieldData(dataJob)));
 
-      return allDataJob;
-   }
+    return allDataJob;
+  }
 
-   private Criteria<V2DataJob> populateCriteria(List<Filter> filterList) {
-      // concurrent result, calculation might be using Fork-Join API to speed-up
-      final AtomicReference<Criteria<V2DataJob>> criteriaResult = new AtomicReference<>(JOB_CRITERIA_DEFAULT);
+  private Criteria<V2DataJob> populateCriteria(List<Filter> filterList) {
+    // concurrent result, calculation might be using Fork-Join API to speed-up
+    final AtomicReference<Criteria<V2DataJob>> criteriaResult =
+        new AtomicReference<>(JOB_CRITERIA_DEFAULT);
 
-      // handle non-supported or invalid filter(s)
-      final Optional<Filter> filterNotSupported = filterList.stream()
-            .filter(e -> e.getProperty() == null || (e.getPattern() == null && e.getSort() == null) || JobFieldStrategyBy.field(e.getProperty()) == null)
+    // handle non-supported or invalid filter(s)
+    final Optional<Filter> filterNotSupported =
+        filterList.stream()
+            .filter(
+                e ->
+                    e.getProperty() == null
+                        || (e.getPattern() == null && e.getSort() == null)
+                        || JobFieldStrategyBy.field(e.getProperty()) == null)
             .findAny(); // or all
-      if (filterNotSupported.isPresent()) {
-         throw GraphqlErrorException.newErrorException()
-               .message("Provided filter for " + filterNotSupported.get().getProperty() + " is either not valid or currently not supported")
-               .build();
+    if (filterNotSupported.isPresent()) {
+      throw GraphqlErrorException.newErrorException()
+          .message(
+              "Provided filter for "
+                  + filterNotSupported.get().getProperty()
+                  + " is either not valid or currently not supported")
+          .build();
+    }
+
+    // populate filter strategies
+    final Map<Filter, FieldStrategy<V2DataJob>> filterStrategyMap =
+        filterList.stream()
+            .collect(
+                Collectors.toMap(
+                    f -> f,
+                    filter ->
+                        strategyFactory.findStrategy(
+                            JobFieldStrategyBy.field(filter.getProperty()))));
+
+    // compute criteria
+    filterStrategyMap.forEach(
+        (key, value) -> criteriaResult.getAndUpdate(c -> value.computeFilterCriteria(c, key)));
+    return criteriaResult.get();
+  }
+
+  private Predicate<V2DataJob> computeSearch(
+      DataFetchingFieldSelectionSet requestedFields, String search) {
+    Predicate<V2DataJob> predicate = null;
+    if (search != null && !search.isBlank()) {
+      for (Map.Entry<JobFieldStrategyBy, FieldStrategy<V2DataJob>> entry :
+          strategyFactory.getStrategies().entrySet()) {
+        JobFieldStrategyBy strategyName = entry.getKey();
+        FieldStrategy<V2DataJob> strategy = entry.getValue();
+
+        if (requestedFields.contains(strategyName.getPath())) {
+          predicate =
+              (predicate == null)
+                  ? strategy.computeSearchCriteria(search)
+                  : predicate.or(strategy.computeSearchCriteria(search));
+        }
       }
+    }
+    return predicate == null ? Objects::nonNull : predicate;
+  }
 
-      // populate filter strategies
-      final Map<Filter, FieldStrategy<V2DataJob>> filterStrategyMap = filterList.stream()
-            .collect(Collectors.toMap(
-                  f -> f,
-                  filter -> strategyFactory.findStrategy(JobFieldStrategyBy.field(filter.getProperty()))
-            ));
+  private List<V2DataJob> populateDeployments(
+      List<V2DataJob> allDataJob, Map<String, DataJob> dataJobs) {
+    Map<String, JobDeploymentStatus> deploymentStatuses =
+        deploymentService.readDeployments().stream()
+            .collect(Collectors.toMap(JobDeploymentStatus::getDataJobName, cronJob -> cronJob));
 
-      // compute criteria
-      filterStrategyMap.forEach((key, value) -> criteriaResult.getAndUpdate(c -> value.computeFilterCriteria(c, key)));
-      return criteriaResult.get();
-   }
-
-   private Predicate<V2DataJob> computeSearch(DataFetchingFieldSelectionSet requestedFields, String search) {
-      Predicate<V2DataJob> predicate = null;
-      if (search != null && !search.isBlank()) {
-         for (Map.Entry<JobFieldStrategyBy, FieldStrategy<V2DataJob>> entry : strategyFactory.getStrategies().entrySet()) {
-            JobFieldStrategyBy strategyName = entry.getKey();
-            FieldStrategy<V2DataJob> strategy = entry.getValue();
-
-            if (requestedFields.contains(strategyName.getPath())) {
-               predicate = (predicate == null) ?
-                     strategy.computeSearchCriteria(search) : predicate.or(strategy.computeSearchCriteria(search));
-            }
-         }
-      }
-      return predicate == null ? Objects::nonNull : predicate;
-   }
-
-   private List<V2DataJob> populateDeployments(List<V2DataJob> allDataJob, Map<String, DataJob> dataJobs) {
-      Map<String, JobDeploymentStatus> deploymentStatuses = deploymentService.readDeployments()
-            .stream().collect(Collectors.toMap(JobDeploymentStatus::getDataJobName, cronJob -> cronJob));
-
-      allDataJob.forEach(dataJob -> {
-         var jobDeploymentStatus = deploymentStatuses.get(dataJob.getJobName());
-         if (jobDeploymentStatus != null) {
+    allDataJob.forEach(
+        dataJob -> {
+          var jobDeploymentStatus = deploymentStatuses.get(dataJob.getJobName());
+          if (jobDeploymentStatus != null) {
             // TODO add multiple deployments when its supported
             var sourceDataJob = dataJobs.get(dataJob.getJobName());
             if (sourceDataJob == null) {
-               log.warn("Data job {} not found when populating deployments", dataJob.getJobName());
+              log.warn("Data job {} not found when populating deployments", dataJob.getJobName());
             }
-            dataJob.setDeployments(Collections.singletonList(
-                  ToApiModelConverter.toV2DataJobDeployment(jobDeploymentStatus, sourceDataJob)));
-         }
-      });
-      return allDataJob;
-   }
+            dataJob.setDeployments(
+                Collections.singletonList(
+                    ToApiModelConverter.toV2DataJobDeployment(jobDeploymentStatus, sourceDataJob)));
+          }
+        });
+    return allDataJob;
+  }
 
-   private static DataJobPage buildResponse(
-         int pageSize,
-         int count,
-         List pageList) {
+  private static DataJobPage buildResponse(int pageSize, int count, List pageList) {
 
-      return DataJobPage.builder()
-            .content(new ArrayList<>(pageList))
-            .totalPages(((count - 1) / pageSize + 1))
-            .totalItems(count).build();
-   }
+    return DataJobPage.builder()
+        .content(new ArrayList<>(pageList))
+        .totalPages(((count - 1) / pageSize + 1))
+        .totalItems(count)
+        .build();
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLProvider.java
@@ -26,44 +26,48 @@ import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring;
 @Component
 public class GraphQLProvider {
 
-   private GraphQL graphQL;
+  private GraphQL graphQL;
 
-   private GraphQLDataFetchers graphQLDataFetchers;
+  private GraphQLDataFetchers graphQLDataFetchers;
 
-   private ExecutionDataFetcher executionDataFetcher;
+  private ExecutionDataFetcher executionDataFetcher;
 
-   public GraphQLProvider(GraphQLDataFetchers graphQLDataFetchers, ExecutionDataFetcher executionDataFetcher) {
-      this.graphQLDataFetchers = graphQLDataFetchers;
-      this.executionDataFetcher = executionDataFetcher;
-   }
+  public GraphQLProvider(
+      GraphQLDataFetchers graphQLDataFetchers, ExecutionDataFetcher executionDataFetcher) {
+    this.graphQLDataFetchers = graphQLDataFetchers;
+    this.executionDataFetcher = executionDataFetcher;
+  }
 
-   @Bean
-   public GraphQL graphQL() {
-      return graphQL;
-   }
+  @Bean
+  public GraphQL graphQL() {
+    return graphQL;
+  }
 
-   @PostConstruct
-   public void init() throws IOException {
-      // TODO refactor this to use non-beta methods
-      URL url = Resources.getResource("schema.graphqls");
-      String sdl = Resources.toString(url, Charsets.UTF_8);
-      GraphQLSchema graphQLSchema = buildSchema(sdl);
-      this.graphQL = GraphQL.newGraphQL(graphQLSchema).build();
-   }
+  @PostConstruct
+  public void init() throws IOException {
+    // TODO refactor this to use non-beta methods
+    URL url = Resources.getResource("schema.graphqls");
+    String sdl = Resources.toString(url, Charsets.UTF_8);
+    GraphQLSchema graphQLSchema = buildSchema(sdl);
+    this.graphQL = GraphQL.newGraphQL(graphQLSchema).build();
+  }
 
-   private GraphQLSchema buildSchema(String sdl) {
-      TypeDefinitionRegistry typeRegistry = new SchemaParser().parse(sdl);
-      RuntimeWiring runtimeWiring = buildWiring();
-      SchemaGenerator schemaGenerator = new SchemaGenerator();
-      return schemaGenerator.makeExecutableSchema(typeRegistry, runtimeWiring);
-   }
+  private GraphQLSchema buildSchema(String sdl) {
+    TypeDefinitionRegistry typeRegistry = new SchemaParser().parse(sdl);
+    RuntimeWiring runtimeWiring = buildWiring();
+    SchemaGenerator schemaGenerator = new SchemaGenerator();
+    return schemaGenerator.makeExecutableSchema(typeRegistry, runtimeWiring);
+  }
 
-   private RuntimeWiring buildWiring() {
-      return RuntimeWiring.newRuntimeWiring()
-            .scalar(ExtendedScalars.DateTime)
-            .type(newTypeWiring("Query")
-                  .dataFetcher(GraphQLUtils.JOBS_QUERY, graphQLDataFetchers.findAllAndBuildDataJobPage())
-                  .dataFetcher(GraphQLUtils.EXECUTIONS_QUERY, executionDataFetcher.findAllAndBuildResponse()))
-            .build();
-   }
+  private RuntimeWiring buildWiring() {
+    return RuntimeWiring.newRuntimeWiring()
+        .scalar(ExtendedScalars.DateTime)
+        .type(
+            newTypeWiring("Query")
+                .dataFetcher(
+                    GraphQLUtils.JOBS_QUERY, graphQLDataFetchers.findAllAndBuildDataJobPage())
+                .dataFetcher(
+                    GraphQLUtils.EXECUTIONS_QUERY, executionDataFetcher.findAllAndBuildResponse()))
+        .build();
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLUtils.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLUtils.java
@@ -18,38 +18,40 @@ import java.util.Set;
 @UtilityClass
 public class GraphQLUtils {
 
-   public static final String JOBS_QUERY = "jobs";
-   public static final String EXECUTIONS_QUERY = "executions";
-   public static final Set<String> QUERIES = Set.of(JOBS_QUERY, EXECUTIONS_QUERY);
+  public static final String JOBS_QUERY = "jobs";
+  public static final String EXECUTIONS_QUERY = "executions";
+  public static final Set<String> QUERIES = Set.of(JOBS_QUERY, EXECUTIONS_QUERY);
 
-   /**
-    * GraphQL's library parses json query variables to List of LinkedHashMaps. In order to use later the
-    * filtering and sorting by specific field easily we convert them to list of Filters
-    * @see Filter
-    * @see GraphQLDataFetchers
-    *
-    * @param rawFilters filters object in fetched from graphql environment to convert
-    * @return List of converted filters
-    */
-   public static List<Filter> convertFilters(List<LinkedHashMap<String, String>> rawFilters) {
-      List<Filter> filters = new ArrayList<>();
-      if (rawFilters != null && !rawFilters.isEmpty()) {
-         rawFilters.forEach(map -> {
+  /**
+   * GraphQL's library parses json query variables to List of LinkedHashMaps. In order to use later
+   * the filtering and sorting by specific field easily we convert them to list of Filters
+   *
+   * @see Filter
+   * @see GraphQLDataFetchers
+   * @param rawFilters filters object in fetched from graphql environment to convert
+   * @return List of converted filters
+   */
+  public static List<Filter> convertFilters(List<LinkedHashMap<String, String>> rawFilters) {
+    List<Filter> filters = new ArrayList<>();
+    if (rawFilters != null && !rawFilters.isEmpty()) {
+      rawFilters.forEach(
+          map -> {
             if (map != null && !map.isEmpty()) {
-               Sort.Direction direction = map.get("sort") == null ? null : Sort.Direction.valueOf(map.get("sort"));
-               filters.add(new Filter(map.get("property"), map.get("pattern"), direction));
+              Sort.Direction direction =
+                  map.get("sort") == null ? null : Sort.Direction.valueOf(map.get("sort"));
+              filters.add(new Filter(map.get("property"), map.get("pattern"), direction));
             }
-         });
-      }
-      return filters;
-   }
+          });
+    }
+    return filters;
+  }
 
-   public static void validatePageInput(int pageSize, int pageNumber) {
-      if (pageSize < 1) {
-         throw new GraphQLException("Page size cannot be less than 1");
-      }
-      if (pageNumber < 1) {
-         throw new GraphQLException("Page cannot be less than 1");
-      }
-   }
+  public static void validatePageInput(int pageSize, int pageNumber) {
+    if (pageSize < 1) {
+      throw new GraphQLException("Page size cannot be less than 1");
+    }
+    if (pageNumber < 1) {
+      throw new GraphQLException("Page cannot be less than 1");
+    }
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/Criteria.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/Criteria.java
@@ -12,6 +12,6 @@ import java.util.function.Predicate;
 
 @Value
 public class Criteria<T> {
-   Predicate<T> predicate;
-   Comparator<T> comparator;
+  Predicate<T> predicate;
+  Comparator<T> comparator;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionFilter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionFilter.java
@@ -15,23 +15,22 @@ import java.util.List;
 
 @Data
 @AllArgsConstructor
-@Builder(toBuilder=true)
+@Builder(toBuilder = true)
 public class DataJobExecutionFilter {
 
-   public static final String START_TIME_GTE_FIELD = "startTimeGte";
-   public static final String END_TIME_GTE_FIELD = "endTimeGte";
-   public static final String STATUS_IN_FIELD = "statusIn";
-   public static final String JOB_NAME_IN_FIELD = "jobNameIn";
-   public static final String START_TIME_LTE_FIELD = "startTimeLte";
-   public static final String END_TIME_LTE_FIELD = "endTimeLte";
-   public static final String TEAM_NAME_IN_FIELD = "teamNameIn";
+  public static final String START_TIME_GTE_FIELD = "startTimeGte";
+  public static final String END_TIME_GTE_FIELD = "endTimeGte";
+  public static final String STATUS_IN_FIELD = "statusIn";
+  public static final String JOB_NAME_IN_FIELD = "jobNameIn";
+  public static final String START_TIME_LTE_FIELD = "startTimeLte";
+  public static final String END_TIME_LTE_FIELD = "endTimeLte";
+  public static final String TEAM_NAME_IN_FIELD = "teamNameIn";
 
-   private OffsetDateTime startTimeGte;
-   private OffsetDateTime endTimeGte;
-   private List<ExecutionStatus> statusIn;
-   private List<String> jobNameIn;
-   private List<String> teamNameIn;
-   private OffsetDateTime startTimeLte;
-   private OffsetDateTime endTimeLte;
-
+  private OffsetDateTime startTimeGte;
+  private OffsetDateTime endTimeGte;
+  private List<ExecutionStatus> statusIn;
+  private List<String> jobNameIn;
+  private List<String> teamNameIn;
+  private OffsetDateTime startTimeLte;
+  private OffsetDateTime endTimeLte;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionOrder.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionOrder.java
@@ -19,39 +19,41 @@ import java.util.Set;
 @Builder
 public class DataJobExecutionOrder {
 
-   public static final String DATA_JOB_NAME = "jobName";
-   public static final String DATA_JOB_TEAM = "jobTeam";
+  public static final String DATA_JOB_NAME = "jobName";
+  public static final String DATA_JOB_TEAM = "jobTeam";
 
-   public static final Set<String> AVAILABLE_PROPERTIES = Set.of(
-         DataJobExecution_.MESSAGE,
-         DataJobExecution_.TYPE,
-         DataJobExecution_.JOB_SCHEDULE,
-         DataJobExecution_.START_TIME,
-         DataJobExecution_.END_TIME,
-         DataJobExecution_.JOB_VERSION,
-         DataJobExecution_.ID,
-         DataJobExecution_.OP_ID,
-         DataJobExecution_.LAST_DEPLOYED_DATE,
-         DataJobExecution_.LAST_DEPLOYED_BY,
-         DataJobExecution_.STARTED_BY,
-         DataJobExecution_.STATUS,
-         DataJobExecution_.VDK_VERSION,
-         DATA_JOB_NAME,
-         DATA_JOB_TEAM);
+  public static final Set<String> AVAILABLE_PROPERTIES =
+      Set.of(
+          DataJobExecution_.MESSAGE,
+          DataJobExecution_.TYPE,
+          DataJobExecution_.JOB_SCHEDULE,
+          DataJobExecution_.START_TIME,
+          DataJobExecution_.END_TIME,
+          DataJobExecution_.JOB_VERSION,
+          DataJobExecution_.ID,
+          DataJobExecution_.OP_ID,
+          DataJobExecution_.LAST_DEPLOYED_DATE,
+          DataJobExecution_.LAST_DEPLOYED_BY,
+          DataJobExecution_.STARTED_BY,
+          DataJobExecution_.STATUS,
+          DataJobExecution_.VDK_VERSION,
+          DATA_JOB_NAME,
+          DATA_JOB_TEAM);
 
-   public static final Map<String, String> PUBLIC_NAME_TO_DB_ENTITY_MAP = Map.of(
-         DATA_JOB_NAME, DataJobExecution_.DATA_JOB + "." + DataJob_.NAME,
-         DATA_JOB_TEAM, DataJobExecution_.DATA_JOB + "." + DataJob_.JOB_CONFIG + "." + JobConfig_.TEAM
-   );
+  public static final Map<String, String> PUBLIC_NAME_TO_DB_ENTITY_MAP =
+      Map.of(
+          DATA_JOB_NAME, DataJobExecution_.DATA_JOB + "." + DataJob_.NAME,
+          DATA_JOB_TEAM,
+              DataJobExecution_.DATA_JOB + "." + DataJob_.JOB_CONFIG + "." + JobConfig_.TEAM);
 
-   public static final String PROPERTY_FIELD = "property";
-   public static final String DIRECTION_FIELD = "direction";
+  public static final String PROPERTY_FIELD = "property";
+  public static final String DIRECTION_FIELD = "direction";
 
-   private String property;
-   private Sort.Direction direction;
+  private String property;
+  private Sort.Direction direction;
 
-   public DataJobExecutionOrder(String property, Sort.Direction direction) {
-      this.property = property;
-      this.direction = direction;
-   }
+  public DataJobExecutionOrder(String property, Sort.Direction direction) {
+    this.property = property;
+    this.direction = direction;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionQueryVariables.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobExecutionQueryVariables.java
@@ -15,13 +15,13 @@ import lombok.Data;
 @Data
 public class DataJobExecutionQueryVariables {
 
-   public static final String PAGE_NUMBER_FIELD = "pageNumber";
-   public static final String PAGE_SIZE_FIELD = "pageSize";
-   public static final String FILTER_FIELD = "filter";
-   public static final String ORDER_FIELD = "order";
+  public static final String PAGE_NUMBER_FIELD = "pageNumber";
+  public static final String PAGE_SIZE_FIELD = "pageSize";
+  public static final String FILTER_FIELD = "filter";
+  public static final String ORDER_FIELD = "order";
 
-   private Integer pageSize;
-   private Integer pageNumber;
-   private DataJobExecutionFilter filter;
-   private DataJobExecutionOrder order;
+  private Integer pageSize;
+  private Integer pageNumber;
+  private DataJobExecutionFilter filter;
+  private DataJobExecutionOrder order;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobPage.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobPage.java
@@ -15,7 +15,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 public class DataJobPage {
-   private List<Object> content;
-   private Integer totalItems;
-   private Integer totalPages;
+  private List<Object> content;
+  private Integer totalItems;
+  private Integer totalPages;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobQueryVariables.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/DataJobQueryVariables.java
@@ -16,8 +16,8 @@ import java.util.List;
 
 @Data
 public class DataJobQueryVariables {
-   private int pageSize;
-   private int pageNumber;
-   private String search;
-   private List<Filter> filters;
+  private int pageSize;
+  private int pageNumber;
+  private String search;
+  private List<Filter> filters;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/ExecutionQueryVariables.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/ExecutionQueryVariables.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 @Data
 public class ExecutionQueryVariables {
-   private int pageNumber;
-   private int pageSize;
-   private List<Filter> filters;
+  private int pageNumber;
+  private int pageSize;
+  private List<Filter> filters;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/Filter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/Filter.java
@@ -12,12 +12,11 @@ import org.springframework.data.domain.Sort;
 @Data
 @AllArgsConstructor
 public class Filter {
-   private String property;
-   private String pattern;
-   private Sort.Direction sort;
+  private String property;
+  private String pattern;
+  private Sort.Direction sort;
 
-   public static Filter of(String property, String pattern, Sort.Direction sort) {
-      return new Filter(property, pattern, sort);
-   }
-
+  public static Filter of(String property, String pattern, Sort.Direction sort) {
+    return new Filter(property, pattern, sort);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/V2DataJob.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/V2DataJob.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 @Data
 public class V2DataJob {
-   private String jobName;
-   private V2DataJobConfig config;
-   private List<V2DataJobDeployment> deployments;
+  private String jobName;
+  private V2DataJobConfig config;
+  private List<V2DataJobDeployment> deployments;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/V2DataJobConfig.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/V2DataJobConfig.java
@@ -10,11 +10,11 @@ import lombok.Data;
 
 @Data
 public class V2DataJobConfig {
-   private String dbDefaultType;
-   private String team;
-   private String description;
-   private V2DataJobSchedule schedule;
-   private DataJobContacts contacts;
-   private Boolean generateKeytab = true;
-   private String sourceUrl;
+  private String dbDefaultType;
+  private String team;
+  private String description;
+  private V2DataJobSchedule schedule;
+  private DataJobContacts contacts;
+  private Boolean generateKeytab = true;
+  private String sourceUrl;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/V2DataJobDeployment.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/V2DataJobDeployment.java
@@ -16,20 +16,20 @@ import java.util.List;
 
 @Data
 public class V2DataJobDeployment {
-   private String id;
-   private String vdkVersion;
-   private String jobVersion;
-   private DataJobMode mode;
-   private Boolean enabled = true;
-   private DataJobContacts contacts;
-   private V2DataJobSchedule schedule;
-   private DataJobResources resources;
-   private List<DataJobExecution> executions;
-   private DataJobExecution.StatusEnum lastExecutionStatus;
-   private OffsetDateTime lastExecutionTime;
-   private Integer lastExecutionDuration;
-   private Integer successfulExecutions;
-   private Integer failedExecutions;
-   private String lastDeployedBy;
-   private String lastDeployedDate;
+  private String id;
+  private String vdkVersion;
+  private String jobVersion;
+  private DataJobMode mode;
+  private Boolean enabled = true;
+  private DataJobContacts contacts;
+  private V2DataJobSchedule schedule;
+  private DataJobResources resources;
+  private List<DataJobExecution> executions;
+  private DataJobExecution.StatusEnum lastExecutionStatus;
+  private OffsetDateTime lastExecutionTime;
+  private Integer lastExecutionDuration;
+  private Integer successfulExecutions;
+  private Integer failedExecutions;
+  private String lastDeployedBy;
+  private String lastDeployedDate;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/V2DataJobSchedule.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/model/V2DataJobSchedule.java
@@ -11,14 +11,15 @@ import lombok.Setter;
 
 @Data
 public class V2DataJobSchedule {
-   private String scheduleCron;
-   @Setter(AccessLevel.NONE)
-   private int nextRunEpochSeconds;
+  private String scheduleCron;
 
-   public void setNextRunEpochSeconds(long nextRunEpochSeconds) {
-      // TODO: rework this if needed, currently it will throw exception for a dates after year 2038
-      // Currently the workaround for this is large, due to lack of native long attribute in
-      // Read more https://en.wikipedia.org/wiki/Year_2038_problem
-      this.nextRunEpochSeconds = Math.toIntExact(nextRunEpochSeconds);
-   }
+  @Setter(AccessLevel.NONE)
+  private int nextRunEpochSeconds;
+
+  public void setNextRunEpochSeconds(long nextRunEpochSeconds) {
+    // TODO: rework this if needed, currently it will throw exception for a dates after year 2038
+    // Currently the workaround for this is large, due to lack of native long attribute in
+    // Read more https://en.wikipedia.org/wiki/Year_2038_problem
+    this.nextRunEpochSeconds = Math.toIntExact(nextRunEpochSeconds);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/FieldStrategy.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/FieldStrategy.java
@@ -15,94 +15,108 @@ import java.util.Comparator;
 import java.util.function.Predicate;
 
 /**
- In order to provide a complex filtering and searching functionality
- as well as data querying to different source (K8s, Database)
- we need to abstract the logic for this into separate classes and Strategy pattern
- seems like a good option. When someone ask for filtering it passes which
- field want to manipulate by and this is the key of the key-value pair of the strategy pattern
-
- When a new field needs to be added the steps are (currently) two:
- 1. Add new enum entry in {@link JobFieldStrategyBy} with the field name
- 2. Create a class which extends this abstract class and is annotated by @Component
-
- Then, Spring will detect automatically that there is new {@link FieldStrategy} instance and it
- will be included in the field manipulation mechanism
+ * In order to provide a complex filtering and searching functionality as well as data querying to
+ * different source (K8s, Database) we need to abstract the logic for this into separate classes and
+ * Strategy pattern seems like a good option. When someone ask for filtering it passes which field
+ * want to manipulate by and this is the key of the key-value pair of the strategy pattern
+ *
+ * <p>When a new field needs to be added the steps are (currently) two: 1. Add new enum entry in
+ * {@link JobFieldStrategyBy} with the field name 2. Create a class which extends this abstract
+ * class and is annotated by @Component
+ *
+ * <p>Then, Spring will detect automatically that there is new {@link FieldStrategy} instance and it
+ * will be included in the field manipulation mechanism
  */
 public abstract class FieldStrategy<T> {
 
-   /**
-    * The getter for the strategy name, required to be unique, not duplicated by other impl classes
-    * @return Strategy unique enum entry
-    */
-   public abstract JobFieldStrategyBy getStrategyName();
+  /**
+   * The getter for the strategy name, required to be unique, not duplicated by other impl classes
+   *
+   * @return Strategy unique enum entry
+   */
+  public abstract JobFieldStrategyBy getStrategyName();
 
-   /**
-    * By provided fields and pattern it computes the predicates needed for later stream filters/sorting
-    * @param criteria Existing criteria containing already chained Predicates and sorting
-    * @param filter Provided filter containing information about needed sorting direction and filtering pattern.
-    * @return The altered chained Predicates and comparator
-    */
-   public abstract Criteria<T> computeFilterCriteria(@NonNull Criteria<T> criteria, @NonNull Filter filter);
+  /**
+   * By provided fields and pattern it computes the predicates needed for later stream
+   * filters/sorting
+   *
+   * @param criteria Existing criteria containing already chained Predicates and sorting
+   * @param filter Provided filter containing information about needed sorting direction and
+   *     filtering pattern.
+   * @return The altered chained Predicates and comparator
+   */
+  public abstract Criteria<T> computeFilterCriteria(
+      @NonNull Criteria<T> criteria, @NonNull Filter filter);
 
-   /**
-    * By provided search string compute a predicate depending on the strategy which could be chained
-    * @param searchStr Search string
-    * @return Predicate for specific field strategy
-    */
-   public abstract Predicate<T> computeSearchCriteria(@NonNull String searchStr);
+  /**
+   * By provided search string compute a predicate depending on the strategy which could be chained
+   *
+   * @param searchStr Search string
+   * @return Predicate for specific field strategy
+   */
+  public abstract Predicate<T> computeSearchCriteria(@NonNull String searchStr);
 
-   /**
-    * If there is need some of the field to be computed separately (e.g the raw list is fetched from database,
-    * and it needs to deep dive in other service, like K8s, in order to populate additional information) this method
-    * will be invoked before computing Filter criteria and search mechanism only if the specific field is requested
-    * @param element Target element to be enriched
-    */
-   public void alterFieldData(T element) {
-      // Default empty action
-   }
+  /**
+   * If there is need some of the field to be computed separately (e.g the raw list is fetched from
+   * database, and it needs to deep dive in other service, like K8s, in order to populate additional
+   * information) this method will be invoked before computing Filter criteria and search mechanism
+   * only if the specific field is requested
+   *
+   * @param element Target element to be enriched
+   */
+  public void alterFieldData(T element) {
+    // Default empty action
+  }
 
-   /**
-    * Helper method to detect if there is sorting needed
-    * @param filter Class which holds filter and sorting field data
-    * @return true if there is provided direction, false if its not
-    */
-   protected boolean sortingProvided(Filter filter) {
-      return filter != null && filter.getSort() != null;
-   }
+  /**
+   * Helper method to detect if there is sorting needed
+   *
+   * @param filter Class which holds filter and sorting field data
+   * @return true if there is provided direction, false if its not
+   */
+  protected boolean sortingProvided(Filter filter) {
+    return filter != null && filter.getSort() != null;
+  }
 
-   /**
-    * By default comparators are in ascending order and we can with ease reverse them using Comparator.reverse()
-    * @param direction ASC or DESC direction
-    * @return true if DESC, false if ASC
-    */
-   protected boolean invertSorting(Sort.Direction direction) {
-      return Sort.Direction.DESC.equals(direction);
-   }
+  /**
+   * By default comparators are in ascending order and we can with ease reverse them using
+   * Comparator.reverse()
+   *
+   * @param direction ASC or DESC direction
+   * @return true if DESC, false if ASC
+   */
+  protected boolean invertSorting(Sort.Direction direction) {
+    return Sort.Direction.DESC.equals(direction);
+  }
 
-   /**
-    * Helper method to detect if there is filtering needed
-    * @param filter Class which holds filter and sorting field data
-    * @return true if there is provided pattern for filtering, false if its not
-    */
-   protected boolean filterProvided(Filter filter) {
-      return filter != null && filter.getPattern() != null;
-   }
+  /**
+   * Helper method to detect if there is filtering needed
+   *
+   * @param filter Class which holds filter and sorting field data
+   * @return true if there is provided pattern for filtering, false if its not
+   */
+  protected boolean filterProvided(Filter filter) {
+    return filter != null && filter.getPattern() != null;
+  }
 
-   /**
-    * Helper method to detect whether we include the comparator provided by the strategy (if its requested for specific field)
-    * or just use the default (last used). This means that sorting is done only by 1 field
-    * @param filter
-    * @param comparator
-    * @param criteria
-    * @return
-    */
-   protected Comparator<T> detectSortingComparator(Filter filter, Comparator<T> comparator, Criteria<T> criteria){
-      if(sortingProvided(filter)) {
-         if (invertSorting(filter.getSort())) {
-            comparator = comparator.reversed();
-         }
-         return comparator;
+  /**
+   * Helper method to detect whether we include the comparator provided by the strategy (if its
+   * requested for specific field) or just use the default (last used). This means that sorting is
+   * done only by 1 field
+   *
+   * @param filter
+   * @param comparator
+   * @param criteria
+   * @return
+   */
+  protected Comparator<T> detectSortingComparator(
+      Filter filter, Comparator<T> comparator, Criteria<T> criteria) {
+    if (sortingProvided(filter)) {
+      if (invertSorting(filter.getSort())) {
+        comparator = comparator.reversed();
       }
-      return criteria.getComparator();
-   }
+      return comparator;
+    }
+    return criteria.getComparator();
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/JobFieldStrategyFactory.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/JobFieldStrategyFactory.java
@@ -16,23 +16,23 @@ import java.util.Set;
 
 @Component
 public class JobFieldStrategyFactory {
-   private Map<JobFieldStrategyBy, FieldStrategy<V2DataJob>> strategies;
+  private Map<JobFieldStrategyBy, FieldStrategy<V2DataJob>> strategies;
 
-   @Autowired
-   public JobFieldStrategyFactory(Set<FieldStrategy<V2DataJob>> strategySet) {
-      createStrategy(strategySet);
-   }
+  @Autowired
+  public JobFieldStrategyFactory(Set<FieldStrategy<V2DataJob>> strategySet) {
+    createStrategy(strategySet);
+  }
 
-   public FieldStrategy<V2DataJob> findStrategy(JobFieldStrategyBy strategyName) {
-      return strategies.get(strategyName);
-   }
+  public FieldStrategy<V2DataJob> findStrategy(JobFieldStrategyBy strategyName) {
+    return strategies.get(strategyName);
+  }
 
-   private void createStrategy(Set<FieldStrategy<V2DataJob>> strategySet) {
-      strategies = new EnumMap<>(JobFieldStrategyBy.class);
-      strategySet.forEach(strategy ->strategies.put(strategy.getStrategyName(), strategy));
-   }
+  private void createStrategy(Set<FieldStrategy<V2DataJob>> strategySet) {
+    strategies = new EnumMap<>(JobFieldStrategyBy.class);
+    strategySet.forEach(strategy -> strategies.put(strategy.getStrategyName(), strategy));
+  }
 
-   public Map<JobFieldStrategyBy, FieldStrategy<V2DataJob>> getStrategies() {
-      return new EnumMap<>(strategies);
-   }
+  public Map<JobFieldStrategyBy, FieldStrategy<V2DataJob>> getStrategies() {
+    return new EnumMap<>(strategies);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyBy.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyBy.java
@@ -10,55 +10,61 @@ import com.vmware.taurus.service.graphql.strategy.JobFieldStrategyFactory;
 import java.util.Arrays;
 
 /**
- * Enum to distinguish between different strategies (fields and paths)
- * Using doubled string instead of prefilled &amp; preformatted hashmap to map the incoming (field) vs outgoing (path) names
- * In future the order could be meaningful (due to dependencies across strategy fields),
- * but it could be controlled with the {@link JobFieldStrategyFactory}
+ * Enum to distinguish between different strategies (fields and paths) Using doubled string instead
+ * of prefilled &amp; preformatted hashmap to map the incoming (field) vs outgoing (path) names In
+ * future the order could be meaningful (due to dependencies across strategy fields), but it could
+ * be controlled with the {@link JobFieldStrategyFactory}
  */
 public enum JobFieldStrategyBy {
-   JOB_NAME("jobName", "content/jobName"),
-   DEPLOYMENT("deployments", "content/deployments"),
-   DEPLOYMENT_ENABLED("deployments.enabled", "content/deployments/enabled"),
-   DEPLOYMENT_EXECUTIONS("deployments.executions", "content/deployments/executions"),
-   DEPLOYMENT_LAST_EXECUTION_STATUS("deployments.lastExecutionStatus", "content/deployments/lastExecutionStatus"),
-   DEPLOYMENT_LAST_EXECUTION_TIME("deployments.lastExecutionTime", "content/deployments/lastExecutionTime"),
-   DEPLOYMENT_LAST_EXECUTION_DURATION("deployments.lastExecutionDuration", "content/deployments/lastExecutionDuration"),
-   DEPLOYMENT_FAILED_EXECUTIONS("deployments.failedExecutions", "content/deployments/failedExecutions"),
-   DEPLOYMENT_SUCCESSFUL_EXECUTIONS("deployments.successfulExecutions", "content/deployments/successfulExecutions"),
-   TEAM("config.team", "content/config/team"),
-   DESCRIPTION("config.description", "content/config/description"),
-   SOURCE_URL("config.sourceUrl", "content/config/sourceUrl"),
-   NEXT_RUN_EPOCH_SECS("config.schedule.nextRunEpochSeconds", "content/config/schedule/nextRunEpochSeconds"),
-   SCHEDULE_CRON("config.schedule.scheduleCron", "content/config/schedule/scheduleCron"),
-   DATA_JOB_CONTACTS("config.contacts.present", "content/config/contacts/present");
+  JOB_NAME("jobName", "content/jobName"),
+  DEPLOYMENT("deployments", "content/deployments"),
+  DEPLOYMENT_ENABLED("deployments.enabled", "content/deployments/enabled"),
+  DEPLOYMENT_EXECUTIONS("deployments.executions", "content/deployments/executions"),
+  DEPLOYMENT_LAST_EXECUTION_STATUS(
+      "deployments.lastExecutionStatus", "content/deployments/lastExecutionStatus"),
+  DEPLOYMENT_LAST_EXECUTION_TIME(
+      "deployments.lastExecutionTime", "content/deployments/lastExecutionTime"),
+  DEPLOYMENT_LAST_EXECUTION_DURATION(
+      "deployments.lastExecutionDuration", "content/deployments/lastExecutionDuration"),
+  DEPLOYMENT_FAILED_EXECUTIONS(
+      "deployments.failedExecutions", "content/deployments/failedExecutions"),
+  DEPLOYMENT_SUCCESSFUL_EXECUTIONS(
+      "deployments.successfulExecutions", "content/deployments/successfulExecutions"),
+  TEAM("config.team", "content/config/team"),
+  DESCRIPTION("config.description", "content/config/description"),
+  SOURCE_URL("config.sourceUrl", "content/config/sourceUrl"),
+  NEXT_RUN_EPOCH_SECS(
+      "config.schedule.nextRunEpochSeconds", "content/config/schedule/nextRunEpochSeconds"),
+  SCHEDULE_CRON("config.schedule.scheduleCron", "content/config/schedule/scheduleCron"),
+  DATA_JOB_CONTACTS("config.contacts.present", "content/config/contacts/present");
 
-   private final String field;
-   private final String path;
+  private final String field;
+  private final String path;
 
-   JobFieldStrategyBy(String field, String path) {
-      this.field = field;
-      this.path = path;
-   }
+  JobFieldStrategyBy(String field, String path) {
+    this.field = field;
+    this.path = path;
+  }
 
-   public String getField() {
-      return field;
-   }
+  public String getField() {
+    return field;
+  }
 
-   public String getPath() {
-      return path;
-   }
+  public String getPath() {
+    return path;
+  }
 
-   public static JobFieldStrategyBy field(String field) {
-      return Arrays.stream(JobFieldStrategyBy.values())
-            .filter(strategy -> strategy.getField().equalsIgnoreCase(field))
-            .findAny()
-            .orElse(null);
-   }
+  public static JobFieldStrategyBy field(String field) {
+    return Arrays.stream(JobFieldStrategyBy.values())
+        .filter(strategy -> strategy.getField().equalsIgnoreCase(field))
+        .findAny()
+        .orElse(null);
+  }
 
-   public static JobFieldStrategyBy path(String path) {
-      return Arrays.stream(JobFieldStrategyBy.values())
-            .filter(strategy -> strategy.getPath().equalsIgnoreCase(path))
-            .findAny()
-            .orElse(null);
-   }
+  public static JobFieldStrategyBy path(String path) {
+    return Arrays.stream(JobFieldStrategyBy.values())
+        .filter(strategy -> strategy.getPath().equalsIgnoreCase(path))
+        .findAny()
+        .orElse(null);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByDataJobContacts.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByDataJobContacts.java
@@ -18,34 +18,37 @@ import java.util.function.Predicate;
 
 @Component
 public class JobFieldStrategyByDataJobContacts extends FieldStrategy<V2DataJob> {
-   private static final Comparator<V2DataJob> COMPARATOR_DEFAULT = Comparator.comparing(e -> e.getConfig().getContacts(),
-         Comparator.nullsLast((o1, o2) -> {
-            boolean o1ContactPresent = isContactPresent(o1);
-            boolean o2ContactPresent = isContactPresent(o2);
-            return Boolean.compare(o1ContactPresent, o2ContactPresent);
-         }));
+  private static final Comparator<V2DataJob> COMPARATOR_DEFAULT =
+      Comparator.comparing(
+          e -> e.getConfig().getContacts(),
+          Comparator.nullsLast(
+              (o1, o2) -> {
+                boolean o1ContactPresent = isContactPresent(o1);
+                boolean o2ContactPresent = isContactPresent(o2);
+                return Boolean.compare(o1ContactPresent, o2ContactPresent);
+              }));
 
-   @Override
-   public JobFieldStrategyBy getStrategyName() {
-      return JobFieldStrategyBy.DATA_JOB_CONTACTS;
-   }
+  @Override
+  public JobFieldStrategyBy getStrategyName() {
+    return JobFieldStrategyBy.DATA_JOB_CONTACTS;
+  }
 
-   @Override
-   public Criteria<V2DataJob> computeFilterCriteria(Criteria<V2DataJob> criteria, Filter filter) {
-      var predicate = criteria.getPredicate();
-      return new Criteria<>(predicate, detectSortingComparator(filter, COMPARATOR_DEFAULT, criteria));
-   }
+  @Override
+  public Criteria<V2DataJob> computeFilterCriteria(Criteria<V2DataJob> criteria, Filter filter) {
+    var predicate = criteria.getPredicate();
+    return new Criteria<>(predicate, detectSortingComparator(filter, COMPARATOR_DEFAULT, criteria));
+  }
 
-   @Override
-   public Predicate<V2DataJob> computeSearchCriteria(String searchStr) {
-      // searching by notification is not meaningful yet
-      return dataJob -> true;
-   }
+  @Override
+  public Predicate<V2DataJob> computeSearchCriteria(String searchStr) {
+    // searching by notification is not meaningful yet
+    return dataJob -> true;
+  }
 
-   private static boolean isContactPresent(DataJobContacts contacts) {
-      return CollectionUtils.isNotEmpty(contacts.getNotifiedOnJobDeploy()) ||
-            CollectionUtils.isNotEmpty(contacts.getNotifiedOnJobFailurePlatformError()) ||
-            CollectionUtils.isNotEmpty(contacts.getNotifiedOnJobFailureUserError()) ||
-            CollectionUtils.isNotEmpty(contacts.getNotifiedOnJobSuccess());
-   }
+  private static boolean isContactPresent(DataJobContacts contacts) {
+    return CollectionUtils.isNotEmpty(contacts.getNotifiedOnJobDeploy())
+        || CollectionUtils.isNotEmpty(contacts.getNotifiedOnJobFailurePlatformError())
+        || CollectionUtils.isNotEmpty(contacts.getNotifiedOnJobFailureUserError())
+        || CollectionUtils.isNotEmpty(contacts.getNotifiedOnJobSuccess());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByDeploymentStatus.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByDeploymentStatus.java
@@ -19,75 +19,80 @@ import java.util.function.Predicate;
 /**
  * Strategy that uses deployment 'enabled' field to compute a deployment status.
  *
- * It follow the algorithm:
- * Job has deployment, and it is property 'enabled' is true - ENABLED;
- * Job has deployment, and it is property 'enabled' is false - DISABLED;
- * Job has no deployment at all - NOT_DEPLOYED
+ * <p>It follow the algorithm: Job has deployment, and it is property 'enabled' is true - ENABLED;
+ * Job has deployment, and it is property 'enabled' is false - DISABLED; Job has no deployment at
+ * all - NOT_DEPLOYED
  *
- * TODO when multiple deployments are implement refactor the class.
+ * <p>TODO when multiple deployments are implement refactor the class.
  */
 @Component
 public class JobFieldStrategyByDeploymentStatus extends FieldStrategy<V2DataJob> {
 
-   private static final Comparator<V2DataJob> COMPARATOR_DEFAULT = Comparator.comparing(JobFieldStrategyByDeploymentStatus::toDeploymentStatus);
+  private static final Comparator<V2DataJob> COMPARATOR_DEFAULT =
+      Comparator.comparing(JobFieldStrategyByDeploymentStatus::toDeploymentStatus);
 
-   @Override
-   public JobFieldStrategyBy getStrategyName() {
-      return JobFieldStrategyBy.DEPLOYMENT_ENABLED;
-   }
+  @Override
+  public JobFieldStrategyBy getStrategyName() {
+    return JobFieldStrategyBy.DEPLOYMENT_ENABLED;
+  }
 
-   @Override
-   public Criteria<V2DataJob> computeFilterCriteria(@NonNull Criteria<V2DataJob> criteria, @NonNull Filter filter) {
-      Predicate<V2DataJob> predicate = criteria.getPredicate();
+  @Override
+  public Criteria<V2DataJob> computeFilterCriteria(
+      @NonNull Criteria<V2DataJob> criteria, @NonNull Filter filter) {
+    Predicate<V2DataJob> predicate = criteria.getPredicate();
 
-      if (filterProvided(filter)) {
-         predicate = predicate.and(computeSearchCriteria(filter.getPattern()));
-      }
+    if (filterProvided(filter)) {
+      predicate = predicate.and(computeSearchCriteria(filter.getPattern()));
+    }
 
-      return new Criteria<>(predicate, detectSortingComparator(filter, COMPARATOR_DEFAULT, criteria));
-   }
+    return new Criteria<>(predicate, detectSortingComparator(filter, COMPARATOR_DEFAULT, criteria));
+  }
 
-   @Override
-   public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
-      try {
-         DeploymentStatus deploymentStatus = DeploymentStatus.fromValue(searchStr);
-         return dataJob -> deploymentStatus.equals(toDeploymentStatus(dataJob));
-      } catch (IllegalArgumentException e) {
-         // searching with non-compatible for the strategy string, ignoring search
-         return x -> false;
-      }
-   }
+  @Override
+  public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
+    try {
+      DeploymentStatus deploymentStatus = DeploymentStatus.fromValue(searchStr);
+      return dataJob -> deploymentStatus.equals(toDeploymentStatus(dataJob));
+    } catch (IllegalArgumentException e) {
+      // searching with non-compatible for the strategy string, ignoring search
+      return x -> false;
+    }
+  }
 
-   private static DeploymentStatus toDeploymentStatus(V2DataJob dataJob) {
-      if (dataJob.getDeployments() == null || dataJob.getDeployments().isEmpty()) {
-         return DeploymentStatus.NOT_DEPLOYED;
-      }
-      // TODO support for multiple deployments
-      return dataJob.getDeployments().stream().findFirst().orElseThrow().getEnabled() ?
-            DeploymentStatus.ENABLED : DeploymentStatus.DISABLED;
-   }
+  private static DeploymentStatus toDeploymentStatus(V2DataJob dataJob) {
+    if (dataJob.getDeployments() == null || dataJob.getDeployments().isEmpty()) {
+      return DeploymentStatus.NOT_DEPLOYED;
+    }
+    // TODO support for multiple deployments
+    return dataJob.getDeployments().stream().findFirst().orElseThrow().getEnabled()
+        ? DeploymentStatus.ENABLED
+        : DeploymentStatus.DISABLED;
+  }
 
-   enum DeploymentStatus {
-      ENABLED("enabled"),
-      DISABLED("disabled"),
-      NOT_DEPLOYED("not_deployed");
+  enum DeploymentStatus {
+    ENABLED("enabled"),
+    DISABLED("disabled"),
+    NOT_DEPLOYED("not_deployed");
 
-      private final String value;
+    private final String value;
 
-      DeploymentStatus(String value) {
-         this.value = value;
-      }
+    DeploymentStatus(String value) {
+      this.value = value;
+    }
 
-      public String getValue() {
-         return value;
-      }
+    public String getValue() {
+      return value;
+    }
 
-      public static DeploymentStatus fromValue(String value) {
-         return Arrays.stream(DeploymentStatus.values())
-               .filter(status -> status.getValue().equalsIgnoreCase(value))
-               .findAny()
-               .orElseThrow(() -> new IllegalArgumentException(
-                     "Deployment status could be only one of " + Arrays.toString(DeploymentStatus.values()).toLowerCase()));
-      }
-   }
+    public static DeploymentStatus fromValue(String value) {
+      return Arrays.stream(DeploymentStatus.values())
+          .filter(status -> status.getValue().equalsIgnoreCase(value))
+          .findAny()
+          .orElseThrow(
+              () ->
+                  new IllegalArgumentException(
+                      "Deployment status could be only one of "
+                          + Arrays.toString(DeploymentStatus.values()).toLowerCase()));
+    }
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByDescription.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByDescription.java
@@ -19,35 +19,39 @@ import java.util.function.Predicate;
 @Component
 public class JobFieldStrategyByDescription extends FieldStrategy<V2DataJob> {
 
-   private static final Comparator<V2DataJob> COMPARATOR_DEFAULT = Comparator.comparing(
-           e -> e.getConfig().getDescription(), Comparator.nullsLast(Comparator.naturalOrder()));
+  private static final Comparator<V2DataJob> COMPARATOR_DEFAULT =
+      Comparator.comparing(
+          e -> e.getConfig().getDescription(), Comparator.nullsLast(Comparator.naturalOrder()));
 
-   @Override
-   public Criteria<V2DataJob> computeFilterCriteria(@NonNull Criteria<V2DataJob> criteria, @NonNull Filter filter) {
-      Predicate<V2DataJob> predicate = criteria.getPredicate();
+  @Override
+  public Criteria<V2DataJob> computeFilterCriteria(
+      @NonNull Criteria<V2DataJob> criteria, @NonNull Filter filter) {
+    Predicate<V2DataJob> predicate = criteria.getPredicate();
 
-      if (filterProvided(filter)) {
-         predicate = predicate.and(dataJob ->
-               dataJob.getConfig() != null &&
-                     StringUtils.containsIgnoreCase(dataJob.getConfig().getDescription(), filter.getPattern()));
+    if (filterProvided(filter)) {
+      predicate =
+          predicate.and(
+              dataJob ->
+                  dataJob.getConfig() != null
+                      && StringUtils.containsIgnoreCase(
+                          dataJob.getConfig().getDescription(), filter.getPattern()));
+    }
+
+    return new Criteria<>(predicate, detectSortingComparator(filter, COMPARATOR_DEFAULT, criteria));
+  }
+
+  @Override
+  public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
+    return dataJob -> {
+      if (dataJob.getConfig() == null) {
+        return false;
       }
+      return StringUtils.containsIgnoreCase(dataJob.getConfig().getDescription(), searchStr);
+    };
+  }
 
-      return new Criteria<>(predicate, detectSortingComparator(filter, COMPARATOR_DEFAULT, criteria));
-   }
-
-   @Override
-   public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
-      return dataJob -> {
-         if (dataJob.getConfig() == null) {
-            return false;
-         }
-         return StringUtils.containsIgnoreCase(dataJob.getConfig().getDescription(), searchStr);
-      };
-   }
-
-   @Override
-   public JobFieldStrategyBy getStrategyName() {
-      return JobFieldStrategyBy.DESCRIPTION;
-   }
-
+  @Override
+  public JobFieldStrategyBy getStrategyName() {
+    return JobFieldStrategyBy.DESCRIPTION;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByLastExecutionDuration.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByLastExecutionDuration.java
@@ -19,36 +19,38 @@ import java.util.function.Predicate;
 @Component
 public class JobFieldStrategyByLastExecutionDuration extends FieldStrategy<V2DataJob> {
 
-   private static final Comparator<V2DataJob> COMPARATOR_DEFAULT = Comparator.comparing(
-           JobFieldStrategyByLastExecutionDuration::getLastExecutionDuration,
-           Comparator.nullsFirst(Comparator.naturalOrder()));
+  private static final Comparator<V2DataJob> COMPARATOR_DEFAULT =
+      Comparator.comparing(
+          JobFieldStrategyByLastExecutionDuration::getLastExecutionDuration,
+          Comparator.nullsFirst(Comparator.naturalOrder()));
 
-   @Override
-   public JobFieldStrategyBy getStrategyName() {
-      return JobFieldStrategyBy.DEPLOYMENT_LAST_EXECUTION_DURATION;
-   }
+  @Override
+  public JobFieldStrategyBy getStrategyName() {
+    return JobFieldStrategyBy.DEPLOYMENT_LAST_EXECUTION_DURATION;
+  }
 
-   @Override
-   public Criteria<V2DataJob> computeFilterCriteria(@NonNull Criteria<V2DataJob> criteria, @NonNull Filter filter) {
-      Predicate<V2DataJob> predicate = criteria.getPredicate();
+  @Override
+  public Criteria<V2DataJob> computeFilterCriteria(
+      @NonNull Criteria<V2DataJob> criteria, @NonNull Filter filter) {
+    Predicate<V2DataJob> predicate = criteria.getPredicate();
 
-      if (filterProvided(filter)) {
-         predicate = predicate.and(computeSearchCriteria(filter.getPattern()));
-      }
+    if (filterProvided(filter)) {
+      predicate = predicate.and(computeSearchCriteria(filter.getPattern()));
+    }
 
-      return new Criteria<>(predicate, detectSortingComparator(filter, COMPARATOR_DEFAULT, criteria));
-   }
+    return new Criteria<>(predicate, detectSortingComparator(filter, COMPARATOR_DEFAULT, criteria));
+  }
 
-   @Override
-   public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
-      return dataJob -> false;
-   }
+  @Override
+  public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
+    return dataJob -> false;
+  }
 
-   private static Integer getLastExecutionDuration(V2DataJob dataJob) {
-      if (CollectionUtils.isEmpty(dataJob.getDeployments())) {
-         return null;
-      }
-      // TODO support for multiple deployments
-      return dataJob.getDeployments().stream().findFirst().orElseThrow().getLastExecutionDuration();
-   }
+  private static Integer getLastExecutionDuration(V2DataJob dataJob) {
+    if (CollectionUtils.isEmpty(dataJob.getDeployments())) {
+      return null;
+    }
+    // TODO support for multiple deployments
+    return dataJob.getDeployments().stream().findFirst().orElseThrow().getLastExecutionDuration();
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByLastExecutionStatus.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByLastExecutionStatus.java
@@ -20,50 +20,53 @@ import java.util.function.Predicate;
 @Component
 public class JobFieldStrategyByLastExecutionStatus extends FieldStrategy<V2DataJob> {
 
-   private static final Comparator<V2DataJob> COMPARATOR_DEFAULT = Comparator.comparing(
-           JobFieldStrategyByLastExecutionStatus::getLastExecutionStatusAsString,
-           Comparator.nullsFirst(Comparator.naturalOrder()));
+  private static final Comparator<V2DataJob> COMPARATOR_DEFAULT =
+      Comparator.comparing(
+          JobFieldStrategyByLastExecutionStatus::getLastExecutionStatusAsString,
+          Comparator.nullsFirst(Comparator.naturalOrder()));
 
-   @Override
-   public JobFieldStrategyBy getStrategyName() {
-      return JobFieldStrategyBy.DEPLOYMENT_LAST_EXECUTION_STATUS;
-   }
+  @Override
+  public JobFieldStrategyBy getStrategyName() {
+    return JobFieldStrategyBy.DEPLOYMENT_LAST_EXECUTION_STATUS;
+  }
 
-   @Override
-   public Criteria<V2DataJob> computeFilterCriteria(@NonNull Criteria<V2DataJob> criteria, @NonNull Filter filter) {
-      Predicate<V2DataJob> predicate = criteria.getPredicate();
+  @Override
+  public Criteria<V2DataJob> computeFilterCriteria(
+      @NonNull Criteria<V2DataJob> criteria, @NonNull Filter filter) {
+    Predicate<V2DataJob> predicate = criteria.getPredicate();
 
-      if (filterProvided(filter)) {
-         predicate = predicate.and(computeSearchCriteria(filter.getPattern()));
-      }
+    if (filterProvided(filter)) {
+      predicate = predicate.and(computeSearchCriteria(filter.getPattern()));
+    }
 
-      return new Criteria<>(predicate, detectSortingComparator(filter, COMPARATOR_DEFAULT, criteria));
-   }
+    return new Criteria<>(predicate, detectSortingComparator(filter, COMPARATOR_DEFAULT, criteria));
+  }
 
-   @Override
-   public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
-      try {
-         DataJobExecution.StatusEnum executionStatus = DataJobExecution.StatusEnum.fromValue(searchStr);
-         return dataJob -> executionStatus.equals(getLastExecutionStatus(dataJob));
-      } catch (IllegalArgumentException e) {
-         // searching with non-compatible for the strategy string, ignoring search
-         return x -> false;
-      }
-   }
+  @Override
+  public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
+    try {
+      DataJobExecution.StatusEnum executionStatus =
+          DataJobExecution.StatusEnum.fromValue(searchStr);
+      return dataJob -> executionStatus.equals(getLastExecutionStatus(dataJob));
+    } catch (IllegalArgumentException e) {
+      // searching with non-compatible for the strategy string, ignoring search
+      return x -> false;
+    }
+  }
 
-   private static DataJobExecution.StatusEnum getLastExecutionStatus(V2DataJob dataJob) {
-      if (CollectionUtils.isEmpty(dataJob.getDeployments())) {
-         return null;
-      }
-      // TODO support for multiple deployments
-      return dataJob.getDeployments().stream().findFirst().orElseThrow().getLastExecutionStatus();
-   }
+  private static DataJobExecution.StatusEnum getLastExecutionStatus(V2DataJob dataJob) {
+    if (CollectionUtils.isEmpty(dataJob.getDeployments())) {
+      return null;
+    }
+    // TODO support for multiple deployments
+    return dataJob.getDeployments().stream().findFirst().orElseThrow().getLastExecutionStatus();
+  }
 
-   private static String getLastExecutionStatusAsString(V2DataJob dataJob) {
-      DataJobExecution.StatusEnum lastExecutionStatus = getLastExecutionStatus(dataJob);
-      if (lastExecutionStatus == null) {
-         return null;
-      }
-      return lastExecutionStatus.getValue();
-   }
+  private static String getLastExecutionStatusAsString(V2DataJob dataJob) {
+    DataJobExecution.StatusEnum lastExecutionStatus = getLastExecutionStatus(dataJob);
+    if (lastExecutionStatus == null) {
+      return null;
+    }
+    return lastExecutionStatus.getValue();
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByLastExecutionTime.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByLastExecutionTime.java
@@ -25,81 +25,93 @@ import java.util.function.Predicate;
 @Component
 public class JobFieldStrategyByLastExecutionTime extends FieldStrategy<V2DataJob> {
 
-   private static final String DATE_SEPARATOR = "-";
-   private static final ZoneId UTC_ZONE = ZoneId.of("UTC");
-   private static final Comparator<V2DataJob> COMPARATOR_DEFAULT = Comparator.comparing(
-           JobFieldStrategyByLastExecutionTime::getLastExecutionTime,
-           Comparator.nullsFirst(Comparator.naturalOrder()));
+  private static final String DATE_SEPARATOR = "-";
+  private static final ZoneId UTC_ZONE = ZoneId.of("UTC");
+  private static final Comparator<V2DataJob> COMPARATOR_DEFAULT =
+      Comparator.comparing(
+          JobFieldStrategyByLastExecutionTime::getLastExecutionTime,
+          Comparator.nullsFirst(Comparator.naturalOrder()));
 
-   @Override
-   public JobFieldStrategyBy getStrategyName() {
-      return JobFieldStrategyBy.DEPLOYMENT_LAST_EXECUTION_TIME;
-   }
+  @Override
+  public JobFieldStrategyBy getStrategyName() {
+    return JobFieldStrategyBy.DEPLOYMENT_LAST_EXECUTION_TIME;
+  }
 
-   /**
-    * The pattern is expected to be in format like 1619460302-1619460302 (two unix times separated with dash)
-    * And the first one should be before (less than) the second one
-    * @param criteria Existing criteria containing already chained Predicates and sorting
-    * @param filter Provided filter containing information about needed sorting direction and filtering pattern.
-    * @throws GraphqlErrorException if the filter pattern contains invalid format or if the first unix time is after the second one
-    * @return The altered chained Predicates and comparator
-    */
-   @Override
-   public Criteria<V2DataJob> computeFilterCriteria(@NonNull Criteria<V2DataJob> criteria, @NonNull Filter filter) {
-      Predicate<V2DataJob> predicate = criteria.getPredicate();
+  /**
+   * The pattern is expected to be in format like 1619460302-1619460302 (two unix times separated
+   * with dash) And the first one should be before (less than) the second one
+   *
+   * @param criteria Existing criteria containing already chained Predicates and sorting
+   * @param filter Provided filter containing information about needed sorting direction and
+   *     filtering pattern.
+   * @throws GraphqlErrorException if the filter pattern contains invalid format or if the first
+   *     unix time is after the second one
+   * @return The altered chained Predicates and comparator
+   */
+  @Override
+  public Criteria<V2DataJob> computeFilterCriteria(
+      @NonNull Criteria<V2DataJob> criteria, @NonNull Filter filter) {
+    Predicate<V2DataJob> predicate = criteria.getPredicate();
 
-      if (filterProvided(filter)) {
-         predicate = predicate.and(dataJob -> {
-            var lastExecutionTime = getLastExecutionTime(dataJob);
-            var range = validateAndExtractDateRange(filter);
+    if (filterProvided(filter)) {
+      predicate =
+          predicate.and(
+              dataJob -> {
+                var lastExecutionTime = getLastExecutionTime(dataJob);
+                var range = validateAndExtractDateRange(filter);
 
-            return lastExecutionTime != null &&
-                    !lastExecutionTime.isBefore(range.getFirst()) &&
-                    !lastExecutionTime.isAfter(range.getSecond());
-         });
+                return lastExecutionTime != null
+                    && !lastExecutionTime.isBefore(range.getFirst())
+                    && !lastExecutionTime.isAfter(range.getSecond());
+              });
+    }
+
+    return new Criteria<>(predicate, detectSortingComparator(filter, COMPARATOR_DEFAULT, criteria));
+  }
+
+  @Override
+  public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
+    return dataJob -> false;
+  }
+
+  private Pair<OffsetDateTime, OffsetDateTime> validateAndExtractDateRange(Filter filter) {
+    String[] parsedStr = filter.getPattern().split(DATE_SEPARATOR);
+    if (parsedStr.length != 2) {
+      throw GraphqlErrorException.newErrorException()
+          .message(getStrategyName().getPath() + " does not contain valid date range.")
+          .build();
+    }
+    try {
+      var start = Integer.parseInt(parsedStr[0]);
+      var end = Integer.parseInt(parsedStr[1]);
+      var startDate = OffsetDateTime.ofInstant(Instant.ofEpochSecond(start), UTC_ZONE);
+      var endDate = OffsetDateTime.ofInstant(Instant.ofEpochSecond(end), UTC_ZONE);
+
+      if (startDate.isAfter(endDate)) {
+        throw GraphqlErrorException.newErrorException()
+            .message(
+                "First date of "
+                    + getStrategyName().getPath()
+                    + " is after the second."
+                    + "The beginning date should be before the ending date")
+            .build();
       }
+      return Pair.of(startDate, endDate);
+    } catch (NumberFormatException | DateTimeException ex) {
+      throw GraphqlErrorException.newErrorException()
+          .message(
+              getStrategyName().getPath()
+                  + " does not contain valid dates."
+                  + "Correct format is \"1619460302-1619460302\"")
+          .build();
+    }
+  }
 
-      return new Criteria<>(predicate, detectSortingComparator(filter, COMPARATOR_DEFAULT, criteria));
-   }
-
-   @Override
-   public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
-      return dataJob -> false;
-   }
-
-   private Pair<OffsetDateTime, OffsetDateTime> validateAndExtractDateRange(Filter filter) {
-      String[] parsedStr = filter.getPattern().split(DATE_SEPARATOR);
-      if (parsedStr.length != 2) {
-         throw GraphqlErrorException.newErrorException()
-               .message(getStrategyName().getPath() + " does not contain valid date range.")
-               .build();
-      }
-      try {
-         var start = Integer.parseInt(parsedStr[0]);
-         var end = Integer.parseInt(parsedStr[1]);
-         var startDate = OffsetDateTime.ofInstant(Instant.ofEpochSecond(start), UTC_ZONE);
-         var endDate = OffsetDateTime.ofInstant(Instant.ofEpochSecond(end), UTC_ZONE);
-
-         if (startDate.isAfter(endDate)) {
-            throw GraphqlErrorException.newErrorException()
-                  .message("First date of " + getStrategyName().getPath() + " is after the second." +
-                        "The beginning date should be before the ending date")
-                  .build();
-         }
-         return Pair.of(startDate, endDate);
-      } catch (NumberFormatException | DateTimeException ex) {
-         throw GraphqlErrorException.newErrorException()
-               .message(getStrategyName().getPath() + " does not contain valid dates." +
-                     "Correct format is \"1619460302-1619460302\"")
-               .build();
-      }
-   }
-
-   private static OffsetDateTime getLastExecutionTime(V2DataJob dataJob) {
-      if (CollectionUtils.isEmpty(dataJob.getDeployments())) {
-         return null;
-      }
-      // TODO support for multiple deployments
-      return dataJob.getDeployments().stream().findFirst().orElseThrow().getLastExecutionTime();
-   }
+  private static OffsetDateTime getLastExecutionTime(V2DataJob dataJob) {
+    if (CollectionUtils.isEmpty(dataJob.getDeployments())) {
+      return null;
+    }
+    // TODO support for multiple deployments
+    return dataJob.getDeployments().stream().findFirst().orElseThrow().getLastExecutionTime();
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByName.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByName.java
@@ -19,25 +19,29 @@ import java.util.function.Predicate;
 @Component
 public class JobFieldStrategyByName extends FieldStrategy<V2DataJob> {
 
-   private static final Comparator<V2DataJob> COMPARATOR_DEFAULT = Comparator.comparing(V2DataJob::getJobName);
+  private static final Comparator<V2DataJob> COMPARATOR_DEFAULT =
+      Comparator.comparing(V2DataJob::getJobName);
 
-   @Override
-   public JobFieldStrategyBy getStrategyName() {
-      return JobFieldStrategyBy.JOB_NAME;
-   }
+  @Override
+  public JobFieldStrategyBy getStrategyName() {
+    return JobFieldStrategyBy.JOB_NAME;
+  }
 
-   @Override
-   public Criteria<V2DataJob> computeFilterCriteria(@NonNull Criteria<V2DataJob> criteria, @NonNull Filter filter) {
-      Predicate<V2DataJob> predicate = criteria.getPredicate();
-      if (filterProvided(filter)) {
-         predicate = predicate.and(dataJob -> StringUtils.containsIgnoreCase(dataJob.getJobName(), filter.getPattern()));
-      }
+  @Override
+  public Criteria<V2DataJob> computeFilterCriteria(
+      @NonNull Criteria<V2DataJob> criteria, @NonNull Filter filter) {
+    Predicate<V2DataJob> predicate = criteria.getPredicate();
+    if (filterProvided(filter)) {
+      predicate =
+          predicate.and(
+              dataJob -> StringUtils.containsIgnoreCase(dataJob.getJobName(), filter.getPattern()));
+    }
 
-      return new Criteria<>(predicate, detectSortingComparator(filter, COMPARATOR_DEFAULT, criteria));
-   }
+    return new Criteria<>(predicate, detectSortingComparator(filter, COMPARATOR_DEFAULT, criteria));
+  }
 
-   @Override
-   public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
-      return dataJob -> StringUtils.containsIgnoreCase(dataJob.getJobName(), searchStr);
-   }
+  @Override
+  public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
+    return dataJob -> StringUtils.containsIgnoreCase(dataJob.getJobName(), searchStr);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByNextRun.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByNextRun.java
@@ -35,133 +35,155 @@ import java.util.function.Predicate;
 @Component
 public class JobFieldStrategyByNextRun extends FieldStrategy<V2DataJob> {
 
-   private final Logger log = LoggerFactory.getLogger(this.getClass());
-   private static final long NEXT_RUN_EPOCH_SECS_INVALID_VALUE = -1L;
-   private static final String DATE_SEPARATOR = "-";
-   private static final CronParser CRON_PARSER = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX));
-   private static final ZoneId UTC_ZONE = ZoneId.of("UTC");
-   private static final Comparator<V2DataJob> COMPARATOR_DEFAULT = Comparator.comparing(
-         V2DataJob::getConfig, Comparator.comparing(
-               V2DataJobConfig::getSchedule,
-               Comparator.nullsFirst(Comparator.comparingInt(V2DataJobSchedule::getNextRunEpochSeconds))));
+  private final Logger log = LoggerFactory.getLogger(this.getClass());
+  private static final long NEXT_RUN_EPOCH_SECS_INVALID_VALUE = -1L;
+  private static final String DATE_SEPARATOR = "-";
+  private static final CronParser CRON_PARSER =
+      new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX));
+  private static final ZoneId UTC_ZONE = ZoneId.of("UTC");
+  private static final Comparator<V2DataJob> COMPARATOR_DEFAULT =
+      Comparator.comparing(
+          V2DataJob::getConfig,
+          Comparator.comparing(
+              V2DataJobConfig::getSchedule,
+              Comparator.nullsFirst(
+                  Comparator.comparingInt(V2DataJobSchedule::getNextRunEpochSeconds))));
 
-   @Override
-   public JobFieldStrategyBy getStrategyName() {
-      return JobFieldStrategyBy.NEXT_RUN_EPOCH_SECS;
-   }
+  @Override
+  public JobFieldStrategyBy getStrategyName() {
+    return JobFieldStrategyBy.NEXT_RUN_EPOCH_SECS;
+  }
 
-   /**
-    * The pattern is expected to be in format like 1619460302-1619460302 (two unix times separated with dash)
-    * And the first one should be before (less than) the second one
-    * @param criteria Existing criteria containing already chained Predicates and sorting
-    * @param filter Provided filter containing information about needed sorting direction and filtering pattern.
-    * @throws GraphqlErrorException if the filter pattern contains invalid format or if the first unix time is after the second one
-    * @return The altered chained Predicates and comparator
-    */
-   @Override
-   public Criteria<V2DataJob> computeFilterCriteria(@NonNull Criteria<V2DataJob> criteria, @NonNull Filter filter) {
-      Predicate<V2DataJob> predicate = criteria.getPredicate();
+  /**
+   * The pattern is expected to be in format like 1619460302-1619460302 (two unix times separated
+   * with dash) And the first one should be before (less than) the second one
+   *
+   * @param criteria Existing criteria containing already chained Predicates and sorting
+   * @param filter Provided filter containing information about needed sorting direction and
+   *     filtering pattern.
+   * @throws GraphqlErrorException if the filter pattern contains invalid format or if the first
+   *     unix time is after the second one
+   * @return The altered chained Predicates and comparator
+   */
+  @Override
+  public Criteria<V2DataJob> computeFilterCriteria(
+      @NonNull Criteria<V2DataJob> criteria, @NonNull Filter filter) {
+    Predicate<V2DataJob> predicate = criteria.getPredicate();
 
-      if (filterProvided(filter)) {
-         predicate = predicate.and(dataJob -> {
-            int nextRun = validateAndExtractNextRun(dataJob);
-            Pair<Integer, Integer> range = validateAndExtractDateRange(filter);
+    if (filterProvided(filter)) {
+      predicate =
+          predicate.and(
+              dataJob -> {
+                int nextRun = validateAndExtractNextRun(dataJob);
+                Pair<Integer, Integer> range = validateAndExtractDateRange(filter);
 
-            return nextRun > 0 && range.getFirst() <= nextRun && nextRun <= range.getSecond();
-         });
+                return nextRun > 0 && range.getFirst() <= nextRun && nextRun <= range.getSecond();
+              });
+    }
+
+    return new Criteria<>(predicate, detectSortingComparator(filter, COMPARATOR_DEFAULT, criteria));
+  }
+
+  @Override
+  public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
+    return dataJob ->
+        dataJob.getConfig() != null
+            && dataJob.getConfig().getSchedule() != null
+            && StringUtils.containsIgnoreCase(
+                Integer.toString(dataJob.getConfig().getSchedule().getNextRunEpochSeconds()),
+                searchStr);
+  }
+
+  /** Parse cron expression, compute the next run in UTC and alter the data job */
+  @Override
+  public void alterFieldData(V2DataJob dataJob) {
+    V2DataJobConfig config = dataJob.getConfig();
+    if (config == null) {
+      return;
+    }
+
+    V2DataJobSchedule schedule = config.getSchedule();
+    if (schedule == null) {
+      return;
+    }
+
+    try {
+      schedule.setNextRunEpochSeconds(parseNextRun(schedule.getScheduleCron()));
+    } catch (IllegalArgumentException e) {
+      log.warn(
+          "Parsing cron expression for job {} with cron expression {} failed: {}",
+          dataJob.getJobName(),
+          schedule.getScheduleCron(),
+          e.getMessage());
+      schedule.setNextRunEpochSeconds(NEXT_RUN_EPOCH_SECS_INVALID_VALUE);
+    }
+
+    config.setSchedule(schedule);
+    dataJob.setConfig(config);
+  }
+
+  private Pair<Integer, Integer> validateAndExtractDateRange(Filter filter) {
+    String[] parsedStr = filter.getPattern().split(DATE_SEPARATOR);
+    if (parsedStr.length != 2) {
+      throw GraphqlErrorException.newErrorException()
+          .message(getStrategyName().getPath() + " does not contains valid date range.")
+          .build();
+    }
+    try {
+      var start = Integer.parseInt(parsedStr[0]);
+      var end = Integer.parseInt(parsedStr[1]);
+      var startDate = Instant.ofEpochSecond(start);
+      var endDate = Instant.ofEpochSecond(end);
+
+      if (startDate.isAfter(endDate)) {
+        throw GraphqlErrorException.newErrorException()
+            .message(
+                "First date of "
+                    + getStrategyName().getPath()
+                    + " is after the second."
+                    + "The beginning date should be before the ending date")
+            .build();
       }
+      return Pair.of(start, end);
+    } catch (NumberFormatException | DateTimeException ex) {
+      throw GraphqlErrorException.newErrorException()
+          .message(
+              getStrategyName().getPath()
+                  + " does not contains valid dates."
+                  + "Correct format is \"1619460302-1619460302\"")
+          .build();
+    }
+  }
 
-      return new Criteria<>(predicate, detectSortingComparator(filter, COMPARATOR_DEFAULT, criteria));
-   }
+  private int validateAndExtractNextRun(V2DataJob dataJob) {
+    V2DataJobConfig config = dataJob.getConfig();
+    if (config == null) {
+      return -1;
+    }
+    V2DataJobSchedule schedule = config.getSchedule();
+    if (schedule == null) {
+      return -1;
+    }
+    return schedule.getNextRunEpochSeconds();
+  }
 
-   @Override
-   public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
-      return dataJob -> dataJob.getConfig() != null &&
-            dataJob.getConfig().getSchedule() != null &&
-            StringUtils.containsIgnoreCase(Integer.toString(dataJob.getConfig().getSchedule().getNextRunEpochSeconds()), searchStr);
-   }
-
-   /**
-    * Parse cron expression, compute the next run in UTC and alter the data job
-    */
-   @Override
-   public void alterFieldData(V2DataJob dataJob) {
-      V2DataJobConfig config = dataJob.getConfig();
-      if(config == null) {
-         return;
-      }
-
-      V2DataJobSchedule schedule = config.getSchedule();
-      if(schedule == null) {
-         return;
-      }
-
-      try {
-         schedule.setNextRunEpochSeconds(parseNextRun(schedule.getScheduleCron()));
-      } catch (IllegalArgumentException e) {
-         log.warn("Parsing cron expression for job {} with cron expression {} failed: {}", dataJob.getJobName(),schedule.getScheduleCron(), e.getMessage());
-         schedule.setNextRunEpochSeconds(NEXT_RUN_EPOCH_SECS_INVALID_VALUE);
-      }
-
-      config.setSchedule(schedule);
-      dataJob.setConfig(config);
-   }
-
-
-   private Pair<Integer, Integer> validateAndExtractDateRange(Filter filter) {
-      String[] parsedStr = filter.getPattern().split(DATE_SEPARATOR);
-      if (parsedStr.length != 2) {
-         throw GraphqlErrorException.newErrorException()
-               .message(getStrategyName().getPath() + " does not contains valid date range.")
-               .build();
-      }
-      try {
-         var start = Integer.parseInt(parsedStr[0]);
-         var end = Integer.parseInt(parsedStr[1]);
-         var startDate = Instant.ofEpochSecond(start);
-         var endDate = Instant.ofEpochSecond(end);
-
-         if (startDate.isAfter(endDate)) {
-            throw GraphqlErrorException.newErrorException()
-                  .message("First date of " + getStrategyName().getPath() + " is after the second." +
-                        "The beginning date should be before the ending date")
-                  .build();
-         }
-         return Pair.of(start, end);
-      } catch (NumberFormatException | DateTimeException ex) {
-         throw GraphqlErrorException.newErrorException()
-               .message(getStrategyName().getPath() + " does not contains valid dates." +
-                     "Correct format is \"1619460302-1619460302\"")
-               .build();
-      }
-   }
-
-   private int validateAndExtractNextRun(V2DataJob dataJob) {
-      V2DataJobConfig config = dataJob.getConfig();
-      if (config == null) {
-         return -1;
-      }
-      V2DataJobSchedule schedule = config.getSchedule();
-      if (schedule == null) {
-         return -1;
-      }
-      return schedule.getNextRunEpochSeconds();
-   }
-
-   /**
-    * Gets the next run by a cron expressions
-    * @throws IllegalArgumentException when invalid string is provided
-    * @param scheduleCron a string that represent the expression
-    * @return a long version of unix timestamp (epoch secs)
-    */
-   private long parseNextRun(String scheduleCron) {
-      if (scheduleCron != null && !StringUtils.isBlank(scheduleCron)) {
-         var executionTime = ExecutionTime.forCron(CRON_PARSER.parse(scheduleCron));
-         Optional<ZonedDateTime> nextExecution = executionTime.nextExecution(ZonedDateTime.now(UTC_ZONE));
-         return Math.toIntExact(nextExecution
-               .map(ChronoZonedDateTime::toEpochSecond)
-               .orElse( NEXT_RUN_EPOCH_SECS_INVALID_VALUE));
-      }
-      return NEXT_RUN_EPOCH_SECS_INVALID_VALUE;
-   }
+  /**
+   * Gets the next run by a cron expressions
+   *
+   * @throws IllegalArgumentException when invalid string is provided
+   * @param scheduleCron a string that represent the expression
+   * @return a long version of unix timestamp (epoch secs)
+   */
+  private long parseNextRun(String scheduleCron) {
+    if (scheduleCron != null && !StringUtils.isBlank(scheduleCron)) {
+      var executionTime = ExecutionTime.forCron(CRON_PARSER.parse(scheduleCron));
+      Optional<ZonedDateTime> nextExecution =
+          executionTime.nextExecution(ZonedDateTime.now(UTC_ZONE));
+      return Math.toIntExact(
+          nextExecution
+              .map(ChronoZonedDateTime::toEpochSecond)
+              .orElse(NEXT_RUN_EPOCH_SECS_INVALID_VALUE));
+    }
+    return NEXT_RUN_EPOCH_SECS_INVALID_VALUE;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByScheduleCron.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByScheduleCron.java
@@ -18,23 +18,24 @@ import java.util.function.Predicate;
 @Component
 public class JobFieldStrategyByScheduleCron extends FieldStrategy<V2DataJob> {
 
-   @Override
-   public JobFieldStrategyBy getStrategyName() {
-      return JobFieldStrategyBy.SCHEDULE_CRON;
-   }
+  @Override
+  public JobFieldStrategyBy getStrategyName() {
+    return JobFieldStrategyBy.SCHEDULE_CRON;
+  }
 
-   /**
-    * Filtering and sorting by schedule is not meaningful
-    */
-   @Override
-   public Criteria<V2DataJob> computeFilterCriteria(@NonNull Criteria<V2DataJob> criteria,@NonNull Filter filter) {
-      return criteria;
-   }
+  /** Filtering and sorting by schedule is not meaningful */
+  @Override
+  public Criteria<V2DataJob> computeFilterCriteria(
+      @NonNull Criteria<V2DataJob> criteria, @NonNull Filter filter) {
+    return criteria;
+  }
 
-   @Override
-   public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
-      return dataJob -> dataJob.getConfig() != null &&
-            dataJob.getConfig().getSchedule() != null &&
-            StringUtils.containsIgnoreCase(dataJob.getConfig().getSchedule().getScheduleCron(), searchStr);
-   }
+  @Override
+  public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
+    return dataJob ->
+        dataJob.getConfig() != null
+            && dataJob.getConfig().getSchedule() != null
+            && StringUtils.containsIgnoreCase(
+                dataJob.getConfig().getSchedule().getScheduleCron(), searchStr);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyBySourceUrl.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyBySourceUrl.java
@@ -66,9 +66,8 @@ public class JobFieldStrategyBySourceUrl extends FieldStrategy<V2DataJob> {
                 String.format(
                     "/-/tree/%s/%s",
                     getGitDataJobsBranch,
-                    dataJob
-                        .getJobName())); // TODO in TAUR-1400, when deployments are implemented,
-                                         // replace master
+                    dataJob.getJobName())); // TODO in TAUR-1400, when deployments are implemented,
+    // replace master
     config.setSourceUrl(sourceUrl);
     dataJob.setConfig(config);
   }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByTeam.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByTeam.java
@@ -20,40 +20,47 @@ import java.util.function.Predicate;
 @Component
 public class JobFieldStrategyByTeam extends FieldStrategy<V2DataJob> {
 
-   private static final Comparator<V2DataJob> COMPARATOR_DEFAULT = Comparator.comparing(
-           e -> e.getConfig().getTeam(), Comparator.nullsLast(Comparator.naturalOrder()));
+  private static final Comparator<V2DataJob> COMPARATOR_DEFAULT =
+      Comparator.comparing(
+          e -> e.getConfig().getTeam(), Comparator.nullsLast(Comparator.naturalOrder()));
 
-   @Override
-   public Criteria<V2DataJob> computeFilterCriteria(@NonNull Criteria<V2DataJob> criteria, @NonNull Filter filter) {
-      Predicate<V2DataJob> predicate = criteria.getPredicate();
+  @Override
+  public Criteria<V2DataJob> computeFilterCriteria(
+      @NonNull Criteria<V2DataJob> criteria, @NonNull Filter filter) {
+    Predicate<V2DataJob> predicate = criteria.getPredicate();
 
-      if (filterProvided(filter)) {
-         predicate = predicate.and(dataJob -> {
-            V2DataJobConfig config = dataJob.getConfig();
-            if (config == null || config.getTeam() == null) {
-               return false;
-            }
+    if (filterProvided(filter)) {
+      predicate =
+          predicate.and(
+              dataJob -> {
+                V2DataJobConfig config = dataJob.getConfig();
+                if (config == null || config.getTeam() == null) {
+                  return false;
+                }
 
-            // Only the team field currently support the 'equals' and 'like' operator
-            String part = filter.getPattern();
-            part = part.replace("%", ".*").trim();
-            var configTeamLower = config.getTeam().toLowerCase();
-            var partLower = part.toLowerCase();
+                // Only the team field currently support the 'equals' and 'like' operator
+                String part = filter.getPattern();
+                part = part.replace("%", ".*").trim();
+                var configTeamLower = config.getTeam().toLowerCase();
+                var partLower = part.toLowerCase();
 
-            return configTeamLower.matches(partLower) || configTeamLower.trim().equals(partLower.trim());
-         });
-      }
+                return configTeamLower.matches(partLower)
+                    || configTeamLower.trim().equals(partLower.trim());
+              });
+    }
 
-      return new Criteria<>(predicate, detectSortingComparator(filter, COMPARATOR_DEFAULT, criteria));
-   }
+    return new Criteria<>(predicate, detectSortingComparator(filter, COMPARATOR_DEFAULT, criteria));
+  }
 
-   @Override
-   public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
-      return dataJob -> dataJob.getConfig() != null && StringUtils.containsIgnoreCase(dataJob.getConfig().getTeam(), searchStr);
-   }
+  @Override
+  public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
+    return dataJob ->
+        dataJob.getConfig() != null
+            && StringUtils.containsIgnoreCase(dataJob.getConfig().getTeam(), searchStr);
+  }
 
-   @Override
-   public JobFieldStrategyBy getStrategyName() {
-      return JobFieldStrategyBy.TEAM;
-   }
+  @Override
+  public JobFieldStrategyBy getStrategyName() {
+    return JobFieldStrategyBy.TEAM;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/ControlKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/ControlKubernetesService.java
@@ -11,18 +11,18 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /**
- * Kubernetes service used for serving system tasks of the Control Service.
- * For example helper jobs to deploy data jobs.
- * Generally it's fine if it's the same as where the Control service runs.
+ * Kubernetes service used for serving system tasks of the Control Service. For example helper jobs
+ * to deploy data jobs. Generally it's fine if it's the same as where the Control service runs.
  */
 @Service
 @Slf4j
 public class ControlKubernetesService extends KubernetesService {
 
-   // those should be null/empty when Control service is deployed in k8s hence default is empty
-   public ControlKubernetesService(@Value("${datajobs.control.k8s.namespace:}") String namespace,
-                                   @Value("${datajobs.control.k8s.kubeconfig:}") String kubeconfig,
-                                   @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob) {
-      super(namespace, kubeconfig, k8sSupportsV1CronJob, log);
-   }
+  // those should be null/empty when Control service is deployed in k8s hence default is empty
+  public ControlKubernetesService(
+      @Value("${datajobs.control.k8s.namespace:}") String namespace,
+      @Value("${datajobs.control.k8s.kubeconfig:}") String kubeconfig,
+      @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob) {
+    super(namespace, kubeconfig, k8sSupportsV1CronJob, log);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
@@ -14,22 +14,25 @@ import org.springframework.stereotype.Service;
 import java.io.File;
 
 /**
- * Kubernetes service used for serving data jobs deployments.
- * All deployed data jobs are executed in this environment and all other necessary resources that are used
- * only during the execution of a data job should be create in this kubernetes.
+ * Kubernetes service used for serving data jobs deployments. All deployed data jobs are executed in
+ * this environment and all other necessary resources that are used only during the execution of a
+ * data job should be create in this kubernetes.
  */
 @Service
 @Slf4j
 public class DataJobsKubernetesService extends KubernetesService {
 
-   public DataJobsKubernetesService(@Value("${datajobs.deployment.k8s.namespace:}") String namespace,
-                                    @Value("${datajobs.deployment.k8s.kubeconfig:}") String kubeconfig,
-                                    @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob) {
-      super(namespace, kubeconfig, k8sSupportsV1CronJob, log);
-      if (StringUtils.isBlank(kubeconfig) && !new File(kubeconfig).isFile()) {
-         log.warn("Data Jobs (Deployment) Kubernetes service may not have been correctly bootstrapped. {} file is missing " +
-                         "Will try to use same cluster as control Plane. But this is not recommended in production.",
-                 kubeconfig);
-      }
-   }
+  public DataJobsKubernetesService(
+      @Value("${datajobs.deployment.k8s.namespace:}") String namespace,
+      @Value("${datajobs.deployment.k8s.kubeconfig:}") String kubeconfig,
+      @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob) {
+    super(namespace, kubeconfig, k8sSupportsV1CronJob, log);
+    if (StringUtils.isBlank(kubeconfig) && !new File(kubeconfig).isFile()) {
+      log.warn(
+          "Data Jobs (Deployment) Kubernetes service may not have been correctly bootstrapped. {}"
+              + " file is missing Will try to use same cluster as control Plane. But this is not"
+              + " recommended in production.",
+          kubeconfig);
+    }
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/locks/CustomLockProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/locks/CustomLockProvider.java
@@ -17,65 +17,62 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * A custom JdbcTemplateLockProvider that keeps track of all acquired and released locks,
- * and can be used on shutdown to release all locks that are still active.
+ * A custom JdbcTemplateLockProvider that keeps track of all acquired and released locks, and can be
+ * used on shutdown to release all locks that are still active.
  */
 @Slf4j
 class CustomLockProvider extends JdbcTemplateLockProvider {
-    private final Map<String, SimpleLock> activeLocks = new ConcurrentHashMap<>();
+  private final Map<String, SimpleLock> activeLocks = new ConcurrentHashMap<>();
 
-    public CustomLockProvider(JdbcTemplate jdbcTemplate, String tableName) {
-        super(jdbcTemplate, tableName);
+  public CustomLockProvider(JdbcTemplate jdbcTemplate, String tableName) {
+    super(jdbcTemplate, tableName);
+  }
+
+  @NotNull
+  @Override
+  public Optional<SimpleLock> lock(@NotNull LockConfiguration lockConfiguration) {
+    var lock = super.lock(lockConfiguration);
+    return lock.map(
+        simpleLock -> new LockWrapper(simpleLock, lockConfiguration.getName(), activeLocks));
+  }
+
+  /** Attempts to release all active locks. */
+  public void releaseActiveLocks() {
+    if (activeLocks.size() > 0) {
+      if (log.isInfoEnabled()) {
+        var lockNames = activeLocks.keySet().stream().reduce((a, b) -> a + ", " + b).orElse("");
+        log.info("Releasing {} active locks: {}", activeLocks.size(), lockNames);
+      }
+      activeLocks.values().forEach(SimpleLock::unlock);
+    } else {
+      log.info("There are no active locks to release");
+    }
+  }
+
+  /**
+   * A simple lock wrapper that tracks the lifetime of a lock. This class will probably not work if
+   * using lock extension.
+   */
+  private static class LockWrapper implements SimpleLock {
+    private final SimpleLock wrappedLock;
+    private final String name;
+    private final Map<String, SimpleLock> activeLocks;
+
+    public LockWrapper(SimpleLock wrappedLock, String name, Map<String, SimpleLock> activeLocks) {
+      log.debug("Acquiring lock {}", name);
+      this.wrappedLock = wrappedLock;
+      this.name = name;
+      this.activeLocks = activeLocks;
+      this.activeLocks.put(name, this);
+      log.debug("Lock {} is acquired", name);
     }
 
-    @NotNull
     @Override
-    public Optional<SimpleLock> lock(@NotNull LockConfiguration lockConfiguration) {
-        var lock = super.lock(lockConfiguration);
-        return lock.map(simpleLock -> new LockWrapper(simpleLock, lockConfiguration.getName(), activeLocks));
+    public void unlock() {
+      log.debug("Releasing lock {}", name);
+      wrappedLock.unlock();
+      activeLocks.remove(name);
+      log.debug("Lock {} is released", name);
     }
-
-    /**
-     * Attempts to release all active locks.
-     */
-    public void releaseActiveLocks() {
-        if (activeLocks.size() > 0) {
-            if (log.isInfoEnabled()) {
-                var lockNames = activeLocks.keySet().stream()
-                        .reduce((a, b) -> a + ", " + b)
-                        .orElse("");
-                log.info("Releasing {} active locks: {}", activeLocks.size(), lockNames);
-            }
-            activeLocks.values().forEach(SimpleLock::unlock);
-        } else {
-            log.info("There are no active locks to release");
-        }
-    }
-
-    /**
-     * A simple lock wrapper that tracks the lifetime of a lock.
-     * This class will probably not work if using lock extension.
-     */
-    private static class LockWrapper implements SimpleLock {
-        private final SimpleLock wrappedLock;
-        private final String name;
-        private final Map<String, SimpleLock> activeLocks;
-
-        public LockWrapper(SimpleLock wrappedLock, String name, Map<String, SimpleLock> activeLocks) {
-            log.debug("Acquiring lock {}", name);
-            this.wrappedLock = wrappedLock;
-            this.name = name;
-            this.activeLocks = activeLocks;
-            this.activeLocks.put(name, this);
-            log.debug("Lock {} is acquired", name);
-        }
-
-        @Override
-        public void unlock() {
-            log.debug("Releasing lock {}", name);
-            wrappedLock.unlock();
-            activeLocks.remove(name);
-            log.debug("Lock {} is released", name);
-        }
-    }
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/locks/LockConfiguration.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/locks/LockConfiguration.java
@@ -22,45 +22,42 @@ import javax.sql.DataSource;
 @Slf4j
 public class LockConfiguration {
 
-    /**
-     * We have experienced cases when operations against the database appear to hang
-     * indefinitely (usually after a connectivity issue with the database). As a result
-     * tasks that attempt to obtain a distributed lock, fail to start.
-     * This value is set directly on the JdbcTemplate as a query timeout in an attempt
-     * to force the database operation to time out and prevent such cases.
-     *
-     * @see   <a href="https://dzone.com/articles/threads-stuck-in-javanetsocketinputstreamsocketrea">
-     *     Threads Stuck in java.net.SocketInputStream.socketRead0 API</a>
-     */
-    private static final int LOCK_PROVIDER_QUERY_TIMEOUT_SECONDS = 60;
+  /**
+   * We have experienced cases when operations against the database appear to hang indefinitely
+   * (usually after a connectivity issue with the database). As a result tasks that attempt to
+   * obtain a distributed lock, fail to start. This value is set directly on the JdbcTemplate as a
+   * query timeout in an attempt to force the database operation to time out and prevent such cases.
+   *
+   * @see <a href="https://dzone.com/articles/threads-stuck-in-javanetsocketinputstreamsocketrea">
+   *     Threads Stuck in java.net.SocketInputStream.socketRead0 API</a>
+   */
+  private static final int LOCK_PROVIDER_QUERY_TIMEOUT_SECONDS = 60;
 
-    private CustomLockProvider customLockProvider;
+  private CustomLockProvider customLockProvider;
 
-    /**
-     * Creates an object that is used by the ShedLock utility to connect to
-     * a database.
-     * <p>
-     * The ShedLock utility ensures that a scheduled task (data job status
-     * monitoring in our case) can only occur in one of the service instances
-     * (in case of a multi-instance service deployment). This is achieved
-     * by using a database table and the LockProvider returned by this method
-     * is used to connect to that table.
-     *
-     * @see   <a href="https://github.com/lukas-krecan/ShedLock">ShedLock</a>
-     */
-    @Bean
-    public LockProvider lockProvider(DataSource dataSource) {
-        JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-        jdbcTemplate.setQueryTimeout(LOCK_PROVIDER_QUERY_TIMEOUT_SECONDS);
-        customLockProvider = new CustomLockProvider(jdbcTemplate, "shedlock");
-        return customLockProvider;
+  /**
+   * Creates an object that is used by the ShedLock utility to connect to a database.
+   *
+   * <p>The ShedLock utility ensures that a scheduled task (data job status monitoring in our case)
+   * can only occur in one of the service instances (in case of a multi-instance service
+   * deployment). This is achieved by using a database table and the LockProvider returned by this
+   * method is used to connect to that table.
+   *
+   * @see <a href="https://github.com/lukas-krecan/ShedLock">ShedLock</a>
+   */
+  @Bean
+  public LockProvider lockProvider(DataSource dataSource) {
+    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+    jdbcTemplate.setQueryTimeout(LOCK_PROVIDER_QUERY_TIMEOUT_SECONDS);
+    customLockProvider = new CustomLockProvider(jdbcTemplate, "shedlock");
+    return customLockProvider;
+  }
+
+  @PreDestroy
+  void releaseActiveLocks() {
+    log.info("Service is shutting down. Releasing active locks...");
+    if (customLockProvider != null) {
+      customLockProvider.releaseActiveLocks();
     }
-
-    @PreDestroy
-    void releaseActiveLocks() {
-        log.info("Service is shutting down. Releasing active locks...");
-        if (customLockProvider != null) {
-            customLockProvider.releaseActiveLocks();
-        }
-    }
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DataJob.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DataJob.java
@@ -23,54 +23,64 @@ import com.vmware.taurus.service.model.converter.ExecutionTerminationStatusConve
 @Entity
 public class DataJob {
 
-   @Id
-   private String name;
+  @Id private String name;
 
-   @Embedded
-   private JobConfig jobConfig;
+  @Embedded private JobConfig jobConfig;
 
-   @Column(name = "latest_job_deployment_status")
-   private DeploymentStatus latestJobDeploymentStatus;
+  @Column(name = "latest_job_deployment_status")
+  private DeploymentStatus latestJobDeploymentStatus;
 
-   @Column(name = "latest_job_termination_status")
-   @Convert(converter = ExecutionTerminationStatusConverter.class)
-   private ExecutionStatus latestJobTerminationStatus;
+  @Column(name = "latest_job_termination_status")
+  @Convert(converter = ExecutionTerminationStatusConverter.class)
+  private ExecutionStatus latestJobTerminationStatus;
 
-   @Column(name = "latest_job_execution_id")
-   private String latestJobExecutionId;
+  @Column(name = "latest_job_execution_id")
+  private String latestJobExecutionId;
 
-   @OneToMany(
-         mappedBy = "dataJob",
-         cascade = CascadeType.ALL
-   )
-   @ToString.Exclude
-   @EqualsAndHashCode.Exclude
-   private Set<DataJobExecution> executions;
+  @OneToMany(mappedBy = "dataJob", cascade = CascadeType.ALL)
+  @ToString.Exclude
+  @EqualsAndHashCode.Exclude
+  private Set<DataJobExecution> executions;
 
-   private Boolean enabled;
+  private Boolean enabled;
 
-   @Column(name = "last_execution_status")
-   @Convert(converter = ExecutionStatusConverter.class)
-   private ExecutionStatus lastExecutionStatus;
+  @Column(name = "last_execution_status")
+  @Convert(converter = ExecutionStatusConverter.class)
+  private ExecutionStatus lastExecutionStatus;
 
-   @Column(name = "last_execution_end_time")
-   private OffsetDateTime lastExecutionEndTime;
+  @Column(name = "last_execution_end_time")
+  private OffsetDateTime lastExecutionEndTime;
 
-   @Column(name = "last_execution_duration")
-   private Integer lastExecutionDuration;
+  @Column(name = "last_execution_duration")
+  private Integer lastExecutionDuration;
 
-   public DataJob(String name, JobConfig jobConfig) {
-      this.name = name;
-      this.jobConfig = jobConfig;
-      this.latestJobDeploymentStatus = DeploymentStatus.NONE;
-      this.latestJobTerminationStatus = null;
-   }
+  public DataJob(String name, JobConfig jobConfig) {
+    this.name = name;
+    this.jobConfig = jobConfig;
+    this.latestJobDeploymentStatus = DeploymentStatus.NONE;
+    this.latestJobTerminationStatus = null;
+  }
 
-   public DataJob(String name, JobConfig jobConfig, DeploymentStatus deploymentStatus) {
-      this(name, jobConfig, deploymentStatus, null, null, null, true, null, null, null);
-   }
+  public DataJob(String name, JobConfig jobConfig, DeploymentStatus deploymentStatus) {
+    this(name, jobConfig, deploymentStatus, null, null, null, true, null, null, null);
+  }
 
-   public DataJob(String name, JobConfig jobConfig, DeploymentStatus deploymentStatus, ExecutionStatus terminationStatus, String latestJobExecutionId) {
-      this(name, jobConfig, deploymentStatus, terminationStatus, latestJobExecutionId, null, true, null, null, null);
-   }
+  public DataJob(
+      String name,
+      JobConfig jobConfig,
+      DeploymentStatus deploymentStatus,
+      ExecutionStatus terminationStatus,
+      String latestJobExecutionId) {
+    this(
+        name,
+        jobConfig,
+        deploymentStatus,
+        terminationStatus,
+        latestJobExecutionId,
+        null,
+        true,
+        null,
+        null,
+        null);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DataJobExecution.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DataJobExecution.java
@@ -18,52 +18,51 @@ import com.vmware.taurus.service.model.converter.ExecutionStatusConverter;
 @AllArgsConstructor
 @EqualsAndHashCode
 @ToString
-@Builder(toBuilder=true)
+@Builder(toBuilder = true)
 @Entity
 public class DataJobExecution {
 
-   @Id
-   private String id;
+  @Id private String id;
 
-   @ManyToOne
-   @JoinColumn(name = "job_name", nullable = false)
-   @ToString.Exclude
-   @EqualsAndHashCode.Exclude
-   private DataJob dataJob;
+  @ManyToOne
+  @JoinColumn(name = "job_name", nullable = false)
+  @ToString.Exclude
+  @EqualsAndHashCode.Exclude
+  private DataJob dataJob;
 
-   @Column(nullable = false)
-   private ExecutionType type;
+  @Column(nullable = false)
+  private ExecutionType type;
 
-   @Column(nullable = false)
-   @Convert(converter = ExecutionStatusConverter.class)
-   private ExecutionStatus status;
+  @Column(nullable = false)
+  @Convert(converter = ExecutionStatusConverter.class)
+  private ExecutionStatus status;
 
-   private String message;
+  private String message;
 
-   @Column(nullable = false)
-   private String opId;
+  @Column(nullable = false)
+  private String opId;
 
-   private OffsetDateTime startTime;
+  private OffsetDateTime startTime;
 
-   private OffsetDateTime endTime;
+  private OffsetDateTime endTime;
 
-   private String vdkVersion;
+  private String vdkVersion;
 
-   private String jobVersion;
+  private String jobVersion;
 
-   private String jobSchedule;
+  private String jobSchedule;
 
-   private Float resourcesCpuRequest;
+  private Float resourcesCpuRequest;
 
-   private Float resourcesCpuLimit;
+  private Float resourcesCpuLimit;
 
-   private Integer resourcesMemoryRequest;
+  private Integer resourcesMemoryRequest;
 
-   private Integer resourcesMemoryLimit;
+  private Integer resourcesMemoryLimit;
 
-   private OffsetDateTime lastDeployedDate;
+  private OffsetDateTime lastDeployedDate;
 
-   private String lastDeployedBy;
+  private String lastDeployedBy;
 
-   private String startedBy;
+  private String startedBy;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DataJobExecutionIdAndEndTime.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DataJobExecutionIdAndEndTime.java
@@ -8,6 +8,7 @@ package com.vmware.taurus.service.model;
 import java.time.OffsetDateTime;
 
 public interface DataJobExecutionIdAndEndTime {
-    String getId();
-    OffsetDateTime getEndTime();
+  String getId();
+
+  OffsetDateTime getEndTime();
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DataJobExecutionStatusCount.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DataJobExecutionStatusCount.java
@@ -6,7 +6,9 @@
 package com.vmware.taurus.service.model;
 
 public interface DataJobExecutionStatusCount {
-    ExecutionStatus getStatus();
-    int getStatusCount();
-    String getJobName();
+  ExecutionStatus getStatus();
+
+  int getStatusCount();
+
+  String getJobName();
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DataJobStatus.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DataJobStatus.java
@@ -6,5 +6,7 @@
 package com.vmware.taurus.service.model;
 
 public enum DataJobStatus {
-   NOT_DEPLOYED, ENABLED, DISABLED
+  NOT_DEPLOYED,
+  ENABLED,
+  DISABLED
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DeploymentStatus.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DeploymentStatus.java
@@ -10,12 +10,10 @@ import lombok.Getter;
 
 @AllArgsConstructor
 public enum DeploymentStatus {
-   NONE(-1),
-   SUCCESS(0),
-   PLATFORM_ERROR(1),
-   USER_ERROR(3);
+  NONE(-1),
+  SUCCESS(0),
+  PLATFORM_ERROR(1),
+  USER_ERROR(3);
 
-   @Getter
-   private int value;
-
+  @Getter private int value;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/ExecutionResult.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/ExecutionResult.java
@@ -11,6 +11,6 @@ import lombok.Data;
 @Builder
 @Data
 public class ExecutionResult {
-   private ExecutionStatus executionStatus;
-   private String vdkVersion;
+  private ExecutionStatus executionStatus;
+  private String vdkVersion;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/ExecutionStatus.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/ExecutionStatus.java
@@ -10,20 +10,17 @@ import lombok.Getter;
 
 @AllArgsConstructor
 public enum ExecutionStatus {
-   SUBMITTED(0, "Submitted", 2),
-   RUNNING(1, "Running", 5),
-   SUCCEEDED(2, "Success", 0),
-   CANCELLED(4, "Cancelled", 6),
-   SKIPPED(5, "Skipped", 4),
-   USER_ERROR(6, "User error", 3),
-   PLATFORM_ERROR(7, "Platform error", 1);
+  SUBMITTED(0, "Submitted", 2),
+  RUNNING(1, "Running", 5),
+  SUCCEEDED(2, "Success", 0),
+  CANCELLED(4, "Cancelled", 6),
+  SKIPPED(5, "Skipped", 4),
+  USER_ERROR(6, "User error", 3),
+  PLATFORM_ERROR(7, "Platform error", 1);
 
-   @Getter
-   private final Integer dbValue;
+  @Getter private final Integer dbValue;
 
-   @Getter
-   private final String podStatus;
+  @Getter private final String podStatus;
 
-   @Getter
-   private final Integer alertValue;
+  @Getter private final Integer alertValue;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/ExecutionType.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/ExecutionType.java
@@ -10,9 +10,8 @@ import lombok.Getter;
 
 @AllArgsConstructor
 public enum ExecutionType {
-   MANUAL(0),
-   SCHEDULED(1);
+  MANUAL(0),
+  SCHEDULED(1);
 
-   @Getter
-   private final int value;
+  @Getter private final int value;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/JobAnnotation.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/JobAnnotation.java
@@ -9,18 +9,17 @@ import com.vmware.taurus.service.KubernetesService;
 import lombok.Getter;
 
 public enum JobAnnotation {
-   SCHEDULE("schedule"),
-   STARTED_BY("started-by"),
-   DEPLOYED_DATE("deployed-date"),
-   DEPLOYED_BY("deployed-by"),
-   EXECUTION_TYPE("execution-type"),
-   OP_ID("op-id"),
-   UNSCHEDULED("unscheduled");
+  SCHEDULE("schedule"),
+  STARTED_BY("started-by"),
+  DEPLOYED_DATE("deployed-date"),
+  DEPLOYED_BY("deployed-by"),
+  EXECUTION_TYPE("execution-type"),
+  OP_ID("op-id"),
+  UNSCHEDULED("unscheduled");
 
-   @Getter
-   private String value;
+  @Getter private String value;
 
-   JobAnnotation(String value) {
-      this.value = String.format("%s/%s", KubernetesService.LABEL_PREFIX, value);
-   }
+  JobAnnotation(String value) {
+    this.value = String.format("%s/%s", KubernetesService.LABEL_PREFIX, value);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/JobConfig.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/JobConfig.java
@@ -11,17 +11,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import org.apache.commons.lang3.StringUtils;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static com.vmware.taurus.service.Utilities.join;
 import static com.vmware.taurus.service.Utilities.parseList;
-
 
 @Getter
 @Setter
@@ -32,53 +28,53 @@ import static com.vmware.taurus.service.Utilities.parseList;
 @AllArgsConstructor
 public class JobConfig {
 
-    private static final String SEPARATOR = ";";
-    private String team;
-    private String description;
-    private String schedule;
+  private static final String SEPARATOR = ";";
+  private String team;
+  private String description;
+  private String schedule;
 
-    // JPA/Hibernate automatically converts camelCase field names to snake_case column names
-    private String dbDefaultType;
-    private Boolean enableExecutionNotifications;
-    private Integer notificationDelayPeriodMinutes;
-    private String notifiedOnJobFailureUserError;
-    private String notifiedOnJobFailurePlatformError;
-    private String notifiedOnJobSuccess;
-    private String notifiedOnJobDeploy;
-    private boolean generateKeytab;
+  // JPA/Hibernate automatically converts camelCase field names to snake_case column names
+  private String dbDefaultType;
+  private Boolean enableExecutionNotifications;
+  private Integer notificationDelayPeriodMinutes;
+  private String notifiedOnJobFailureUserError;
+  private String notifiedOnJobFailurePlatformError;
+  private String notifiedOnJobSuccess;
+  private String notifiedOnJobDeploy;
+  private boolean generateKeytab;
 
-    @Column(name = "name_deprecated")
-    private String jobName;
+  @Column(name = "name_deprecated")
+  private String jobName;
 
-    public List<String> getNotifiedOnJobFailureUserError() {
-        return parseList(notifiedOnJobFailureUserError);
-    }
+  public List<String> getNotifiedOnJobFailureUserError() {
+    return parseList(notifiedOnJobFailureUserError);
+  }
 
-    public void setNotifiedOnJobFailureUserError(List<String> list) {
-        this.notifiedOnJobFailureUserError = join(list);
-    }
+  public void setNotifiedOnJobFailureUserError(List<String> list) {
+    this.notifiedOnJobFailureUserError = join(list);
+  }
 
-    public List<String> getNotifiedOnJobFailurePlatformError() {
-        return parseList(notifiedOnJobFailurePlatformError);
-    }
+  public List<String> getNotifiedOnJobFailurePlatformError() {
+    return parseList(notifiedOnJobFailurePlatformError);
+  }
 
-    public void setNotifiedOnJobFailurePlatformError(List<String> list) {
-        this.notifiedOnJobFailurePlatformError = join(list);
-    }
+  public void setNotifiedOnJobFailurePlatformError(List<String> list) {
+    this.notifiedOnJobFailurePlatformError = join(list);
+  }
 
-    public List<String> getNotifiedOnJobSuccess() {
-        return parseList(notifiedOnJobSuccess);
-    }
+  public List<String> getNotifiedOnJobSuccess() {
+    return parseList(notifiedOnJobSuccess);
+  }
 
-    public void setNotifiedOnJobSuccess(List<String> list) {
-        this.notifiedOnJobSuccess = join(list);
-    }
+  public void setNotifiedOnJobSuccess(List<String> list) {
+    this.notifiedOnJobSuccess = join(list);
+  }
 
-    public List<String> getNotifiedOnJobDeploy() {
-        return parseList(notifiedOnJobDeploy);
-    }
+  public List<String> getNotifiedOnJobDeploy() {
+    return parseList(notifiedOnJobDeploy);
+  }
 
-    public void setNotifiedOnJobDeploy(List<String> list) {
-        this.notifiedOnJobDeploy = join(list);
-    }
+  public void setNotifiedOnJobDeploy(List<String> list) {
+    this.notifiedOnJobDeploy = join(list);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/JobDeployment.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/JobDeployment.java
@@ -9,31 +9,31 @@ import com.vmware.taurus.controlplane.model.data.DataJobResources;
 import lombok.Data;
 
 /**
- * Store this in the database if the data job configuration could not or should not
- * be retrieved from the kubernetes manifest of the data job deployment like Airflow DAG locations.
+ * Store this in the database if the data job configuration could not or should not be retrieved
+ * from the kubernetes manifest of the data job deployment like Airflow DAG locations.
  */
 @Data
 public class JobDeployment {
 
-   private String dataJobTeam;
+  private String dataJobTeam;
 
-   private String dataJobName;
+  private String dataJobName;
 
-   private String gitCommitSha;
+  private String gitCommitSha;
 
-   private String vdkVersion;
+  private String vdkVersion;
 
-   private String imageName;
+  private String imageName;
 
-   private String cronJobName;
+  private String cronJobName;
 
-   /**
-    * When disabled, the DataJob will still be deployed but it will never be executed.
-    * When enabled, the DataJob will be executed according to its {@link JobConfig#getSchedule()}
-    */
-   private Boolean enabled;
+  /**
+   * When disabled, the DataJob will still be deployed but it will never be executed. When enabled,
+   * the DataJob will be executed according to its {@link JobConfig#getSchedule()}
+   */
+  private Boolean enabled;
 
-   private String mode;
+  private String mode;
 
-   private DataJobResources resources;
+  private DataJobResources resources;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/JobDeploymentStatus.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/JobDeploymentStatus.java
@@ -8,31 +8,29 @@ package com.vmware.taurus.service.model;
 import com.vmware.taurus.controlplane.model.data.DataJobResources;
 import lombok.Data;
 
-/**
- * Object used for providing users with information about data job deployments.
- */
+/** Object used for providing users with information about data job deployments. */
 @Data
 public class JobDeploymentStatus {
 
-    private String dataJobName;
+  private String dataJobName;
 
-    private String gitCommitSha;
+  private String gitCommitSha;
 
-    private String vdkImageName;
+  private String vdkImageName;
 
-    private String vdkVersion;
+  private String vdkVersion;
 
-    private String imageName;
+  private String imageName;
 
-    private String cronJobName;
+  private String cronJobName;
 
-    private Boolean enabled;
+  private Boolean enabled;
 
-    private String mode;
+  private String mode;
 
-    private DataJobResources resources;
+  private DataJobResources resources;
 
-    private String lastDeployedBy;
+  private String lastDeployedBy;
 
-    private String lastDeployedDate;
+  private String lastDeployedDate;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/JobEnvVar.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/JobEnvVar.java
@@ -8,13 +8,10 @@ package com.vmware.taurus.service.model;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-/**
- * Used for setting of Kubernetes Job Container environment variables
- */
+/** Used for setting of Kubernetes Job Container environment variables */
 @AllArgsConstructor
 public enum JobEnvVar {
-   VDK_OP_ID("VDK_OP_ID");
+  VDK_OP_ID("VDK_OP_ID");
 
-   @Getter
-   private String value;
+  @Getter private String value;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/JobLabel.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/JobLabel.java
@@ -9,16 +9,15 @@ import com.vmware.taurus.service.KubernetesService;
 import lombok.Getter;
 
 public enum JobLabel {
-   NAME("name"),
-   VERSION("version"),
-   TYPE("type"),
-   EXECUTION_ID("data-job-execution-id"),
-   STARTED_BY_USER("start-by-user");
+  NAME("name"),
+  VERSION("version"),
+  TYPE("type"),
+  EXECUTION_ID("data-job-execution-id"),
+  STARTED_BY_USER("start-by-user");
 
-   @Getter
-   private String value;
+  @Getter private String value;
 
-   JobLabel(String value) {
-      this.value = String.format("%s/%s", KubernetesService.LABEL_PREFIX, value);
-   }
+  JobLabel(String value) {
+    this.value = String.format("%s/%s", KubernetesService.LABEL_PREFIX, value);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/converter/ExecutionStatusConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/converter/ExecutionStatusConverter.java
@@ -14,25 +14,25 @@ import com.vmware.taurus.service.model.ExecutionStatus;
 @Converter
 public class ExecutionStatusConverter implements AttributeConverter<ExecutionStatus, Integer> {
 
-   @Override
-   public Integer convertToDatabaseColumn(ExecutionStatus executionStatus) {
-      return executionStatus != null ? executionStatus.getDbValue() : null;
-   }
+  @Override
+  public Integer convertToDatabaseColumn(ExecutionStatus executionStatus) {
+    return executionStatus != null ? executionStatus.getDbValue() : null;
+  }
 
-   @Override
-   public ExecutionStatus convertToEntityAttribute(Integer dbValue) {
-      if (dbValue == null) {
-         return null;
-      }
+  @Override
+  public ExecutionStatus convertToEntityAttribute(Integer dbValue) {
+    if (dbValue == null) {
+      return null;
+    }
 
-      // temporary solution for backward compatibility.
-      if (dbValue == 3) {
-         return ExecutionStatus.PLATFORM_ERROR;
-      }
+    // temporary solution for backward compatibility.
+    if (dbValue == 3) {
+      return ExecutionStatus.PLATFORM_ERROR;
+    }
 
-      return Arrays.stream(ExecutionStatus.values())
-            .filter(terminationStatus -> terminationStatus.getDbValue().equals(dbValue))
-            .findAny()
-            .orElse(null);
-   }
+    return Arrays.stream(ExecutionStatus.values())
+        .filter(terminationStatus -> terminationStatus.getDbValue().equals(dbValue))
+        .findAny()
+        .orElse(null);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/converter/ExecutionTerminationStatusConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/converter/ExecutionTerminationStatusConverter.java
@@ -14,23 +14,24 @@ import com.google.common.primitives.Ints;
 import com.vmware.taurus.service.model.ExecutionStatus;
 
 @Converter
-public class ExecutionTerminationStatusConverter implements AttributeConverter<ExecutionStatus, String> {
+public class ExecutionTerminationStatusConverter
+    implements AttributeConverter<ExecutionStatus, String> {
 
-   @Override
-   public String convertToDatabaseColumn(ExecutionStatus executionStatus) {
-      return executionStatus != null ? String.valueOf(executionStatus.getAlertValue()) : null;
-   }
+  @Override
+  public String convertToDatabaseColumn(ExecutionStatus executionStatus) {
+    return executionStatus != null ? String.valueOf(executionStatus.getAlertValue()) : null;
+  }
 
-   @Override
-   public ExecutionStatus convertToEntityAttribute(String dbValueString) {
-      if (dbValueString == null) {
-         return null;
-      }
+  @Override
+  public ExecutionStatus convertToEntityAttribute(String dbValueString) {
+    if (dbValueString == null) {
+      return null;
+    }
 
-      Integer dbValueInteger = Ints.tryParse(dbValueString);
-      return Arrays.stream(ExecutionStatus.values())
-            .filter(terminationStatus -> terminationStatus.getAlertValue().equals(dbValueInteger))
-            .findAny()
-            .orElse(null);
-   }
+    Integer dbValueInteger = Ints.tryParse(dbValueString);
+    return Arrays.stream(ExecutionStatus.values())
+        .filter(terminationStatus -> terminationStatus.getAlertValue().equals(dbValueInteger))
+        .findAny()
+        .orElse(null);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobExecutionCleanupMonitor.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobExecutionCleanupMonitor.java
@@ -11,66 +11,71 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-
 @Slf4j
 @Component
 public class DataJobExecutionCleanupMonitor {
 
-    public static final String SUCCESSFUL_DELETIONS_COUNTER_NAME = "vdk.execution.cleanup.task.datajob.successful.deletions.counter";
-    public static final String FAILED_DELETIONS_COUNTER_NAME = "vdk.execution.cleanup.task.datajob.failed.deletions.counter";
-    public static final String CLEANUP_JOB_INVOCATIONS_COUNTER_NAME = "vdk.execution.cleanup.task.datajob.invocations.counter";
+  public static final String SUCCESSFUL_DELETIONS_COUNTER_NAME =
+      "vdk.execution.cleanup.task.datajob.successful.deletions.counter";
+  public static final String FAILED_DELETIONS_COUNTER_NAME =
+      "vdk.execution.cleanup.task.datajob.failed.deletions.counter";
+  public static final String CLEANUP_JOB_INVOCATIONS_COUNTER_NAME =
+      "vdk.execution.cleanup.task.datajob.invocations.counter";
 
-    private final MeterRegistry meterRegistry;
-    private final Counter invocationsCounter;
-    private final Counter failedDeletionsCounter;
-    private final Counter successfulDeletionsCounter;
+  private final MeterRegistry meterRegistry;
+  private final Counter invocationsCounter;
+  private final Counter failedDeletionsCounter;
+  private final Counter successfulDeletionsCounter;
 
-    @Autowired(required = true)
-    public DataJobExecutionCleanupMonitor(MeterRegistry meterRegistry) {
-        this.meterRegistry = meterRegistry;
+  @Autowired(required = true)
+  public DataJobExecutionCleanupMonitor(MeterRegistry meterRegistry) {
+    this.meterRegistry = meterRegistry;
 
-        invocationsCounter = Counter.builder(CLEANUP_JOB_INVOCATIONS_COUNTER_NAME)
-                .description("Counts the number of times the cleanup task is called.")
-                .register(this.meterRegistry);
+    invocationsCounter =
+        Counter.builder(CLEANUP_JOB_INVOCATIONS_COUNTER_NAME)
+            .description("Counts the number of times the cleanup task is called.")
+            .register(this.meterRegistry);
 
-        failedDeletionsCounter = Counter.builder(FAILED_DELETIONS_COUNTER_NAME)
-                .description("Counts the total times the data job execution cleanup task was unsuccessful for a data job.")
-                .register(this.meterRegistry);
+    failedDeletionsCounter =
+        Counter.builder(FAILED_DELETIONS_COUNTER_NAME)
+            .description(
+                "Counts the total times the data job execution cleanup task was unsuccessful for a"
+                    + " data job.")
+            .register(this.meterRegistry);
 
-        successfulDeletionsCounter = Counter.builder(SUCCESSFUL_DELETIONS_COUNTER_NAME)
-                .description("Counts the total times the data job execution cleanup task was successful for a data job.")
-                .register(this.meterRegistry);
+    successfulDeletionsCounter =
+        Counter.builder(SUCCESSFUL_DELETIONS_COUNTER_NAME)
+            .description(
+                "Counts the total times the data job execution cleanup task was successful for a"
+                    + " data job.")
+            .register(this.meterRegistry);
+  }
+
+  /**
+   * Counts the number of times the JobExecutionCleanupService's cleanup data job execution method
+   * was invoked.
+   */
+  public void countInvocation() {
+    incrementCounter(invocationsCounter);
+  }
+
+  /** Counts the number of failed data job execution deletions by the JobExecutionCleanupService */
+  public void countFailedDeletion() {
+    incrementCounter(failedDeletionsCounter);
+  }
+
+  /**
+   * Counts the number of successful data job execution deletions by the JobExecutionCleanupService.
+   */
+  public void countSuccessfulDeletion() {
+    incrementCounter(successfulDeletionsCounter);
+  }
+
+  private void incrementCounter(Counter counter) {
+    try {
+      counter.increment();
+    } catch (Exception e) {
+      log.warn("Error while trying to increment counter.", e);
     }
-
-    /**
-     * Counts the number of times the JobExecutionCleanupService's cleanup
-     * data job execution method was invoked.
-     */
-    public void countInvocation() {
-        incrementCounter(invocationsCounter);
-    }
-
-    /**
-     * Counts the number of failed data job execution deletions
-     * by the JobExecutionCleanupService
-     */
-    public void countFailedDeletion() {
-        incrementCounter(failedDeletionsCounter);
-    }
-
-    /**
-     * Counts the number of successful data job execution deletions
-     * by the JobExecutionCleanupService.
-     */
-    public void countSuccessfulDeletion() {
-        incrementCounter(successfulDeletionsCounter);
-    }
-
-    private void incrementCounter(Counter counter) {
-        try {
-            counter.increment();
-        } catch (Exception e) {
-            log.warn("Error while trying to increment counter.", e);
-        }
-    }
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMetrics.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMetrics.java
@@ -25,313 +25,362 @@ import java.util.stream.Collectors;
 
 import static com.vmware.taurus.service.Utilities.join;
 
-/**
- * This class manages data job monitoring metrics exposed by the service.
- */
+/** This class manages data job monitoring metrics exposed by the service. */
 @Slf4j
 @Component
 public class DataJobMetrics {
-    public static final String TAURUS_DATAJOB_INFO_METRIC_NAME = "taurus.datajob.info";
-    public static final String TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME = "taurus.datajob.notification.delay";
-    public static final String TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME = "taurus.datajob.termination.status";
-    public static final String TAURUS_DATAJOB_WATCH_TASK_INVOCATIONS_COUNTER_NAME = "taurus.datajob.watch.task.invocations.counter";
-    public static final String TAG_DATA_JOB = "data_job";
-    public static final String TAG_EXECUTION_ID = "execution_id";
-    public static final String TAG_TEAM = "team";
-    public static final String TAG_EMAIL_NOTIFIED_ON_SUCCESS = "email_notified_on_success";
-    public static final String TAG_EMAIL_NOTIFIED_ON_USER_ERROR = "email_notified_on_user_error";
-    public static final String TAG_EMAIL_NOTIFIED_ON_PLATFORM_ERROR = "email_notified_on_platform_error";
+  public static final String TAURUS_DATAJOB_INFO_METRIC_NAME = "taurus.datajob.info";
+  public static final String TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME =
+      "taurus.datajob.notification.delay";
+  public static final String TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME =
+      "taurus.datajob.termination.status";
+  public static final String TAURUS_DATAJOB_WATCH_TASK_INVOCATIONS_COUNTER_NAME =
+      "taurus.datajob.watch.task.invocations.counter";
+  public static final String TAG_DATA_JOB = "data_job";
+  public static final String TAG_EXECUTION_ID = "execution_id";
+  public static final String TAG_TEAM = "team";
+  public static final String TAG_EMAIL_NOTIFIED_ON_SUCCESS = "email_notified_on_success";
+  public static final String TAG_EMAIL_NOTIFIED_ON_USER_ERROR = "email_notified_on_user_error";
+  public static final String TAG_EMAIL_NOTIFIED_ON_PLATFORM_ERROR =
+      "email_notified_on_platform_error";
 
-    public static final Integer GAUGE_METRIC_VALUE = 1;
-    public static final int DEFAULT_NOTIFICATION_DELAY_PERIOD_MINUTES = 240;
+  public static final Integer GAUGE_METRIC_VALUE = 1;
+  public static final int DEFAULT_NOTIFICATION_DELAY_PERIOD_MINUTES = 240;
 
-    private final MeterRegistry meterRegistry;
-    private final Counter watchTaskInvocationsCounter;
-    private final Map<String, Gauge> infoGauges = new ConcurrentHashMap<>();
-    private final Map<String, Gauge> delayGauges = new ConcurrentHashMap<>();
-    private final Map<String, Gauge> statusGauges = new ConcurrentHashMap<>();
-    private final Map<String, Integer> currentDelays = new ConcurrentHashMap<>();
-    private final Map<String, Integer> currentStatuses = new ConcurrentHashMap<>();
+  private final MeterRegistry meterRegistry;
+  private final Counter watchTaskInvocationsCounter;
+  private final Map<String, Gauge> infoGauges = new ConcurrentHashMap<>();
+  private final Map<String, Gauge> delayGauges = new ConcurrentHashMap<>();
+  private final Map<String, Gauge> statusGauges = new ConcurrentHashMap<>();
+  private final Map<String, Integer> currentDelays = new ConcurrentHashMap<>();
+  private final Map<String, Integer> currentStatuses = new ConcurrentHashMap<>();
 
-    @Autowired
-    public DataJobMetrics(MeterRegistry meterRegistry) {
-        this.meterRegistry = meterRegistry;
+  @Autowired
+  public DataJobMetrics(MeterRegistry meterRegistry) {
+    this.meterRegistry = meterRegistry;
 
-        watchTaskInvocationsCounter = Counter.builder(TAURUS_DATAJOB_WATCH_TASK_INVOCATIONS_COUNTER_NAME)
-                .description("Counts the number of times the data jobs watching task is called.")
-                .register(this.meterRegistry);
+    watchTaskInvocationsCounter =
+        Counter.builder(TAURUS_DATAJOB_WATCH_TASK_INVOCATIONS_COUNTER_NAME)
+            .description("Counts the number of times the data jobs watching task is called.")
+            .register(this.meterRegistry);
+  }
+
+  /**
+   * Increments the counter used to track the number of times the {@link DataJobMonitor#watchJobs}
+   * method was invoked.
+   */
+  public void incrementWatchTaskInvocations() {
+    try {
+      watchTaskInvocationsCounter.increment();
+    } catch (Exception e) {
+      log.warn("Error while trying to increment counter.", e);
     }
+  }
 
-    /**
-     * Increments the counter used to track the number of times the {@link DataJobMonitor#watchJobs} method was invoked.
-     */
-    public void incrementWatchTaskInvocations() {
-        try {
-            watchTaskInvocationsCounter.increment();
-        } catch (Exception e) {
-            log.warn("Error while trying to increment counter.", e);
-        }
-    }
+  /**
+   * Creates a "taurus.datajob.info" and a "taurus.datajob.notification.delay" gauge for the
+   * specified data job if they do not exist. If a gauge already exists, but it has different tags,
+   * the existing gauge is deleted and a new one is created. If the data job does not have a
+   * configuration, no gauges are created.
+   *
+   * @param dataJob The data job for which to update the gauges.
+   */
+  public void updateInfoGauges(final DataJob dataJob) {
+    Objects.requireNonNull(dataJob);
 
-    /**
-     * Creates a "taurus.datajob.info" and a "taurus.datajob.notification.delay" gauge for the specified data job
-     * if they do not exist. If a gauge already exists, but it has different tags, the existing gauge is deleted
-     * and a new one is created. If the data job does not have a configuration, no gauges are created.
-     *
-     * @param dataJob The data job for which to update the gauges.
-     */
-    public void updateInfoGauges(final DataJob dataJob) {
-        Objects.requireNonNull(dataJob);
+    updateInfoGauge(dataJob);
+    updateNotificationDelayGauge(dataJob);
+  }
 
-        updateInfoGauge(dataJob);
-        updateNotificationDelayGauge(dataJob);
-    }
+  /**
+   * Creates a "taurus.datajob.info" gauge for the specified data job if one does not exist. If a
+   * gauge already exists, but it has different tags, the existing gauge is deleted and a new one is
+   * created. If the data job does not have a configuration, no gauge is created.
+   *
+   * @param dataJob The data job for which to update the gauge.
+   */
+  private void updateInfoGauge(final DataJob dataJob) {
+    Objects.requireNonNull(dataJob);
 
-    /**
-     * Creates a "taurus.datajob.info" gauge for the specified data job if one does not exist.
-     * If a gauge already exists, but it has different tags, the existing gauge is deleted and a new one is created.
-     * If the data job does not have a configuration, no gauge is created.
-     *
-     * @param dataJob The data job for which to update the gauge.
-     */
-    private void updateInfoGauge(final DataJob dataJob) {
-        Objects.requireNonNull(dataJob);
+    try {
+      var dataJobName = dataJob.getName();
+      if (dataJob.getJobConfig() == null) {
+        log.debug("The data job {} does not have configuration", dataJobName);
+        return;
+      }
 
-        try {
-            var dataJobName = dataJob.getName();
-            if (dataJob.getJobConfig() == null) {
-                log.debug("The data job {} does not have configuration", dataJobName);
-                return;
-            }
-
-            var gauge = infoGauges.getOrDefault(dataJobName, null);
-            var newTags = createInfoGaugeTags(dataJob);
-            if (isGaugeChanged(gauge, newTags)) {
-                log.info("The configuration of data job {} has changed", dataJobName);
-                removeInfoGauge(dataJobName);
-            }
-
-            infoGauges.computeIfAbsent(dataJobName, name -> createInfoGauge(name, newTags));
-        } catch (Exception e) {
-            log.warn("An exception occurred while updating the info gauge of data job {}", dataJob.getName(), e);
-        }
-    }
-
-    /**
-     * Creates a "taurus.datajob.notification.delay" gauge for the specified data job if one does not exist.
-     * If a gauge already exists, its value is updated.
-     * If the data job does not have a configuration, no gauge is created.
-     *
-     * @param dataJob The data job for which to update the gauge.
-     */
-    private void updateNotificationDelayGauge(final DataJob dataJob) {
-        Objects.requireNonNull(dataJob);
-
-        try {
-            var dataJobName = dataJob.getName();
-            if (dataJob.getJobConfig() == null) {
-                log.debug("The data job {} does not have configuration", dataJobName);
-                return;
-            }
-
-            currentDelays.put(dataJobName,
-                    Optional.ofNullable(dataJob.getJobConfig().getNotificationDelayPeriodMinutes()).orElse(DEFAULT_NOTIFICATION_DELAY_PERIOD_MINUTES));
-            delayGauges.computeIfAbsent(dataJobName, this::createNotificationDelayGauge);
-        } catch (Exception e) {
-            log.warn("An exception occurred while updating the notification delay gauge of data job {}", dataJob.getName(), e);
-        }
-    }
-
-    /**
-     * Creates a "taurus.datajob.termination.status" gauge for the specified data job if one does not exist.
-     * If a gauge already exists, its value is updated.
-     *
-     * @param dataJob The data job for which to update the gauge.
-     */
-    public void updateTerminationStatusGauge(final DataJob dataJob) {
-        Objects.requireNonNull(dataJob);
-
-        try {
-            var dataJobName = dataJob.getName();
-            var gauge = statusGauges.getOrDefault(dataJobName, null);
-            var newTags = createStatusGaugeTags(dataJob);
-            if (isGaugeChanged(gauge, newTags)) {
-                log.info("The last termination status of data job {} has changed", dataJobName);
-                removeTerminationStatusGauge(dataJobName);
-            }
-
-            Integer previousTerminationStatus = currentStatuses.get(dataJobName);
-            Integer newTerminationStatus = dataJob.getLatestJobTerminationStatus().getAlertValue();
-            currentStatuses.put(dataJobName, newTerminationStatus);
-            statusGauges.computeIfAbsent(dataJobName, name -> createTerminationStatusGauge(name, newTags));
-            if (!Objects.equals(previousTerminationStatus, newTerminationStatus)) {
-                log.debug("The termination status gauge value for data job {} with execution {} was changed from {} to {}",
-                        dataJobName, dataJob.getLatestJobExecutionId(), previousTerminationStatus, newTerminationStatus);
-            }
-        } catch (Exception e) {
-            log.warn("An exception occurred while updating the termination status gauge of data job {}", dataJob.getName(), e);
-        }
-    }
-
-    /**
-     * Removes all gauges associated with the specified data job.
-     *
-     * @param dataJobName The name of the data job for which to clear all gauges.
-     */
-    public void clearGauges(final String dataJobName) {
+      var gauge = infoGauges.getOrDefault(dataJobName, null);
+      var newTags = createInfoGaugeTags(dataJob);
+      if (isGaugeChanged(gauge, newTags)) {
+        log.info("The configuration of data job {} has changed", dataJobName);
         removeInfoGauge(dataJobName);
-        removeNotificationDelayGauge(dataJobName);
+      }
+
+      infoGauges.computeIfAbsent(dataJobName, name -> createInfoGauge(name, newTags));
+    } catch (Exception e) {
+      log.warn(
+          "An exception occurred while updating the info gauge of data job {}",
+          dataJob.getName(),
+          e);
+    }
+  }
+
+  /**
+   * Creates a "taurus.datajob.notification.delay" gauge for the specified data job if one does not
+   * exist. If a gauge already exists, its value is updated. If the data job does not have a
+   * configuration, no gauge is created.
+   *
+   * @param dataJob The data job for which to update the gauge.
+   */
+  private void updateNotificationDelayGauge(final DataJob dataJob) {
+    Objects.requireNonNull(dataJob);
+
+    try {
+      var dataJobName = dataJob.getName();
+      if (dataJob.getJobConfig() == null) {
+        log.debug("The data job {} does not have configuration", dataJobName);
+        return;
+      }
+
+      currentDelays.put(
+          dataJobName,
+          Optional.ofNullable(dataJob.getJobConfig().getNotificationDelayPeriodMinutes())
+              .orElse(DEFAULT_NOTIFICATION_DELAY_PERIOD_MINUTES));
+      delayGauges.computeIfAbsent(dataJobName, this::createNotificationDelayGauge);
+    } catch (Exception e) {
+      log.warn(
+          "An exception occurred while updating the notification delay gauge of data job {}",
+          dataJob.getName(),
+          e);
+    }
+  }
+
+  /**
+   * Creates a "taurus.datajob.termination.status" gauge for the specified data job if one does not
+   * exist. If a gauge already exists, its value is updated.
+   *
+   * @param dataJob The data job for which to update the gauge.
+   */
+  public void updateTerminationStatusGauge(final DataJob dataJob) {
+    Objects.requireNonNull(dataJob);
+
+    try {
+      var dataJobName = dataJob.getName();
+      var gauge = statusGauges.getOrDefault(dataJobName, null);
+      var newTags = createStatusGaugeTags(dataJob);
+      if (isGaugeChanged(gauge, newTags)) {
+        log.info("The last termination status of data job {} has changed", dataJobName);
         removeTerminationStatusGauge(dataJobName);
+      }
+
+      Integer previousTerminationStatus = currentStatuses.get(dataJobName);
+      Integer newTerminationStatus = dataJob.getLatestJobTerminationStatus().getAlertValue();
+      currentStatuses.put(dataJobName, newTerminationStatus);
+      statusGauges.computeIfAbsent(
+          dataJobName, name -> createTerminationStatusGauge(name, newTags));
+      if (!Objects.equals(previousTerminationStatus, newTerminationStatus)) {
+        log.debug(
+            "The termination status gauge value for data job {} with execution {} was changed from"
+                + " {} to {}",
+            dataJobName,
+            dataJob.getLatestJobExecutionId(),
+            previousTerminationStatus,
+            newTerminationStatus);
+      }
+    } catch (Exception e) {
+      log.warn(
+          "An exception occurred while updating the termination status gauge of data job {}",
+          dataJob.getName(),
+          e);
     }
+  }
 
-    /**
-     * Removes all gauges associated with data jobs that are not present in the specified iterable.
-     *
-     * @param dataJobNames The names of the data jobs which will still have gauges.
-     */
-    public void clearGaugesNotIn(final Set<String> dataJobNames) {
-        var absentEntries = filterByKeyNotIn(infoGauges, dataJobNames);
-        absentEntries.forEach(e -> removeInfoGauge(e.getKey()));
+  /**
+   * Removes all gauges associated with the specified data job.
+   *
+   * @param dataJobName The name of the data job for which to clear all gauges.
+   */
+  public void clearGauges(final String dataJobName) {
+    removeInfoGauge(dataJobName);
+    removeNotificationDelayGauge(dataJobName);
+    removeTerminationStatusGauge(dataJobName);
+  }
 
-        absentEntries = filterByKeyNotIn(delayGauges, dataJobNames);
-        absentEntries.forEach(e -> removeNotificationDelayGauge(e.getKey()));
+  /**
+   * Removes all gauges associated with data jobs that are not present in the specified iterable.
+   *
+   * @param dataJobNames The names of the data jobs which will still have gauges.
+   */
+  public void clearGaugesNotIn(final Set<String> dataJobNames) {
+    var absentEntries = filterByKeyNotIn(infoGauges, dataJobNames);
+    absentEntries.forEach(e -> removeInfoGauge(e.getKey()));
 
-        absentEntries = filterByKeyNotIn(statusGauges, dataJobNames);
-        absentEntries.forEach(e -> removeTerminationStatusGauge(e.getKey()));
-    }
+    absentEntries = filterByKeyNotIn(delayGauges, dataJobNames);
+    absentEntries.forEach(e -> removeNotificationDelayGauge(e.getKey()));
 
-    /**
-     * Returns a list consisting of the entries of the specified map, that do not have their keys in the specified set.
-     *
-     * @param from The map to filter.
-     * @param set A set containing keys for the elements that should <b>NOT</b> be returned.
-     * @return A list of all Map.Entry objects with keys inside {@code set}.
-     */
-    private <K> List<Map.Entry<K, ?>> filterByKeyNotIn(final Map<K, ?> from, final Set<K> set) {
-        return from.entrySet().stream()
-                .filter(e -> !set.contains(e.getKey()))
-                .collect(Collectors.toList());
-    }
+    absentEntries = filterByKeyNotIn(statusGauges, dataJobNames);
+    absentEntries.forEach(e -> removeTerminationStatusGauge(e.getKey()));
+  }
 
-    private Gauge createInfoGauge(final String dataJobName, final Tags tags) {
-        var gauge = Gauge.builder(TAURUS_DATAJOB_INFO_METRIC_NAME, GAUGE_METRIC_VALUE, value -> value)
-                .tags(tags)
-                .description("Info about data jobs")
-                .register(meterRegistry);
-        log.info("The info gauge for data job {} was created", dataJobName);
-        return gauge;
-    }
+  /**
+   * Returns a list consisting of the entries of the specified map, that do not have their keys in
+   * the specified set.
+   *
+   * @param from The map to filter.
+   * @param set A set containing keys for the elements that should <b>NOT</b> be returned.
+   * @return A list of all Map.Entry objects with keys inside {@code set}.
+   */
+  private <K> List<Map.Entry<K, ?>> filterByKeyNotIn(final Map<K, ?> from, final Set<K> set) {
+    return from.entrySet().stream()
+        .filter(e -> !set.contains(e.getKey()))
+        .collect(Collectors.toList());
+  }
 
-    private void removeInfoGauge(final String dataJobName) {
-        try {
-            if (StringUtils.isNotBlank(dataJobName)) {
-                var gauge = infoGauges.getOrDefault(dataJobName, null);
-                if (gauge != null) {
-                    meterRegistry.remove(gauge);
-                    infoGauges.remove(dataJobName);
-                    log.info("The info gauge for data job {} was removed", dataJobName);
-                } else {
-                    log.info("The info gauge for data job {} cannot be removed: gauge not found", dataJobName);
-                }
-            } else {
-                log.warn("The info gauge cannot be removed: data job name is empty");
-            }
-        } catch (Exception e) {
-            log.warn("An exception occurred while removing the info gauge of data job {}", dataJobName, e);
+  private Gauge createInfoGauge(final String dataJobName, final Tags tags) {
+    var gauge =
+        Gauge.builder(TAURUS_DATAJOB_INFO_METRIC_NAME, GAUGE_METRIC_VALUE, value -> value)
+            .tags(tags)
+            .description("Info about data jobs")
+            .register(meterRegistry);
+    log.info("The info gauge for data job {} was created", dataJobName);
+    return gauge;
+  }
+
+  private void removeInfoGauge(final String dataJobName) {
+    try {
+      if (StringUtils.isNotBlank(dataJobName)) {
+        var gauge = infoGauges.getOrDefault(dataJobName, null);
+        if (gauge != null) {
+          meterRegistry.remove(gauge);
+          infoGauges.remove(dataJobName);
+          log.info("The info gauge for data job {} was removed", dataJobName);
+        } else {
+          log.info(
+              "The info gauge for data job {} cannot be removed: gauge not found", dataJobName);
         }
+      } else {
+        log.warn("The info gauge cannot be removed: data job name is empty");
+      }
+    } catch (Exception e) {
+      log.warn(
+          "An exception occurred while removing the info gauge of data job {}", dataJobName, e);
     }
+  }
 
-    private Gauge createNotificationDelayGauge(final String dataJobName) {
-        var gauge = Gauge.builder(TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME, currentDelays,
-                        map -> map.getOrDefault(dataJobName, 0))
-                .tags(Tags.of(TAG_DATA_JOB, dataJobName))
-                .description("The time (in minutes) a job execution is allowed to be delayed from its schedule before an alert is triggered")
-                .register(meterRegistry);
-        log.info("The notification delay gauge for data job {} was created", dataJobName);
-        return gauge;
-    }
+  private Gauge createNotificationDelayGauge(final String dataJobName) {
+    var gauge =
+        Gauge.builder(
+                TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME,
+                currentDelays,
+                map -> map.getOrDefault(dataJobName, 0))
+            .tags(Tags.of(TAG_DATA_JOB, dataJobName))
+            .description(
+                "The time (in minutes) a job execution is allowed to be delayed from its schedule"
+                    + " before an alert is triggered")
+            .register(meterRegistry);
+    log.info("The notification delay gauge for data job {} was created", dataJobName);
+    return gauge;
+  }
 
-    private void removeNotificationDelayGauge(final String dataJobName) {
-        try {
-            if (StringUtils.isNotBlank(dataJobName)) {
-                var gauge = delayGauges.getOrDefault(dataJobName, null);
-                if (gauge != null) {
-                    meterRegistry.remove(gauge);
-                    delayGauges.remove(dataJobName);
-                    currentDelays.remove(dataJobName);
-                    log.info("The notification delay gauge for data job {} was removed", dataJobName);
-                } else {
-                    log.info("The notification delay gauge for data job {} cannot be removed: gauge not found", dataJobName);
-                }
-            } else {
-                log.warn("The notification delay gauge cannot be removed: data job name is empty");
-            }
-        } catch (Exception e) {
-            log.warn("An exception occurred while removing the notification delay gauge of data job {}", dataJobName, e);
+  private void removeNotificationDelayGauge(final String dataJobName) {
+    try {
+      if (StringUtils.isNotBlank(dataJobName)) {
+        var gauge = delayGauges.getOrDefault(dataJobName, null);
+        if (gauge != null) {
+          meterRegistry.remove(gauge);
+          delayGauges.remove(dataJobName);
+          currentDelays.remove(dataJobName);
+          log.info("The notification delay gauge for data job {} was removed", dataJobName);
+        } else {
+          log.info(
+              "The notification delay gauge for data job {} cannot be removed: gauge not found",
+              dataJobName);
         }
+      } else {
+        log.warn("The notification delay gauge cannot be removed: data job name is empty");
+      }
+    } catch (Exception e) {
+      log.warn(
+          "An exception occurred while removing the notification delay gauge of data job {}",
+          dataJobName,
+          e);
     }
+  }
 
-    private Gauge createTerminationStatusGauge(final String dataJobName, final Tags tags) {
-        var gauge = Gauge.builder(TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME, currentStatuses,
-                        map -> map.getOrDefault(dataJobName, -1))
-                .tags(tags)
-                .description("Termination status of data job executions (0 - Success, 1 - Platform error, 3 - User error)")
-                .register(meterRegistry);
-        log.info("The termination status gauge for data job {} was created", dataJobName);
-        return gauge;
-    }
+  private Gauge createTerminationStatusGauge(final String dataJobName, final Tags tags) {
+    var gauge =
+        Gauge.builder(
+                TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME,
+                currentStatuses,
+                map -> map.getOrDefault(dataJobName, -1))
+            .tags(tags)
+            .description(
+                "Termination status of data job executions (0 - Success, 1 - Platform error, 3 -"
+                    + " User error)")
+            .register(meterRegistry);
+    log.info("The termination status gauge for data job {} was created", dataJobName);
+    return gauge;
+  }
 
-    private void removeTerminationStatusGauge(final String dataJobName) {
-        try {
-            if (StringUtils.isNotBlank(dataJobName)) {
-                var gauge = statusGauges.getOrDefault(dataJobName, null);
-                if (gauge != null) {
-                    meterRegistry.remove(gauge);
-                    statusGauges.remove(dataJobName);
-                    currentStatuses.remove(dataJobName);
-                    log.info("The termination status gauge for data job {} was removed", dataJobName);
-                } else {
-                    log.info("The termination status gauge for data job {} cannot be removed: gauge not found", dataJobName);
-                }
-            } else {
-                log.warn("The termination status gauge cannot be removed: data job name is empty");
-            }
-        } catch (Exception e) {
-            log.warn("An exception occurred while removing the termination status gauge of data job {}", dataJobName, e);
+  private void removeTerminationStatusGauge(final String dataJobName) {
+    try {
+      if (StringUtils.isNotBlank(dataJobName)) {
+        var gauge = statusGauges.getOrDefault(dataJobName, null);
+        if (gauge != null) {
+          meterRegistry.remove(gauge);
+          statusGauges.remove(dataJobName);
+          currentStatuses.remove(dataJobName);
+          log.info("The termination status gauge for data job {} was removed", dataJobName);
+        } else {
+          log.info(
+              "The termination status gauge for data job {} cannot be removed: gauge not found",
+              dataJobName);
         }
+      } else {
+        log.warn("The termination status gauge cannot be removed: data job name is empty");
+      }
+    } catch (Exception e) {
+      log.warn(
+          "An exception occurred while removing the termination status gauge of data job {}",
+          dataJobName,
+          e);
+    }
+  }
+
+  private boolean isGaugeChanged(final Gauge gauge, final Tags newTags) {
+    if (gauge == null) {
+      return false;
     }
 
-    private boolean isGaugeChanged(final Gauge gauge, final Tags newTags) {
-        if (gauge == null) {
-            return false;
-        }
+    var existingTags = gauge.getId().getTags();
+    return !newTags.stream().allMatch(existingTags::contains);
+  }
 
-        var existingTags = gauge.getId().getTags();
-        return !newTags.stream().allMatch(existingTags::contains);
-    }
+  private Tags createInfoGaugeTags(final DataJob dataJob) {
+    Objects.requireNonNull(dataJob);
 
-    private Tags createInfoGaugeTags(final DataJob dataJob) {
-        Objects.requireNonNull(dataJob);
+    var jobConfig = dataJob.getJobConfig();
+    boolean enableExecutionNotifications =
+        jobConfig.getEnableExecutionNotifications() == null
+            || jobConfig.getEnableExecutionNotifications();
+    return Tags.of(
+        TAG_DATA_JOB, dataJob.getName(),
+        TAG_TEAM, StringUtils.defaultString(jobConfig.getTeam()),
+        TAG_EMAIL_NOTIFIED_ON_SUCCESS,
+            enableExecutionNotifications ? join(jobConfig.getNotifiedOnJobSuccess()) : "",
+        TAG_EMAIL_NOTIFIED_ON_USER_ERROR,
+            enableExecutionNotifications ? join(jobConfig.getNotifiedOnJobFailureUserError()) : "",
+        TAG_EMAIL_NOTIFIED_ON_PLATFORM_ERROR,
+            enableExecutionNotifications
+                ? join(jobConfig.getNotifiedOnJobFailurePlatformError())
+                : "");
+  }
 
-        var jobConfig = dataJob.getJobConfig();
-        boolean enableExecutionNotifications = jobConfig.getEnableExecutionNotifications() == null ||
-                jobConfig.getEnableExecutionNotifications();
-        return Tags.of(
-                TAG_DATA_JOB, dataJob.getName(),
-                TAG_TEAM, StringUtils.defaultString(jobConfig.getTeam()),
-                TAG_EMAIL_NOTIFIED_ON_SUCCESS, enableExecutionNotifications ?
-                        join(jobConfig.getNotifiedOnJobSuccess()) : "",
-                TAG_EMAIL_NOTIFIED_ON_USER_ERROR, enableExecutionNotifications ?
-                        join(jobConfig.getNotifiedOnJobFailureUserError()) : "",
-                TAG_EMAIL_NOTIFIED_ON_PLATFORM_ERROR, enableExecutionNotifications ?
-                        join(jobConfig.getNotifiedOnJobFailurePlatformError()) : "");
-    }
+  private Tags createStatusGaugeTags(final DataJob dataJob) {
+    Objects.requireNonNull(dataJob);
 
-    private Tags createStatusGaugeTags(final DataJob dataJob) {
-        Objects.requireNonNull(dataJob);
-
-        return Tags.of(
-                TAG_DATA_JOB, dataJob.getName(),
-                TAG_EXECUTION_ID, dataJob.getLatestJobExecutionId());
-    }
+    return Tags.of(
+        TAG_DATA_JOB, dataJob.getName(),
+        TAG_EXECUTION_ID, dataJob.getLatestJobExecutionId());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMonitor.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMonitor.java
@@ -39,171 +39,185 @@ import java.util.stream.Collectors;
 @Component
 public class DataJobMonitor {
 
-    private static final long ONE_MINUTE_MILLIS = TimeUnit.MINUTES.toMillis(1);
+  private static final long ONE_MINUTE_MILLIS = TimeUnit.MINUTES.toMillis(1);
 
-    private final Map<String, String> labelsToWatch = Collections.singletonMap(JobLabel.TYPE.getValue(), "DataJob");
+  private final Map<String, String> labelsToWatch =
+      Collections.singletonMap(JobLabel.TYPE.getValue(), "DataJob");
 
-    private final JobsRepository jobsRepository;
-    private final DataJobsKubernetesService dataJobsKubernetesService;
-    private final JobsService jobsService;
-    private final JobExecutionService jobExecutionService;
-    private final DataJobMetrics dataJobMetrics;
+  private final JobsRepository jobsRepository;
+  private final DataJobsKubernetesService dataJobsKubernetesService;
+  private final JobsService jobsService;
+  private final JobExecutionService jobExecutionService;
+  private final DataJobMetrics dataJobMetrics;
 
-    private long lastWatchTime = Instant.now().minusMillis(TimeUnit.MINUTES.toMillis(30)).toEpochMilli();
+  private long lastWatchTime =
+      Instant.now().minusMillis(TimeUnit.MINUTES.toMillis(30)).toEpochMilli();
 
-    @Autowired
-    public DataJobMonitor(
-            JobsRepository jobsRepository,
-            DataJobsKubernetesService dataJobsKubernetesService,
-            JobsService jobsService,
-            JobExecutionService jobExecutionService,
-            DataJobMetrics dataJobMetrics) {
-        this.dataJobsKubernetesService = dataJobsKubernetesService;
-        this.jobsRepository = jobsRepository;
-        this.jobsService = jobsService;
-        this.jobExecutionService = jobExecutionService;
-        this.dataJobMetrics = dataJobMetrics;
+  @Autowired
+  public DataJobMonitor(
+      JobsRepository jobsRepository,
+      DataJobsKubernetesService dataJobsKubernetesService,
+      JobsService jobsService,
+      JobExecutionService jobExecutionService,
+      DataJobMetrics dataJobMetrics) {
+    this.dataJobsKubernetesService = dataJobsKubernetesService;
+    this.jobsRepository = jobsRepository;
+    this.jobsService = jobsService;
+    this.jobExecutionService = jobExecutionService;
+    this.dataJobMetrics = dataJobMetrics;
+  }
+
+  /**
+   * This method is annotated with {@link SchedulerLock} to prevent it from being executed
+   * simultaneously by more than one instance of the service in a multi-node deployment. This aims
+   * to reduce the number of rps to the Kubernetes API as well as to avoid errors due to concurrent
+   * database writes.
+   *
+   * <p>The flow is as follows:
+   *
+   * <ol>
+   *   <li>At any given point only one of the nodes will acquire the lock and execute the method.
+   *   <li>A lock will be held for no longer than 10 minutes (as configured in {@link
+   *       ThreadPoolConf}), which should be enough for a watch to complete (it currently has 5
+   *       minutes timeout).
+   *   <li>The other nodes will skip their schedules until after this node completes.
+   *   <li>When a termination status of a job is updated by the node holding the lock, the other
+   *       nodes will be eventually consistent within 5 seconds (by default) due to the continuous
+   *       updates done here: {@link DataJobMonitorSync#updateDataJobStatus}.
+   *   <li>Subsequently, when one of the other nodes acquires the lock, it will detect all changes
+   *       since its own last run (see {@code lastWatchTime}) and rewrite them. We can potentially
+   *       improve on this by sharing the lastWatchTime amongst the nodes.
+   * </ol>
+   *
+   * @see <a href="https://github.com/lukas-krecan/ShedLock">ShedLock</a>
+   */
+  @Scheduled(
+      fixedDelayString = "${datajobs.status.watch.interval:1000}",
+      initialDelayString = "${datajobs.status.watch.initial.delay:10000}")
+  @SchedulerLock(name = "watchJobs_schedulerLock")
+  public void watchJobs() {
+    dataJobMetrics.incrementWatchTaskInvocations();
+    try {
+      dataJobsKubernetesService.watchJobs(
+          labelsToWatch,
+          s -> {
+            log.info(
+                "Termination message of Data Job {} with execution {}: {}",
+                s.getJobName(),
+                s.getExecutionId(),
+                s.getPodTerminationMessage());
+            recordJobExecutionStatus(s);
+          },
+          runningJobExecutionIds -> {
+            jobExecutionService.syncJobExecutionStatuses(runningJobExecutionIds);
+          },
+          lastWatchTime);
+      // Move the lastWatchTime one minute into the past to account for events that
+      // could have happened after the watch has completed until now
+      lastWatchTime = Instant.now().minusMillis(ONE_MINUTE_MILLIS).toEpochMilli();
+    } catch (IOException | ApiException e) {
+      log.info("Failed to watch jobs. Error was: {}", e.getMessage());
     }
+  }
 
-    /**
-     * This method is annotated with {@link SchedulerLock} to prevent it from being executed simultaneously
-     * by more than one instance of the service in a multi-node deployment. This aims to reduce the number
-     * of rps to the Kubernetes API as well as to avoid errors due to concurrent database writes.
-     * <p>
-     * The flow is as follows:
-     * <ol>
-     *     <li>At any given point only one of the nodes will acquire the lock and execute the method.</li>
-     *     <li>A lock will be held for no longer than 10 minutes (as configured in {@link ThreadPoolConf}),
-     *     which should be enough for a watch to complete (it currently has 5 minutes timeout).</li>
-     *     <li>The other nodes will skip their schedules until after this node completes.</li>
-     *     <li>When a termination status of a job is updated by the node holding the lock, the other nodes will
-     *     be eventually consistent within 5 seconds (by default) due to the continuous updates done here:
-     *     {@link DataJobMonitorSync#updateDataJobStatus}.</li>
-     *     <li>Subsequently, when one of the other nodes acquires the lock, it will detect all changes since
-     *     its own last run (see {@code lastWatchTime}) and rewrite them. We can potentially improve on
-     *     this by sharing the lastWatchTime amongst the nodes.</li>
-     * </ol>
-     *
-     * @see <a href="https://github.com/lukas-krecan/ShedLock">ShedLock</a>
-     */
-    @Scheduled(
-            fixedDelayString = "${datajobs.status.watch.interval:1000}",
-            initialDelayString = "${datajobs.status.watch.initial.delay:10000}")
-    @SchedulerLock(name = "watchJobs_schedulerLock")
-    public void watchJobs() {
-        dataJobMetrics.incrementWatchTaskInvocations();
-        try {
-            dataJobsKubernetesService.watchJobs(
-                    labelsToWatch,
-                    s -> {
-                        log.info("Termination message of Data Job {} with execution {}: {}",
-                                s.getJobName(), s.getExecutionId(), s.getPodTerminationMessage());
-                        recordJobExecutionStatus(s);
-                    },
-                    runningJobExecutionIds -> {
-                        jobExecutionService.syncJobExecutionStatuses(runningJobExecutionIds);
-                    },
-                    lastWatchTime);
-            // Move the lastWatchTime one minute into the past to account for events that
-            // could have happened after the watch has completed until now
-            lastWatchTime = Instant.now().minusMillis(ONE_MINUTE_MILLIS).toEpochMilli();
-        } catch (IOException | ApiException e) {
-            log.info("Failed to watch jobs. Error was: {}", e.getMessage());
-        }
-    }
+  /**
+   * Creates gauges that expose configuration information and termination status for the specified
+   * data jobs. If the gauges already exist for a particular data job, they are updated if
+   * necessary.
+   *
+   * @param dataJobs The data jobs for which to create or update gauges.
+   */
+  public void updateDataJobsGauges(final Iterable<DataJob> dataJobs) {
+    Objects.requireNonNull(dataJobs);
 
-
-    /**
-     * Creates gauges that expose configuration information and termination status for the specified data jobs.
-     * If the gauges already exist for a particular data job, they are updated if necessary.
-     *
-     * @param dataJobs The data jobs for which to create or update gauges.
-     */
-    public void updateDataJobsGauges(final Iterable<DataJob> dataJobs) {
-        Objects.requireNonNull(dataJobs);
-
-        dataJobs.forEach(job -> {
-            updateDataJobInfoGauges(job);
-            updateDataJobTerminationStatusGauge(job);
+    dataJobs.forEach(
+        job -> {
+          updateDataJobInfoGauges(job);
+          updateDataJobTerminationStatusGauge(job);
         });
+  }
+
+  /**
+   * Deletes the gauges for all data jobs that are not present in the specified iterable.
+   *
+   * @param dataJobs The data jobs for which to keep gauges.
+   */
+  public void clearDataJobsGaugesNotIn(final Iterable<DataJob> dataJobs) {
+    var jobs = Streams.stream(dataJobs).map(DataJob::getName).collect(Collectors.toSet());
+    dataJobMetrics.clearGaugesNotIn(jobs);
+  }
+
+  /**
+   * Creates a gauge that exposes termination status for the specified data job. If a gauge already
+   * exists for the data job, it is updated if necessary.
+   *
+   * @param dataJob The data job for which to create or update a gauge.
+   */
+  void updateDataJobTerminationStatusGauge(final DataJob dataJob) {
+    Objects.requireNonNull(dataJob);
+
+    if (dataJob.getLatestJobTerminationStatus() == null
+        || StringUtils.isEmpty(dataJob.getLatestJobExecutionId())) {
+      return;
     }
 
-    /**
-     * Deletes the gauges for all data jobs that are not present in the specified iterable.
-     *
-     * @param dataJobs The data jobs for which to keep gauges.
-     */
-    public void clearDataJobsGaugesNotIn(final Iterable<DataJob> dataJobs) {
-        var jobs = Streams.stream(dataJobs)
-                .map(DataJob::getName)
-                .collect(Collectors.toSet());
-        dataJobMetrics.clearGaugesNotIn(jobs);
+    dataJobMetrics.updateTerminationStatusGauge(dataJob);
+  }
+
+  /**
+   * Creates gauges that expose configuration information for the specified data job. If the gauges
+   * already exist for the data job, they are updated if necessary.
+   *
+   * @param dataJob The data job for which to create or update the gauges.
+   */
+  void updateDataJobInfoGauges(final DataJob dataJob) {
+    Objects.requireNonNull(dataJob);
+
+    dataJobMetrics.updateInfoGauges(dataJob);
+  }
+
+  /**
+   * Record Data Job execution status. It will record when a job has started, finished, failed or
+   * skipped.
+   *
+   * @param jobStatus - the job status of the job. The same information is sent as telemetry by
+   *     Measureable annotation.
+   */
+  @Measurable(includeArg = 0, argName = "execution_status")
+  @Transactional
+  void recordJobExecutionStatus(KubernetesService.JobExecution jobStatus) {
+    log.debug("Storing Data Job execution status: {}", jobStatus);
+    String dataJobName = jobStatus.getJobName();
+    ExecutionResult executionResult = JobExecutionResultManager.getResult(jobStatus);
+
+    if (StringUtils.isBlank(dataJobName)) {
+      log.warn("Data job name is empty");
+      return;
     }
 
-    /**
-     * Creates a gauge that exposes termination status for the specified data job.
-     * If a gauge already exists for the data job, it is updated if necessary.
-     *
-     * @param dataJob The data job for which to create or update a gauge.
-     */
-    void updateDataJobTerminationStatusGauge(final DataJob dataJob) {
-        Objects.requireNonNull(dataJob);
-
-        if (dataJob.getLatestJobTerminationStatus() == null ||
-                StringUtils.isEmpty(dataJob.getLatestJobExecutionId())) {
-            return;
-        }
-
-        dataJobMetrics.updateTerminationStatusGauge(dataJob);
+    Optional<DataJob> dataJobOptional = jobsRepository.findById(dataJobName);
+    if (dataJobOptional.isEmpty()) {
+      log.debug("Data job {} was deleted or hasn't been created", dataJobName);
+      return;
     }
 
-    /**
-     * Creates gauges that expose configuration information for the specified data job.
-     * If the gauges already exist for the data job, they are updated if necessary.
-     *
-     * @param dataJob The data job for which to create or update the gauges.
-     */
-    void updateDataJobInfoGauges(final DataJob dataJob) {
-        Objects.requireNonNull(dataJob);
+    final DataJob dataJob = dataJobOptional.get();
 
-        dataJobMetrics.updateInfoGauges(dataJob);
-    }
+    // Update the job execution and the last execution state
+    jobExecutionService
+        .updateJobExecution(dataJob, jobStatus, executionResult)
+        .ifPresent(jobsService::updateLastExecution);
 
-    /**
-     * Record Data Job execution status. It will record when a job has started, finished, failed or skipped.
-     *
-     * @param jobStatus - the job status of the job. The same information is sent as telemetry by Measureable annotation.
-     */
-    @Measurable(includeArg = 0, argName = "execution_status")
-    @Transactional
-    void recordJobExecutionStatus(KubernetesService.JobExecution jobStatus) {
-        log.debug("Storing Data Job execution status: {}", jobStatus);
-        String dataJobName = jobStatus.getJobName();
-        ExecutionResult executionResult = JobExecutionResultManager.getResult(jobStatus);
-
-        if (StringUtils.isBlank(dataJobName)) {
-            log.warn("Data job name is empty");
-            return;
-        }
-
-        Optional<DataJob> dataJobOptional = jobsRepository.findById(dataJobName);
-        if (dataJobOptional.isEmpty()) {
-            log.debug("Data job {} was deleted or hasn't been created", dataJobName);
-            return;
-        }
-
-        final DataJob dataJob = dataJobOptional.get();
-
-        // Update the job execution and the last execution state
-        jobExecutionService.updateJobExecution(dataJob, jobStatus, executionResult)
-                .ifPresent(jobsService::updateLastExecution);
-
-        // Update the termination status from the last execution
-        jobExecutionService.getLastExecution(dataJobName)
-                .ifPresent(e -> {
-                    if (jobsService.updateTerminationStatus(e)) {
-                        jobsRepository.findById(dataJobName).ifPresent(this::updateDataJobTerminationStatusGauge);
-                    }
-                });
-    }
+    // Update the termination status from the last execution
+    jobExecutionService
+        .getLastExecution(dataJobName)
+        .ifPresent(
+            e -> {
+              if (jobsService.updateTerminationStatus(e)) {
+                jobsRepository
+                    .findById(dataJobName)
+                    .ifPresent(this::updateDataJobTerminationStatusGauge);
+              }
+            });
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMonitorSync.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMonitorSync.java
@@ -15,21 +15,21 @@ import org.springframework.stereotype.Component;
 @Component
 public class DataJobMonitorSync {
 
-    private final DataJobMonitor dataJobMonitor;
-    private final JobsRepository jobsRepository;
+  private final DataJobMonitor dataJobMonitor;
+  private final JobsRepository jobsRepository;
 
-    @Autowired
-    public DataJobMonitorSync(DataJobMonitor dataJobMonitor, JobsRepository jobsRepository) {
-        this.dataJobMonitor = dataJobMonitor;
-        this.jobsRepository = jobsRepository;
-    }
+  @Autowired
+  public DataJobMonitorSync(DataJobMonitor dataJobMonitor, JobsRepository jobsRepository) {
+    this.dataJobMonitor = dataJobMonitor;
+    this.jobsRepository = jobsRepository;
+  }
 
-    @Scheduled(
-            fixedDelayString = "${datajobs.monitoring.sync.interval:5000}",
-            initialDelayString = "${datajobs.monitoring.sync.initial.delay:10000}")
-    public void updateDataJobStatus() {
-        final var dataJobs = jobsRepository.findAll();
-        dataJobMonitor.updateDataJobsGauges(dataJobs);
-        dataJobMonitor.clearDataJobsGaugesNotIn(dataJobs);
-    }
+  @Scheduled(
+      fixedDelayString = "${datajobs.monitoring.sync.interval:5000}",
+      initialDelayString = "${datajobs.monitoring.sync.initial.delay:10000}")
+  public void updateDataJobStatus() {
+    final var dataJobs = jobsRepository.findAll();
+    dataJobMonitor.updateDataJobsGauges(dataJobs);
+    dataJobMonitor.clearDataJobsGaugesNotIn(dataJobs);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitor.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitor.java
@@ -6,7 +6,6 @@
 package com.vmware.taurus.service.monitoring;
 
 import com.vmware.taurus.service.JobsRepository;
-import com.vmware.taurus.service.model.DataJob;
 import com.vmware.taurus.service.model.DeploymentStatus;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Gauge;
@@ -24,69 +23,70 @@ import java.util.concurrent.ConcurrentHashMap;
 @Component
 public class DeploymentMonitor {
 
-   static Logger log = LoggerFactory.getLogger(DeploymentMonitor.class);
+  static Logger log = LoggerFactory.getLogger(DeploymentMonitor.class);
 
-   public static String GAUGE_METRIC_NAME = "taurus.deployment.status.gauge";
+  public static String GAUGE_METRIC_NAME = "taurus.deployment.status.gauge";
 
-   public static String SUMMARY_METRIC_NAME = "taurus.deployment.status.summary";
+  public static String SUMMARY_METRIC_NAME = "taurus.deployment.status.summary";
 
-   private final MeterRegistry meterRegistry;
+  private final MeterRegistry meterRegistry;
 
-   private final JobsRepository jobsRepository;
+  private final JobsRepository jobsRepository;
 
-   private final Map<String, Integer> currentStatuses = new ConcurrentHashMap<>();
+  private final Map<String, Integer> currentStatuses = new ConcurrentHashMap<>();
 
-   @Autowired
-   public DeploymentMonitor(MeterRegistry meterRegistry, JobsRepository jobsRepository) {
-      this.meterRegistry = meterRegistry;
-      this.jobsRepository = jobsRepository;
-   }
+  @Autowired
+  public DeploymentMonitor(MeterRegistry meterRegistry, JobsRepository jobsRepository) {
+    this.meterRegistry = meterRegistry;
+    this.jobsRepository = jobsRepository;
+  }
 
-   /**
-    * Updates the current deployment status of a data job
-    *
-    * @param dataJob
-    * @param deploymentStatus
-    */
-   public void updateDataJobStatus(String dataJob, DeploymentStatus deploymentStatus) {
-      if (!currentStatuses.containsKey(dataJob)) {
-         Tags tags = Tags.of("dataJob", dataJob);
-         Gauge.builder(GAUGE_METRIC_NAME, currentStatuses,
-                 map -> map.getOrDefault(dataJob, 0))
-                 .tags(tags)
-                 .register(meterRegistry);
-      }
-      currentStatuses.put(dataJob, deploymentStatus.getValue());
-   }
-
-   /**
-    * Records and persists a deployment event of a data job
-    *
-    * @param dataJobName
-    * @param deploymentStatus
-    */
-   public void recordDeploymentStatus(String dataJobName, DeploymentStatus deploymentStatus) {
-      if (StringUtils.isNotBlank(dataJobName)) {
-         boolean jobExists = saveDataJobStatus(dataJobName, deploymentStatus);
-         if (jobExists || currentStatuses.containsKey(dataJobName)) {
-            // TODO: Add tag for data job mode
-            DistributionSummary.builder(SUMMARY_METRIC_NAME)
-                    .tag("dataJob", dataJobName)
-                    .tag("status", deploymentStatus.toString())
-                    .register(meterRegistry)
-                    .record(1);
-            updateDataJobStatus(dataJobName, deploymentStatus);
-         }
-      } else {
-         log.warn("Data job name is empty.");
-      }
-   }
-
-    private boolean saveDataJobStatus(final String dataJobName, final DeploymentStatus deploymentStatus) {
-        if (jobsRepository.updateDataJobLatestJobDeploymentStatusByName(dataJobName, deploymentStatus) > 0) {
-            return true;
-        }
-        log.debug("Data job: {} was deleted or hasn't been created", dataJobName);
-        return false;
+  /**
+   * Updates the current deployment status of a data job
+   *
+   * @param dataJob
+   * @param deploymentStatus
+   */
+  public void updateDataJobStatus(String dataJob, DeploymentStatus deploymentStatus) {
+    if (!currentStatuses.containsKey(dataJob)) {
+      Tags tags = Tags.of("dataJob", dataJob);
+      Gauge.builder(GAUGE_METRIC_NAME, currentStatuses, map -> map.getOrDefault(dataJob, 0))
+          .tags(tags)
+          .register(meterRegistry);
     }
+    currentStatuses.put(dataJob, deploymentStatus.getValue());
+  }
+
+  /**
+   * Records and persists a deployment event of a data job
+   *
+   * @param dataJobName
+   * @param deploymentStatus
+   */
+  public void recordDeploymentStatus(String dataJobName, DeploymentStatus deploymentStatus) {
+    if (StringUtils.isNotBlank(dataJobName)) {
+      boolean jobExists = saveDataJobStatus(dataJobName, deploymentStatus);
+      if (jobExists || currentStatuses.containsKey(dataJobName)) {
+        // TODO: Add tag for data job mode
+        DistributionSummary.builder(SUMMARY_METRIC_NAME)
+            .tag("dataJob", dataJobName)
+            .tag("status", deploymentStatus.toString())
+            .register(meterRegistry)
+            .record(1);
+        updateDataJobStatus(dataJobName, deploymentStatus);
+      }
+    } else {
+      log.warn("Data job name is empty.");
+    }
+  }
+
+  private boolean saveDataJobStatus(
+      final String dataJobName, final DeploymentStatus deploymentStatus) {
+    if (jobsRepository.updateDataJobLatestJobDeploymentStatusByName(dataJobName, deploymentStatus)
+        > 0) {
+      return true;
+    }
+    log.debug("Data job: {} was deleted or hasn't been created", dataJobName);
+    return false;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitorSync.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitorSync.java
@@ -22,44 +22,44 @@ import java.util.Iterator;
 @EnableAsync
 public class DeploymentMonitorSync {
 
-   static Logger log = LoggerFactory.getLogger(DeploymentMonitorSync.class);
+  static Logger log = LoggerFactory.getLogger(DeploymentMonitorSync.class);
 
-   @Autowired
-   private final DeploymentMonitor deploymentMonitor;
+  @Autowired private final DeploymentMonitor deploymentMonitor;
 
-   @Autowired
-   private final JobsRepository jobsRepository;
+  @Autowired private final JobsRepository jobsRepository;
 
-   @Autowired
-   public DeploymentMonitorSync(DeploymentMonitor deploymentMonitor, JobsRepository jobsRepository) {
-      this.deploymentMonitor = deploymentMonitor;
-      this.jobsRepository = jobsRepository;
-   }
+  @Autowired
+  public DeploymentMonitorSync(DeploymentMonitor deploymentMonitor, JobsRepository jobsRepository) {
+    this.deploymentMonitor = deploymentMonitor;
+    this.jobsRepository = jobsRepository;
+  }
 
-   @Async
-   @Scheduled(fixedDelayString = "${datajobs.monitoring.sync.interval}", initialDelayString = "${datajobs.monitoring.sync.initial.delay}")
-   public void updateJobDeploymentStatuses() {
-      // TODO: Potentially we can create custom query if this is not optimal.
-      Iterator<DataJob> dataJobs = jobsRepository.findAll().iterator();
+  @Async
+  @Scheduled(
+      fixedDelayString = "${datajobs.monitoring.sync.interval}",
+      initialDelayString = "${datajobs.monitoring.sync.initial.delay}")
+  public void updateJobDeploymentStatuses() {
+    // TODO: Potentially we can create custom query if this is not optimal.
+    Iterator<DataJob> dataJobs = jobsRepository.findAll().iterator();
 
-      if (!dataJobs.hasNext()) {
-         log.debug("There are no data jobs");
-      } else {
-         while (dataJobs.hasNext()) {
-            DataJob dataJob = dataJobs.next();
-            var status = dataJob.getLatestJobDeploymentStatus();
-            if (status != null) {
-               if (!status.equals(DeploymentStatus.NONE)) {
-                  String jobName = dataJob.getName();
-                  DeploymentStatus latestDeploymentStatus = dataJob.getLatestJobDeploymentStatus();
-                  deploymentMonitor.updateDataJobStatus(jobName, latestDeploymentStatus);
-               } else {
-                  log.trace("Data job: {} has no deployment process started yet", dataJob.getName());
-               }
-            } else {
-               log.debug("Data job: {} has no status", dataJob.getName());
-            }
-         }
+    if (!dataJobs.hasNext()) {
+      log.debug("There are no data jobs");
+    } else {
+      while (dataJobs.hasNext()) {
+        DataJob dataJob = dataJobs.next();
+        var status = dataJob.getLatestJobDeploymentStatus();
+        if (status != null) {
+          if (!status.equals(DeploymentStatus.NONE)) {
+            String jobName = dataJob.getName();
+            DeploymentStatus latestDeploymentStatus = dataJob.getLatestJobDeploymentStatus();
+            deploymentMonitor.updateDataJobStatus(jobName, latestDeploymentStatus);
+          } else {
+            log.trace("Data job: {} has no deployment process started yet", dataJob.getName());
+          }
+        } else {
+          log.debug("Data job: {} has no status", dataJob.getName());
+        }
       }
-   }
+    }
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/notification/DataJobNotification.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/notification/DataJobNotification.java
@@ -16,9 +16,9 @@ import javax.mail.internet.AddressException;
 import java.util.List;
 
 /**
- * The DataJobNotification class is the interface used by the Versatile Data Kit service in order to notify
- * the customers about the status of their Job.
- * The class's methods build notification content object and send it to the user through email.
+ * The DataJobNotification class is the interface used by the Versatile Data Kit service in order to
+ * notify the customers about the status of their Job. The class's methods build notification
+ * content object and send it to the user through email.
  *
  * @see NotificationContent
  * @see EmailNotification
@@ -26,60 +26,66 @@ import java.util.List;
 @Component
 public class DataJobNotification {
 
-    static Logger log = LoggerFactory.getLogger(DataJobNotification.class);
+  static Logger log = LoggerFactory.getLogger(DataJobNotification.class);
 
-    private static final String DEPLOY_STAGE = "deploy";
+  private static final String DEPLOY_STAGE = "deploy";
 
-    private static final String RUN_STAGE = "run";
+  private static final String RUN_STAGE = "run";
 
-    private static final String FAILURE_STATUS = "failure";
+  private static final String FAILURE_STATUS = "failure";
 
-    private static final String SUCCESS_STATUS = "success";
+  private static final String SUCCESS_STATUS = "success";
 
+  private String ownerName;
 
-    private String ownerName;
+  private String ownerEmail;
 
-    private String ownerEmail;
+  private List<String> ccEmails;
 
-    private List<String> ccEmails;
+  private EmailNotification notification;
 
-    private EmailNotification notification;
+  public DataJobNotification(
+      EmailNotification notification,
+      @Value("${datajobs.notification.owner.name}") String ownerName,
+      @Value("${datajobs.notification.owner.email}") String ownerEmail,
+      @Value("${datajobs.notification.cc.emails:}") List<String> ccEmails) {
+    this.notification = notification;
+    this.ownerName = ownerName;
+    this.ownerEmail = ownerEmail;
+    this.ccEmails = ccEmails;
+  }
 
-    public DataJobNotification(EmailNotification notification,
-                               @Value("${datajobs.notification.owner.name}") String ownerName,
-                               @Value("${datajobs.notification.owner.email}") String ownerEmail,
-                               @Value("${datajobs.notification.cc.emails:}") List<String> ccEmails) {
-        this.notification = notification;
-        this.ownerName = ownerName;
-        this.ownerEmail = ownerEmail;
-        this.ccEmails = ccEmails;
+  public void notifyJobDeploySuccess(JobConfig jobConfig) {
+    try {
+      NotificationContent notificationContent =
+          new NotificationContent(
+              jobConfig, DEPLOY_STAGE, SUCCESS_STATUS, ownerName, ownerEmail, ccEmails);
+      notification.send(notificationContent);
+    } catch (AddressException e) {
+      log.warn("Could not send notification due to bad email format", e);
+    } catch (MessagingException e) {
+      log.warn("Could not send notification due to message error", e);
     }
+  }
 
-    public void notifyJobDeploySuccess(JobConfig jobConfig) {
-        try {
-            NotificationContent notificationContent =
-                    new NotificationContent(jobConfig, DEPLOY_STAGE, SUCCESS_STATUS, ownerName, ownerEmail, ccEmails);
-            notification.send(notificationContent);
-        } catch (AddressException e) {
-            log.warn("Could not send notification due to bad email format", e);
-        } catch (MessagingException e) {
-            log.warn("Could not send notification due to message error", e);
-        }
+  // TODO: Potentially split to infrastructure and user error if possible
+  public void notifyJobDeployError(JobConfig jobConfig, String errorName, String errorBody) {
+    try {
+      NotificationContent notificationContent =
+          new NotificationContent(
+              jobConfig,
+              DEPLOY_STAGE,
+              FAILURE_STATUS,
+              errorName,
+              errorBody,
+              ownerName,
+              ownerEmail,
+              ccEmails);
+      notification.send(notificationContent);
+    } catch (AddressException e) {
+      log.warn("Could not send notification due to bad email format", e);
+    } catch (MessagingException e) {
+      log.warn("Could not send notification due to message error", e);
     }
-
-
-    // TODO: Potentially split to infrastructure and user error if possible
-    public void notifyJobDeployError(JobConfig jobConfig, String errorName, String errorBody) {
-        try {
-            NotificationContent notificationContent =
-                    new NotificationContent(jobConfig, DEPLOY_STAGE, FAILURE_STATUS, errorName, errorBody, ownerName, ownerEmail, ccEmails);
-            notification.send(notificationContent);
-        } catch (AddressException e) {
-            log.warn("Could not send notification due to bad email format", e);
-        } catch (MessagingException e) {
-            log.warn("Could not send notification due to message error", e);
-        }
-    }
-
-
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/notification/EmailNotification.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/notification/EmailNotification.java
@@ -25,8 +25,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 
 /**
- * The EmailNotification class is responsible for implementing the email notifications functionality.
- * The single exposed send method accepts pre-build notification object.
+ * The EmailNotification class is responsible for implementing the email notifications
+ * functionality. The single exposed send method accepts pre-build notification object.
  *
  * @see DataJobNotification
  * @see NotificationContent
@@ -34,79 +34,79 @@ import org.springframework.stereotype.Component;
 @Component
 public class EmailNotification {
 
-    @Configuration
-    public static class SmtpProperties {
+  @Configuration
+  public static class SmtpProperties {
 
-        @Bean
-        @ConfigurationProperties(prefix = "mail.smtp")
-        public Map<String, String> smtp() {
-            return new HashMap<>();
-        }
-
-        public Map<String, String> smtpWithPrefix() {
-            Map<String, String> result = new HashMap<>();
-            var props = this.smtp();
-            props.forEach(((key, value) -> result.put("mail.smtp." + key, value)));
-            return result;
-        }
-     }
-
-
-    static Logger log = LoggerFactory.getLogger(EmailNotification.class);
-
-    private static final String CONTENT_TYPE = "text/html; charset=utf-8";
-
-    private final Session session;
-
-    public EmailNotification(SmtpProperties smtpProperties) {
-        Properties properties = System.getProperties();
-        properties.putAll(smtpProperties.smtpWithPrefix());
-        session = Session.getDefaultInstance(properties);
+    @Bean
+    @ConfigurationProperties(prefix = "mail.smtp")
+    public Map<String, String> smtp() {
+      return new HashMap<>();
     }
 
-    public void send(NotificationContent notificationContent)
-            throws MessagingException {
-        if (recipientsExist(notificationContent.getRecipients())) {
-            MimeMessage mimeMessage = new MimeMessage(session);
-            mimeMessage.setFrom(notificationContent.getSender());
-            mimeMessage.setRecipients(MimeMessage.RecipientType.TO, notificationContent.getRecipients());
-            mimeMessage.setSubject(notificationContent.getSubject());
-            mimeMessage.setContent(notificationContent.getContent(), CONTENT_TYPE);
-            try {
-                Transport.send(mimeMessage);
-            } catch (SendFailedException firstException) {
-                log.info("Following addresses are invalid: {}", concatAddresses(firstException.getInvalidAddresses()));
-                var validUnsentAddresses = firstException.getValidUnsentAddresses();
-                if (recipientsExist(validUnsentAddresses)) {
-                    log.info("Retrying unsent valid addresses: {}", concatAddresses(validUnsentAddresses));
-                    mimeMessage.setRecipients(MimeMessage.RecipientType.TO, validUnsentAddresses);
-                    try {
-                        Transport.send(mimeMessage);
-                    } catch (SendFailedException retriedException) {
-                        log.warn("\nwhat: {}\nwhy: {}\nconsequence: {}\ncountermeasure: {}",
-                                "Unable to send notification to the recipients",
-                                retriedException.getMessage(),
-                                "Listed recipients won't receive notifications for the job's status",
-                                "There might be misconfiguration or outage. Check error message for more details");
-                    }
-                }
-            }
-        }
+    public Map<String, String> smtpWithPrefix() {
+      Map<String, String> result = new HashMap<>();
+      var props = this.smtp();
+      props.forEach(((key, value) -> result.put("mail.smtp." + key, value)));
+      return result;
     }
+  }
 
-    private boolean recipientsExist(Address[] recipients) {
-        if (recipients.length == 0) {
-            return false;
-        }
-        return true;
-    }
+  static Logger log = LoggerFactory.getLogger(EmailNotification.class);
 
-    String concatAddresses(Address[] addresses) {
-        return addresses == null ?
-              null :
-              Arrays.asList(addresses)
-                    .stream()
-                    .map(addr -> addr.toString())
-                    .collect(Collectors.joining(" "));
+  private static final String CONTENT_TYPE = "text/html; charset=utf-8";
+
+  private final Session session;
+
+  public EmailNotification(SmtpProperties smtpProperties) {
+    Properties properties = System.getProperties();
+    properties.putAll(smtpProperties.smtpWithPrefix());
+    session = Session.getDefaultInstance(properties);
+  }
+
+  public void send(NotificationContent notificationContent) throws MessagingException {
+    if (recipientsExist(notificationContent.getRecipients())) {
+      MimeMessage mimeMessage = new MimeMessage(session);
+      mimeMessage.setFrom(notificationContent.getSender());
+      mimeMessage.setRecipients(MimeMessage.RecipientType.TO, notificationContent.getRecipients());
+      mimeMessage.setSubject(notificationContent.getSubject());
+      mimeMessage.setContent(notificationContent.getContent(), CONTENT_TYPE);
+      try {
+        Transport.send(mimeMessage);
+      } catch (SendFailedException firstException) {
+        log.info(
+            "Following addresses are invalid: {}",
+            concatAddresses(firstException.getInvalidAddresses()));
+        var validUnsentAddresses = firstException.getValidUnsentAddresses();
+        if (recipientsExist(validUnsentAddresses)) {
+          log.info("Retrying unsent valid addresses: {}", concatAddresses(validUnsentAddresses));
+          mimeMessage.setRecipients(MimeMessage.RecipientType.TO, validUnsentAddresses);
+          try {
+            Transport.send(mimeMessage);
+          } catch (SendFailedException retriedException) {
+            log.warn(
+                "\nwhat: {}\nwhy: {}\nconsequence: {}\ncountermeasure: {}",
+                "Unable to send notification to the recipients",
+                retriedException.getMessage(),
+                "Listed recipients won't receive notifications for the job's status",
+                "There might be misconfiguration or outage. Check error message for more details");
+          }
+        }
+      }
     }
+  }
+
+  private boolean recipientsExist(Address[] recipients) {
+    if (recipients.length == 0) {
+      return false;
+    }
+    return true;
+  }
+
+  String concatAddresses(Address[] addresses) {
+    return addresses == null
+        ? null
+        : Arrays.asList(addresses).stream()
+            .map(addr -> addr.toString())
+            .collect(Collectors.joining(" "));
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/notification/NotificationContent.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/notification/NotificationContent.java
@@ -13,7 +13,6 @@ import javax.mail.internet.InternetAddress;
 import java.util.ArrayList;
 import java.util.List;
 
-
 @Getter
 /**
  * The NotificationContent class is used to build the notifications which will be sent to the users.
@@ -23,101 +22,121 @@ import java.util.List;
  */
 public class NotificationContent {
 
-    private static final String NOTIFICATION_MSG_TEMPLATE = "<p>Dear Data Pipelines user,<br/>\n" +
-            "Last %s of your data job <strong>%s</strong> has status: %s.</p>\n" +
-            "%s\n" + // exec_type, job_name, result, error details
-            "<p>The sender mailbox is not monitored, please do not reply to this email.</p>\n" +
-            "<p>Best,<br/>%s</p>\n";
+  private static final String NOTIFICATION_MSG_TEMPLATE =
+      "<p>Dear Data Pipelines user,<br/>\n"
+          + "Last %s of your data job <strong>%s</strong> has status: %s.</p>\n"
+          + "%s\n"
+          + // exec_type, job_name, result, error details
+          "<p>The sender mailbox is not monitored, please do not reply to this email.</p>\n"
+          + "<p>Best,<br/>%s</p>\n";
 
-    private static final String NOTIFICATION_MSG_SUBJECT_TEMPLATE = "[%s][data job %s] %s";
+  private static final String NOTIFICATION_MSG_SUBJECT_TEMPLATE = "[%s][data job %s] %s";
 
-    private static final String USER_ERROR_TEMPLATE =
-            "<p style=\"padding-left: 30px; color:red;\">" +
-            "<br/>WHAT HAPPENED: %s" +
-            "<br/>WHY IT HAPPENED: %s" +
-            "<br/>CONSEQUENCES: %s" +
-            "<br/>COUNTERMEASURES: %s" +
-            "</p>";
+  private static final String USER_ERROR_TEMPLATE =
+      "<p style=\"padding-left: 30px; color:red;\">"
+          + "<br/>WHAT HAPPENED: %s"
+          + "<br/>WHY IT HAPPENED: %s"
+          + "<br/>CONSEQUENCES: %s"
+          + "<br/>COUNTERMEASURES: %s"
+          + "</p>";
 
-    // TODO: Find usage once infra error is defined in the context of the service
-    private static final String INFRA_ERROR_TEMPLATE = "<p>Details:</p>\n" +
-            "<p style=\"padding-left: 30px; color:red;\">%s</p>"; // error_msg - Exception
+  // TODO: Find usage once infra error is defined in the context of the service
+  private static final String INFRA_ERROR_TEMPLATE =
+      "<p>Details:</p>\n"
+          + "<p style=\"padding-left: 30px; color:red;\">%s</p>"; // error_msg - Exception
 
-    // TODO: Move user guide to the Taurus one once it is out
-    // TODO: allow IT Ops/Admin team to customize the template
-    private static final String GENERAL_ERROR_TEMPLATE = "<p>Data job: %s error.</p>\n" +
-            "<p>Details:</p>\n" +
-            "<p style=\"padding-left: 30px; color:red;\">%s</p>\n" +
-            "<p>%s</p>\n" +
-            "<p>For more information please visit&nbsp;\n" +
-            "<a href=\"https://confluence.eng.vmware.com/display/SUPCR/Data+Pipelines+User+Guide#DataPipelinesUserGuide-Monitoring&amp;Troubleshooting\">" +
-            "Data Pipelines User Guide - Monitoring&amp;Troubleshooting</a>.</p>";
-    // TODO Make "Data Pipelines" name configurable
+  // TODO: Move user guide to the Taurus one once it is out
+  // TODO: allow IT Ops/Admin team to customize the template
+  private static final String GENERAL_ERROR_TEMPLATE =
+      "<p>Data job: %s error.</p>\n"
+          + "<p>Details:</p>\n"
+          + "<p style=\"padding-left: 30px; color:red;\">%s</p>\n"
+          + "<p>%s</p>\n"
+          + "<p>For more information please visit&nbsp;\n"
+          + "<a href=\"https://confluence.eng.vmware.com/display/SUPCR/Data+Pipelines+User+Guide#DataPipelinesUserGuide-Monitoring&amp;Troubleshooting\">Data"
+          + " Pipelines User Guide - Monitoring&amp;Troubleshooting</a>.</p>";
+  // TODO Make "Data Pipelines" name configurable
 
-    private InternetAddress sender;
-    private InternetAddress[] recipients;
-    private String subject;
-    private String content;
-    private List<String> ccEmails;
+  private InternetAddress sender;
+  private InternetAddress[] recipients;
+  private String subject;
+  private String content;
+  private List<String> ccEmails;
 
+  public NotificationContent(
+      JobConfig jobConfig,
+      String stage,
+      String status,
+      String ownerName,
+      String ownerEmail,
+      List<String> ccEmails)
+      throws AddressException {
+    this.sender = new InternetAddress(ownerEmail);
+    this.ccEmails = ccEmails;
+    // TODO: all recipients are defined in notified_on_job_deploy in the job's ini file for now
+    this.recipients = createInternetAddresses(jobConfig.getNotifiedOnJobDeploy());
+    this.subject = formatNotificationSubject(stage, status, jobConfig.getJobName());
+    this.content = formatNotificationContent(stage, jobConfig.getJobName(), status, "", ownerName);
+  }
 
-    public NotificationContent(JobConfig jobConfig, String stage,
-                               String status, String ownerName, String ownerEmail, List<String> ccEmails)
-            throws AddressException {
-        this.sender = new InternetAddress(ownerEmail);
-        this.ccEmails = ccEmails;
-        // TODO: all recipients are defined in notified_on_job_deploy in the job's ini file for now
-        this.recipients = createInternetAddresses(jobConfig.getNotifiedOnJobDeploy());
-        this.subject = formatNotificationSubject(stage, status, jobConfig.getJobName());
-        this.content = formatNotificationContent(stage, jobConfig.getJobName(), status, "", ownerName);
+  public NotificationContent(
+      JobConfig jobConfig,
+      String stage,
+      String status,
+      String errName,
+      String errBody,
+      String ownerName,
+      String ownerEmail,
+      List<String> ccEmails)
+      throws AddressException {
+    this.sender = new InternetAddress(ownerEmail);
+    this.ccEmails = ccEmails;
+    this.recipients = createInternetAddresses(jobConfig.getNotifiedOnJobDeploy());
+    this.subject = formatNotificationSubject(stage, status, jobConfig.getJobName());
+    String errorContent = formatErrNotificationContent(jobConfig.getJobName(), errName, errBody);
+    this.content =
+        formatNotificationContent(stage, jobConfig.getJobName(), status, errorContent, ownerName);
+  }
+
+  public static String getErrorBody(
+      String what, String why, String consequences, String countermeasures) {
+    // TODO: might be good idea to convert new lines to html new lines (<br>)
+    return String.format(USER_ERROR_TEMPLATE, what, why, consequences, countermeasures);
+  }
+
+  public static String getPlatformErrorBody() {
+    return getErrorBody(
+        "Tried to deploy a data job",
+        "There has been a platform error.",
+        "Your new/updated job was not deployed. Your job will run its latest successfully deployed"
+            + " version (if any) as scheduled.",
+        "Try the operation again in a few minutes and open a ticket to the SRE team if the problem"
+            + " persists.");
+  }
+
+  private InternetAddress[] createInternetAddresses(List<String> recipients)
+      throws AddressException {
+    List<InternetAddress> ccAddresses = new ArrayList();
+    for (String cc : this.ccEmails) {
+      ccAddresses.add(new InternetAddress(cc));
     }
-
-    public NotificationContent(JobConfig jobConfig, String stage,
-                               String status, String errName, String errBody, String ownerName, String ownerEmail, List<String> ccEmails)
-            throws AddressException {
-        this.sender = new InternetAddress(ownerEmail);
-        this.ccEmails = ccEmails;
-        this.recipients = createInternetAddresses(jobConfig.getNotifiedOnJobDeploy());
-        this.subject = formatNotificationSubject(stage, status, jobConfig.getJobName());
-        String errorContent = formatErrNotificationContent(jobConfig.getJobName(), errName, errBody);
-        this.content = formatNotificationContent(stage, jobConfig.getJobName(), status, errorContent, ownerName);
+    for (String receiver : recipients) {
+      ccAddresses.add(new InternetAddress(receiver));
     }
+    return ccAddresses.stream().toArray(InternetAddress[]::new);
+  }
 
-    public static String getErrorBody(String what, String why, String consequences, String countermeasures) {
-        // TODO: might be good idea to convert new lines to html new lines (<br>)
-        return String.format(USER_ERROR_TEMPLATE, what, why, consequences, countermeasures);
-    }
+  String formatNotificationSubject(String stage, String status, String jobName) {
+    return String.format(NOTIFICATION_MSG_SUBJECT_TEMPLATE, stage, status, jobName);
+  }
 
-    public static String getPlatformErrorBody() {
-        return getErrorBody(
-                "Tried to deploy a data job",
-                "There has been a platform error." ,
-                "Your new/updated job was not deployed. Your job will run its latest successfully deployed version (if any) as scheduled.",
-                "Try the operation again in a few minutes and open a ticket to the SRE team if the problem persists."
-        );
-    }
+  String formatNotificationContent(
+      String stage, String status, String jobName, String content, String notificationOwner) {
+    return String.format(
+        NOTIFICATION_MSG_TEMPLATE, stage, status, jobName, content, notificationOwner);
+  }
 
-    private InternetAddress[] createInternetAddresses(List<String> recipients) throws AddressException {
-        List<InternetAddress> ccAddresses = new ArrayList();
-        for (String cc : this.ccEmails) {
-            ccAddresses.add(new InternetAddress(cc));
-        }
-        for (String receiver : recipients) {
-            ccAddresses.add(new InternetAddress(receiver));
-        }
-        return ccAddresses.stream().toArray(InternetAddress[]::new);
-    }
-
-    String formatNotificationSubject(String stage, String status, String jobName) {
-        return String.format(NOTIFICATION_MSG_SUBJECT_TEMPLATE, stage, status, jobName);
-    }
-
-    String formatNotificationContent(String stage, String status, String jobName, String content, String notificationOwner) {
-        return String.format(NOTIFICATION_MSG_TEMPLATE, stage, status, jobName, content, notificationOwner);
-    }
-
-    String formatErrNotificationContent(String jobName, String errorName, String errorBody) {
-        return String.format(GENERAL_ERROR_TEMPLATE, jobName, errorName, errorBody);
-    }
-
+  String formatErrNotificationContent(String jobName, String errorName, String errorBody) {
+    return String.format(GENERAL_ERROR_TEMPLATE, jobName, errorName, errorBody);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/threads/ThreadPoolConf.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/threads/ThreadPoolConf.java
@@ -12,33 +12,30 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
-
 /**
- * This class configures thread pool which which is used in all methods
- * which have Async annotation.
+ * This class configures thread pool which which is used in all methods which have Async annotation.
  *
- * TODO: every class which has asynchronous methods should have dedicated thread
- *  executor instead of having generic thread pool for all asynchronous methods
+ * <p>TODO: every class which has asynchronous methods should have dedicated thread executor instead
+ * of having generic thread pool for all asynchronous methods
  */
 @EnableAsync
 @Configuration
 public class ThreadPoolConf {
 
-   /**
-    * This method configures the max number of scheduled threads which for
-    * now is one as we only use it in a single place
-    *
-    * @see DeploymentMonitorSync
-    * @see DataJobMonitorSync
-    *
-    * @return
-    */
-   @Bean()
-   public ThreadPoolTaskScheduler taskScheduler() {
-      ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
-      taskScheduler.setPoolSize(6);
-      taskScheduler.setThreadNamePrefix("thread-");
-      taskScheduler.initialize();
-      return taskScheduler;
-   }
+  /**
+   * This method configures the max number of scheduled threads which for now is one as we only use
+   * it in a single place
+   *
+   * @see DeploymentMonitorSync
+   * @see DataJobMonitorSync
+   * @return
+   */
+  @Bean()
+  public ThreadPoolTaskScheduler taskScheduler() {
+    ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+    taskScheduler.setPoolSize(6);
+    taskScheduler.setThreadNamePrefix("thread-");
+    taskScheduler.initialize();
+    return taskScheduler;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/upload/FileUtils.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/upload/FileUtils.java
@@ -18,102 +18,101 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Class responsible to handle file operations of primarily for {@link JobUpload}
- * but is generic enough to be used in more broad context.
+ * Class responsible to handle file operations of primarily for {@link JobUpload} but is generic
+ * enough to be used in more broad context.
  *
- * TODO: deprecate this class and reuse the FileUtils class from Apache
+ * <p>TODO: deprecate this class and reuse the FileUtils class from Apache
  */
 public class FileUtils {
 
-    /**
-     * Helper class that will delete the file upon close.
-     * Used to return resource hold in temp file which after it's sent can be deleted.
-     */
-    static class CleanupFileInputStreamResource extends FileSystemResource {
-        public CleanupFileInputStreamResource(File file) {
-            super(file);
-        }
-
-        @Override
-        public InputStream getInputStream() throws IOException {
-            return new DeleteOnCloseFileInputStream(super.getFile());
-        }
-
-        private static final class DeleteOnCloseFileInputStream extends FileInputStream {
-
-            private File file;
-            DeleteOnCloseFileInputStream(File file) throws FileNotFoundException    {
-                super(file);
-                this.file = file;
-            }
-
-            @Override
-            public void close() throws IOException {
-                super.close();
-                file.delete();
-            }
-        }
+  /**
+   * Helper class that will delete the file upon close. Used to return resource hold in temp file
+   * which after it's sent can be deleted.
+   */
+  static class CleanupFileInputStreamResource extends FileSystemResource {
+    public CleanupFileInputStreamResource(File file) {
+      super(file);
     }
 
-
-    public static Path createTempDir(String prefix) throws IOException {
-        return Files.createTempDirectory(prefix);
+    @Override
+    public InputStream getInputStream() throws IOException {
+      return new DeleteOnCloseFileInputStream(super.getFile());
     }
 
-    public static void removeDir(Path tempDirPath) throws IOException {
-        if (Files.exists(tempDirPath)) {
-            Files.walk(tempDirPath)
-                    .sorted(Comparator.reverseOrder())
-                    .map(Path::toFile)
-                    .forEach(File::delete);
-        }
-    }
+    private static final class DeleteOnCloseFileInputStream extends FileInputStream {
 
-    public static void copy(String jobFolder, String jobRepoFolder, String jobName) throws IOException {
-        String jobNewLocation = jobRepoFolder + File.separator + jobName;
-        if (Files.exists(Paths.get(jobNewLocation))) {
-            removeDir(Paths.get(jobNewLocation));
-        }
-        Files.move(Paths.get(jobFolder), Paths.get(jobNewLocation));
-    }
+      private File file;
 
-    /**
-     * The method unzips zip file received as binary in this format:
-     *  - job.zip
-     *    - job_folder
-     *      - x.py
-     *      - y.sql
-     *
-     * in case the job_folder name is different than the job name the method will rename it to
-     * be the same as the job name.
-     *
-     * @param resource binary containing the zip file sent to the service
-     * @param tempDir temporary directory containing all the files for the upload process
-     * @param jobName name of the data job so we can unzip the job contents in folder with that name
-     * @return folder containing data job files
-     * @throws IOException
-     */
-    public static File unzipDataJob(Resource resource, File tempDir, String jobName) throws IOException {
-        File jobZipFile = new File(tempDir, "job_zip.zip");
-        File jobTempDir = new File(tempDir, "job_dir");
-        org.apache.commons.io.FileUtils.copyInputStreamToFile(resource.getInputStream(), jobZipFile);
-        new ZipFile(jobZipFile).extractAll(jobTempDir.getAbsolutePath());
-        List<Path> paths = Files.list(jobTempDir.toPath()).collect(Collectors.toList());
-        return paths.get(0).toFile();
-    }
+      DeleteOnCloseFileInputStream(File file) throws FileNotFoundException {
+        super(file);
+        this.file = file;
+      }
 
-    public static void zipDataJob(File fromDataJobDirectory, File intoNewZipFile) throws IOException {
-        ZipFile theZipFile = new ZipFile(intoNewZipFile);
-        theZipFile.addFolder(fromDataJobDirectory);
+      @Override
+      public void close() throws IOException {
+        super.close();
+        file.delete();
+      }
     }
+  }
 
-    public static File renameFile(String oldPath, String newPath) throws IOException {
-        File newFile = Paths.get(newPath).toFile();
-        File oldFile = Paths.get(oldPath).toFile();
-        boolean renamed = oldFile.renameTo(newFile);
-        if (!renamed) {
-            throw new IOException(String.format("Unable to rename file: %s to %s", oldFile, newFile));
-        }
-        return newFile;
+  public static Path createTempDir(String prefix) throws IOException {
+    return Files.createTempDirectory(prefix);
+  }
+
+  public static void removeDir(Path tempDirPath) throws IOException {
+    if (Files.exists(tempDirPath)) {
+      Files.walk(tempDirPath)
+          .sorted(Comparator.reverseOrder())
+          .map(Path::toFile)
+          .forEach(File::delete);
     }
+  }
+
+  public static void copy(String jobFolder, String jobRepoFolder, String jobName)
+      throws IOException {
+    String jobNewLocation = jobRepoFolder + File.separator + jobName;
+    if (Files.exists(Paths.get(jobNewLocation))) {
+      removeDir(Paths.get(jobNewLocation));
+    }
+    Files.move(Paths.get(jobFolder), Paths.get(jobNewLocation));
+  }
+
+  /**
+   * The method unzips zip file received as binary in this format: - job.zip - job_folder - x.py -
+   * y.sql
+   *
+   * <p>in case the job_folder name is different than the job name the method will rename it to be
+   * the same as the job name.
+   *
+   * @param resource binary containing the zip file sent to the service
+   * @param tempDir temporary directory containing all the files for the upload process
+   * @param jobName name of the data job so we can unzip the job contents in folder with that name
+   * @return folder containing data job files
+   * @throws IOException
+   */
+  public static File unzipDataJob(Resource resource, File tempDir, String jobName)
+      throws IOException {
+    File jobZipFile = new File(tempDir, "job_zip.zip");
+    File jobTempDir = new File(tempDir, "job_dir");
+    org.apache.commons.io.FileUtils.copyInputStreamToFile(resource.getInputStream(), jobZipFile);
+    new ZipFile(jobZipFile).extractAll(jobTempDir.getAbsolutePath());
+    List<Path> paths = Files.list(jobTempDir.toPath()).collect(Collectors.toList());
+    return paths.get(0).toFile();
+  }
+
+  public static void zipDataJob(File fromDataJobDirectory, File intoNewZipFile) throws IOException {
+    ZipFile theZipFile = new ZipFile(intoNewZipFile);
+    theZipFile.addFolder(fromDataJobDirectory);
+  }
+
+  public static File renameFile(String oldPath, String newPath) throws IOException {
+    File newFile = Paths.get(newPath).toFile();
+    File oldFile = Paths.get(oldPath).toFile();
+    boolean renamed = oldFile.renameTo(newFile);
+    if (!renamed) {
+      throw new IOException(String.format("Unable to rename file: %s to %s", oldFile, newFile));
+    }
+    return newFile;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/upload/GitCredentialsProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/upload/GitCredentialsProvider.java
@@ -12,21 +12,20 @@ import org.springframework.stereotype.Component;
 
 /**
  * Class responsible for handling different credential providers.
- * <p>
- * Currently the implementation is using access token the way
- * GitLab authentication expects it. Other providers are explained:
- * https://www.codeaffine.com/2014/12/09/jgit-authentication/
+ *
+ * <p>Currently the implementation is using access token the way GitLab authentication expects it.
+ * Other providers are explained: https://www.codeaffine.com/2014/12/09/jgit-authentication/
  */
 @Component
 public class GitCredentialsProvider {
 
-    @Value("${datajobs.git.read.write.username:}")
-    private String gitReadWriteUsername;
+  @Value("${datajobs.git.read.write.username:}")
+  private String gitReadWriteUsername;
 
-    @Value("${datajobs.git.read.write.password:}")
-    private String gitReadWritePassword;
+  @Value("${datajobs.git.read.write.password:}")
+  private String gitReadWritePassword;
 
-    public CredentialsProvider getProvider() {
-        return new UsernamePasswordCredentialsProvider(gitReadWriteUsername, gitReadWritePassword);
-    }
+  public CredentialsProvider getProvider() {
+    return new UsernamePasswordCredentialsProvider(gitReadWriteUsername, gitReadWritePassword);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/upload/GitWrapper.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/upload/GitWrapper.java
@@ -26,229 +26,281 @@ import java.util.ArrayList;
 import java.util.Iterator;
 
 /**
- * Wrapper which eases the usage of JGit and is used in {@link JobUpload} to operate
- * on the repository data jobs repository.
+ * Wrapper which eases the usage of JGit and is used in {@link JobUpload} to operate on the
+ * repository data jobs repository.
  *
- * TODO: transform into a full facade by handling git object internally
+ * <p>TODO: transform into a full facade by handling git object internally
  */
 @Component
 @Slf4j
 public class GitWrapper {
 
-    @FunctionalInterface
-    interface PrePushOperation {
-        void apply() throws IOException, GitAPIException;
-    }
+  @FunctionalInterface
+  interface PrePushOperation {
+    void apply() throws IOException, GitAPIException;
+  }
 
+  private static final String COMMIT_TEMPLATE_SIGNED =
+      "Update data job: %s\n\n%s\n\nSigned-off-by: %s";
 
-    private static final String COMMIT_TEMPLATE_SIGNED = "Update data job: %s\n\n%s\n\nSigned-off-by: %s";
+  private static final String COMMIT_TEMPLATE_UNSIGNED = "Update data job: %s\n\n%s";
 
-    private static final String COMMIT_TEMPLATE_UNSIGNED = "Update data job: %s\n\n%s";
+  private static final String FILE_PATTERN = ".";
 
-    private static final String FILE_PATTERN = ".";
+  private static final String REPOSITORY = "data-jobs";
 
-    private static final String REPOSITORY = "data-jobs";
+  private final String gitDataJobsUrl;
 
-    private final String gitDataJobsUrl;
+  private final String gitDataJobsBranch;
 
-    private final String gitDataJobsBranch;
+  private final String gitDataJobsRemote;
 
-    private final String gitDataJobsRemote;
+  public GitWrapper(
+      @Value("${datajobs.git.url}") String gitDataJobsUrl,
+      @Value("${datajobs.git.branch}") String gitDataJobsBranch,
+      @Value("${datajobs.git.remote}") String gitDataJobsRemote,
+      @Value("${datajobs.git.ssl.enabled}") boolean gitDataJobsSslEnabled) {
 
-    public GitWrapper(
-          @Value("${datajobs.git.url}") String gitDataJobsUrl,
-          @Value("${datajobs.git.branch}") String gitDataJobsBranch,
-          @Value("${datajobs.git.remote}") String gitDataJobsRemote,
-          @Value("${datajobs.git.ssl.enabled}") boolean gitDataJobsSslEnabled) {
+    this.gitDataJobsUrl = constructCorrectGitUrl(gitDataJobsUrl, gitDataJobsSslEnabled);
+    this.gitDataJobsBranch = gitDataJobsBranch;
+    this.gitDataJobsRemote = gitDataJobsRemote;
+  }
 
-        this.gitDataJobsUrl = constructCorrectGitUrl(gitDataJobsUrl, gitDataJobsSslEnabled);
-        this.gitDataJobsBranch = gitDataJobsBranch;
-        this.gitDataJobsRemote = gitDataJobsRemote;
-    }
+  public Git cloneJobRepository(File tempDirPath, CredentialsProvider credentialsProvider)
+      throws GitAPIException {
+    // TODO: optimise to not clone the whole repository for every upload endpoint, but rather
+    //  reuse the same repository but updating the a single job file:
+    //
+    // https://stackoverflow.com/questions/600079/how-do-i-clone-a-subdirectory-only-of-a-git-repository/52269934#52269934
+    File jobsRepository = new File(tempDirPath, REPOSITORY);
+    return Git.cloneRepository()
+        .setURI(gitDataJobsUrl)
+        .setBranch(gitDataJobsBranch)
+        .setRemote(gitDataJobsRemote)
+        .setDirectory(jobsRepository)
+        .setCredentialsProvider(credentialsProvider)
+        .call();
+  }
 
-    public Git cloneJobRepository(File tempDirPath, CredentialsProvider credentialsProvider) throws GitAPIException {
-        // TODO: optimise to not clone the whole repository for every upload endpoint, but rather
-        //  reuse the same repository but updating the a single job file:
-        //  https://stackoverflow.com/questions/600079/how-do-i-clone-a-subdirectory-only-of-a-git-repository/52269934#52269934
-        File jobsRepository = new File(tempDirPath, REPOSITORY);
-        return Git.cloneRepository()
-                .setURI(gitDataJobsUrl)
-                .setBranch(gitDataJobsBranch)
-                .setRemote(gitDataJobsRemote)
-                .setDirectory(jobsRepository)
-                .setCredentialsProvider(credentialsProvider)
-                .call();
-    }
+  public String pushCreateJob(
+      Git git,
+      String jobName,
+      CredentialsProvider credentialsProvider,
+      String username,
+      String reason,
+      File newJobDir)
+      throws GitAPIException, IOException {
+    pushChanges(
+        git,
+        jobName,
+        credentialsProvider,
+        username,
+        reason,
+        () -> updateDataJobDirectory(git, jobName, newJobDir));
+    return getLatestCommitSHAFile(git, jobName);
+  }
 
-    public String pushCreateJob(Git git, String jobName, CredentialsProvider credentialsProvider, String username, String reason, File newJobDir)
-            throws GitAPIException, IOException {
-        pushChanges(git, jobName, credentialsProvider, username, reason, () -> updateDataJobDirectory(git, jobName, newJobDir));
-        return getLatestCommitSHAFile(git, jobName);
-    }
-
-    private void pushChanges(Git git, String jobName, CredentialsProvider credentialsProvider, String username, String reason, PrePushOperation op) throws IOException, GitAPIException {
-        PushCommand push = git.push().setCredentialsProvider(credentialsProvider);
+  private void pushChanges(
+      Git git,
+      String jobName,
+      CredentialsProvider credentialsProvider,
+      String username,
+      String reason,
+      PrePushOperation op)
+      throws IOException, GitAPIException {
+    PushCommand push = git.push().setCredentialsProvider(credentialsProvider);
+    op.apply();
+    Status gitStatus = git.status().call();
+    // if no changes are introduced, no point in try to push we skip
+    if (gitStatus.hasUncommittedChanges()) {
+      commitChanges(git, username, jobName, reason);
+      while (tryToPush(push)) {
+        revertAndPullRemote(git, credentialsProvider);
         op.apply();
-        Status gitStatus = git.status().call();
-        // if no changes are introduced, no point in try to push we skip
+        gitStatus = git.status().call();
         if (gitStatus.hasUncommittedChanges()) {
-            commitChanges(git, username, jobName, reason);
-            while (tryToPush(push)) {
-                revertAndPullRemote(git, credentialsProvider);
-                op.apply();
-                gitStatus = git.status().call();
-                if (gitStatus.hasUncommittedChanges()) {
-                    commitChanges(git, username, jobName, reason);
-                } else {
-                    break;
-                }
-            }
-        }
-    }
-
-    public void pushDeleteJob(Git git, String jobName, CredentialsProvider credentialsProvider, String username, String reason) throws IOException, GitAPIException {
-        pushChanges(git, jobName, credentialsProvider, username, reason, () -> deleteDataJobFromDirectory(git, jobName));
-    }
-
-    public File getDataJobDirectory(Git git, String jobName) {
-        File repositoryLocation = git.getRepository().getDirectory().getParentFile();
-        var jobRepositoryFolderJobPath = new File(repositoryLocation, jobName);
-        if (jobRepositoryFolderJobPath.getAbsolutePath().equals(repositoryLocation.getAbsolutePath())) {
-            throw new Bug("Trying to get the full repo folder for a single job. " +
-                    "That should not be possible.", null);
-        }
-        return jobRepositoryFolderJobPath;
-    }
-
-    private boolean tryToPush(PushCommand push) throws GitAPIException {
-        log.debug("Try to push: repo: {} remote: {} ref: {} with options {}", push.getRepository(), push.getRemote(), push.getRefSpecs(), push.getPushOptions());
-        Iterator<PushResult> pushResults = push.setForce(false).call().iterator();
-        return verifyFailedPush(pushResults);
-    }
-
-    public void gitAdd(Git git) throws GitAPIException {
-        git.add().addFilepattern(FILE_PATTERN).call();
-        git.add().addFilepattern(FILE_PATTERN).setUpdate(true).call();
-    }
-
-    public static String constructCorrectGitUrl(String gitDataJobsUrl, boolean gitDataJobsSslEnabled) {
-        URI u =  URI.create(gitDataJobsUrl);
-        if (StringUtils.isBlank(u.getScheme())) {
-            String scheme = gitDataJobsSslEnabled ? "https" : "http";
-            return scheme + "://" + u.toString();
-        }
-        return gitDataJobsUrl;
-    }
-
-    private void revertAndPullRemote(Git git,
-                                     CredentialsProvider credentialsProvider) throws GitAPIException {
-        // This removes the latest commit with the new data job to reset the branch to remote in
-        // order to have a clean fast forward pull from remote with no conflicts. We can't pull
-        // with rebase as there might be conflicts which can be resolve with merge strategies,
-        // but they don't work properly.
-        log.debug("Revert local change and reset to {}/{} in order to try to push again", gitDataJobsRemote, gitDataJobsBranch);
-        git.reset().setRef("HEAD~1").setMode(ResetCommand.ResetType.HARD).call();
-        git.pull().setCredentialsProvider(credentialsProvider).call();
-    }
-
-    private void updateDataJobDirectory(Git git, String jobName, File newJobDir) throws IOException, GitAPIException {
-        log.debug("Add job {} content directory to local git", jobName);
-        File repositoryLocation = git.getRepository().getDirectory().getParentFile();
-        var jobRepositoryFolderJobPath = new File(repositoryLocation, jobName);
-        if (jobRepositoryFolderJobPath.getAbsolutePath().equals(repositoryLocation.getAbsolutePath())) {
-            throw new Bug("Trying to delete the full repo folder when deploying job. " +
-                    "That should not be possible.", null);
-        }
-        org.apache.commons.io.FileUtils.deleteDirectory(jobRepositoryFolderJobPath);
-        org.apache.commons.io.FileUtils.copyDirectory(newJobDir, jobRepositoryFolderJobPath);
-        gitAdd(git);
-    }
-
-    private void deleteDataJobFromDirectory(Git git, String jobName) throws IOException, GitAPIException {
-        File repositoryLocation = git.getRepository().getDirectory().getParentFile();
-        var jobRepositoryFolderJobPath = new File(repositoryLocation, jobName);
-        if (jobRepositoryFolderJobPath.getAbsolutePath().equals(repositoryLocation.getAbsolutePath())) {
-            throw new Bug("Trying to delete the full repo folder when deploying job. " +
-                    "That should not be possible.", null);
-        }
-        org.apache.commons.io.FileUtils.deleteDirectory(jobRepositoryFolderJobPath);
-        gitAdd(git);
-    }
-
-    /**
-     * @return true if push has failed and should be retried. If it's succesful it returns false.
-     * If there's unrecoverable issue - throws an error.
-     */
-    private boolean verifyFailedPush(Iterator<PushResult> pushResults) {
-        if (pushResults.hasNext()) {
-            while (pushResults.hasNext()) {
-                PushResult result = pushResults.next();
-                log.debug("Verify if the push has passed: {}", ToStringBuilder.reflectionToString(result));
-                ArrayList<RemoteRefUpdate> updates = new ArrayList<>(result.getRemoteUpdates());
-                for (RemoteRefUpdate refUpdate : updates) {
-                    RemoteRefUpdate.Status status = refUpdate.getStatus();
-                    switch (status) {
-                        case REJECTED_NONFASTFORWARD:
-                        case NOT_ATTEMPTED:
-                        case REJECTED_REMOTE_CHANGED:
-                        case AWAITING_REPORT:
-                            return true; // we failed but we should retry
-                        case NON_EXISTING:
-                        case REJECTED_NODELETE:
-                        case REJECTED_OTHER_REASON:
-                            throw new ExternalSystemError(ExternalSystemError.MainExternalSystem.GIT,
-                                    String.format("We failed to push successfully source for data job. " +
-                                            "Failure status is %s, message: %s: .",
-                                            refUpdate.getStatus().toString(),
-                                            refUpdate.getMessage() ));
-                        case OK:
-                        case UP_TO_DATE:
-                            return false; // we did not fail - aka we succeeded. Yay.
-
-                        default:
-                             throw new ExternalSystemError(ExternalSystemError.MainExternalSystem.GIT,
-                                    String.format("We failed to push successfully source for data job. " +
-                                                    "Remote git return unknown status: Failure status is %s, message: %s: .",
-                                            refUpdate.getStatus().toString(),
-                                            refUpdate.getMessage() ));
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
-    RevCommit commitChanges(Git git, String username, String jobName, String reason) throws GitAPIException {
-        log.debug("Commit changes to job {} on behalf of {} to local git", jobName, username);
-        RevCommit commit;
-        if (StringUtils.isBlank(reason)) {
-            reason = "Updating data job: " + jobName;
-        }
-        if (StringUtils.isBlank(username)) {
-            String commitMessage = String.format(COMMIT_TEMPLATE_UNSIGNED, jobName, reason);
-            commit = git.commit().setMessage(commitMessage).call();
+          commitChanges(git, username, jobName, reason);
         } else {
-            String commitMessage = String.format(COMMIT_TEMPLATE_SIGNED, jobName, reason, username);
-            commit = git.commit().setMessage(commitMessage).setAuthor(username, "").call();
+          break;
         }
-        return commit;
+      }
     }
+  }
 
-    String getLatestCommitSHAFile(Git git, String fileName) throws GitAPIException {
-        RevCommit latestCommit = null;
-        Iterator<RevCommit> commits;
-        LogCommand log = git.log();
-        if (fileName != null) {
-            log = log.addPath(fileName);
-        }
-        commits = log.call().iterator();
-        if (commits.hasNext()) {
-            latestCommit = commits.next();
-        }
-        return latestCommit != null ? latestCommit.name(): null;
-    }
+  public void pushDeleteJob(
+      Git git,
+      String jobName,
+      CredentialsProvider credentialsProvider,
+      String username,
+      String reason)
+      throws IOException, GitAPIException {
+    pushChanges(
+        git,
+        jobName,
+        credentialsProvider,
+        username,
+        reason,
+        () -> deleteDataJobFromDirectory(git, jobName));
+  }
 
-    String getLatestCommitSHARepository(Git git) throws GitAPIException {
-        return getLatestCommitSHAFile(git, null);
+  public File getDataJobDirectory(Git git, String jobName) {
+    File repositoryLocation = git.getRepository().getDirectory().getParentFile();
+    var jobRepositoryFolderJobPath = new File(repositoryLocation, jobName);
+    if (jobRepositoryFolderJobPath.getAbsolutePath().equals(repositoryLocation.getAbsolutePath())) {
+      throw new Bug(
+          "Trying to get the full repo folder for a single job. " + "That should not be possible.",
+          null);
     }
+    return jobRepositoryFolderJobPath;
+  }
+
+  private boolean tryToPush(PushCommand push) throws GitAPIException {
+    log.debug(
+        "Try to push: repo: {} remote: {} ref: {} with options {}",
+        push.getRepository(),
+        push.getRemote(),
+        push.getRefSpecs(),
+        push.getPushOptions());
+    Iterator<PushResult> pushResults = push.setForce(false).call().iterator();
+    return verifyFailedPush(pushResults);
+  }
+
+  public void gitAdd(Git git) throws GitAPIException {
+    git.add().addFilepattern(FILE_PATTERN).call();
+    git.add().addFilepattern(FILE_PATTERN).setUpdate(true).call();
+  }
+
+  public static String constructCorrectGitUrl(
+      String gitDataJobsUrl, boolean gitDataJobsSslEnabled) {
+    URI u = URI.create(gitDataJobsUrl);
+    if (StringUtils.isBlank(u.getScheme())) {
+      String scheme = gitDataJobsSslEnabled ? "https" : "http";
+      return scheme + "://" + u.toString();
+    }
+    return gitDataJobsUrl;
+  }
+
+  private void revertAndPullRemote(Git git, CredentialsProvider credentialsProvider)
+      throws GitAPIException {
+    // This removes the latest commit with the new data job to reset the branch to remote in
+    // order to have a clean fast forward pull from remote with no conflicts. We can't pull
+    // with rebase as there might be conflicts which can be resolve with merge strategies,
+    // but they don't work properly.
+    log.debug(
+        "Revert local change and reset to {}/{} in order to try to push again",
+        gitDataJobsRemote,
+        gitDataJobsBranch);
+    git.reset().setRef("HEAD~1").setMode(ResetCommand.ResetType.HARD).call();
+    git.pull().setCredentialsProvider(credentialsProvider).call();
+  }
+
+  private void updateDataJobDirectory(Git git, String jobName, File newJobDir)
+      throws IOException, GitAPIException {
+    log.debug("Add job {} content directory to local git", jobName);
+    File repositoryLocation = git.getRepository().getDirectory().getParentFile();
+    var jobRepositoryFolderJobPath = new File(repositoryLocation, jobName);
+    if (jobRepositoryFolderJobPath.getAbsolutePath().equals(repositoryLocation.getAbsolutePath())) {
+      throw new Bug(
+          "Trying to delete the full repo folder when deploying job. "
+              + "That should not be possible.",
+          null);
+    }
+    org.apache.commons.io.FileUtils.deleteDirectory(jobRepositoryFolderJobPath);
+    org.apache.commons.io.FileUtils.copyDirectory(newJobDir, jobRepositoryFolderJobPath);
+    gitAdd(git);
+  }
+
+  private void deleteDataJobFromDirectory(Git git, String jobName)
+      throws IOException, GitAPIException {
+    File repositoryLocation = git.getRepository().getDirectory().getParentFile();
+    var jobRepositoryFolderJobPath = new File(repositoryLocation, jobName);
+    if (jobRepositoryFolderJobPath.getAbsolutePath().equals(repositoryLocation.getAbsolutePath())) {
+      throw new Bug(
+          "Trying to delete the full repo folder when deploying job. "
+              + "That should not be possible.",
+          null);
+    }
+    org.apache.commons.io.FileUtils.deleteDirectory(jobRepositoryFolderJobPath);
+    gitAdd(git);
+  }
+
+  /**
+   * @return true if push has failed and should be retried. If it's succesful it returns false. If
+   *     there's unrecoverable issue - throws an error.
+   */
+  private boolean verifyFailedPush(Iterator<PushResult> pushResults) {
+    if (pushResults.hasNext()) {
+      while (pushResults.hasNext()) {
+        PushResult result = pushResults.next();
+        log.debug("Verify if the push has passed: {}", ToStringBuilder.reflectionToString(result));
+        ArrayList<RemoteRefUpdate> updates = new ArrayList<>(result.getRemoteUpdates());
+        for (RemoteRefUpdate refUpdate : updates) {
+          RemoteRefUpdate.Status status = refUpdate.getStatus();
+          switch (status) {
+            case REJECTED_NONFASTFORWARD:
+            case NOT_ATTEMPTED:
+            case REJECTED_REMOTE_CHANGED:
+            case AWAITING_REPORT:
+              return true; // we failed but we should retry
+            case NON_EXISTING:
+            case REJECTED_NODELETE:
+            case REJECTED_OTHER_REASON:
+              throw new ExternalSystemError(
+                  ExternalSystemError.MainExternalSystem.GIT,
+                  String.format(
+                      "We failed to push successfully source for data job. "
+                          + "Failure status is %s, message: %s: .",
+                      refUpdate.getStatus().toString(), refUpdate.getMessage()));
+            case OK:
+            case UP_TO_DATE:
+              return false; // we did not fail - aka we succeeded. Yay.
+
+            default:
+              throw new ExternalSystemError(
+                  ExternalSystemError.MainExternalSystem.GIT,
+                  String.format(
+                      "We failed to push successfully source for data job. Remote git return"
+                          + " unknown status: Failure status is %s, message: %s: .",
+                      refUpdate.getStatus().toString(), refUpdate.getMessage()));
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  RevCommit commitChanges(Git git, String username, String jobName, String reason)
+      throws GitAPIException {
+    log.debug("Commit changes to job {} on behalf of {} to local git", jobName, username);
+    RevCommit commit;
+    if (StringUtils.isBlank(reason)) {
+      reason = "Updating data job: " + jobName;
+    }
+    if (StringUtils.isBlank(username)) {
+      String commitMessage = String.format(COMMIT_TEMPLATE_UNSIGNED, jobName, reason);
+      commit = git.commit().setMessage(commitMessage).call();
+    } else {
+      String commitMessage = String.format(COMMIT_TEMPLATE_SIGNED, jobName, reason, username);
+      commit = git.commit().setMessage(commitMessage).setAuthor(username, "").call();
+    }
+    return commit;
+  }
+
+  String getLatestCommitSHAFile(Git git, String fileName) throws GitAPIException {
+    RevCommit latestCommit = null;
+    Iterator<RevCommit> commits;
+    LogCommand log = git.log();
+    if (fileName != null) {
+      log = log.addPath(fileName);
+    }
+    commits = log.call().iterator();
+    if (commits.hasNext()) {
+      latestCommit = commits.next();
+    }
+    return latestCommit != null ? latestCommit.name() : null;
+  }
+
+  String getLatestCommitSHARepository(Git git) throws GitAPIException {
+    return getLatestCommitSHAFile(git, null);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/upload/JobUpload.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/upload/JobUpload.java
@@ -27,193 +27,239 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 /**
- * Class responsible for handling the data job archive coming from the client.
- * The main functionality of the class is to hadnle the archive binary containing
- * the data job using {@link FileUtils} and push the data job to the data jobs repository
- * using {@link GitWrapper}.
+ * Class responsible for handling the data job archive coming from the client. The main
+ * functionality of the class is to hadnle the archive binary containing the data job using {@link
+ * FileUtils} and push the data job to the data jobs repository using {@link GitWrapper}.
  */
 @Service
 @AllArgsConstructor
 public class JobUpload {
 
-    private static final Logger log = LoggerFactory.getLogger(JobUpload.class);
+  private static final Logger log = LoggerFactory.getLogger(JobUpload.class);
 
-    private static final String TEMPORARY_DIRECTORY_PREFIX = "job_";
+  private static final String TEMPORARY_DIRECTORY_PREFIX = "job_";
 
-    @Autowired
-    private final GitCredentialsProvider gitCredentialsProvider;
+  @Autowired private final GitCredentialsProvider gitCredentialsProvider;
 
-    @Autowired
-    private final GitWrapper gitWrapper;
+  @Autowired private final GitWrapper gitWrapper;
 
-    @Autowired
-    private final FeatureFlags featureFlags;
+  @Autowired private final FeatureFlags featureFlags;
 
-    @Autowired
-    private final AuthorizationProvider authorizationProvider;
+  @Autowired private final AuthorizationProvider authorizationProvider;
 
-    /**
-     * Get data job source as a zip file.
-     *
-     * @param jobName the data job whose source it will get
-     * @return resource containing data job content in a zip format.
-     */
-    public Optional<Resource> getDataJob(String jobName) {
-        Path tempDirPath = null;
-        CredentialsProvider credentialsProvider = gitCredentialsProvider.getProvider();
+  /**
+   * Get data job source as a zip file.
+   *
+   * @param jobName the data job whose source it will get
+   * @return resource containing data job content in a zip format.
+   */
+  public Optional<Resource> getDataJob(String jobName) {
+    Path tempDirPath = null;
+    CredentialsProvider credentialsProvider = gitCredentialsProvider.getProvider();
+    try {
+      tempDirPath = FileUtils.createTempDir(TEMPORARY_DIRECTORY_PREFIX);
+
+      Git git =
+          gitWrapper.cloneJobRepository(
+              new File(tempDirPath.toFile(), "repo"), credentialsProvider);
+      File jobDirectory = gitWrapper.getDataJobDirectory(git, jobName);
+      if (jobDirectory.isDirectory()) {
+        File tempFile = File.createTempFile(jobName, "zip");
+        tempFile.delete();
+        FileUtils.zipDataJob(jobDirectory, tempFile);
+        return Optional.of(new FileUtils.CleanupFileInputStreamResource(tempFile));
+      } else {
+        return Optional.empty();
+      }
+
+    } catch (GitAPIException e) {
+      // TODO: split into 5xx and 4xx errors depending on exception (e.g too big upload is client
+      // error and not server error)
+      throw new ExternalSystemError(
+          ExternalSystemError.MainExternalSystem.GIT,
+          String.format(
+              "Communication with the git server failed while trying to get data job source: %s. "
+                  + "Please read the exception and follow the instructions.",
+              jobName),
+          e);
+    } catch (IOException e) {
+      throw new ExternalSystemError(
+          ExternalSystemError.MainExternalSystem.HOST_CONTAINER,
+          String.format(
+              "Operations on the file system failed while trying to get data job source: %s",
+              jobName),
+          e);
+    } finally {
+      if (tempDirPath != null) {
         try {
-            tempDirPath = FileUtils.createTempDir(TEMPORARY_DIRECTORY_PREFIX);
-
-            Git git = gitWrapper.cloneJobRepository(new File(tempDirPath.toFile(), "repo"), credentialsProvider);
-            File jobDirectory = gitWrapper.getDataJobDirectory(git, jobName);
-            if (jobDirectory.isDirectory()) {
-                File tempFile = File.createTempFile(jobName, "zip");
-                tempFile.delete();
-                FileUtils.zipDataJob(jobDirectory, tempFile);
-                return Optional.of(new FileUtils.CleanupFileInputStreamResource(tempFile));
-            } else {
-                return Optional.empty();
-            }
-
-        } catch (GitAPIException e) {
-            // TODO: split into 5xx and 4xx errors depending on exception (e.g too big upload is client error and not server error)
-            throw new ExternalSystemError(ExternalSystemError.MainExternalSystem.GIT,
-                    String.format("Communication with the git server failed while trying to get data job source: %s. " +
-                            "Please read the exception and follow the instructions.", jobName), e);
+          FileUtils.removeDir(tempDirPath);
         } catch (IOException e) {
-            throw new ExternalSystemError(ExternalSystemError.MainExternalSystem.HOST_CONTAINER,
-                    String.format("Operations on the file system failed while trying to get data job source: %s", jobName),
-                    e);
-        }finally {
-            if (tempDirPath != null) {
-                try {
-                    FileUtils.removeDir(tempDirPath);
-                } catch (IOException e) {
-                    log.warn(new ErrorMessage(
-                            String.format("Unable to clean up temporary files while tyring to get data job source: %s", jobName),
-                            String.format("Error: %s", e.getMessage()),
-                            "Operation may be successful, but temporary files are left on the file system.",
-                            "Contact the provider to resolve the issue or clean up the temporary files manually.")
-                            .toString(), e);
-                }
-            }
+          log.warn(
+              new ErrorMessage(
+                      String.format(
+                          "Unable to clean up temporary files while tyring to get data job source:"
+                              + " %s",
+                          jobName),
+                      String.format("Error: %s", e.getMessage()),
+                      "Operation may be successful, but temporary files are left on the file"
+                          + " system.",
+                      "Contact the provider to resolve the issue or clean up the temporary files"
+                          + " manually.")
+                  .toString(),
+              e);
         }
-
+      }
     }
+  }
 
-    /**
-     * Public data job to remote git repository and return its version (git version)
-     *
-     * @param jobName - the data job name
-     * @param resource - the data job source  as a zip file.
-     * @param reason - reason specified by user for publishing the data job
-     * @return the new version (commit hash) of the data job. If there are not changes it will return the latest version (commit) of the data job.
-     */
-    public String publishDataJob(String jobName, Resource resource, String reason) {
-        log.debug("Publish datajob to git {}", jobName);
-        Path tempDirPath = null;
-        String jobVersion;
-        CredentialsProvider credentialsProvider = gitCredentialsProvider.getProvider();
+  /**
+   * Public data job to remote git repository and return its version (git version)
+   *
+   * @param jobName - the data job name
+   * @param resource - the data job source as a zip file.
+   * @param reason - reason specified by user for publishing the data job
+   * @return the new version (commit hash) of the data job. If there are not changes it will return
+   *     the latest version (commit) of the data job.
+   */
+  public String publishDataJob(String jobName, Resource resource, String reason) {
+    log.debug("Publish datajob to git {}", jobName);
+    Path tempDirPath = null;
+    String jobVersion;
+    CredentialsProvider credentialsProvider = gitCredentialsProvider.getProvider();
+    try {
+      tempDirPath = FileUtils.createTempDir(TEMPORARY_DIRECTORY_PREFIX);
+
+      File jobFolder =
+          FileUtils.unzipDataJob(resource, new File(tempDirPath.toFile(), "job"), jobName);
+
+      Git git =
+          gitWrapper.cloneJobRepository(
+              new File(tempDirPath.toFile(), "repo"), credentialsProvider);
+
+      jobVersion = createRemoteJob(git, jobName, credentialsProvider, reason, jobFolder);
+    } catch (GitAPIException e) {
+      // TODO: split into 5xx and 4xx errors depending on exception (e.g too big upload is client
+      // error and not server error)
+      throw new ExternalSystemError(
+          ExternalSystemError.MainExternalSystem.GIT,
+          String.format(
+              "Communication with the git server failed while trying to deploy data job: %s. "
+                  + "Please read the exception and follow the instructions.",
+              jobName),
+          e);
+    } catch (IOException e) {
+      throw new ExternalSystemError(
+          ExternalSystemError.MainExternalSystem.HOST_CONTAINER,
+          String.format(
+              "Operations on the file system failed while trying to handle deployment of job: %s",
+              jobName),
+          e);
+    } finally {
+      if (tempDirPath != null) {
         try {
-            tempDirPath = FileUtils.createTempDir(TEMPORARY_DIRECTORY_PREFIX);
-
-            File jobFolder = FileUtils.unzipDataJob(resource, new File(tempDirPath.toFile(), "job"), jobName);
-
-            Git git = gitWrapper.cloneJobRepository(new File(tempDirPath.toFile(), "repo"), credentialsProvider);
-
-            jobVersion = createRemoteJob(git, jobName, credentialsProvider, reason, jobFolder);
-        } catch (GitAPIException e) {
-            // TODO: split into 5xx and 4xx errors depending on exception (e.g too big upload is client error and not server error)
-            throw new ExternalSystemError(ExternalSystemError.MainExternalSystem.GIT,
-                    String.format("Communication with the git server failed while trying to deploy data job: %s. " +
-                            "Please read the exception and follow the instructions.", jobName), e);
+          // TODO: go with try with resources:
+          //
+          // https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html#:~:text=Note%3A%20A%20try%20%2Dwith%2D,resources%20declared%20have%20been%20closed.
+          FileUtils.removeDir(tempDirPath);
         } catch (IOException e) {
-            throw new ExternalSystemError(ExternalSystemError.MainExternalSystem.HOST_CONTAINER,
-                    String.format("Operations on the file system failed while trying to handle deployment of job: %s", jobName),
-                    e);
-        } finally {
-            if (tempDirPath != null) {
-                try {
-                    // TODO: go with try with resources:
-                    //  https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html#:~:text=Note%3A%20A%20try%20%2Dwith%2D,resources%20declared%20have%20been%20closed.
-                    FileUtils.removeDir(tempDirPath);
-                } catch (IOException e) {
-                    log.warn(new ErrorMessage(
-                            String.format("Unable to clean up temporary files while tyring to deploy: %s", jobName),
-                            String.format("Error: %s", e.getMessage()),
-                            "Job is successfully deployed, but temporary files are left on the file system.",
-                            "Contact the provider to resolve the issue or clean up the temporary files manually.")
-                            .toString(), e);
-                }
-            }
+          log.warn(
+              new ErrorMessage(
+                      String.format(
+                          "Unable to clean up temporary files while tyring to deploy: %s", jobName),
+                      String.format("Error: %s", e.getMessage()),
+                      "Job is successfully deployed, but temporary files are left on the file"
+                          + " system.",
+                      "Contact the provider to resolve the issue or clean up the temporary files"
+                          + " manually.")
+                  .toString(),
+              e);
         }
-        return jobVersion;
+      }
     }
+    return jobVersion;
+  }
 
-    /**
-     * Delete the data job source directory.
-     * @param jobName the data job name
-     * @param reason reason specified by user for deleting the data job
-     */
-    public void deleteDataJob(String jobName, String reason){
-        Path tempDirPath = null;
-        CredentialsProvider credentialsProvider = gitCredentialsProvider.getProvider();
+  /**
+   * Delete the data job source directory.
+   *
+   * @param jobName the data job name
+   * @param reason reason specified by user for deleting the data job
+   */
+  public void deleteDataJob(String jobName, String reason) {
+    Path tempDirPath = null;
+    CredentialsProvider credentialsProvider = gitCredentialsProvider.getProvider();
+    try {
+      tempDirPath = FileUtils.createTempDir(TEMPORARY_DIRECTORY_PREFIX);
+
+      Git git =
+          gitWrapper.cloneJobRepository(
+              new File(tempDirPath.toFile(), "repo"), credentialsProvider);
+
+      removeRemoteJob(git, jobName, credentialsProvider, reason);
+    } catch (GitAPIException e) {
+      // TODO: split into 5xx and 4xx errors depending on exception (e.g too big upload is client
+      // error and not server error)
+      throw new ExternalSystemError(
+          ExternalSystemError.MainExternalSystem.GIT,
+          String.format(
+              "Communication with the git server failed while trying to delete data job: %s. "
+                  + "Please read the exception and follow the instructions.",
+              jobName),
+          e);
+    } catch (IOException e) {
+      throw new ExternalSystemError(
+          ExternalSystemError.MainExternalSystem.HOST_CONTAINER,
+          String.format(
+              "Operations on the file system failed while trying to handle deletion of job: %s",
+              jobName),
+          e);
+    } finally {
+      if (tempDirPath != null) {
         try {
-            tempDirPath = FileUtils.createTempDir(TEMPORARY_DIRECTORY_PREFIX);
-
-            Git git = gitWrapper.cloneJobRepository(new File(tempDirPath.toFile(), "repo"), credentialsProvider);
-
-            removeRemoteJob(git, jobName, credentialsProvider, reason);
-        } catch (GitAPIException e) {
-            // TODO: split into 5xx and 4xx errors depending on exception (e.g too big upload is client error and not server error)
-            throw new ExternalSystemError(ExternalSystemError.MainExternalSystem.GIT,
-                    String.format("Communication with the git server failed while trying to delete data job: %s. " +
-                            "Please read the exception and follow the instructions.", jobName), e);
+          // TODO: go with try with resources:
+          //
+          // https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html#:~:text=Note%3A%20A%20try%20%2Dwith%2D,resources%20declared%20have%20been%20closed.
+          FileUtils.removeDir(tempDirPath);
         } catch (IOException e) {
-            throw new ExternalSystemError(ExternalSystemError.MainExternalSystem.HOST_CONTAINER,
-                    String.format("Operations on the file system failed while trying to handle deletion of job: %s", jobName),
-                    e);
-        } finally {
-            if (tempDirPath != null) {
-                try {
-                    // TODO: go with try with resources:
-                    //  https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html#:~:text=Note%3A%20A%20try%20%2Dwith%2D,resources%20declared%20have%20been%20closed.
-                    FileUtils.removeDir(tempDirPath);
-                } catch (IOException e) {
-                    log.warn(new ErrorMessage(
-                            String.format("Unable to clean up temporary files while tyring to delete: %s", jobName),
-                            String.format("Error: %s", e.getMessage()),
-                            "Job is successfully deleted, but temporary files are left on the file system.",
-                            "Contact the provider to resolve the issue or clean up the temporary files manually.")
-                            .toString(), e);
-                }
-            }
+          log.warn(
+              new ErrorMessage(
+                      String.format(
+                          "Unable to clean up temporary files while tyring to delete: %s", jobName),
+                      String.format("Error: %s", e.getMessage()),
+                      "Job is successfully deleted, but temporary files are left on the file"
+                          + " system.",
+                      "Contact the provider to resolve the issue or clean up the temporary files"
+                          + " manually.")
+                  .toString(),
+              e);
         }
+      }
     }
+  }
 
-    private String createRemoteJob(Git git, String jobName, CredentialsProvider credentialsProvider, String reason, File jobFolder)
-            throws GitAPIException, IOException {
-        String userID = null;
-        if (featureFlags.isSecurityEnabled()) {
-            Authentication authentication =
-                    SecurityContextHolder
-                            .getContext()
-                            .getAuthentication();
-            userID = authorizationProvider.getUserId(authentication);
-        }
-        return gitWrapper.pushCreateJob(git, jobName, credentialsProvider, userID, reason, jobFolder);
+  private String createRemoteJob(
+      Git git,
+      String jobName,
+      CredentialsProvider credentialsProvider,
+      String reason,
+      File jobFolder)
+      throws GitAPIException, IOException {
+    String userID = null;
+    if (featureFlags.isSecurityEnabled()) {
+      Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+      userID = authorizationProvider.getUserId(authentication);
     }
+    return gitWrapper.pushCreateJob(git, jobName, credentialsProvider, userID, reason, jobFolder);
+  }
 
-    private void removeRemoteJob(Git git, String jobName, CredentialsProvider credentialsProvider, String reason)
-            throws GitAPIException, IOException {
-        String userID = null;
-        if (featureFlags.isSecurityEnabled()) {
-            Authentication authentication =
-                    SecurityContextHolder
-                            .getContext()
-                            .getAuthentication();
-            userID = authorizationProvider.getUserId(authentication);
-        }
-        gitWrapper.pushDeleteJob(git, jobName, credentialsProvider, userID, reason);
+  private void removeRemoteJob(
+      Git git, String jobName, CredentialsProvider credentialsProvider, String reason)
+      throws GitAPIException, IOException {
+    String userID = null;
+    if (featureFlags.isSecurityEnabled()) {
+      Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+      userID = authorizationProvider.getUserId(authentication);
     }
+    gitWrapper.pushDeleteJob(git, jobName, credentialsProvider, userID, reason);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/webhook/WebHookRequestBody.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/webhook/WebHookRequestBody.java
@@ -18,39 +18,39 @@ import java.io.Serializable;
 @Data
 public class WebHookRequestBody implements Serializable {
 
-    @JsonProperty(REQUESTER_USER_ID)
-    private String requesterUserId;
+  @JsonProperty(REQUESTER_USER_ID)
+  private String requesterUserId;
 
-    @JsonProperty(REQUESTED_RESOURCE_TEAM)
-    private String requestedResourceTeam;
+  @JsonProperty(REQUESTED_RESOURCE_TEAM)
+  private String requestedResourceTeam;
 
-    @JsonProperty(REQUESTED_RESOURCE_NAME)
-    private String requestedResourceName;
+  @JsonProperty(REQUESTED_RESOURCE_NAME)
+  private String requestedResourceName;
 
-    @JsonProperty(REQUESTED_RESOURCE_ID)
-    private String requestedResourceId;
+  @JsonProperty(REQUESTED_RESOURCE_ID)
+  private String requestedResourceId;
 
-    @JsonProperty(REQUESTED_HTTP_PATH)
-    private String requestedHttpPath;
+  @JsonProperty(REQUESTED_HTTP_PATH)
+  private String requestedHttpPath;
 
-    @JsonProperty(REQUESTED_HTTP_VERB)
-    private String requestedHttpVerb;
+  @JsonProperty(REQUESTED_HTTP_VERB)
+  private String requestedHttpVerb;
 
-    @JsonProperty(REQUESTED_RESOURCE_NEW_TEAM)
-    private String requestedResourceNewTeam;
+  @JsonProperty(REQUESTED_RESOURCE_NEW_TEAM)
+  private String requestedResourceNewTeam;
 
-    private static final String REQUESTER_USER_ID = "requester_user_id";
-    private static final String REQUESTED_RESOURCE_TEAM = "requested_resource_team";
-    private static final String REQUESTED_RESOURCE_NAME = "requested_resource_name";
-    private static final String REQUESTED_RESOURCE_ID = "requested_resource_id";
-    private static final String REQUESTED_HTTP_PATH = "requested_http_path";
-    private static final String REQUESTED_HTTP_VERB = "requested_http_verb";
-    private static final String REQUESTED_RESOURCE_NEW_TEAM = "requested_resource_new_team";
+  private static final String REQUESTER_USER_ID = "requester_user_id";
+  private static final String REQUESTED_RESOURCE_TEAM = "requested_resource_team";
+  private static final String REQUESTED_RESOURCE_NAME = "requested_resource_name";
+  private static final String REQUESTED_RESOURCE_ID = "requested_resource_id";
+  private static final String REQUESTED_HTTP_PATH = "requested_http_path";
+  private static final String REQUESTED_HTTP_VERB = "requested_http_verb";
+  private static final String REQUESTED_RESOURCE_NEW_TEAM = "requested_resource_new_team";
 
-    @SneakyThrows
-    public String toString(){
-        ObjectMapper mapper = new ObjectMapper();
-        String jsonBody = mapper.writeValueAsString(this);
-        return jsonBody;
-    }
+  @SneakyThrows
+  public String toString() {
+    ObjectMapper mapper = new ObjectMapper();
+    String jsonBody = mapper.writeValueAsString(this);
+    return jsonBody;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/webhook/WebHookRequestBodyProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/webhook/WebHookRequestBodyProvider.java
@@ -12,39 +12,40 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 /**
- * Helper service which provide useful methods to construct various types of WebHookRequestBody instances.
+ * Helper service which provide useful methods to construct various types of WebHookRequestBody
+ * instances.
  */
 @Service
 @AllArgsConstructor
 public class WebHookRequestBodyProvider {
-   private static final String CREATE_OPERATION_PATH = "/data-jobs/for-team/%s/jobs";
-   private static final String DELETE_OPERATION_PATH = CREATE_OPERATION_PATH + "/%s";
+  private static final String CREATE_OPERATION_PATH = "/data-jobs/for-team/%s/jobs";
+  private static final String DELETE_OPERATION_PATH = CREATE_OPERATION_PATH + "/%s";
 
-   private final AuthorizationProvider authorizationProvider;
+  private final AuthorizationProvider authorizationProvider;
 
-   public WebHookRequestBody constructPostDeleteBody(DataJob jobInfo) {
-      WebHookRequestBody body = constructWebHookRequestBody(jobInfo);
-      body.setRequestedHttpPath(String.format(DELETE_OPERATION_PATH,
-              jobInfo.getJobConfig().getTeam(),
-              jobInfo.getName()));
-      body.setRequestedHttpVerb("DELETE");
-      return body;
-   }
+  public WebHookRequestBody constructPostDeleteBody(DataJob jobInfo) {
+    WebHookRequestBody body = constructWebHookRequestBody(jobInfo);
+    body.setRequestedHttpPath(
+        String.format(DELETE_OPERATION_PATH, jobInfo.getJobConfig().getTeam(), jobInfo.getName()));
+    body.setRequestedHttpVerb("DELETE");
+    return body;
+  }
 
-   public WebHookRequestBody constructPostCreateBody(DataJob jobInfo) {
-      WebHookRequestBody body = constructWebHookRequestBody(jobInfo);
-      body.setRequestedHttpPath(String.format(CREATE_OPERATION_PATH,
-              jobInfo.getJobConfig().getTeam()));
-      body.setRequestedHttpVerb("POST");
-      return body;
-   }
+  public WebHookRequestBody constructPostCreateBody(DataJob jobInfo) {
+    WebHookRequestBody body = constructWebHookRequestBody(jobInfo);
+    body.setRequestedHttpPath(
+        String.format(CREATE_OPERATION_PATH, jobInfo.getJobConfig().getTeam()));
+    body.setRequestedHttpVerb("POST");
+    return body;
+  }
 
-   private WebHookRequestBody constructWebHookRequestBody(DataJob jobInfo) {
-      WebHookRequestBody body = new WebHookRequestBody();
-      body.setRequesterUserId(authorizationProvider.getUserId(SecurityContextHolder.getContext().getAuthentication()));
-      body.setRequestedResourceTeam(jobInfo.getJobConfig().getTeam());
-      body.setRequestedResourceName("data-job");
-      body.setRequestedResourceId(jobInfo.getName());
-      return body;
-   }
+  private WebHookRequestBody constructWebHookRequestBody(DataJob jobInfo) {
+    WebHookRequestBody body = new WebHookRequestBody();
+    body.setRequesterUserId(
+        authorizationProvider.getUserId(SecurityContextHolder.getContext().getAuthentication()));
+    body.setRequestedResourceTeam(jobInfo.getJobConfig().getTeam());
+    body.setRequestedResourceName("data-job");
+    body.setRequestedResourceId(jobInfo.getName());
+    return body;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/webhook/WebHookResult.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/webhook/WebHookResult.java
@@ -10,13 +10,13 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 /**
- * WebHookResult class with sole responsibility to leave post operations actions to the client code using
- * webhook invocations.
+ * WebHookResult class with sole responsibility to leave post operations actions to the client code
+ * using webhook invocations.
  */
 @Getter
 @Builder
 public class WebHookResult {
-    private final HttpStatus status;
-    private final String message;
-    private final boolean success;
+  private final HttpStatus status;
+  private final String message;
+  private final boolean success;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/webhook/WebHookService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/webhook/WebHookService.java
@@ -23,154 +23,156 @@ import org.springframework.web.client.RestTemplate;
 import java.util.Optional;
 
 /**
- * WebHook Provider abstraction that provides a template for the invocation of a WebHook.
- * It is not expected to use this service directly (hence abstract), instead provide a specific implementation
+ * WebHook Provider abstraction that provides a template for the invocation of a WebHook. It is not
+ * expected to use this service directly (hence abstract), instead provide a specific implementation
  * that provides the webHookEndpoint, retriesOn5xxErrors and possibly other details in the future.
  *
- *  For examples of the existing implementations:
- *  @see com.vmware.taurus.datajobs.webhook.PostDeleteWebHookProvider
- *  @see com.vmware.taurus.datajobs.webhook.PostCreateWebHookProvider
- *  @see com.vmware.taurus.authorization.webhook.AuthorizationWebHookProvider
+ * <p>For examples of the existing implementations:
  *
+ * @see com.vmware.taurus.datajobs.webhook.PostDeleteWebHookProvider
+ * @see com.vmware.taurus.datajobs.webhook.PostCreateWebHookProvider
+ * @see com.vmware.taurus.authorization.webhook.AuthorizationWebHookProvider
  */
 @Service
 @RequiredArgsConstructor
 public abstract class WebHookService<T extends WebHookRequestBody> implements InitializingBean {
 
-   @Getter
-   private final String webHookEndpoint;
+  @Getter private final String webHookEndpoint;
 
-   private final int retriesOn5xxErrors;
+  private final int retriesOn5xxErrors;
 
-   private final Logger log;
+  private final Logger log;
 
-   @Autowired
-   private RestTemplate restTemplate;
+  @Autowired private RestTemplate restTemplate;
 
-   public Optional<WebHookResult> invokeWebHook(T webHookRequestBody) {
-      ensureConfigured();
+  public Optional<WebHookResult> invokeWebHook(T webHookRequestBody) {
+    ensureConfigured();
 
-      if(StringUtils.isBlank(getWebHookEndpoint())) {
-         log.debug("The webHook Endpoint is not configured. Requests will not be send ...");
-         return Optional.empty();
-      }
+    if (StringUtils.isBlank(getWebHookEndpoint())) {
+      log.debug("The webHook Endpoint is not configured. Requests will not be send ...");
+      return Optional.empty();
+    }
 
-      ResponseEntity responseEntity = sendRequest(webHookRequestBody);
+    ResponseEntity responseEntity = sendRequest(webHookRequestBody);
 
-      if (responseEntity.getStatusCode().is5xxServerError()) {
-         log.debug("The WebHook invocation {} returns 5xxServerError ...", getWebHookEndpoint());
-         responseEntity = retry5xxWebHookRequest(webHookRequestBody, responseEntity);
-      }
-      if (responseEntity.getStatusCode().is4xxClientError()) {
-         log.debug("The WebHook invocation {} returns 4xxClientError ...", getWebHookEndpoint());
-         return Optional.of(provideClientErrorMessage(responseEntity));
-      }
-      if (responseEntity.getStatusCode().is2xxSuccessful()) {
-         log.debug("The WebHook invocation {} is successful ...", getWebHookEndpoint());
-         return Optional.of(provideSuccessMessage(responseEntity));
-      }
+    if (responseEntity.getStatusCode().is5xxServerError()) {
+      log.debug("The WebHook invocation {} returns 5xxServerError ...", getWebHookEndpoint());
+      responseEntity = retry5xxWebHookRequest(webHookRequestBody, responseEntity);
+    }
+    if (responseEntity.getStatusCode().is4xxClientError()) {
+      log.debug("The WebHook invocation {} returns 4xxClientError ...", getWebHookEndpoint());
+      return Optional.of(provideClientErrorMessage(responseEntity));
+    }
+    if (responseEntity.getStatusCode().is2xxSuccessful()) {
+      log.debug("The WebHook invocation {} is successful ...", getWebHookEndpoint());
+      return Optional.of(provideSuccessMessage(responseEntity));
+    }
 
-      log.debug("The WebHook invocation {} returns unhandled status code:  {}",
-              getWebHookEndpoint(), responseEntity.getStatusCode().value());
-      ExternalSystemError.MainExternalSystem mainExternalSystem = getExternalSystemType();
-      throw new ExternalSystemError(
-              mainExternalSystem,
-              String.format("Webhook server returned non successful status code: %d",
-                      responseEntity.getStatusCode().value()));
-   }
+    log.debug(
+        "The WebHook invocation {} returns unhandled status code:  {}",
+        getWebHookEndpoint(),
+        responseEntity.getStatusCode().value());
+    ExternalSystemError.MainExternalSystem mainExternalSystem = getExternalSystemType();
+    throw new ExternalSystemError(
+        mainExternalSystem,
+        String.format(
+            "Webhook server returned non successful status code: %d",
+            responseEntity.getStatusCode().value()));
+  }
 
-   private ResponseEntity retry5xxWebHookRequest(T webHookRequestBody,
-                                                 ResponseEntity responseEntity) {
-      int current5xxServerRetry = 0;
-      while(responseEntity.getStatusCode().is5xxServerError() &&
-              current5xxServerRetry < retriesOn5xxErrors) {
-         current5xxServerRetry++;
+  private ResponseEntity retry5xxWebHookRequest(
+      T webHookRequestBody, ResponseEntity responseEntity) {
+    int current5xxServerRetry = 0;
+    while (responseEntity.getStatusCode().is5xxServerError()
+        && current5xxServerRetry < retriesOn5xxErrors) {
+      current5xxServerRetry++;
 
-         log.debug("WebHook retry #{} for the 5xxServerError ...", current5xxServerRetry);
-         responseEntity = sendRequest(webHookRequestBody);
-      }
+      log.debug("WebHook retry #{} for the 5xxServerError ...", current5xxServerRetry);
+      responseEntity = sendRequest(webHookRequestBody);
+    }
 
-      if(current5xxServerRetry == 0) {
-         log.debug("No WebHook reties are attempted for the 5xxServerError ...", current5xxServerRetry);
-      }
-      return responseEntity;
-   }
+    if (current5xxServerRetry == 0) {
+      log.debug(
+          "No WebHook reties are attempted for the 5xxServerError ...", current5xxServerRetry);
+    }
+    return responseEntity;
+  }
 
-   private ResponseEntity sendRequest(T webHookRequestBody) {
-      // TODO: possibly implement custom ResponseErrorHandler and add it to the restTemplate if necessary
-      log.info("WebHook body: {}", webHookRequestBody.toString());
-      try {
-         HttpEntity<WebHookRequestBody> request = new HttpEntity<>(webHookRequestBody);
-         return restTemplate.exchange(
-                 getWebHookRequestURL(webHookRequestBody),
-                 HttpMethod.POST,
-                 request,
-                 String.class);
-      } catch (RestClientResponseException responseException) {
-         return new ResponseEntity<>(
-                 responseException.getResponseBodyAsString(),
-                 responseException.getResponseHeaders(),
-                 HttpStatus.resolve(responseException.getRawStatusCode()));
-      }
-   }
+  private ResponseEntity sendRequest(T webHookRequestBody) {
+    // TODO: possibly implement custom ResponseErrorHandler and add it to the restTemplate if
+    // necessary
+    log.info("WebHook body: {}", webHookRequestBody.toString());
+    try {
+      HttpEntity<WebHookRequestBody> request = new HttpEntity<>(webHookRequestBody);
+      return restTemplate.exchange(
+          getWebHookRequestURL(webHookRequestBody), HttpMethod.POST, request, String.class);
+    } catch (RestClientResponseException responseException) {
+      return new ResponseEntity<>(
+          responseException.getResponseBodyAsString(),
+          responseException.getResponseHeaders(),
+          HttpStatus.resolve(responseException.getRawStatusCode()));
+    }
+  }
 
-   @Override
-   public void afterPropertiesSet() {
-   }
+  @Override
+  public void afterPropertiesSet() {}
 
-   /**
-    * Callback invoked before the execution of the requests to the WebHook server. <br>
-    * By default, the service is considered as configured, however this is a good place to throw an exception
-    * to break the execution flow. <br>
-    * Note: If the webHookEndpoint is not configured, the service will skip the invocation anyway.
-    */
-   protected void ensureConfigured() {
-   }
+  /**
+   * Callback invoked before the execution of the requests to the WebHook server. <br>
+   * By default, the service is considered as configured, however this is a good place to throw an
+   * exception to break the execution flow. <br>
+   * Note: If the webHookEndpoint is not configured, the service will skip the invocation anyway.
+   */
+  protected void ensureConfigured() {}
 
-   /**
-    * Callback that allows the implementations to construct specific Request URL for each request
-    * sent to the WebHook server.
-    * @param webHookRequestBody the request body that gives the context of the execution
-    * @return a valid URL
-    */
-   protected String getWebHookRequestURL(T webHookRequestBody) {
-      return getWebHookEndpoint() + webHookRequestBody.getRequestedHttpPath();
-   }
+  /**
+   * Callback that allows the implementations to construct specific Request URL for each request
+   * sent to the WebHook server.
+   *
+   * @param webHookRequestBody the request body that gives the context of the execution
+   * @return a valid URL
+   */
+  protected String getWebHookRequestURL(T webHookRequestBody) {
+    return getWebHookEndpoint() + webHookRequestBody.getRequestedHttpPath();
+  }
 
-   /**
-    * Instruct the system what is the external system type of the webhook server.<br>
-    * By default, the external system type is considered as the generic WEBHOOK_SERVER.
-    * @return the Main External System Type
-    */
-   protected ExternalSystemError.MainExternalSystem getExternalSystemType() {
-      return ExternalSystemError.MainExternalSystem.WEBHOOK_SERVER;
-   }
+  /**
+   * Instruct the system what is the external system type of the webhook server.<br>
+   * By default, the external system type is considered as the generic WEBHOOK_SERVER.
+   *
+   * @return the Main External System Type
+   */
+  protected ExternalSystemError.MainExternalSystem getExternalSystemType() {
+    return ExternalSystemError.MainExternalSystem.WEBHOOK_SERVER;
+  }
 
-   /**
-    * Construct the Client Error Message based on the response Entity(4xx Response Code)
-    * that is returned by the request.
-    * @param responseEntity the 4xx response entity of the request
-    * @return the Client Error Message
-    */
-   protected WebHookResult provideClientErrorMessage(ResponseEntity responseEntity) {
-      return WebHookResult.builder()
-              .status(responseEntity.getStatusCode())
-              .message(responseEntity.getBody().toString())
-              .success(false)
-              .build();
-   }
+  /**
+   * Construct the Client Error Message based on the response Entity(4xx Response Code) that is
+   * returned by the request.
+   *
+   * @param responseEntity the 4xx response entity of the request
+   * @return the Client Error Message
+   */
+  protected WebHookResult provideClientErrorMessage(ResponseEntity responseEntity) {
+    return WebHookResult.builder()
+        .status(responseEntity.getStatusCode())
+        .message(responseEntity.getBody().toString())
+        .success(false)
+        .build();
+  }
 
-   /**
-    * Construct the Success Message based on the response Entity(2xx Response Code)
-    * that is returned by the request.
-    * @param responseEntity the 2xx response entity of the request
-    * @return the Success Message
-    */
-   protected WebHookResult provideSuccessMessage(ResponseEntity responseEntity) {
-      return WebHookResult.builder()
-              .status(responseEntity.getStatusCode())
-              .message("")
-              .success(true)
-              .build();
-   }
+  /**
+   * Construct the Success Message based on the response Entity(2xx Response Code) that is returned
+   * by the request.
+   *
+   * @param responseEntity the 2xx response entity of the request
+   * @return the Success Message
+   */
+  protected WebHookResult provideSuccessMessage(ResponseEntity responseEntity) {
+    return WebHookResult.builder()
+        .status(responseEntity.getStatusCode())
+        .message("")
+        .success(true)
+        .build();
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/KerberosUtil.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/KerberosUtil.java
@@ -15,27 +15,26 @@ import java.net.URL;
 import java.security.PrivilegedActionException;
 
 public class KerberosUtil {
-   /**
-    * Creates and returns a connection to a kerberos secured endpoint.
-    *
-    * @param requestURL the endpoint to make the connection to.
-    * @param kdcAuthURL the KDC server's host.
-    * @param clientPrincipal the principal aka username.
-    * @param keytabLocation the keytab file with the credentials.
-    * @return HttpURLConnection object which can be used to make requests.
-    * @throws IOException
-    * @throws PrivilegedActionException
-    * @throws GSSException
-    */
-   public static HttpURLConnection requestWithKerberosAuth(URL requestURL, URL kdcAuthURL,
-                                                           String clientPrincipal, String keytabLocation)
-         throws IOException, PrivilegedActionException, GSSException {
+  /**
+   * Creates and returns a connection to a kerberos secured endpoint.
+   *
+   * @param requestURL the endpoint to make the connection to.
+   * @param kdcAuthURL the KDC server's host.
+   * @param clientPrincipal the principal aka username.
+   * @param keytabLocation the keytab file with the credentials.
+   * @return HttpURLConnection object which can be used to make requests.
+   * @throws IOException
+   * @throws PrivilegedActionException
+   * @throws GSSException
+   */
+  public static HttpURLConnection requestWithKerberosAuth(
+      URL requestURL, URL kdcAuthURL, String clientPrincipal, String keytabLocation)
+      throws IOException, PrivilegedActionException, GSSException {
 
-      SpnegoClient spnegoClient = SpnegoClient.loginWithKeyTab(clientPrincipal, keytabLocation);
-      SpnegoContext context = spnegoClient.createContext(kdcAuthURL);
-      HttpURLConnection conn = (HttpURLConnection) requestURL.openConnection();
-      conn.setRequestProperty("Authorization", context.createTokenAsAuthroizationHeader());
-      return conn;
-
-   }
+    SpnegoClient spnegoClient = SpnegoClient.loginWithKeyTab(clientPrincipal, keytabLocation);
+    SpnegoContext context = spnegoClient.createContext(kdcAuthURL);
+    HttpURLConnection conn = (HttpURLConnection) requestURL.openConnection();
+    conn.setRequestProperty("Authorization", context.createTokenAsAuthroizationHeader());
+    return conn;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/RepositoryUtil.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/RepositoryUtil.java
@@ -19,87 +19,117 @@ import java.time.OffsetDateTime;
 
 public final class RepositoryUtil {
 
-   public static DataJob createDataJob(JobsRepository jobsRepository) {
-      return createDataJob(jobsRepository, "test-job");
-   }
+  public static DataJob createDataJob(JobsRepository jobsRepository) {
+    return createDataJob(jobsRepository, "test-job");
+  }
 
-   public static DataJob createDataJob(JobsRepository jobsRepository, String jobName){
-      return createDataJob(jobsRepository, jobName, "test-team");
-   }
+  public static DataJob createDataJob(JobsRepository jobsRepository, String jobName) {
+    return createDataJob(jobsRepository, jobName, "test-team");
+  }
 
-   public static DataJob createDataJob(JobsRepository jobsRepository, String jobName, String jobTeam) {
-      JobConfig config = new JobConfig();
-      config.setSchedule("schedule");
-      config.setTeam(jobTeam);
-      var expectedJob = new DataJob(jobName, config, DeploymentStatus.NONE);
-      var actualJob = jobsRepository.save(expectedJob);
-      Assertions.assertEquals(expectedJob, actualJob);
+  public static DataJob createDataJob(
+      JobsRepository jobsRepository, String jobName, String jobTeam) {
+    JobConfig config = new JobConfig();
+    config.setSchedule("schedule");
+    config.setTeam(jobTeam);
+    var expectedJob = new DataJob(jobName, config, DeploymentStatus.NONE);
+    var actualJob = jobsRepository.save(expectedJob);
+    Assertions.assertEquals(expectedJob, actualJob);
 
-      return actualJob;
-   }
+    return actualJob;
+  }
 
+  public static DataJobExecution createDataJobExecution(
+      JobExecutionRepository jobExecutionRepository,
+      String executionId,
+      DataJob dataJob,
+      ExecutionStatus executionStatus) {
 
-   public static DataJobExecution createDataJobExecution(
-         JobExecutionRepository jobExecutionRepository,
-         String executionId,
-         DataJob dataJob,
-         ExecutionStatus executionStatus) {
+    return createDataJobExecution(
+        jobExecutionRepository, executionId, dataJob, executionStatus, "test_message");
+  }
 
-      return createDataJobExecution(jobExecutionRepository, executionId, dataJob, executionStatus, "test_message");
-   }
+  public static DataJobExecution createDataJobExecution(
+      JobExecutionRepository jobExecutionRepository,
+      String executionId,
+      DataJob dataJob,
+      ExecutionStatus executionStatus,
+      OffsetDateTime startTime,
+      OffsetDateTime endTime) {
 
-   public static DataJobExecution createDataJobExecution(
-         JobExecutionRepository jobExecutionRepository,
-         String executionId,
-         DataJob dataJob,
-         ExecutionStatus executionStatus,
-         OffsetDateTime startTime,
-         OffsetDateTime endTime) {
+    return createDataJobExecution(
+        jobExecutionRepository,
+        executionId,
+        dataJob,
+        executionStatus,
+        "test_message",
+        startTime,
+        endTime);
+  }
 
-      return createDataJobExecution(jobExecutionRepository, executionId, dataJob, executionStatus, "test_message", startTime, endTime);
-   }
+  public static DataJobExecution createDataJobExecution(
+      JobExecutionRepository jobExecutionRepository,
+      String executionId,
+      DataJob dataJob,
+      ExecutionStatus executionStatus,
+      String message,
+      OffsetDateTime startTime) {
 
-   public static DataJobExecution createDataJobExecution(
-         JobExecutionRepository jobExecutionRepository,
-         String executionId,
-         DataJob dataJob,
-         ExecutionStatus executionStatus,
-         String message,
-         OffsetDateTime startTime) {
+    return createDataJobExecution(
+        jobExecutionRepository,
+        executionId,
+        dataJob,
+        executionStatus,
+        message,
+        startTime,
+        OffsetDateTime.now());
+  }
 
-      return createDataJobExecution(jobExecutionRepository, executionId, dataJob, executionStatus, message, startTime, OffsetDateTime.now());
-   }
+  public static DataJobExecution createDataJobExecution(
+      JobExecutionRepository jobExecutionRepository,
+      String executionId,
+      DataJob dataJob,
+      ExecutionStatus executionStatus,
+      OffsetDateTime startTime) {
 
-   public static DataJobExecution createDataJobExecution(
-         JobExecutionRepository jobExecutionRepository,
-         String executionId,
-         DataJob dataJob,
-         ExecutionStatus executionStatus,
-         OffsetDateTime startTime) {
+    return createDataJobExecution(
+        jobExecutionRepository,
+        executionId,
+        dataJob,
+        executionStatus,
+        "test_message",
+        startTime,
+        OffsetDateTime.now());
+  }
 
-      return createDataJobExecution(jobExecutionRepository, executionId, dataJob, executionStatus, "test_message", startTime, OffsetDateTime.now());
-   }
+  public static DataJobExecution createDataJobExecution(
+      JobExecutionRepository jobExecutionRepository,
+      String executionId,
+      DataJob dataJob,
+      ExecutionStatus executionStatus,
+      String message) {
 
-   public static DataJobExecution createDataJobExecution(
-         JobExecutionRepository jobExecutionRepository,
-         String executionId,
-         DataJob dataJob,
-         ExecutionStatus executionStatus,
-         String message) {
+    return createDataJobExecution(
+        jobExecutionRepository,
+        executionId,
+        dataJob,
+        executionStatus,
+        message,
+        OffsetDateTime.now(),
+        OffsetDateTime.now());
+  }
 
-      return createDataJobExecution(jobExecutionRepository, executionId, dataJob, executionStatus, message, OffsetDateTime.now(), OffsetDateTime.now());
-   }
+  public static DataJobExecution createDataJobExecution(
+      JobExecutionRepository jobExecutionRepository,
+      String executionId,
+      DataJob dataJob,
+      ExecutionStatus executionStatus,
+      String message,
+      OffsetDateTime startTime,
+      OffsetDateTime endTime) {
 
-   public static DataJobExecution createDataJobExecution(
-         JobExecutionRepository jobExecutionRepository,
-         String executionId,
-         DataJob dataJob,
-         ExecutionStatus executionStatus,
-         String message,
-         OffsetDateTime startTime,
-         OffsetDateTime endTime) {
-
-      var expectedJobExecution = DataJobExecution.builder()
+    var expectedJobExecution =
+        DataJobExecution.builder()
             .id(executionId)
             .dataJob(dataJob)
             .startTime(startTime)
@@ -119,6 +149,6 @@ public final class RepositoryUtil {
             .vdkVersion("test_vdk_version")
             .build();
 
-      return jobExecutionRepository.save(expectedJobExecution);
-   }
+    return jobExecutionRepository.save(expectedJobExecution);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/TestIOUtils.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/TestIOUtils.java
@@ -15,29 +15,40 @@ import java.nio.file.Path;
 
 public final class TestIOUtils {
 
-   public static void compareDirectories(File expectedDirectory, File actualDirectory) throws IOException {
-       Files.walk(expectedDirectory.toPath())
-               .forEach( expected ->  {
-                   // System.out.println(expected);
-                   Path actual = new File(actualDirectory, expectedDirectory.toPath().relativize(expected).toString()).toPath();
-                   if (expected.toFile().isDirectory()) {
-                       Assertions.assertTrue(actual.toFile().isDirectory(), "Expected directory: " + actual);
-                   } else {
-                       Assertions.assertTrue(actual.toFile().isFile(), "Expected file: " + actual);
-                       Assertions.assertEquals(fileToString(expected), fileToString(actual));
-                   }
-               });
-       Files.walk(actualDirectory.toPath())
-               .forEach( actual ->  {
-                   Path expected = new File(expectedDirectory, actualDirectory.toPath().relativize(actual).toString()).toPath();
-                   if (!expected.toFile().exists()) {
-                       Assertions.fail("Did not expect this file or directory: " + actual);
-                   }
-               });
-   }
+  public static void compareDirectories(File expectedDirectory, File actualDirectory)
+      throws IOException {
+    Files.walk(expectedDirectory.toPath())
+        .forEach(
+            expected -> {
+              // System.out.println(expected);
+              Path actual =
+                  new File(
+                          actualDirectory,
+                          expectedDirectory.toPath().relativize(expected).toString())
+                      .toPath();
+              if (expected.toFile().isDirectory()) {
+                Assertions.assertTrue(
+                    actual.toFile().isDirectory(), "Expected directory: " + actual);
+              } else {
+                Assertions.assertTrue(actual.toFile().isFile(), "Expected file: " + actual);
+                Assertions.assertEquals(fileToString(expected), fileToString(actual));
+              }
+            });
+    Files.walk(actualDirectory.toPath())
+        .forEach(
+            actual -> {
+              Path expected =
+                  new File(
+                          expectedDirectory, actualDirectory.toPath().relativize(actual).toString())
+                      .toPath();
+              if (!expected.toFile().exists()) {
+                Assertions.fail("Did not expect this file or directory: " + actual);
+              }
+            });
+  }
 
-   @SneakyThrows
-   private static String fileToString(Path filePath) {
-      return Files.readString(filePath);
-   }
+  @SneakyThrows
+  private static String fileToString(Path filePath) {
+    return Files.readString(filePath);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/authorization/AuthorizationInterceptorTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/authorization/AuthorizationInterceptorTest.java
@@ -30,181 +30,167 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import java.io.IOException;
 import java.util.Optional;
 
-
 @ExtendWith(MockitoExtension.class)
 public class AuthorizationInterceptorTest {
 
-    @Mock
-    private SecurityContextHolder securityContextHolder;
+  @Mock private SecurityContextHolder securityContextHolder;
 
-    @Mock
-    private FeatureFlags featureFlags;
+  @Mock private FeatureFlags featureFlags;
 
-    @Mock
-    private AuthorizationWebHookProvider webhookProvider;
+  @Mock private AuthorizationWebHookProvider webhookProvider;
 
-    @Mock
-    private JobsRepository jobsRepository;
+  @Mock private JobsRepository jobsRepository;
 
-    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-    private AuthorizationProvider authorizationProvider;
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private AuthorizationProvider authorizationProvider;
 
-    @Mock
-    private JwtAuthenticationToken jwtAuthenticationToken;
+  @Mock private JwtAuthenticationToken jwtAuthenticationToken;
 
-    @Mock
-    private OperationContext opCtx;
+  @Mock private OperationContext opCtx;
 
-    @InjectMocks
-    private AuthorizationInterceptor authorizationInterceptor;
+  @InjectMocks private AuthorizationInterceptor authorizationInterceptor;
 
+  @Test
+  public void testAuthAndAuthzEnabledSuccessPOST() throws IOException {
+    Mockito.when(featureFlags.isSecurityEnabled()).thenReturn(true);
+    Mockito.when(featureFlags.isAuthorizationEnabled()).thenReturn(true);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    request.setMethod("post");
+    Mockito.when(webhookProvider.invokeWebHook(Mockito.any()))
+        .thenReturn(
+            Optional.of(
+                WebHookResult.builder().status(HttpStatus.OK).message("").success(true).build()));
+    Mockito.when(jwtAuthenticationToken.isAuthenticated()).thenReturn(true);
+    SecurityContext securityContext = Mockito.mock(SecurityContext.class);
+    Mockito.when(securityContext.getAuthentication()).thenReturn(jwtAuthenticationToken);
+    SecurityContextHolder.setContext(securityContext);
 
-    @Test
-    public void testAuthAndAuthzEnabledSuccessPOST() throws IOException {
-        Mockito.when(featureFlags.isSecurityEnabled()).thenReturn(true);
-        Mockito.when(featureFlags.isAuthorizationEnabled()).thenReturn(true);
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        request.setMethod("post");
-        Mockito.when(webhookProvider.invokeWebHook(Mockito.any()))
-                .thenReturn(Optional.of(WebHookResult.builder()
-                        .status(HttpStatus.OK)
-                        .message("")
-                        .success(true)
-                        .build()));
-        Mockito.when(jwtAuthenticationToken.isAuthenticated()).thenReturn(true);
-        SecurityContext securityContext = Mockito.mock(SecurityContext.class);
-        Mockito.when(securityContext.getAuthentication()).thenReturn(jwtAuthenticationToken);
-        SecurityContextHolder.setContext(securityContext);
+    var pass = authorizationInterceptor.preHandle(request, response, new Object());
 
-        var pass = authorizationInterceptor.preHandle(request, response, new Object());
+    Assertions.assertEquals(true, pass);
+    Assertions.assertEquals(HttpStatus.OK.value(), response.getStatus());
+    Assertions.assertEquals("", response.getContentAsString());
+  }
 
-        Assertions.assertEquals(true, pass);
-        Assertions.assertEquals(HttpStatus.OK.value(), response.getStatus());
-        Assertions.assertEquals("", response.getContentAsString());
-    }
+  @Test
+  public void testAuthAndAuthzEnabledSuccessGET() throws IOException {
+    Mockito.when(featureFlags.isSecurityEnabled()).thenReturn(true);
+    Mockito.when(featureFlags.isAuthorizationEnabled()).thenReturn(true);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    request.setMethod("get");
+    Mockito.when(webhookProvider.invokeWebHook(Mockito.any()))
+        .thenReturn(
+            Optional.of(
+                WebHookResult.builder().status(HttpStatus.OK).message("").success(true).build()));
+    Mockito.when(jwtAuthenticationToken.isAuthenticated()).thenReturn(true);
+    SecurityContext securityContext = Mockito.mock(SecurityContext.class);
+    Mockito.when(securityContext.getAuthentication()).thenReturn(jwtAuthenticationToken);
+    SecurityContextHolder.setContext(securityContext);
 
-    @Test
-    public void testAuthAndAuthzEnabledSuccessGET() throws IOException {
-        Mockito.when(featureFlags.isSecurityEnabled()).thenReturn(true);
-        Mockito.when(featureFlags.isAuthorizationEnabled()).thenReturn(true);
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        request.setMethod("get");
-        Mockito.when(webhookProvider.invokeWebHook(Mockito.any()))
-                .thenReturn(Optional.of(WebHookResult.builder()
-                        .status(HttpStatus.OK)
-                        .message("")
-                        .success(true)
-                        .build()));
-        Mockito.when(jwtAuthenticationToken.isAuthenticated()).thenReturn(true);
-        SecurityContext securityContext = Mockito.mock(SecurityContext.class);
-        Mockito.when(securityContext.getAuthentication()).thenReturn(jwtAuthenticationToken);
-        SecurityContextHolder.setContext(securityContext);
+    var pass = authorizationInterceptor.preHandle(request, response, new Object());
 
-        var pass = authorizationInterceptor.preHandle(request, response, new Object());
+    Assertions.assertEquals(true, pass);
+    Assertions.assertEquals(HttpStatus.OK.value(), response.getStatus());
+    Assertions.assertEquals("", response.getContentAsString());
+  }
 
-        Assertions.assertEquals(true, pass);
-        Assertions.assertEquals(HttpStatus.OK.value(), response.getStatus());
-        Assertions.assertEquals("", response.getContentAsString());
-    }
+  @Test
+  public void testAuthAndAuthzEnabledSuccessPUT() throws IOException {
+    Mockito.when(featureFlags.isSecurityEnabled()).thenReturn(true);
+    Mockito.when(featureFlags.isAuthorizationEnabled()).thenReturn(true);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    request.setMethod("put");
+    Mockito.when(jwtAuthenticationToken.isAuthenticated()).thenReturn(true);
+    SecurityContext securityContext = Mockito.mock(SecurityContext.class);
+    Mockito.when(webhookProvider.invokeWebHook(Mockito.any()))
+        .thenReturn(
+            Optional.of(
+                WebHookResult.builder().status(HttpStatus.OK).message("").success(true).build()));
+    Mockito.when(securityContext.getAuthentication()).thenReturn(jwtAuthenticationToken);
+    SecurityContextHolder.setContext(securityContext);
 
-    @Test
-    public void testAuthAndAuthzEnabledSuccessPUT() throws IOException {
-        Mockito.when(featureFlags.isSecurityEnabled()).thenReturn(true);
-        Mockito.when(featureFlags.isAuthorizationEnabled()).thenReturn(true);
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        request.setMethod("put");
-        Mockito.when(jwtAuthenticationToken.isAuthenticated()).thenReturn(true);
-        SecurityContext securityContext = Mockito.mock(SecurityContext.class);
-        Mockito.when(webhookProvider.invokeWebHook(Mockito.any()))
-                .thenReturn(Optional.of(WebHookResult.builder()
-                        .status(HttpStatus.OK)
-                        .message("")
-                        .success(true)
-                        .build()));
-        Mockito.when(securityContext.getAuthentication()).thenReturn(jwtAuthenticationToken);
-        SecurityContextHolder.setContext(securityContext);
+    var pass = authorizationInterceptor.preHandle(request, response, new Object());
 
-        var pass = authorizationInterceptor.preHandle(request, response, new Object());
+    Assertions.assertEquals(true, pass);
+    Assertions.assertEquals(HttpStatus.OK.value(), response.getStatus());
+    Assertions.assertEquals("", response.getContentAsString());
+  }
 
-        Assertions.assertEquals(true, pass);
-        Assertions.assertEquals(HttpStatus.OK.value(), response.getStatus());
-        Assertions.assertEquals("", response.getContentAsString());
-    }
+  @Test
+  public void testAuthAndAuthzEnabledUnauthorizedPUT() throws IOException {
+    Mockito.when(featureFlags.isSecurityEnabled()).thenReturn(true);
+    Mockito.when(featureFlags.isAuthorizationEnabled()).thenReturn(true);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    request.setMethod("put");
+    Mockito.when(jwtAuthenticationToken.isAuthenticated()).thenReturn(true);
+    SecurityContext securityContext = Mockito.mock(SecurityContext.class);
+    Mockito.when(webhookProvider.invokeWebHook(Mockito.any()))
+        .thenReturn(
+            Optional.of(
+                WebHookResult.builder()
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .message("Missing team body")
+                    .success(true)
+                    .build()));
+    Mockito.when(securityContext.getAuthentication()).thenReturn(jwtAuthenticationToken);
+    SecurityContextHolder.setContext(securityContext);
 
-    @Test
-    public void testAuthAndAuthzEnabledUnauthorizedPUT() throws IOException {
-        Mockito.when(featureFlags.isSecurityEnabled()).thenReturn(true);
-        Mockito.when(featureFlags.isAuthorizationEnabled()).thenReturn(true);
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        request.setMethod("put");
-        Mockito.when(jwtAuthenticationToken.isAuthenticated()).thenReturn(true);
-        SecurityContext securityContext = Mockito.mock(SecurityContext.class);
-        Mockito.when(webhookProvider.invokeWebHook(Mockito.any()))
-                .thenReturn(Optional.of(WebHookResult.builder()
-                        .status(HttpStatus.UNAUTHORIZED)
-                        .message("Missing team body")
-                        .success(true)
-                        .build()));
-        Mockito.when(securityContext.getAuthentication()).thenReturn(jwtAuthenticationToken);
-        SecurityContextHolder.setContext(securityContext);
+    var pass = authorizationInterceptor.preHandle(request, response, new Object());
 
-        var pass = authorizationInterceptor.preHandle(request, response, new Object());
+    Assertions.assertEquals(true, pass);
+    Assertions.assertEquals(HttpStatus.UNAUTHORIZED.value(), response.getStatus());
+    Assertions.assertEquals("Missing team body", response.getContentAsString());
+  }
 
-        Assertions.assertEquals(true, pass);
-        Assertions.assertEquals(HttpStatus.UNAUTHORIZED.value(), response.getStatus());
-        Assertions.assertEquals("Missing team body", response.getContentAsString());
-    }
+  @Test
+  public void testAuthDisabled() throws IOException {
+    Mockito.when(featureFlags.isSecurityEnabled()).thenReturn(false);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
 
-    @Test
-    public void testAuthDisabled() throws IOException {
-        Mockito.when(featureFlags.isSecurityEnabled()).thenReturn(false);
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
+    var pass = authorizationInterceptor.preHandle(request, response, new Object());
 
-        var pass = authorizationInterceptor.preHandle(request, response, new Object());
+    Assertions.assertEquals(true, pass);
+    Assertions.assertEquals(HttpStatus.OK.value(), response.getStatus());
+    Assertions.assertEquals("", response.getContentAsString());
+  }
 
-        Assertions.assertEquals(true, pass);
-        Assertions.assertEquals(HttpStatus.OK.value(), response.getStatus());
-        Assertions.assertEquals("", response.getContentAsString());
-    }
+  @Test
+  public void testAuthDisabledAuthzEnabled() throws IOException {
+    Mockito.when(featureFlags.isSecurityEnabled()).thenReturn(true);
+    Mockito.when(featureFlags.isAuthorizationEnabled()).thenReturn(false);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
 
-    @Test
-    public void testAuthDisabledAuthzEnabled() throws IOException {
-        Mockito.when(featureFlags.isSecurityEnabled()).thenReturn(true);
-        Mockito.when(featureFlags.isAuthorizationEnabled()).thenReturn(false);
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
+    var pass = authorizationInterceptor.preHandle(request, response, new Object());
 
-        var pass = authorizationInterceptor.preHandle(request, response, new Object());
+    Assertions.assertEquals(true, pass);
+    Assertions.assertEquals(HttpStatus.OK.value(), response.getStatus());
+    Assertions.assertEquals("", response.getContentAsString());
+  }
 
-        Assertions.assertEquals(true, pass);
-        Assertions.assertEquals(HttpStatus.OK.value(), response.getStatus());
-        Assertions.assertEquals("", response.getContentAsString());
-    }
+  /**
+   * The test shows that given the endpoints which does not have authentication enabled as per
+   * {@link SecurityConfiguration} and are missing authentication token the preHandle method won't
+   * throw an exception, but rather let the request pass due to the null authentication
+   */
+  @Test
+  public void testAuthenticationNullForDisabledEndpoints() throws IOException {
+    Mockito.when(featureFlags.isSecurityEnabled()).thenReturn(true);
+    SecurityContext securityContext = Mockito.mock(SecurityContext.class);
+    Mockito.when(securityContext.getAuthentication()).thenReturn(null);
+    SecurityContextHolder.setContext(securityContext);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
 
-    /**
-     * The test shows that given the endpoints which does not have authentication
-     * enabled as per {@link SecurityConfiguration} and are missing authentication
-     * token the preHandle method won't throw an exception, but rather let the
-     * request pass due to the null authentication
-     */
-    @Test
-    public void testAuthenticationNullForDisabledEndpoints() throws IOException {
-        Mockito.when(featureFlags.isSecurityEnabled()).thenReturn(true);
-        SecurityContext securityContext = Mockito.mock(SecurityContext.class);
-        Mockito.when(securityContext.getAuthentication()).thenReturn(null);
-        SecurityContextHolder.setContext(securityContext);
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
+    var pass = authorizationInterceptor.preHandle(request, response, new Object());
 
-        var pass = authorizationInterceptor.preHandle(request, response, new Object());
-
-        Assertions.assertEquals(true, pass);
-        Assertions.assertEquals(HttpStatus.OK.value(), response.getStatus());
-        Assertions.assertEquals("", response.getContentAsString());
-    }
+    Assertions.assertEquals(true, pass);
+    Assertions.assertEquals(HttpStatus.OK.value(), response.getStatus());
+    Assertions.assertEquals("", response.getContentAsString());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/authorization/KerberosAuthenticationIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/authorization/KerberosAuthenticationIT.java
@@ -27,19 +27,16 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 
 /**
- * This test is in the unit tests directory, because:
- * A) it's fast (it takes a few seconds)
- * B) It mocks and manages all its dependencies and does not create side effects .
- * C) It does not work well with MiniKDC e.g
- * Our integration tests use the MiniKdc server provided
- * by spring which as of today hasn't received any updates
- * in a long time and is problematic. However, minikdc leaves
- * some files and configurations that interfere with apache kerby
- * and both tests cannot run on the same runner (even after invoking
- * the provided cleanup mehtods by the libraries). We should look into
+ * This test is in the unit tests directory, because: A) it's fast (it takes a few seconds) B) It
+ * mocks and manages all its dependencies and does not create side effects . C) It does not work
+ * well with MiniKDC e.g Our integration tests use the MiniKdc server provided by spring which as of
+ * today hasn't received any updates in a long time and is problematic. However, minikdc leaves some
+ * files and configurations that interfere with apache kerby and both tests cannot run on the same
+ * runner (even after invoking the provided cleanup mehtods by the libraries). We should look into
  * migrating to apache kerby for our integration tests too.
  */
-@TestPropertySource(properties = {
+@TestPropertySource(
+    properties = {
       "test.dir=target",
       "featureflag.security.enabled=true",
       "datajobs.security.kerberos.enabled=true",
@@ -50,54 +47,57 @@ import java.net.URL;
       "java.security.krb5.conf=target/krb5.conf",
       "sun.security.krb5.debug=true",
       "datajobs.authorization.authorized-roles="
-})
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = ControlplaneApplication.class)
+    })
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = ControlplaneApplication.class)
 @ExtendWith(SpringExtension.class)
 public class KerberosAuthenticationIT extends TestKerberosServerHelper {
 
-   @Autowired
-   private JobsRepository jobsRepository;
+  @Autowired private JobsRepository jobsRepository;
 
-   private DataJob dataJob;
+  private DataJob dataJob;
 
-   @LocalServerPort
-   int randomPort;
+  @LocalServerPort int randomPort;
 
-   @BeforeEach
-   public void addTestJob() {
-      // Add a dummy data job so that endpoint call returns 200 instead of 404
-      dataJob = new DataJob();
-      var config = new JobConfig();
-      config.setTeam("test-team");
-      dataJob.setName("test-name");
-      dataJob.setJobConfig(config);
-      jobsRepository.save(dataJob);
-   }
+  @BeforeEach
+  public void addTestJob() {
+    // Add a dummy data job so that endpoint call returns 200 instead of 404
+    dataJob = new DataJob();
+    var config = new JobConfig();
+    config.setTeam("test-team");
+    dataJob.setName("test-name");
+    dataJob.setJobConfig(config);
+    jobsRepository.save(dataJob);
+  }
 
-   @Test
-   public void testAuthenticatedCall() throws Exception {
-      URL requestUrl = new URL("http://127.0.0.1:" + randomPort + "/data-jobs/for-team/test-team/jobs/test-name");
-      var krb5 = getSimpleKdcServer().getKrbClient().getKrbConfig();
-      URL authUrl = new URL("http://" + krb5.getKdcHost() + "/" + krb5.getKdcPort());
-      var res = KerberosUtil.requestWithKerberosAuth(requestUrl, authUrl, getCLIENT_PRINCIPAL(), getKEYTAB().getPath());
-      Assertions.assertEquals(200, res.getResponseCode());
-   }
+  @Test
+  public void testAuthenticatedCall() throws Exception {
+    URL requestUrl =
+        new URL("http://127.0.0.1:" + randomPort + "/data-jobs/for-team/test-team/jobs/test-name");
+    var krb5 = getSimpleKdcServer().getKrbClient().getKrbConfig();
+    URL authUrl = new URL("http://" + krb5.getKdcHost() + "/" + krb5.getKdcPort());
+    var res =
+        KerberosUtil.requestWithKerberosAuth(
+            requestUrl, authUrl, getCLIENT_PRINCIPAL(), getKEYTAB().getPath());
+    Assertions.assertEquals(200, res.getResponseCode());
+  }
 
-   @Test
-   public void testUnauthenticatedCall() throws Exception {
-      URL url = new URL("http://127.0.0.1:" + randomPort + "/data-jobs/for-team/test/jobs/test");
-      HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-      var res = conn.getResponseCode();
-      Assertions.assertEquals(401, res);
-   }
+  @Test
+  public void testUnauthenticatedCall() throws Exception {
+    URL url = new URL("http://127.0.0.1:" + randomPort + "/data-jobs/for-team/test/jobs/test");
+    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    var res = conn.getResponseCode();
+    Assertions.assertEquals(401, res);
+  }
 
-   @AfterEach
-   public void cleanupJob() {
-      jobsRepository.delete(dataJob);
-   }
+  @AfterEach
+  public void cleanupJob() {
+    jobsRepository.delete(dataJob);
+  }
 
-   @AfterAll
-   public static void cleanup() throws KrbException, IOException {
-      shutdownServer();
-   }
+  @AfterAll
+  public static void cleanup() throws KrbException, IOException {
+    shutdownServer();
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/authorization/TestKerberosServerHelper.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/authorization/TestKerberosServerHelper.java
@@ -16,57 +16,51 @@ import java.io.IOException;
 import java.nio.file.Files;
 
 /**
- * This class instantiates a test Kerberos server with a
- * client and server principals which can be used in testing
- * to authorize requests.
+ * This class instantiates a test Kerberos server with a client and server principals which can be
+ * used in testing to authorize requests.
  */
 @Slf4j
 public class TestKerberosServerHelper {
 
-   private static final String WORK_DIR = "target";
-   private static final File KDC_WORK_DIR = new File(WORK_DIR);
-   private static final String TGT_PRINCIPAL = "HTTP/localhost";
+  private static final String WORK_DIR = "target";
+  private static final File KDC_WORK_DIR = new File(WORK_DIR);
+  private static final String TGT_PRINCIPAL = "HTTP/localhost";
 
-   @Getter
-   private static final File KEYTAB = new File(WORK_DIR + "/foo.keytab");
-   @Getter
-   private static final String CLIENT_PRINCIPAL = "client/localhost";
-   @Getter
-   private static SimpleKdcServer simpleKdcServer;
+  @Getter private static final File KEYTAB = new File(WORK_DIR + "/foo.keytab");
+  @Getter private static final String CLIENT_PRINCIPAL = "client/localhost";
+  @Getter private static SimpleKdcServer simpleKdcServer;
 
-   /**
-    * Using static block to initialize instead of constructor
-    * because this is the only reliable way to have this code
-    * run before Spring boot test annotations. When using a
-    * constructor or JUnit Extensions test classes annotated
-    * with the @SpringBootTest annotation that depend on an
-    * initialized Kerberos server will fail.
-    */
-   static {
-      try {
-         Files.createDirectory(KDC_WORK_DIR.toPath());
-      } catch (IOException e) {
-         log.error("Failed to create test directory.", e);
-      }
+  /**
+   * Using static block to initialize instead of constructor because this is the only reliable way
+   * to have this code run before Spring boot test annotations. When using a constructor or JUnit
+   * Extensions test classes annotated with the @SpringBootTest annotation that depend on an
+   * initialized Kerberos server will fail.
+   */
+  static {
+    try {
+      Files.createDirectory(KDC_WORK_DIR.toPath());
+    } catch (IOException e) {
+      log.error("Failed to create test directory.", e);
+    }
 
-      try {
-         simpleKdcServer = new SimpleKdcServer();
-         simpleKdcServer.setWorkDir(KDC_WORK_DIR);
-         simpleKdcServer.setAllowTcp(true);
-         simpleKdcServer.setAllowUdp(true);
-         simpleKdcServer.setKdcUdpPort(NetworkUtil.getServerPort());
-         // Start the KDC server
-         simpleKdcServer.init();
-         simpleKdcServer.start();
-         simpleKdcServer.createAndExportPrincipals(KEYTAB, CLIENT_PRINCIPAL, TGT_PRINCIPAL);
-      } catch (Exception e) {
-         log.error("Failed to initialize test server. Tests will likely fail.", e);
-      }
-   }
+    try {
+      simpleKdcServer = new SimpleKdcServer();
+      simpleKdcServer.setWorkDir(KDC_WORK_DIR);
+      simpleKdcServer.setAllowTcp(true);
+      simpleKdcServer.setAllowUdp(true);
+      simpleKdcServer.setKdcUdpPort(NetworkUtil.getServerPort());
+      // Start the KDC server
+      simpleKdcServer.init();
+      simpleKdcServer.start();
+      simpleKdcServer.createAndExportPrincipals(KEYTAB, CLIENT_PRINCIPAL, TGT_PRINCIPAL);
+    } catch (Exception e) {
+      log.error("Failed to initialize test server. Tests will likely fail.", e);
+    }
+  }
 
-   public static void shutdownServer() throws KrbException, IOException {
-      simpleKdcServer.stop();
-      Files.delete(KEYTAB.toPath());
-      Files.delete(KDC_WORK_DIR.toPath());
-   }
+  public static void shutdownServer() throws KrbException, IOException {
+    simpleKdcServer.stop();
+    Files.delete(KEYTAB.toPath());
+    Files.delete(KDC_WORK_DIR.toPath());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/authorization/provider/AuthorizationProviderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/authorization/provider/AuthorizationProviderTest.java
@@ -34,244 +34,250 @@ import static org.mockito.Mockito.mock;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class AuthorizationProviderTest {
 
-    @Mock
-    private JobsRepository repository;
+  @Mock private JobsRepository repository;
 
-    @InjectMocks
-    private AuthorizationProvider provider;
+  @InjectMocks private AuthorizationProvider provider;
 
-    @BeforeEach
-    public void setUp() {
-        ReflectionTestUtils.setField(provider, "usernameField", "username");
-        JobConfig config = new JobConfig();
-        config.setTeam("job-repo-example-team");
-        DataJob job = new DataJob("job-repo-example", config, DeploymentStatus.NONE);
-        Mockito.when(repository.findById(anyString())).thenReturn(java.util.Optional.of(job));
-        MockitoAnnotations.initMocks(this);
-    }
+  @BeforeEach
+  public void setUp() {
+    ReflectionTestUtils.setField(provider, "usernameField", "username");
+    JobConfig config = new JobConfig();
+    config.setTeam("job-repo-example-team");
+    DataJob job = new DataJob("job-repo-example", config, DeploymentStatus.NONE);
+    Mockito.when(repository.findById(anyString())).thenReturn(java.util.Optional.of(job));
+    MockitoAnnotations.initMocks(this);
+  }
 
-    @Test
-    public void testParsePropertyFromURI() {
-        var provider = new AuthorizationProvider(repository);
-        String createJob = provider.parsePropertyFromURI("",
-                "/data-jobs/for-team/example-team/jobs", 5);
-        String createJobSlash = provider.parsePropertyFromURI("",
-                "/data-jobs/for-team/example-team/jobs/", 5);
-        String jobNameService = provider.parsePropertyFromURI("",
-                "/data-jobs/for-team/example-team/jobs/example", 5);
-        String jobNameDeploy = provider.parsePropertyFromURI("",
-                "/data-jobs/for-team/example-team/jobs/example/deployments", 5);
-        String jobNameServiceSlash = provider.parsePropertyFromURI("",
-                "/data-jobs/for-team/example-team/jobs/example/", 5);
+  @Test
+  public void testParsePropertyFromURI() {
+    var provider = new AuthorizationProvider(repository);
+    String createJob =
+        provider.parsePropertyFromURI("", "/data-jobs/for-team/example-team/jobs", 5);
+    String createJobSlash =
+        provider.parsePropertyFromURI("", "/data-jobs/for-team/example-team/jobs/", 5);
+    String jobNameService =
+        provider.parsePropertyFromURI("", "/data-jobs/for-team/example-team/jobs/example", 5);
+    String jobNameDeploy =
+        provider.parsePropertyFromURI(
+            "", "/data-jobs/for-team/example-team/jobs/example/deployments", 5);
+    String jobNameServiceSlash =
+        provider.parsePropertyFromURI("", "/data-jobs/for-team/example-team/jobs/example/", 5);
 
-        String newTeamName = provider.parsePropertyFromURI("",
-                "/data-jobs/for-team/example-team/jobs/example/team/new-example-team", 7);
-        String newTeamNameSlash = provider.parsePropertyFromURI("",
-                "/data-jobs/for-team/example-team/jobs/example/team/new-example-team/", 7);
-        String newTeamNameMissing = provider.parsePropertyFromURI("",
-                "/data-jobs/for-team/example-team/jobs", 7);
+    String newTeamName =
+        provider.parsePropertyFromURI(
+            "", "/data-jobs/for-team/example-team/jobs/example/team/new-example-team", 7);
+    String newTeamNameSlash =
+        provider.parsePropertyFromURI(
+            "", "/data-jobs/for-team/example-team/jobs/example/team/new-example-team/", 7);
+    String newTeamNameMissing =
+        provider.parsePropertyFromURI("", "/data-jobs/for-team/example-team/jobs", 7);
 
-        String teamName = provider.parsePropertyFromURI("",
-                "/data-jobs/for-team/example-team/jobs", 3);
-        String teamNameSlash = provider.parsePropertyFromURI("",
-                "/data-jobs/for-team/example-team/jobs/", 3);
-        String teamNameMissing = provider.parsePropertyFromURI("",
-                "/data-jobs/for-team/", 3);
+    String teamName = provider.parsePropertyFromURI("", "/data-jobs/for-team/example-team/jobs", 3);
+    String teamNameSlash =
+        provider.parsePropertyFromURI("", "/data-jobs/for-team/example-team/jobs/", 3);
+    String teamNameMissing = provider.parsePropertyFromURI("", "/data-jobs/for-team/", 3);
 
-        Assertions.assertEquals("", createJob);
-        Assertions.assertEquals("", createJobSlash);
-        Assertions.assertEquals("example", jobNameService);
-        Assertions.assertEquals("example", jobNameDeploy);
-        Assertions.assertEquals("example", jobNameServiceSlash);
+    Assertions.assertEquals("", createJob);
+    Assertions.assertEquals("", createJobSlash);
+    Assertions.assertEquals("example", jobNameService);
+    Assertions.assertEquals("example", jobNameDeploy);
+    Assertions.assertEquals("example", jobNameServiceSlash);
 
-        Assertions.assertEquals("new-example-team", newTeamName);
-        Assertions.assertEquals("new-example-team", newTeamNameSlash);
-        Assertions.assertEquals("", newTeamNameMissing);
+    Assertions.assertEquals("new-example-team", newTeamName);
+    Assertions.assertEquals("new-example-team", newTeamNameSlash);
+    Assertions.assertEquals("", newTeamNameMissing);
 
-        Assertions.assertEquals("example-team",teamName);
-        Assertions.assertEquals("example-team",teamNameSlash);
-        Assertions.assertEquals("", teamNameMissing);
-    }
+    Assertions.assertEquals("example-team", teamName);
+    Assertions.assertEquals("example-team", teamNameSlash);
+    Assertions.assertEquals("", teamNameMissing);
+  }
 
-    @Test
-    public void testParseJobNameFromURIContext() {
-        var provider = new AuthorizationProvider(repository);
-        String createJob = provider.parsePropertyFromURI("/api/v1",
-                "/data-jobs/for-team/example-team/jobs", 5);
-        String createJobSlash = provider.parsePropertyFromURI("/api/v1",
-                "/data-jobs/for-team/example-team/jobs/", 5);
-        String jobNameService = provider.parsePropertyFromURI("/api/v1",
-                "/data-jobs/for-team/example-team/jobs/example", 5);
-        String jobNameDeploy = provider.parsePropertyFromURI("/api/v1",
-                "/data-jobs/for-team/example-team/jobs/example/deployments", 5);
-        String jobNameServiceSlash = provider.parsePropertyFromURI("/api/v1",
-                "/data-jobs/for-team/example-team/jobs/example/", 5);
+  @Test
+  public void testParseJobNameFromURIContext() {
+    var provider = new AuthorizationProvider(repository);
+    String createJob =
+        provider.parsePropertyFromURI("/api/v1", "/data-jobs/for-team/example-team/jobs", 5);
+    String createJobSlash =
+        provider.parsePropertyFromURI("/api/v1", "/data-jobs/for-team/example-team/jobs/", 5);
+    String jobNameService =
+        provider.parsePropertyFromURI(
+            "/api/v1", "/data-jobs/for-team/example-team/jobs/example", 5);
+    String jobNameDeploy =
+        provider.parsePropertyFromURI(
+            "/api/v1", "/data-jobs/for-team/example-team/jobs/example/deployments", 5);
+    String jobNameServiceSlash =
+        provider.parsePropertyFromURI(
+            "/api/v1", "/data-jobs/for-team/example-team/jobs/example/", 5);
 
-        String newTeamName = provider.parsePropertyFromURI("/api/v1",
-                "/data-jobs/for-team/example-team/jobs/example/team/new-example-team", 7);
-        String newTeamNameSlash = provider.parsePropertyFromURI("/api/v1",
-                "/data-jobs/for-team/example-team/jobs/example/team/new-example-team/", 7);
-        String newTeamNameMissing = provider.parsePropertyFromURI("/api/v1",
-                "/data-jobs/for-team/example-team/jobs", 7);
+    String newTeamName =
+        provider.parsePropertyFromURI(
+            "/api/v1", "/data-jobs/for-team/example-team/jobs/example/team/new-example-team", 7);
+    String newTeamNameSlash =
+        provider.parsePropertyFromURI(
+            "/api/v1", "/data-jobs/for-team/example-team/jobs/example/team/new-example-team/", 7);
+    String newTeamNameMissing =
+        provider.parsePropertyFromURI("/api/v1", "/data-jobs/for-team/example-team/jobs", 7);
 
-        String teamName = provider.parsePropertyFromURI("/api/v1",
-                "/data-jobs/for-team/example-team/jobs", 3);
-        String teamNameSlash = provider.parsePropertyFromURI("/api/v1",
-                "/data-jobs/for-team/example-team/jobs/", 3);
-        String teamNameMissing = provider.parsePropertyFromURI("/api/v1",
-                "/data-jobs/for-team/", 3);
+    String teamName =
+        provider.parsePropertyFromURI("/api/v1", "/data-jobs/for-team/example-team/jobs", 3);
+    String teamNameSlash =
+        provider.parsePropertyFromURI("/api/v1", "/data-jobs/for-team/example-team/jobs/", 3);
+    String teamNameMissing = provider.parsePropertyFromURI("/api/v1", "/data-jobs/for-team/", 3);
 
-        Assertions.assertEquals("", createJob);
-        Assertions.assertEquals("", createJobSlash);
-        Assertions.assertEquals("example", jobNameService);
-        Assertions.assertEquals("example", jobNameDeploy);
-        Assertions.assertEquals("example", jobNameServiceSlash);
+    Assertions.assertEquals("", createJob);
+    Assertions.assertEquals("", createJobSlash);
+    Assertions.assertEquals("example", jobNameService);
+    Assertions.assertEquals("example", jobNameDeploy);
+    Assertions.assertEquals("example", jobNameServiceSlash);
 
-        Assertions.assertEquals("new-example-team", newTeamName);
-        Assertions.assertEquals("new-example-team", newTeamNameSlash);
-        Assertions.assertEquals("", newTeamNameMissing);
+    Assertions.assertEquals("new-example-team", newTeamName);
+    Assertions.assertEquals("new-example-team", newTeamNameSlash);
+    Assertions.assertEquals("", newTeamNameMissing);
 
-        Assertions.assertEquals("example-team",teamName);
-        Assertions.assertEquals("example-team",teamNameSlash);
-        Assertions.assertEquals("", teamNameMissing);
-    }
+    Assertions.assertEquals("example-team", teamName);
+    Assertions.assertEquals("example-team", teamNameSlash);
+    Assertions.assertEquals("", teamNameMissing);
+  }
 
-    @Test
-    public void testJobCreateWithParameters() {
-        HttpServletRequest request = mock(HttpServletRequest.class);
-        JwtAuthenticationToken authentication = mock(JwtAuthenticationToken.class);
-        Mockito.when(authentication.getTokenAttributes()).thenReturn(Map.of("username", "auserov"));
-        Mockito.when(request.getMethod()).thenReturn("post");
-        Mockito.when(request.getRequestURI()).thenReturn("/data-jobs/for-team/example-team/jobs");
-        Mockito.when(request.getParameter("name")).thenReturn("example");
+  @Test
+  public void testJobCreateWithParameters() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    JwtAuthenticationToken authentication = mock(JwtAuthenticationToken.class);
+    Mockito.when(authentication.getTokenAttributes()).thenReturn(Map.of("username", "auserov"));
+    Mockito.when(request.getMethod()).thenReturn("post");
+    Mockito.when(request.getRequestURI()).thenReturn("/data-jobs/for-team/example-team/jobs");
+    Mockito.when(request.getParameter("name")).thenReturn("example");
 
-        AuthorizationBody actualBody = provider.createAuthorizationBody(request, authentication);
-        AuthorizationBody expectedBody = new AuthorizationBody();
-        expectedBody.setRequestedResourceName("data-job");
-        expectedBody.setRequestedResourceTeam("example-team");
-        expectedBody.setRequesterUserId("auserov");
-        expectedBody.setRequestedResourceId("example");
-        expectedBody.setRequestedPermission("write");
-        expectedBody.setRequestedHttpPath("/data-jobs/for-team/example-team/jobs");
-        expectedBody.setRequestedHttpVerb("POST");
-        expectedBody.setRequestedResourceNewTeam("example-team");
+    AuthorizationBody actualBody = provider.createAuthorizationBody(request, authentication);
+    AuthorizationBody expectedBody = new AuthorizationBody();
+    expectedBody.setRequestedResourceName("data-job");
+    expectedBody.setRequestedResourceTeam("example-team");
+    expectedBody.setRequesterUserId("auserov");
+    expectedBody.setRequestedResourceId("example");
+    expectedBody.setRequestedPermission("write");
+    expectedBody.setRequestedHttpPath("/data-jobs/for-team/example-team/jobs");
+    expectedBody.setRequestedHttpVerb("POST");
+    expectedBody.setRequestedResourceNewTeam("example-team");
 
-        Assertions.assertEquals(actualBody, expectedBody);
-    }
+    Assertions.assertEquals(actualBody, expectedBody);
+  }
 
-    @Test
-    public void testJobCreateWithoutParameters() {
-        HttpServletRequest request = mock(HttpServletRequest.class);
-        JwtAuthenticationToken authentication = mock(JwtAuthenticationToken.class);
-        Mockito.when(authentication.getTokenAttributes()).thenReturn(Map.of("username", "auserov"));
-        Mockito.when(request.getMethod()).thenReturn("post");
-        Mockito.when(request.getRequestURI()).thenReturn("/data-jobs/for-team/example-team/jobs");
+  @Test
+  public void testJobCreateWithoutParameters() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    JwtAuthenticationToken authentication = mock(JwtAuthenticationToken.class);
+    Mockito.when(authentication.getTokenAttributes()).thenReturn(Map.of("username", "auserov"));
+    Mockito.when(request.getMethod()).thenReturn("post");
+    Mockito.when(request.getRequestURI()).thenReturn("/data-jobs/for-team/example-team/jobs");
 
-        AuthorizationBody actualBody = provider.createAuthorizationBody(request, authentication);
-        AuthorizationBody expectedBody = new AuthorizationBody();
-        expectedBody.setRequestedResourceName("data-job");
-        expectedBody.setRequestedResourceTeam("example-team");
-        expectedBody.setRequesterUserId("auserov");
-        expectedBody.setRequestedResourceId("");
-        expectedBody.setRequestedPermission("write");
-        expectedBody.setRequestedHttpPath("/data-jobs/for-team/example-team/jobs");
-        expectedBody.setRequestedHttpVerb("POST");
-        expectedBody.setRequestedResourceNewTeam("example-team");
+    AuthorizationBody actualBody = provider.createAuthorizationBody(request, authentication);
+    AuthorizationBody expectedBody = new AuthorizationBody();
+    expectedBody.setRequestedResourceName("data-job");
+    expectedBody.setRequestedResourceTeam("example-team");
+    expectedBody.setRequesterUserId("auserov");
+    expectedBody.setRequestedResourceId("");
+    expectedBody.setRequestedPermission("write");
+    expectedBody.setRequestedHttpPath("/data-jobs/for-team/example-team/jobs");
+    expectedBody.setRequestedHttpVerb("POST");
+    expectedBody.setRequestedResourceNewTeam("example-team");
 
-        Assertions.assertEquals(actualBody, expectedBody);
-    }
+    Assertions.assertEquals(actualBody, expectedBody);
+  }
 
-    @Test
-    public void testJobPut() {
-        HttpServletRequest request = mock(HttpServletRequest.class);
-        JwtAuthenticationToken authentication = mock(JwtAuthenticationToken.class);
-        Mockito.when(authentication.getTokenAttributes()).thenReturn(Map.of("username", "auserov"));
-        Mockito.when(request.getMethod()).thenReturn("put");
-        Mockito.when(request.getRequestURI()).thenReturn("/data-jobs/for-team/example-team/jobs/example/deployments");
+  @Test
+  public void testJobPut() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    JwtAuthenticationToken authentication = mock(JwtAuthenticationToken.class);
+    Mockito.when(authentication.getTokenAttributes()).thenReturn(Map.of("username", "auserov"));
+    Mockito.when(request.getMethod()).thenReturn("put");
+    Mockito.when(request.getRequestURI())
+        .thenReturn("/data-jobs/for-team/example-team/jobs/example/deployments");
 
-        AuthorizationBody actualBody = provider.createAuthorizationBody(request, authentication);
-        AuthorizationBody expectedBody = new AuthorizationBody();
-        expectedBody.setRequestedResourceName("data-job");
-        expectedBody.setRequestedResourceTeam("example-team");
-        expectedBody.setRequesterUserId("auserov");
-        expectedBody.setRequestedResourceId("example");
-        expectedBody.setRequestedPermission("write");
-        expectedBody.setRequestedHttpPath("/data-jobs/for-team/example-team/jobs/example/deployments");
-        expectedBody.setRequestedHttpVerb("PUT");
-        expectedBody.setRequestedResourceNewTeam("example-team");
+    AuthorizationBody actualBody = provider.createAuthorizationBody(request, authentication);
+    AuthorizationBody expectedBody = new AuthorizationBody();
+    expectedBody.setRequestedResourceName("data-job");
+    expectedBody.setRequestedResourceTeam("example-team");
+    expectedBody.setRequesterUserId("auserov");
+    expectedBody.setRequestedResourceId("example");
+    expectedBody.setRequestedPermission("write");
+    expectedBody.setRequestedHttpPath("/data-jobs/for-team/example-team/jobs/example/deployments");
+    expectedBody.setRequestedHttpVerb("PUT");
+    expectedBody.setRequestedResourceNewTeam("example-team");
 
-        Assertions.assertEquals(actualBody, expectedBody);
-    }
+    Assertions.assertEquals(actualBody, expectedBody);
+  }
 
-    @Test
-    public void testJobWithContextPath() {
-        HttpServletRequest request = mock(HttpServletRequest.class);
-        JwtAuthenticationToken authentication = mock(JwtAuthenticationToken.class);
-        Mockito.when(authentication.getTokenAttributes()).thenReturn(Map.of("username", "auserov"));
-        Mockito.when(request.getMethod()).thenReturn("put");
-        Mockito.when(request.getRequestURI())
-                .thenReturn("/api/v1/data-jobs/for-team/example-team/jobs/example/deployments");
-        Mockito.when(request.getContextPath()).thenReturn("/api/v1");
+  @Test
+  public void testJobWithContextPath() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    JwtAuthenticationToken authentication = mock(JwtAuthenticationToken.class);
+    Mockito.when(authentication.getTokenAttributes()).thenReturn(Map.of("username", "auserov"));
+    Mockito.when(request.getMethod()).thenReturn("put");
+    Mockito.when(request.getRequestURI())
+        .thenReturn("/api/v1/data-jobs/for-team/example-team/jobs/example/deployments");
+    Mockito.when(request.getContextPath()).thenReturn("/api/v1");
 
-        AuthorizationBody actualBody = provider.createAuthorizationBody(request, authentication);
-        AuthorizationBody expectedBody = new AuthorizationBody();
-        expectedBody.setRequestedResourceName("data-job");
-        expectedBody.setRequestedResourceTeam("example-team");
-        expectedBody.setRequesterUserId("auserov");
-        expectedBody.setRequestedResourceId("example");
-        expectedBody.setRequestedPermission("write");
-        expectedBody.setRequestedHttpPath("/api/v1/data-jobs/for-team/example-team/jobs/example/deployments");
-        expectedBody.setRequestedHttpVerb("PUT");
-        expectedBody.setRequestedResourceNewTeam("example-team");
+    AuthorizationBody actualBody = provider.createAuthorizationBody(request, authentication);
+    AuthorizationBody expectedBody = new AuthorizationBody();
+    expectedBody.setRequestedResourceName("data-job");
+    expectedBody.setRequestedResourceTeam("example-team");
+    expectedBody.setRequesterUserId("auserov");
+    expectedBody.setRequestedResourceId("example");
+    expectedBody.setRequestedPermission("write");
+    expectedBody.setRequestedHttpPath(
+        "/api/v1/data-jobs/for-team/example-team/jobs/example/deployments");
+    expectedBody.setRequestedHttpVerb("PUT");
+    expectedBody.setRequestedResourceNewTeam("example-team");
 
-        Assertions.assertEquals(actualBody, expectedBody);
-    }
+    Assertions.assertEquals(actualBody, expectedBody);
+  }
 
-    @Test
-    public void testJobTeamPutWithTeamWithSpaces() {
-        HttpServletRequest request = mock(HttpServletRequest.class);
-        JwtAuthenticationToken authentication = mock(JwtAuthenticationToken.class);
-        Mockito.when(authentication.getTokenAttributes()).thenReturn(Map.of("username", "auserov"));
-        Mockito.when(request.getMethod()).thenReturn("put");
-        // TODO: the job "example" has team "job-repo-example-team" in the db so we don't parse the job's team from the URI
-        Mockito.when(request.getRequestURI())
-                .thenReturn("/data-jobs/for-team/example+team/jobs/example/team/new+example+team");
+  @Test
+  public void testJobTeamPutWithTeamWithSpaces() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    JwtAuthenticationToken authentication = mock(JwtAuthenticationToken.class);
+    Mockito.when(authentication.getTokenAttributes()).thenReturn(Map.of("username", "auserov"));
+    Mockito.when(request.getMethod()).thenReturn("put");
+    // TODO: the job "example" has team "job-repo-example-team" in the db so we don't parse the
+    // job's team from the URI
+    Mockito.when(request.getRequestURI())
+        .thenReturn("/data-jobs/for-team/example+team/jobs/example/team/new+example+team");
 
-        AuthorizationBody actualBody = provider.createAuthorizationBody(request, authentication);
-        AuthorizationBody expectedBody = new AuthorizationBody();
-        expectedBody.setRequestedResourceName("data-job");
-        expectedBody.setRequestedResourceTeam("example team");
-        expectedBody.setRequesterUserId("auserov");
-        expectedBody.setRequestedResourceId("example");
-        expectedBody.setRequestedPermission("write");
-        expectedBody.setRequestedHttpPath("/data-jobs/for-team/example+team/jobs/example/team/new+example+team");
-        expectedBody.setRequestedHttpVerb("PUT");
-        expectedBody.setRequestedResourceNewTeam("new example team");
+    AuthorizationBody actualBody = provider.createAuthorizationBody(request, authentication);
+    AuthorizationBody expectedBody = new AuthorizationBody();
+    expectedBody.setRequestedResourceName("data-job");
+    expectedBody.setRequestedResourceTeam("example team");
+    expectedBody.setRequesterUserId("auserov");
+    expectedBody.setRequestedResourceId("example");
+    expectedBody.setRequestedPermission("write");
+    expectedBody.setRequestedHttpPath(
+        "/data-jobs/for-team/example+team/jobs/example/team/new+example+team");
+    expectedBody.setRequestedHttpVerb("PUT");
+    expectedBody.setRequestedResourceNewTeam("new example team");
 
-        Assertions.assertEquals(actualBody, expectedBody);
-    }
+    Assertions.assertEquals(actualBody, expectedBody);
+  }
 
-    @Test
-    @Deprecated
-    public void testJobGetWithTeamWithSpaces() {
-        HttpServletRequest request = mock(HttpServletRequest.class);
-        JwtAuthenticationToken authentication = mock(JwtAuthenticationToken.class);
-        Mockito.when(authentication.getTokenAttributes()).thenReturn(Map.of("username", "auserov"));
-        Mockito.when(request.getMethod()).thenReturn("get");
-        Mockito.when(request.getRequestURI()).thenReturn("/data-jobs/for-team/example%20team");
+  @Test
+  @Deprecated
+  public void testJobGetWithTeamWithSpaces() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    JwtAuthenticationToken authentication = mock(JwtAuthenticationToken.class);
+    Mockito.when(authentication.getTokenAttributes()).thenReturn(Map.of("username", "auserov"));
+    Mockito.when(request.getMethod()).thenReturn("get");
+    Mockito.when(request.getRequestURI()).thenReturn("/data-jobs/for-team/example%20team");
 
-        AuthorizationBody actualBody = provider.createAuthorizationBody(request, authentication);
-        AuthorizationBody expectedBody = new AuthorizationBody();
-        expectedBody.setRequestedResourceName("data-job");
-        expectedBody.setRequestedResourceTeam("example team");
-        expectedBody.setRequesterUserId("auserov");
-        expectedBody.setRequestedResourceId("");
-        expectedBody.setRequestedPermission("read");
-        expectedBody.setRequestedHttpPath("/data-jobs/for-team/example%20team");
-        expectedBody.setRequestedHttpVerb("GET");
-        expectedBody.setRequestedResourceNewTeam("example team");
+    AuthorizationBody actualBody = provider.createAuthorizationBody(request, authentication);
+    AuthorizationBody expectedBody = new AuthorizationBody();
+    expectedBody.setRequestedResourceName("data-job");
+    expectedBody.setRequestedResourceTeam("example team");
+    expectedBody.setRequesterUserId("auserov");
+    expectedBody.setRequestedResourceId("");
+    expectedBody.setRequestedPermission("read");
+    expectedBody.setRequestedHttpPath("/data-jobs/for-team/example%20team");
+    expectedBody.setRequestedHttpVerb("GET");
+    expectedBody.setRequestedResourceNewTeam("example team");
 
-        Assertions.assertEquals(actualBody, expectedBody);
-    }
-
+    Assertions.assertEquals(actualBody, expectedBody);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/authorization/webhook/AuthorizationBodyTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/authorization/webhook/AuthorizationBodyTest.java
@@ -11,60 +11,60 @@ import org.junit.jupiter.api.Test;
 
 import java.io.*;
 
-
 public class AuthorizationBodyTest {
 
-    private AuthorizationBody authzBody;
+  private AuthorizationBody authzBody;
 
-    @BeforeEach
-    public void setUp() {
-        authzBody = new AuthorizationBody();
-        authzBody.setRequestedHttpPath("/data-jobs");
-        authzBody.setRequestedHttpVerb("POST");
-        authzBody.setRequestedPermission("write");
-        authzBody.setRequestedResourceId("");
-        authzBody.setRequesterUserId("auserov");
-        authzBody.setRequestedResourceTeam("example-team");
-        authzBody.setRequestedResourceName("data-job");
-        authzBody.setRequestedResourceNewTeam("example-team");
-    }
+  @BeforeEach
+  public void setUp() {
+    authzBody = new AuthorizationBody();
+    authzBody.setRequestedHttpPath("/data-jobs");
+    authzBody.setRequestedHttpVerb("POST");
+    authzBody.setRequestedPermission("write");
+    authzBody.setRequestedResourceId("");
+    authzBody.setRequesterUserId("auserov");
+    authzBody.setRequestedResourceTeam("example-team");
+    authzBody.setRequestedResourceName("data-job");
+    authzBody.setRequestedResourceNewTeam("example-team");
+  }
 
-    @Test
-    public void testParseJsonObjectNoIdTeam() throws IOException, ClassNotFoundException {
-        byte[] serialized1 = serialize(authzBody);
-        byte[] serialized2 = serialize(authzBody);
+  @Test
+  public void testParseJsonObjectNoIdTeam() throws IOException, ClassNotFoundException {
+    byte[] serialized1 = serialize(authzBody);
+    byte[] serialized2 = serialize(authzBody);
 
-        Object deserialized1 = deserialize(serialized1);
-        Object deserialized2 = deserialize(serialized2);
-        Assertions.assertEquals(deserialized1, deserialized2);
-        Assertions.assertEquals(authzBody, deserialized1);
-        Assertions.assertEquals(authzBody, deserialized2);
-    }
+    Object deserialized1 = deserialize(serialized1);
+    Object deserialized2 = deserialize(serialized2);
+    Assertions.assertEquals(deserialized1, deserialized2);
+    Assertions.assertEquals(authzBody, deserialized1);
+    Assertions.assertEquals(authzBody, deserialized2);
+  }
 
-    @Test
-    public void testVerifyJsonString(){
-        String expectedJson = "{\"requester_user_id\":\"auserov\"," +
-                "\"requested_resource_team\":\"example-team\"," +
-                "\"requested_resource_name\":\"data-job\"," +
-                "\"requested_resource_id\":\"\"," +
-                "\"requested_http_path\":\"/data-jobs\"," +
-                "\"requested_http_verb\":\"POST\"," +
-                "\"requested_resource_new_team\":\"example-team\"," +
-                "\"requested_permission\":\"write\"}";
+  @Test
+  public void testVerifyJsonString() {
+    String expectedJson =
+        "{\"requester_user_id\":\"auserov\","
+            + "\"requested_resource_team\":\"example-team\","
+            + "\"requested_resource_name\":\"data-job\","
+            + "\"requested_resource_id\":\"\","
+            + "\"requested_http_path\":\"/data-jobs\","
+            + "\"requested_http_verb\":\"POST\","
+            + "\"requested_resource_new_team\":\"example-team\","
+            + "\"requested_permission\":\"write\"}";
 
-        Assertions.assertEquals(authzBody.toString(), expectedJson);
-    }
+    Assertions.assertEquals(authzBody.toString(), expectedJson);
+  }
 
-    private static byte[] serialize(Object object) throws IOException {
-        ByteArrayOutputStream arrayOutputStream = new ByteArrayOutputStream();
-        ObjectOutputStream objectOutputStream = new ObjectOutputStream(arrayOutputStream);
-        objectOutputStream.writeObject(object);
-        return arrayOutputStream.toByteArray();
-    }
+  private static byte[] serialize(Object object) throws IOException {
+    ByteArrayOutputStream arrayOutputStream = new ByteArrayOutputStream();
+    ObjectOutputStream objectOutputStream = new ObjectOutputStream(arrayOutputStream);
+    objectOutputStream.writeObject(object);
+    return arrayOutputStream.toByteArray();
+  }
 
-    private static Object deserialize(byte[] bytes) throws IOException, ClassNotFoundException {
-        ByteArrayInputStream arrayOutputStream = new ByteArrayInputStream(bytes);
-        ObjectInputStream objectOutputStream = new ObjectInputStream(arrayOutputStream);
-        return objectOutputStream.readObject();
-    }
+  private static Object deserialize(byte[] bytes) throws IOException, ClassNotFoundException {
+    ByteArrayInputStream arrayOutputStream = new ByteArrayInputStream(bytes);
+    ObjectInputStream objectOutputStream = new ObjectInputStream(arrayOutputStream);
+    return objectOutputStream.readObject();
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/authorization/webhook/AuthorizationWebHookProviderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/authorization/webhook/AuthorizationWebHookProviderTest.java
@@ -30,79 +30,86 @@ import static org.mockito.ArgumentMatchers.anyString;
 @ExtendWith(MockitoExtension.class)
 public class AuthorizationWebHookProviderTest {
 
-    @Mock
-    private RestTemplate restTemplate;
+  @Mock private RestTemplate restTemplate;
 
-    @InjectMocks
-    private AuthorizationWebHookProvider webhookProvider = new AuthorizationWebHookProvider("", 1);
+  @InjectMocks
+  private AuthorizationWebHookProvider webhookProvider = new AuthorizationWebHookProvider("", 1);
 
-    private AuthorizationBody authzBody;
+  private AuthorizationBody authzBody;
 
-    private static String EXPECTED_JSON_BODY = "{\"requester_user_id\":\"auserov\"," +
-            "\"requested_resource_team\":\"\"," +
-            "\"requested_resource_name\":\"data-job\"," +
-            "\"requested_resource_id\":\"\"," +
-            "\"requested_http_path\":\"/data-jobs\"," +
-            "\"requested_http_verb\":\"POST\"," +
-            "\"requested_resource_new_team\":\"\"," +
-            "\"requested_permission\":\"write\"}";
+  private static String EXPECTED_JSON_BODY =
+      "{\"requester_user_id\":\"auserov\","
+          + "\"requested_resource_team\":\"\","
+          + "\"requested_resource_name\":\"data-job\","
+          + "\"requested_resource_id\":\"\","
+          + "\"requested_http_path\":\"/data-jobs\","
+          + "\"requested_http_verb\":\"POST\","
+          + "\"requested_resource_new_team\":\"\","
+          + "\"requested_permission\":\"write\"}";
 
-    @BeforeEach
-    public void setUp() {
-        authzBody = new AuthorizationBody();
-        authzBody.setRequestedHttpPath("/data-jobs");
-        authzBody.setRequestedHttpVerb("POST");
-        authzBody.setRequestedPermission("write");
-        authzBody.setRequestedResourceId("");
-        authzBody.setRequesterUserId("auserov");
-        authzBody.setRequestedResourceTeam("");
-        authzBody.setRequestedResourceName("data-job");
-        authzBody.setRequestedResourceNewTeam("");
-    }
+  @BeforeEach
+  public void setUp() {
+    authzBody = new AuthorizationBody();
+    authzBody.setRequestedHttpPath("/data-jobs");
+    authzBody.setRequestedHttpVerb("POST");
+    authzBody.setRequestedPermission("write");
+    authzBody.setRequestedResourceId("");
+    authzBody.setRequesterUserId("auserov");
+    authzBody.setRequestedResourceTeam("");
+    authzBody.setRequestedResourceName("data-job");
+    authzBody.setRequestedResourceNewTeam("");
+  }
 
-    @Test
-    public void testUnauthorizedStatus() throws UnsupportedEncodingException {
-        ReflectionTestUtils.setField(webhookProvider, "webHookEndpoint", "http://localhost:4444");
-        ResponseEntity re = new ResponseEntity<>(
-                "Authorization response: User does not have team",
-                null,
-                HttpStatus.UNAUTHORIZED);
-        Mockito.when(restTemplate.exchange(Mockito.anyString(),
+  @Test
+  public void testUnauthorizedStatus() throws UnsupportedEncodingException {
+    ReflectionTestUtils.setField(webhookProvider, "webHookEndpoint", "http://localhost:4444");
+    ResponseEntity re =
+        new ResponseEntity<>(
+            "Authorization response: User does not have team", null, HttpStatus.UNAUTHORIZED);
+    Mockito.when(
+            restTemplate.exchange(
+                Mockito.anyString(),
                 Mockito.any(HttpMethod.class),
                 Mockito.any(),
-                Mockito.<Class<String>>any())).thenReturn(re);
+                Mockito.<Class<String>>any()))
+        .thenReturn(re);
 
-        WebHookResult decision = webhookProvider.invokeWebHook(authzBody).get();
-        Assertions.assertEquals("Authorization response: User does not have team", decision.getMessage());
-        Assertions.assertEquals(HttpStatus.UNAUTHORIZED, decision.getStatus());
-        Assertions.assertEquals(false, decision.isSuccess());
-    }
+    WebHookResult decision = webhookProvider.invokeWebHook(authzBody).get();
+    Assertions.assertEquals(
+        "Authorization response: User does not have team", decision.getMessage());
+    Assertions.assertEquals(HttpStatus.UNAUTHORIZED, decision.getStatus());
+    Assertions.assertEquals(false, decision.isSuccess());
+  }
 
-    @Test
-    public void testWebhookAuthorizationSuccess() {
-        ReflectionTestUtils.setField(webhookProvider, "webHookEndpoint", "http://localhost:4444");
-        ResponseEntity re = new ResponseEntity<>(
-                "User authorized",
-                null,
-                HttpStatus.OK);
-        Mockito.when(restTemplate.exchange(Mockito.anyString(),
+  @Test
+  public void testWebhookAuthorizationSuccess() {
+    ReflectionTestUtils.setField(webhookProvider, "webHookEndpoint", "http://localhost:4444");
+    ResponseEntity re = new ResponseEntity<>("User authorized", null, HttpStatus.OK);
+    Mockito.when(
+            restTemplate.exchange(
+                Mockito.anyString(),
                 Mockito.any(HttpMethod.class),
                 Mockito.any(),
-                Mockito.<Class<String>>any())).thenReturn(re);
+                Mockito.<Class<String>>any()))
+        .thenReturn(re);
 
-        WebHookResult decision = webhookProvider.invokeWebHook(authzBody).get();
-        Assertions.assertEquals("", decision.getMessage());
-        Assertions.assertEquals(HttpStatus.OK, decision.getStatus());
-        Assertions.assertEquals(true, decision.isSuccess());
-    }
+    WebHookResult decision = webhookProvider.invokeWebHook(authzBody).get();
+    Assertions.assertEquals("", decision.getMessage());
+    Assertions.assertEquals(HttpStatus.OK, decision.getStatus());
+    Assertions.assertEquals(true, decision.isSuccess());
+  }
 
-    @Test
-    public void testRestClientResponseExceptionHandling() {
-        ReflectionTestUtils.setField(webhookProvider, "webHookEndpoint", "http://localhost:4444");
-        Mockito.when(restTemplate.exchange(Mockito.anyString(),
+  @Test
+  public void testRestClientResponseExceptionHandling() {
+    ReflectionTestUtils.setField(webhookProvider, "webHookEndpoint", "http://localhost:4444");
+    Mockito.when(
+            restTemplate.exchange(
+                Mockito.anyString(),
                 Mockito.any(HttpMethod.class),
                 Mockito.any(),
-                Mockito.<Class<String>>any())).thenThrow(new RestClientResponseException(
+                Mockito.<Class<String>>any()))
+        .thenThrow(
+            new RestClientResponseException(
                 "Server down",
                 HttpStatus.UNAUTHORIZED.value(),
                 anyString(),
@@ -110,94 +117,98 @@ public class AuthorizationWebHookProviderTest {
                 any(),
                 any()));
 
-        WebHookResult decision = webhookProvider.invokeWebHook(authzBody).get();
-        Assertions.assertEquals("", decision.getMessage());
-        Assertions.assertEquals(HttpStatus.UNAUTHORIZED, decision.getStatus());
-        Assertions.assertEquals(false, decision.isSuccess());
-    }
+    WebHookResult decision = webhookProvider.invokeWebHook(authzBody).get();
+    Assertions.assertEquals("", decision.getMessage());
+    Assertions.assertEquals(HttpStatus.UNAUTHORIZED, decision.getStatus());
+    Assertions.assertEquals(false, decision.isSuccess());
+  }
 
-    @Test
-    public void testInformationalStatusCode() {
-        ReflectionTestUtils.setField(webhookProvider, "webHookEndpoint", "http://localhost:4444");
-        ResponseEntity re = new ResponseEntity<>(
-                "User authorized",
-                null,
-                HttpStatus.CONTINUE);
-        Mockito.when(restTemplate.exchange(Mockito.anyString(),
+  @Test
+  public void testInformationalStatusCode() {
+    ReflectionTestUtils.setField(webhookProvider, "webHookEndpoint", "http://localhost:4444");
+    ResponseEntity re = new ResponseEntity<>("User authorized", null, HttpStatus.CONTINUE);
+    Mockito.when(
+            restTemplate.exchange(
+                Mockito.anyString(),
                 Mockito.any(HttpMethod.class),
                 Mockito.any(),
-                Mockito.<Class<String>>any())).thenReturn(re);
+                Mockito.<Class<String>>any()))
+        .thenReturn(re);
 
-        Assertions.assertThrows(ExternalSystemError.class, () -> webhookProvider.invokeWebHook(authzBody));
-    }
+    Assertions.assertThrows(
+        ExternalSystemError.class, () -> webhookProvider.invokeWebHook(authzBody));
+  }
 
-    @Test
-    public void testRedirectionStatusCode() {
-        ReflectionTestUtils.setField(webhookProvider, "webHookEndpoint", "http://localhost:4444");
-        ResponseEntity re = new ResponseEntity<>(
-                "User authorized",
-                null,
-                HttpStatus.MOVED_PERMANENTLY);
-        Mockito.when(restTemplate.exchange(Mockito.anyString(),
+  @Test
+  public void testRedirectionStatusCode() {
+    ReflectionTestUtils.setField(webhookProvider, "webHookEndpoint", "http://localhost:4444");
+    ResponseEntity re = new ResponseEntity<>("User authorized", null, HttpStatus.MOVED_PERMANENTLY);
+    Mockito.when(
+            restTemplate.exchange(
+                Mockito.anyString(),
                 Mockito.any(HttpMethod.class),
                 Mockito.any(),
-                Mockito.<Class<String>>any())).thenReturn(re);
+                Mockito.<Class<String>>any()))
+        .thenReturn(re);
 
-        Assertions.assertThrows(ExternalSystemError.class, () -> webhookProvider.invokeWebHook(authzBody));
-    }
+    Assertions.assertThrows(
+        ExternalSystemError.class, () -> webhookProvider.invokeWebHook(authzBody));
+  }
 
-    @Test
-    public void testServiceUnavailable() {
-        ReflectionTestUtils.setField(webhookProvider, "webHookEndpoint", "http://localhost:4444");
-        ResponseEntity re = new ResponseEntity<>(
-                "Service unavailable",
-                null,
-                HttpStatus.SERVICE_UNAVAILABLE);
-        Mockito.when(restTemplate.exchange(Mockito.anyString(),
+  @Test
+  public void testServiceUnavailable() {
+    ReflectionTestUtils.setField(webhookProvider, "webHookEndpoint", "http://localhost:4444");
+    ResponseEntity re =
+        new ResponseEntity<>("Service unavailable", null, HttpStatus.SERVICE_UNAVAILABLE);
+    Mockito.when(
+            restTemplate.exchange(
+                Mockito.anyString(),
                 Mockito.any(HttpMethod.class),
                 Mockito.any(),
-                Mockito.<Class<String>>any())).thenReturn(re);
+                Mockito.<Class<String>>any()))
+        .thenReturn(re);
 
-        Assertions.assertThrows(ExternalSystemError.class, () -> webhookProvider.invokeWebHook(authzBody));
-    }
+    Assertions.assertThrows(
+        ExternalSystemError.class, () -> webhookProvider.invokeWebHook(authzBody));
+  }
 
-    @Test
-    public void testWebhookEndpointMissing() {
-        ReflectionTestUtils.setField(webhookProvider, "webHookEndpoint", "");
+  @Test
+  public void testWebhookEndpointMissing() {
+    ReflectionTestUtils.setField(webhookProvider, "webHookEndpoint", "");
 
-        Assertions.assertThrows(AuthorizationError.class, () -> webhookProvider.invokeWebHook(authzBody));
-    }
+    Assertions.assertThrows(
+        AuthorizationError.class, () -> webhookProvider.invokeWebHook(authzBody));
+  }
 
+  @Test
+  public void testExchangeCalledWithValid() {
+    // TODO: probably we should add that argument validation test logic to other tests
+    ReflectionTestUtils.setField(webhookProvider, "webHookEndpoint", "http://localhost:4444");
 
-    @Test
-    public void testExchangeCalledWithValid(){
-        // TODO: probably we should add that argument validation test logic to other tests
-        ReflectionTestUtils.setField(webhookProvider, "webHookEndpoint", "http://localhost:4444");
+    ResponseEntity re = new ResponseEntity<>("User authorized", null, HttpStatus.OK);
 
-        ResponseEntity re = new ResponseEntity<>(
-                "User authorized",
-                null,
-                HttpStatus.OK);
-
-        ArgumentCaptor<String> urlArgument = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<HttpMethod> httpMethodArgument = ArgumentCaptor.forClass(HttpMethod.class);
-        ArgumentCaptor<HttpEntity> httpEntityArgument = ArgumentCaptor.forClass(HttpEntity.class);
-        ArgumentCaptor<Class> classArgument = ArgumentCaptor.forClass(Class.class);
-        Mockito.when(restTemplate.exchange(urlArgument.capture(),
+    ArgumentCaptor<String> urlArgument = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<HttpMethod> httpMethodArgument = ArgumentCaptor.forClass(HttpMethod.class);
+    ArgumentCaptor<HttpEntity> httpEntityArgument = ArgumentCaptor.forClass(HttpEntity.class);
+    ArgumentCaptor<Class> classArgument = ArgumentCaptor.forClass(Class.class);
+    Mockito.when(
+            restTemplate.exchange(
+                urlArgument.capture(),
                 httpMethodArgument.capture(),
                 httpEntityArgument.capture(),
-                classArgument.capture())).thenReturn(re);
+                classArgument.capture()))
+        .thenReturn(re);
 
-        webhookProvider.invokeWebHook(authzBody);
+    webhookProvider.invokeWebHook(authzBody);
 
-        String actualUrlArgument = urlArgument.getValue();
-        HttpMethod actualMethodArgument = httpMethodArgument.getValue();
-        HttpEntity actualEntityArgument = httpEntityArgument.getValue();
-        Class actualClassArgument = classArgument.getValue();
+    String actualUrlArgument = urlArgument.getValue();
+    HttpMethod actualMethodArgument = httpMethodArgument.getValue();
+    HttpEntity actualEntityArgument = httpEntityArgument.getValue();
+    Class actualClassArgument = classArgument.getValue();
 
-        Assertions.assertEquals("http://localhost:4444", actualUrlArgument);
-        Assertions.assertEquals(HttpMethod.POST, actualMethodArgument);
-        Assertions.assertEquals(EXPECTED_JSON_BODY, actualEntityArgument.getBody().toString());
-        Assertions.assertEquals(String.class, actualClassArgument);
-    }
+    Assertions.assertEquals("http://localhost:4444", actualUrlArgument);
+    Assertions.assertEquals(HttpMethod.POST, actualMethodArgument);
+    Assertions.assertEquals(EXPECTED_JSON_BODY, actualEntityArgument.getBody().toString());
+    Assertions.assertEquals(String.class, actualClassArgument);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/DataJobsControllerTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/DataJobsControllerTest.java
@@ -33,111 +33,123 @@ import static org.mockito.Mockito.*;
 
 public class DataJobsControllerTest {
 
+  private JobsService jobsService = mock(JobsService.class);
+  private GraphQL graphQL = mock(GraphQL.class);
+  @Captor private ArgumentCaptor<ExecutionInput> queryCaptor;
 
-   private JobsService jobsService = mock(JobsService.class);
-   private GraphQL graphQL = mock(GraphQL.class);
-   @Captor
-   private ArgumentCaptor<ExecutionInput> queryCaptor;
+  @Test
+  public void testDataJobCreate() {
+    when(jobsService.createJob(any()))
+        .thenReturn(JobOperationResult.builder().completed(true).build());
+    UriBuilder builder = UriComponentsBuilder.fromHttpUrl("http://test.com/");
+    var testInst = new DataJobsController(jobsService, null, null, null, () -> builder);
+    DataJob dataJob = newJob("test-job");
+    var response = testInst.dataJobCreate("team", dataJob, "");
+    var location = response.getHeaders().get(HttpHeaders.LOCATION).get(0);
+    assertEquals("http://test.com/data-jobs/for-team/team/jobs/test-job", location);
+  }
 
-   @Test
-   public void testDataJobCreate() {
-      when(jobsService.createJob(any())).thenReturn(JobOperationResult.builder()
-            .completed(true)
-            .build());
-      UriBuilder builder = UriComponentsBuilder.fromHttpUrl("http://test.com/");
-      var testInst = new DataJobsController(jobsService, null, null, null, () -> builder);
-      DataJob dataJob = newJob("test-job");
-      var response = testInst.dataJobCreate("team", dataJob, "");
-      var location = response.getHeaders().get(HttpHeaders.LOCATION).get(0);
-      assertEquals("http://test.com/data-jobs/for-team/team/jobs/test-job", location);
-   }
+  @Test
+  public void testDataJobCreateNameValidity() {
+    when(jobsService.createJob(any()))
+        .thenReturn(JobOperationResult.builder().completed(true).build());
+    UriBuilder builder = UriComponentsBuilder.fromHttpUrl("http://test.com/");
+    var testInst = new DataJobsController(jobsService, null, null, null, () -> builder);
 
-   @Test
-   public void testDataJobCreateNameValidity() {
-      when(jobsService.createJob(any())).thenReturn(JobOperationResult.builder()
-            .completed(true)
-            .build());
-      UriBuilder builder = UriComponentsBuilder.fromHttpUrl("http://test.com/");
-      var testInst = new DataJobsController(jobsService, null, null, null,  () -> builder);
+    Assertions.assertThrows(
+        ApiConstraintError.class,
+        () -> testInst.dataJobCreate("team", newJob("1_job_with_starting_number"), ""));
+    Assertions.assertThrows(
+        ApiConstraintError.class,
+        () -> testInst.dataJobCreate("team", newJob("NameWithCapitalLetters"), ""));
+    Assertions.assertThrows(
+        ApiConstraintError.class,
+        () -> testInst.dataJobCreate("team", newJob("job name with spaces"), ""));
+    Assertions.assertThrows(
+        ApiConstraintError.class,
+        () -> testInst.dataJobCreate("team", newJob("job_name_with_underscore"), ""));
+    Assertions.assertThrows(
+        ApiConstraintError.class, () -> testInst.dataJobCreate("team", newJob("a".repeat(51)), ""));
+    Assertions.assertThrows(
+        ApiConstraintError.class, () -> testInst.dataJobCreate("team", newJob("a".repeat(5)), ""));
 
-      Assertions.assertThrows(ApiConstraintError.class, () -> testInst.dataJobCreate("team", newJob("1_job_with_starting_number"), ""));
-      Assertions.assertThrows(ApiConstraintError.class, () -> testInst.dataJobCreate("team", newJob("NameWithCapitalLetters"), ""));
-      Assertions.assertThrows(ApiConstraintError.class, () -> testInst.dataJobCreate("team", newJob("job name with spaces"), ""));
-      Assertions.assertThrows(ApiConstraintError.class, () -> testInst.dataJobCreate("team", newJob("job_name_with_underscore"), ""));
-      Assertions.assertThrows(ApiConstraintError.class, () -> testInst.dataJobCreate("team", newJob("a".repeat(51)), ""));
-      Assertions.assertThrows(ApiConstraintError.class, () -> testInst.dataJobCreate("team", newJob("a".repeat(5)),""));
+    testInst.dataJobCreate("team", newJob("a".repeat(6)), "");
+    testInst.dataJobCreate("team", newJob("a".repeat(45)), "");
+    testInst.dataJobCreate("team", newJob("a".repeat(50)), "");
+    testInst.dataJobCreate("team", newJob("job-name-with-dash"), "");
+  }
 
-      testInst.dataJobCreate("team", newJob("a".repeat(6)), "");
-      testInst.dataJobCreate("team", newJob("a".repeat(45)), "");
-      testInst.dataJobCreate("team", newJob("a".repeat(50)), "");
-      testInst.dataJobCreate("team", newJob("job-name-with-dash"), "");
-   }
+  @Test
+  public void testDataJobUpdateTeamChange() {
+    when(jobsService.updateJob(any())).thenReturn(true);
+    when(jobsService.getByName(any()))
+        .thenReturn(Optional.of(getServiceModelDataJob("test-job", "team")));
+    when(jobsService.jobWithTeamExists("test-job", "team")).thenReturn(true);
+    UriBuilder builder = UriComponentsBuilder.fromHttpUrl("http://test.com/");
+    var testInst = new DataJobsController(jobsService, null, null, null, () -> builder);
 
-   @Test
-   public void testDataJobUpdateTeamChange() {
-      when(jobsService.updateJob(any())).thenReturn(true);
-      when(jobsService.getByName(any())).thenReturn(Optional.of(getServiceModelDataJob("test-job", "team")));
-      when(jobsService.jobWithTeamExists("test-job", "team")).thenReturn(true);
-      UriBuilder builder = UriComponentsBuilder.fromHttpUrl("http://test.com/");
-      var testInst = new DataJobsController(jobsService, null, null, null, () -> builder);
+    Assertions.assertThrows(
+        ApiConstraintError.class,
+        () -> testInst.dataJobUpdate("team", "test-job", newJob("test-job", "team2", "* * * * *")));
 
-      Assertions.assertThrows(ApiConstraintError.class, () -> testInst.dataJobUpdate("team", "test-job",
-              newJob("test-job", "team2", "* * * * *")));
+    testInst.dataJobUpdate("team", "test-job", newJob("test-job", "team", "* * * * *"));
+  }
 
-      testInst.dataJobUpdate("team", "test-job", newJob("test-job", "team", "* * * * *"));
-   }
+  @Test
+  public void testDataJobList() {
+    DataJobsController testInst = constructTestListController();
 
-   @Test
-   public void testDataJobList() {
-      DataJobsController testInst = constructTestListController();
+    var response = testInst.jobsList("team", Boolean.FALSE, 0, 10);
+    Assertions.assertEquals(1, response.getBody().size());
+    Assertions.assertEquals("test-job", response.getBody().get(0).getJobName());
+  }
 
-      var response = testInst.jobsList("team", Boolean.FALSE, 0, 10);
-      Assertions.assertEquals(1, response.getBody().size());
-      Assertions.assertEquals("test-job", response.getBody().get(0).getJobName());
-   }
+  @Test
+  public void testDataJobListForAllTeams() {
+    DataJobsController testInst = constructTestListController();
 
-   @Test
-   public void testDataJobListForAllTeams() {
-      DataJobsController testInst = constructTestListController();
+    var response = testInst.jobsList("team", Boolean.TRUE, 0, 10);
+    Assertions.assertEquals(2, response.getBody().size());
+    Assertions.assertEquals("test-job", response.getBody().get(0).getJobName());
+    Assertions.assertEquals("test-job2", response.getBody().get(1).getJobName());
+  }
 
-      var response = testInst.jobsList("team", Boolean.TRUE, 0, 10);
-      Assertions.assertEquals(2, response.getBody().size());
-      Assertions.assertEquals("test-job", response.getBody().get(0).getJobName());
-      Assertions.assertEquals("test-job2", response.getBody().get(1).getJobName());
-   }
+  // @NotNull
+  private DataJobsController constructTestListController() {
+    com.vmware.taurus.service.model.DataJob testJobTeam =
+        getServiceModelDataJob("test-job", "team");
+    com.vmware.taurus.service.model.DataJob testJobTwoTeamAnother =
+        getServiceModelDataJob("test-job2", "team-another");
 
-   //@NotNull
-   private DataJobsController constructTestListController() {
-      com.vmware.taurus.service.model.DataJob testJobTeam = getServiceModelDataJob("test-job", "team");
-      com.vmware.taurus.service.model.DataJob testJobTwoTeamAnother = getServiceModelDataJob("test-job2", "team-another");
+    List<com.vmware.taurus.service.model.DataJob> jobList = new ArrayList<>();
+    jobList.add(testJobTeam);
+    jobList.add(testJobTwoTeamAnother);
 
-      List<com.vmware.taurus.service.model.DataJob> jobList = new ArrayList<>();
-      jobList.add(testJobTeam);
-      jobList.add(testJobTwoTeamAnother);
+    when(jobsService.getAllJobs(anyInt(), anyInt())).thenReturn(jobList);
+    when(jobsService.getTeamJobs(anyInt(), anyInt(), eq("team"))).thenReturn(List.of(testJobTeam));
+    when(jobsService.getTeamJobs(anyInt(), anyInt(), eq("team-another")))
+        .thenReturn(List.of(testJobTwoTeamAnother));
 
-      when(jobsService.getAllJobs(anyInt(), anyInt())).thenReturn(jobList);
-      when(jobsService.getTeamJobs(anyInt(), anyInt(), eq("team"))).thenReturn(List.of(testJobTeam));
-      when(jobsService.getTeamJobs(anyInt(),anyInt(), eq("team-another"))).thenReturn(List.of(testJobTwoTeamAnother));
+    UriBuilder builder = UriComponentsBuilder.fromHttpUrl("http://test.com/");
+    return new DataJobsController(jobsService, null, null, null, () -> builder);
+  }
 
+  private static com.vmware.taurus.service.model.DataJob getServiceModelDataJob(
+      String name, String team) {
+    JobConfig jobConfig = new JobConfig();
+    jobConfig.setJobName(name);
+    jobConfig.setTeam(team);
+    return new com.vmware.taurus.service.model.DataJob(name, jobConfig, DeploymentStatus.NONE);
+  }
 
-      UriBuilder builder = UriComponentsBuilder.fromHttpUrl("http://test.com/");
-      return new DataJobsController(jobsService, null, null, null, () -> builder);
-   }
+  private static DataJob newJob(String s) {
+    return newJob(s, "team", "* * * * *");
+  }
 
-   private static com.vmware.taurus.service.model.DataJob getServiceModelDataJob(String name, String team) {
-      JobConfig jobConfig = new JobConfig();
-      jobConfig.setJobName(name);
-      jobConfig.setTeam(team);
-      return new com.vmware.taurus.service.model.DataJob(name, jobConfig, DeploymentStatus.NONE);
-   }
-
-   private static DataJob newJob(String s) {
-      return newJob(s, "team", "* * * * *");
-   }
-   private static DataJob newJob(String s, String team, String cron) {
-      DataJob dataJob = new DataJob();
-      DataJobSchedule schedule = new DataJobSchedule().scheduleCron(cron);
-      DataJobConfig config = new DataJobConfig().schedule(schedule);
-      return dataJob.jobName(s).config(config).team(team);
-   }
+  private static DataJob newJob(String s, String team, String cron) {
+    DataJob dataJob = new DataJob();
+    DataJobSchedule schedule = new DataJobSchedule().scheduleCron(cron);
+    DataJobConfig config = new DataJobConfig().schedule(schedule);
+    return dataJob.jobName(s).config(config).team(team);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/DataJobsExecutionControllerIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/DataJobsExecutionControllerIT.java
@@ -23,49 +23,56 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ActiveProfiles({"MockKubernetes", "MockKerberos", "unittest", "MockTelemetry"})
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = ControlplaneApplication.class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    classes = ControlplaneApplication.class)
 @AutoConfigureMockMvc
 public class DataJobsExecutionControllerIT {
 
-   private static final String TEST_TEAM_NAME = "test-team";
-   private static final String TEST_JOB_NAME = "test-job";
+  private static final String TEST_TEAM_NAME = "test-team";
+  private static final String TEST_JOB_NAME = "test-job";
 
-   @Autowired
-   private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
-   @Test
-   @WithMockUser
-   @DirtiesContext
-   public void testDataJobExecutionStartNotFound() throws Exception {
-      ResultActions mockExecution = TestUtils.startMockExecution(mockMvc, TEST_TEAM_NAME, TEST_JOB_NAME);
-      mockExecution.andExpect(status().isNotFound());
-   }
+  @Test
+  @WithMockUser
+  @DirtiesContext
+  public void testDataJobExecutionStartNotFound() throws Exception {
+    ResultActions mockExecution =
+        TestUtils.startMockExecution(mockMvc, TEST_TEAM_NAME, TEST_JOB_NAME);
+    mockExecution.andExpect(status().isNotFound());
+  }
 
-   // TODO: test all methods
+  // TODO: test all methods
 
-   @Test
-   @WithMockUser
-   @DirtiesContext
-   public void testDataJobExecutionLogs() throws Exception {
-      TestUtils.createDataJob(mockMvc, TEST_TEAM_NAME, TEST_JOB_NAME);
-      TestUtils.createDeployment(mockMvc, TEST_TEAM_NAME, TEST_JOB_NAME);
-      ResultActions mockExecution = TestUtils.startMockExecution(mockMvc, TEST_TEAM_NAME, TEST_JOB_NAME);
-      var location = mockExecution.andReturn().getResponse().getHeader("Location");
-      String id = location.substring(location.lastIndexOf('/') + 1);
+  @Test
+  @WithMockUser
+  @DirtiesContext
+  public void testDataJobExecutionLogs() throws Exception {
+    TestUtils.createDataJob(mockMvc, TEST_TEAM_NAME, TEST_JOB_NAME);
+    TestUtils.createDeployment(mockMvc, TEST_TEAM_NAME, TEST_JOB_NAME);
+    ResultActions mockExecution =
+        TestUtils.startMockExecution(mockMvc, TEST_TEAM_NAME, TEST_JOB_NAME);
+    var location = mockExecution.andReturn().getResponse().getHeader("Location");
+    String id = location.substring(location.lastIndexOf('/') + 1);
 
-      String url = String.format("/data-jobs/for-team/%s/jobs/%s/executions/%s/logs", TEST_TEAM_NAME, TEST_JOB_NAME, id);
-      mockMvc.perform(get(url)).andExpect(status().isOk());
-   }
+    String url =
+        String.format(
+            "/data-jobs/for-team/%s/jobs/%s/executions/%s/logs", TEST_TEAM_NAME, TEST_JOB_NAME, id);
+    mockMvc.perform(get(url)).andExpect(status().isOk());
+  }
 
-   @Test
-   @WithMockUser
-   @DirtiesContext
-   public void testDataJobExecutionLogsNoExecution() throws Exception {
-      TestUtils.createDataJob(mockMvc, TEST_TEAM_NAME, TEST_JOB_NAME);
-      TestUtils.createDeployment(mockMvc, TEST_TEAM_NAME, TEST_JOB_NAME);
+  @Test
+  @WithMockUser
+  @DirtiesContext
+  public void testDataJobExecutionLogsNoExecution() throws Exception {
+    TestUtils.createDataJob(mockMvc, TEST_TEAM_NAME, TEST_JOB_NAME);
+    TestUtils.createDeployment(mockMvc, TEST_TEAM_NAME, TEST_JOB_NAME);
 
-      String url = String.format("/data-jobs/for-team/%s/jobs/%s/executions/%s/logs", TEST_TEAM_NAME, TEST_JOB_NAME, "no-exec");
-      mockMvc.perform(get(url)).andExpect(status().isNotFound());
-   }
-
+    String url =
+        String.format(
+            "/data-jobs/for-team/%s/jobs/%s/executions/%s/logs",
+            TEST_TEAM_NAME, TEST_JOB_NAME, "no-exec");
+    mockMvc.perform(get(url)).andExpect(status().isNotFound());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/DeploymentModelConverterTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/DeploymentModelConverterTest.java
@@ -12,46 +12,46 @@ import org.junit.jupiter.api.Test;
 
 public class DeploymentModelConverterTest {
 
-    @Test
-    void test_mergeDeployments() {
-        var oldDeployment = getTestJobDeployment();
-        var newDeployment = new JobDeployment();
-        newDeployment.setDataJobTeam(oldDeployment.getDataJobTeam());
-        newDeployment.setDataJobName(oldDeployment.getDataJobName());
-        newDeployment.setEnabled(false);
-        newDeployment.setVdkVersion("new");
+  @Test
+  void test_mergeDeployments() {
+    var oldDeployment = getTestJobDeployment();
+    var newDeployment = new JobDeployment();
+    newDeployment.setDataJobTeam(oldDeployment.getDataJobTeam());
+    newDeployment.setDataJobName(oldDeployment.getDataJobName());
+    newDeployment.setEnabled(false);
+    newDeployment.setVdkVersion("new");
 
-        var mergedDeployment = DeploymentModelConverter.mergeDeployments(oldDeployment, newDeployment);
+    var mergedDeployment = DeploymentModelConverter.mergeDeployments(oldDeployment, newDeployment);
 
-        Assertions.assertEquals(false, mergedDeployment.getEnabled());
-        Assertions.assertEquals(oldDeployment.getMode(), mergedDeployment.getMode());
-        Assertions.assertEquals("new", mergedDeployment.getVdkVersion());
-    }
+    Assertions.assertEquals(false, mergedDeployment.getEnabled());
+    Assertions.assertEquals(oldDeployment.getMode(), mergedDeployment.getMode());
+    Assertions.assertEquals("new", mergedDeployment.getVdkVersion());
+  }
 
-    @Test
-    void test_mergeDeployments_resources() {
-        var oldDeployment = getTestJobDeployment();
-        var newDeployment = new JobDeployment();
-        newDeployment.setDataJobTeam(oldDeployment.getDataJobTeam());
-        newDeployment.setDataJobName(oldDeployment.getDataJobName());
-        newDeployment.setGitCommitSha("new-version");
-        var newResources = new DataJobResources();
-        newResources.setMemoryLimit(2);
-        newDeployment.setResources(newResources);
+  @Test
+  void test_mergeDeployments_resources() {
+    var oldDeployment = getTestJobDeployment();
+    var newDeployment = new JobDeployment();
+    newDeployment.setDataJobTeam(oldDeployment.getDataJobTeam());
+    newDeployment.setDataJobName(oldDeployment.getDataJobName());
+    newDeployment.setGitCommitSha("new-version");
+    var newResources = new DataJobResources();
+    newResources.setMemoryLimit(2);
+    newDeployment.setResources(newResources);
 
-        var mergedDeployment = DeploymentModelConverter.mergeDeployments(oldDeployment, newDeployment);
-        Assertions.assertEquals(2, mergedDeployment.getResources().getMemoryLimit());
-    }
+    var mergedDeployment = DeploymentModelConverter.mergeDeployments(oldDeployment, newDeployment);
+    Assertions.assertEquals(2, mergedDeployment.getResources().getMemoryLimit());
+  }
 
-    private static JobDeployment getTestJobDeployment() {
-        JobDeployment jobDeployment = new JobDeployment();
-        jobDeployment.setDataJobTeam("job-team");
-        jobDeployment.setDataJobName("job-name");
-        jobDeployment.setEnabled(true);
-        jobDeployment.setResources(new DataJobResources());
-        jobDeployment.setMode("mode");
-        jobDeployment.setGitCommitSha("job-version");
-        jobDeployment.setVdkVersion("release");
-        return jobDeployment;
-    }
+  private static JobDeployment getTestJobDeployment() {
+    JobDeployment jobDeployment = new JobDeployment();
+    jobDeployment.setDataJobTeam("job-team");
+    jobDeployment.setDataJobName("job-name");
+    jobDeployment.setEnabled(true);
+    jobDeployment.setResources(new DataJobResources());
+    jobDeployment.setMode("mode");
+    jobDeployment.setGitCommitSha("job-version");
+    jobDeployment.setVdkVersion("release");
+    return jobDeployment;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/MockGit.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/MockGit.java
@@ -16,19 +16,18 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
 /**
- * Registers a bean with a non-functional mock mainly for {@link JobUpload}.
- * The class can be used to mock any Git related functionality.
+ * Registers a bean with a non-functional mock mainly for {@link JobUpload}. The class can be used
+ * to mock any Git related functionality.
  */
 @Profile("MockGit")
 @Configuration
 public class MockGit {
 
-   @Bean
-   @Primary
-   public JobUpload mockJobUpload() {
-      JobUpload mock = mock(JobUpload.class);
-      Mockito.doNothing().when(mock).deleteDataJob(any(), any());
-      return mock;
-   }
-
+  @Bean
+  @Primary
+  public JobUpload mockJobUpload() {
+    JobUpload mock = mock(JobUpload.class);
+    Mockito.doNothing().when(mock).deleteDataJob(any(), any());
+    return mock;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/MockKerberos.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/MockKerberos.java
@@ -25,34 +25,35 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 /**
- * Registers a bean with a mock, but fairly functional, implementation of a {@link KerberosCredentialsRepository}
+ * Registers a bean with a mock, but fairly functional, implementation of a {@link
+ * KerberosCredentialsRepository}
  */
 @Profile("MockKerberos")
 @Configuration
 public class MockKerberos {
 
-   private final Set<String> principals = new HashSet<>();
-   private final Random rand = new Random();
+  private final Set<String> principals = new HashSet<>();
+  private final Random rand = new Random();
 
-   @Bean
-   @Primary
-   public KerberosCredentialsRepository mockCredentialsRepository() {
-      KerberosCredentialsRepository mock = mock(KerberosCredentialsRepository.class);
-      doAnswer(answerVoid(this::createPrincipalMock)).when(mock).createPrincipal(any(), any());
-      when(mock.principalExists(any())).thenAnswer(answer(principals::contains));
-      doAnswer(answer(principals::remove)).when(mock).deletePrincipal(any());
-      return mock;
-   }
+  @Bean
+  @Primary
+  public KerberosCredentialsRepository mockCredentialsRepository() {
+    KerberosCredentialsRepository mock = mock(KerberosCredentialsRepository.class);
+    doAnswer(answerVoid(this::createPrincipalMock)).when(mock).createPrincipal(any(), any());
+    when(mock.principalExists(any())).thenAnswer(answer(principals::contains));
+    doAnswer(answer(principals::remove)).when(mock).deletePrincipal(any());
+    return mock;
+  }
 
-   private void createPrincipalMock(String principal, Optional<File> localKeyTab) {
-      principals.add(principal);
-      byte[] keytab = new byte[100];
-      rand.nextBytes(keytab);
-      localKeyTab.ifPresent(file -> writeBytes(keytab, file));
-   }
+  private void createPrincipalMock(String principal, Optional<File> localKeyTab) {
+    principals.add(principal);
+    byte[] keytab = new byte[100];
+    rand.nextBytes(keytab);
+    localKeyTab.ifPresent(file -> writeBytes(keytab, file));
+  }
 
-   @SneakyThrows
-   private void writeBytes(byte[] keytab, File file) {
-      Files.write(keytab, file);
-   }
+  @SneakyThrows
+  private void writeBytes(byte[] keytab, File file) {
+    Files.write(keytab, file);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/MockKubernetes.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/MockKubernetes.java
@@ -30,95 +30,162 @@ import static org.mockito.Mockito.*;
 
 /**
  * Registers a bean with a partially functional mock implementation of a {@link KubernetesService}
- * Since the mock implementation keep state of the kubernetes service resources created.
- * If cleaning that state after each test method is necessary it is a good idea to use DirtiesContext annotation on the test method.
- * See https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/test/annotation/DirtiesContext.html
+ * Since the mock implementation keep state of the kubernetes service resources created. If cleaning
+ * that state after each test method is necessary it is a good idea to use DirtiesContext annotation
+ * on the test method. See
+ * https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/test/annotation/DirtiesContext.html
  */
 @Profile("MockKubernetes")
 @Configuration
 public class MockKubernetes {
 
-   @Bean
-   @Primary
-   public DataJobsKubernetesService mockDataJobsKubernetesService() throws ApiException, IOException, InterruptedException {
-      DataJobsKubernetesService mock = mock(DataJobsKubernetesService.class);
-      mockKubernetesService(mock);
-      return mock;
-   }
+  @Bean
+  @Primary
+  public DataJobsKubernetesService mockDataJobsKubernetesService()
+      throws ApiException, IOException, InterruptedException {
+    DataJobsKubernetesService mock = mock(DataJobsKubernetesService.class);
+    mockKubernetesService(mock);
+    return mock;
+  }
 
-   @Bean
-   @Primary
-   public ControlKubernetesService mockControlKubernetesService() throws ApiException, IOException, InterruptedException {
-      ControlKubernetesService mock = mock(ControlKubernetesService.class);
-      mockKubernetesService(mock);
-      return mock;
-   }
+  @Bean
+  @Primary
+  public ControlKubernetesService mockControlKubernetesService()
+      throws ApiException, IOException, InterruptedException {
+    ControlKubernetesService mock = mock(ControlKubernetesService.class);
+    mockKubernetesService(mock);
+    return mock;
+  }
 
-   @Bean
-   @Primary
-   public TaskExecutor taskExecutor() {
-      // Deployment methods are non-blocking (Async) which makes them harder to test.
-      // Making them sync for the purposes of this test.
-      return new SyncTaskExecutor();
-   }
+  @Bean
+  @Primary
+  public TaskExecutor taskExecutor() {
+    // Deployment methods are non-blocking (Async) which makes them harder to test.
+    // Making them sync for the purposes of this test.
+    return new SyncTaskExecutor();
+  }
 
-   /**
-    * Mocks interactions with KubernetesService as much as necessary for unit testing purpose.
-    *
-    * NOTES:
-    * If job name starts with 'failure-' (e.g failure-my-job) - then Job status will be fail otherwise it's success.
-    */
-   private void mockKubernetesService(KubernetesService mock) throws ApiException, IOException, InterruptedException {
-      // By defautl beans are singleton scoped so we are sure this will be called once
-      // hence it's safe to keep the variables here isntead of static.
-      final Map<String, Map<String, byte[]>> secrets = new ConcurrentHashMap<>();
-      final Map<String, InvocationOnMock> crons = new ConcurrentHashMap<>();
-      final Map<String, InvocationOnMock> jobs = new ConcurrentHashMap<>();
+  /**
+   * Mocks interactions with KubernetesService as much as necessary for unit testing purpose.
+   *
+   * <p>NOTES: If job name starts with 'failure-' (e.g failure-my-job) - then Job status will be
+   * fail otherwise it's success.
+   */
+  private void mockKubernetesService(KubernetesService mock)
+      throws ApiException, IOException, InterruptedException {
+    // By defautl beans are singleton scoped so we are sure this will be called once
+    // hence it's safe to keep the variables here isntead of static.
+    final Map<String, Map<String, byte[]>> secrets = new ConcurrentHashMap<>();
+    final Map<String, InvocationOnMock> crons = new ConcurrentHashMap<>();
+    final Map<String, InvocationOnMock> jobs = new ConcurrentHashMap<>();
 
-      when(mock.getSecretData(any())).thenAnswer(inv -> secrets.getOrDefault(inv.getArgument(0), Collections.emptyMap()));
-      doAnswer(answer(secrets::put)).when(mock).saveSecretData(any(), any());
-      doAnswer(inv -> secrets.remove(inv.getArgument(0))).when(mock).removeSecretData(any());
+    when(mock.getSecretData(any()))
+        .thenAnswer(inv -> secrets.getOrDefault(inv.getArgument(0), Collections.emptyMap()));
+    doAnswer(answer(secrets::put)).when(mock).saveSecretData(any(), any());
+    doAnswer(inv -> secrets.remove(inv.getArgument(0))).when(mock).removeSecretData(any());
 
+    doAnswer(inv -> crons.put(inv.getArgument(0), inv))
+        .when(mock)
+        .createCronJob(
+            anyString(),
+            anyString(),
+            any(),
+            anyString(),
+            anyBoolean(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
+    doAnswer(inv -> crons.put(inv.getArgument(0), inv))
+        .when(mock)
+        .createCronJob(
+            anyString(),
+            anyString(),
+            any(),
+            anyString(),
+            anyBoolean(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyList());
+    doAnswer(inv -> crons.put(inv.getArgument(0), inv))
+        .when(mock)
+        .updateCronJob(
+            anyString(),
+            anyString(),
+            any(),
+            anyString(),
+            anyBoolean(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
+    doAnswer(inv -> crons.keySet()).when(mock).listCronJobs();
+    doAnswer(inv -> crons.remove(inv.getArgument(0))).when(mock).deleteCronJob(anyString());
+    doAnswer(
+            inv -> {
+              JobDeploymentStatus deployment = null;
+              if (crons.containsKey(inv.getArgument(0))) {
+                deployment = new JobDeploymentStatus();
+                deployment.setMode("release");
+                deployment.setCronJobName(inv.getArgument(0));
+                deployment.setImageName("image-name");
+                deployment.setGitCommitSha("foo");
+              }
+              return Optional.ofNullable(deployment);
+            })
+        .when(mock)
+        .readCronJob(anyString());
 
-      doAnswer(inv -> crons.put(inv.getArgument(0), inv))
-              .when(mock).createCronJob(anyString(), anyString(), any(), anyString(), anyBoolean(), any(), any(), any(), any(), any(), any(), any());
-      doAnswer(inv -> crons.put(inv.getArgument(0), inv))
-              .when(mock).createCronJob(anyString(), anyString(), any(), anyString(), anyBoolean(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), anyList());
-      doAnswer(inv -> crons.put(inv.getArgument(0), inv))
-              .when(mock).updateCronJob(anyString(), anyString(), any(), anyString(), anyBoolean(), any(), any(), any(), any(), any(), any(), any());
-      doAnswer(inv -> crons.keySet()).when(mock).listCronJobs();
-      doAnswer(inv -> crons.remove(inv.getArgument(0))).when(mock).deleteCronJob(anyString());
-      doAnswer(inv -> {
-         JobDeploymentStatus deployment = null;
-         if (crons.containsKey(inv.getArgument(0))) {
-            deployment = new JobDeploymentStatus();
-            deployment.setMode("release");
-            deployment.setCronJobName(inv.getArgument(0));
-            deployment.setImageName("image-name");
-            deployment.setGitCommitSha("foo");
-         }
-         return Optional.ofNullable(deployment);
-      }).when(mock).readCronJob(anyString());
+    doAnswer(inv -> jobs.put(inv.getArgument(0), inv))
+        .when(mock)
+        .createJob(
+            anyString(),
+            anyString(),
+            anyBoolean(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyString(),
+            any(),
+            any(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyString());
+    doAnswer(inv -> jobs.keySet()).when(mock).listCronJobs();
+    doAnswer(inv -> jobs.remove(inv.getArgument(0))).when(mock).deleteJob(anyString());
 
+    doAnswer(
+            inv -> {
+              String jobName = inv.getArgument(0);
+              if (jobs.containsKey(jobName)) {
+                if (jobName.startsWith("failure-")) {
+                  return new KubernetesService.JobStatusCondition(
+                      false, "Status", "Job name starts with 'failure-'", "", 0);
+                } else {
+                  return new KubernetesService.JobStatusCondition(true, "Status", "", "", 0);
+                }
+              }
+              return new KubernetesService.JobStatusCondition(false, null, "No such job", "", 0);
+            })
+        .when(mock)
+        .watchJob(anyString(), anyInt(), any());
 
-      doAnswer(inv -> jobs.put(inv.getArgument(0), inv)).when(mock)
-              .createJob(anyString(), anyString(), anyBoolean(), any(), any(), any(), any(),
-                    anyString(), any(), any(), anyLong(), anyLong(), anyLong(), anyString());
-      doAnswer(inv -> jobs.keySet()).when(mock).listCronJobs();
-      doAnswer(inv -> jobs.remove(inv.getArgument(0))).when(mock).deleteJob(anyString());
-
-      doAnswer(inv ->{
-         String jobName = inv.getArgument(0);
-         if (jobs.containsKey(jobName)) {
-            if (jobName.startsWith("failure-")) {
-               return new KubernetesService.JobStatusCondition(false, "Status", "Job name starts with 'failure-'", "", 0);
-            } else {
-               return new KubernetesService.JobStatusCondition(true, "Status", "", "", 0);
-            }
-         }
-         return new KubernetesService.JobStatusCondition(false, null, "No such job", "", 0);
-      }).when(mock).watchJob(anyString(), anyInt(), any());
-
-      doAnswer(inv -> "logs").when(mock).getJobLogs(anyString(), anyInt());
-   }
+    doAnswer(inv -> "logs").when(mock).getJobLogs(anyString(), anyInt());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/MockTelemetry.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/MockTelemetry.java
@@ -18,16 +18,16 @@ import java.util.List;
 @Configuration
 public class MockTelemetry {
 
-    public static List<String> payloads = new ArrayList<>();
+  public static List<String> payloads = new ArrayList<>();
 
-    @Bean
-    @Primary
-    public ITelemetry telemetryClient() {
-        return new ITelemetry() {
-            @Override
-            public void sendAsync(String payload) {
-                payloads.add(payload);
-            }
-        };
-    }
+  @Bean
+  @Primary
+  public ITelemetry telemetryClient() {
+    return new ITelemetry() {
+      @Override
+      public void sendAsync(String payload) {
+        payloads.add(payload);
+      }
+    };
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/TestUtils.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/TestUtils.java
@@ -19,88 +19,98 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 public class TestUtils {
 
-   public static final String TEST_TEAM_NAME = "test-team-name";
+  public static final String TEST_TEAM_NAME = "test-team-name";
 
-   private static final ObjectMapper mapper = new ObjectMapper();
+  private static final ObjectMapper mapper = new ObjectMapper();
 
-   //@NotNull
-   public static DataJob getDataJob(String teamName, String name) {
-      var job = new DataJob();
-      job.setJobName(name);
-      job.setTeam(teamName);
-      var dataJobConfig = new DataJobConfig();
-      dataJobConfig.setGenerateKeytab(true);
-      dataJobConfig.setSchedule(new DataJobSchedule());
-      dataJobConfig.getSchedule().setScheduleCron("15 10 * * *");
-      dataJobConfig.setContacts(new DataJobContacts());
-      dataJobConfig.setDbDefaultType("");
-      job.setConfig(dataJobConfig);
-      return job;
-   }
+  // @NotNull
+  public static DataJob getDataJob(String teamName, String name) {
+    var job = new DataJob();
+    job.setJobName(name);
+    job.setTeam(teamName);
+    var dataJobConfig = new DataJobConfig();
+    dataJobConfig.setGenerateKeytab(true);
+    dataJobConfig.setSchedule(new DataJobSchedule());
+    dataJobConfig.getSchedule().setScheduleCron("15 10 * * *");
+    dataJobConfig.setContacts(new DataJobContacts());
+    dataJobConfig.setDbDefaultType("");
+    job.setConfig(dataJobConfig);
+    return job;
+  }
 
-   public static DataJobDeployment getDataJobDeployment(String deploymentId, String jobVersion) {
-      var jobDeployment = new DataJobDeployment();
-      jobDeployment.setVdkVersion("");
-      jobDeployment.setJobVersion(jobVersion);
-      jobDeployment.setMode(DataJobMode.RELEASE);
-      jobDeployment.setEnabled(true);
-      jobDeployment.setResources(new DataJobResources());
-      jobDeployment.setSchedule(new DataJobSchedule());
-      jobDeployment.setId(deploymentId);
+  public static DataJobDeployment getDataJobDeployment(String deploymentId, String jobVersion) {
+    var jobDeployment = new DataJobDeployment();
+    jobDeployment.setVdkVersion("");
+    jobDeployment.setJobVersion(jobVersion);
+    jobDeployment.setMode(DataJobMode.RELEASE);
+    jobDeployment.setEnabled(true);
+    jobDeployment.setResources(new DataJobResources());
+    jobDeployment.setSchedule(new DataJobSchedule());
+    jobDeployment.setId(deploymentId);
 
-      return jobDeployment;
-   }
+    return jobDeployment;
+  }
 
+  public static ResultActions createDataJob(MockMvc mockMvc, String teamName, String jobName)
+      throws Exception {
+    var job = TestUtils.getDataJob(teamName, jobName);
 
-   public static ResultActions createDataJob(MockMvc mockMvc, String teamName, String jobName) throws Exception {
-      var job = TestUtils.getDataJob(teamName, jobName);
+    String body = mapper.writeValueAsString(job);
+    var result =
+        mockMvc
+            .perform(
+                post(String.format("/data-jobs/for-team/%s/jobs", teamName))
+                    .content(body)
+                    .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated());
+    return result;
+  }
 
-      String body = mapper.writeValueAsString(job);
-      var result = mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs", teamName))
-                      .content(body).contentType(MediaType.APPLICATION_JSON))
-              .andExpect(status().isCreated());
-      return result;
-   }
+  public static ResultActions createDeployment(MockMvc mockMvc, String teamName, String jobName)
+      throws Exception {
+    var jobDeployment = TestUtils.getDataJobDeployment(jobName, "1");
 
-   public static ResultActions createDeployment(MockMvc mockMvc, String teamName, String jobName) throws Exception {
-      var jobDeployment = TestUtils.getDataJobDeployment(jobName, "1");
+    var result =
+        mockMvc.perform(
+            post(String.format("/data-jobs/for-team/%s/jobs/%s/deployments", teamName, jobName))
+                .content(mapper.writeValueAsString(jobDeployment))
+                .contentType(MediaType.APPLICATION_JSON));
+    return result;
+  }
 
-      var result = mockMvc.perform(post(String.format("/data-jobs/for-team/%s/jobs/%s/deployments", teamName, jobName))
-                      .content(mapper.writeValueAsString(jobDeployment))
-                      .contentType(MediaType.APPLICATION_JSON));
-      return result;
-   }
+  @NotNull
+  public static ResultActions startMockExecution(MockMvc mockMvc, String teamName, String jobName)
+      throws Exception {
+    DataJobExecutionRequest executionRequest = new DataJobExecutionRequest();
+    executionRequest.setStartedBy("unit-test");
+    String body = mapper.writeValueAsString(executionRequest);
 
-   @NotNull
-   public static ResultActions startMockExecution(MockMvc mockMvc, String teamName, String jobName) throws Exception {
-      DataJobExecutionRequest executionRequest = new DataJobExecutionRequest();
-      executionRequest.setStartedBy("unit-test");
-      String body = mapper.writeValueAsString(executionRequest);
+    String url =
+        String.format(
+            "/data-jobs/for-team/%s/jobs/%s/deployments/%s/executions", teamName, jobName, jobName);
+    var mockExecution =
+        mockMvc.perform(post(url).content(body).contentType(MediaType.APPLICATION_JSON));
+    return mockExecution;
+  }
 
-      String url = String.format("/data-jobs/for-team/%s/jobs/%s/deployments/%s/executions",
-              teamName, jobName, jobName);
-      var mockExecution = mockMvc.perform(post(url).content(body).contentType(MediaType.APPLICATION_JSON));
-      return mockExecution;
-   }
+  public static JobDeploymentStatus getJobDeploymentStatus() {
+    JobDeploymentStatus jobDeploymentStatus = new JobDeploymentStatus();
+    jobDeploymentStatus.setGitCommitSha("version");
+    jobDeploymentStatus.setEnabled(true);
+    jobDeploymentStatus.setImageName("test-job-image-name");
+    jobDeploymentStatus.setMode("mode");
+    jobDeploymentStatus.setCronJobName("cron");
+    return jobDeploymentStatus;
+  }
 
-   public static JobDeploymentStatus getJobDeploymentStatus() {
-      JobDeploymentStatus jobDeploymentStatus = new JobDeploymentStatus();
-      jobDeploymentStatus.setGitCommitSha("version");
-      jobDeploymentStatus.setEnabled(true);
-      jobDeploymentStatus.setImageName("test-job-image-name");
-      jobDeploymentStatus.setMode("mode");
-      jobDeploymentStatus.setCronJobName("cron");
-      return jobDeploymentStatus;
-   }
-
-   public static JobDeployment getJobDeployment() {
-      JobDeployment jobDeployment = new JobDeployment();
-      jobDeployment.setDataJobTeam(TestUtils.TEST_TEAM_NAME);
-      jobDeployment.setGitCommitSha("version");
-      jobDeployment.setEnabled(true);
-      jobDeployment.setImageName("test-job-image-name");
-      jobDeployment.setMode("mode");
-      jobDeployment.setCronJobName("cron");
-      return jobDeployment;
-   }
+  public static JobDeployment getJobDeployment() {
+    JobDeployment jobDeployment = new JobDeployment();
+    jobDeployment.setDataJobTeam(TestUtils.TEST_TEAM_NAME);
+    jobDeployment.setGitCommitSha("version");
+    jobDeployment.setEnabled(true);
+    jobDeployment.setImageName("test-job-image-name");
+    jobDeployment.setMode("mode");
+    jobDeployment.setCronJobName("cron");
+    return jobDeployment;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/BaseWebHookProviderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/BaseWebHookProviderTest.java
@@ -30,157 +30,175 @@ import static org.mockito.ArgumentMatchers.anyString;
 @ExtendWith(MockitoExtension.class)
 public abstract class BaseWebHookProviderTest {
 
-   private static final int ONE_RETRY = 1;
-   private static final int INVOCATION_PLUS_ONE_RETRY_COUNT = 2;
-   private static final int SINGLE_INVOCATION_COUNT = 1;
+  private static final int ONE_RETRY = 1;
+  private static final int INVOCATION_PLUS_ONE_RETRY_COUNT = 2;
+  private static final int SINGLE_INVOCATION_COUNT = 1;
 
-   @Mock
-   RestTemplate restTemplate;
+  @Mock RestTemplate restTemplate;
 
-   WebHookRequestBody requestBody;
+  WebHookRequestBody requestBody;
 
-   abstract WebHookService<WebHookRequestBody> getWebHookProvider();
+  abstract WebHookService<WebHookRequestBody> getWebHookProvider();
 
-   @BeforeEach
-   public void setUp() {
-      requestBody = new WebHookRequestBody();
-      requestBody.setRequestedHttpPath("/data-jobs");
-      requestBody.setRequestedHttpVerb("SOME");
-      requestBody.setRequestedResourceId(null);
-      requestBody.setRequesterUserId("auserov");
-      requestBody.setRequestedResourceTeam(null);
-      requestBody.setRequestedResourceName("data-job");
-   }
+  @BeforeEach
+  public void setUp() {
+    requestBody = new WebHookRequestBody();
+    requestBody.setRequestedHttpPath("/data-jobs");
+    requestBody.setRequestedHttpVerb("SOME");
+    requestBody.setRequestedResourceId(null);
+    requestBody.setRequesterUserId("auserov");
+    requestBody.setRequestedResourceTeam(null);
+    requestBody.setRequestedResourceName("data-job");
+  }
 
-   @Test
-   public void testBadRequestStatus() {
-      ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "http://localhost:4444");
-      ResponseEntity re = new ResponseEntity<>(
-              "Bad request: The post create action needs more parameters",
-              null,
-              HttpStatus.BAD_REQUEST);
-      Mockito.when(restTemplate.exchange(Mockito.anyString(),
-              Mockito.any(HttpMethod.class),
-              Mockito.any(),
-              Mockito.<Class<String>>any())).thenReturn(re);
+  @Test
+  public void testBadRequestStatus() {
+    ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "http://localhost:4444");
+    ResponseEntity re =
+        new ResponseEntity<>(
+            "Bad request: The post create action needs more parameters",
+            null,
+            HttpStatus.BAD_REQUEST);
+    Mockito.when(
+            restTemplate.exchange(
+                Mockito.anyString(),
+                Mockito.any(HttpMethod.class),
+                Mockito.any(),
+                Mockito.<Class<String>>any()))
+        .thenReturn(re);
 
-      WebHookResult webHookResult = getWebHookProvider().invokeWebHook(requestBody).get();
-      Assertions.assertEquals("Bad request: The post create action needs more parameters", webHookResult.getMessage());
-      Assertions.assertEquals(HttpStatus.BAD_REQUEST, webHookResult.getStatus());
-      Assertions.assertEquals(false, webHookResult.isSuccess());
-   }
+    WebHookResult webHookResult = getWebHookProvider().invokeWebHook(requestBody).get();
+    Assertions.assertEquals(
+        "Bad request: The post create action needs more parameters", webHookResult.getMessage());
+    Assertions.assertEquals(HttpStatus.BAD_REQUEST, webHookResult.getStatus());
+    Assertions.assertEquals(false, webHookResult.isSuccess());
+  }
 
-   @Test
-   public void testWebHookSuccess() {
-      ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "http://localhost:4444");
-      ResponseEntity re = new ResponseEntity<>(
-              "Good request",
-              null,
-              HttpStatus.ACCEPTED);
-      Mockito.when(restTemplate.exchange(Mockito.anyString(),
-              Mockito.any(HttpMethod.class),
-              Mockito.any(),
-              Mockito.<Class<String>>any())).thenReturn(re);
+  @Test
+  public void testWebHookSuccess() {
+    ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "http://localhost:4444");
+    ResponseEntity re = new ResponseEntity<>("Good request", null, HttpStatus.ACCEPTED);
+    Mockito.when(
+            restTemplate.exchange(
+                Mockito.anyString(),
+                Mockito.any(HttpMethod.class),
+                Mockito.any(),
+                Mockito.<Class<String>>any()))
+        .thenReturn(re);
 
-      WebHookResult webHookResult = getWebHookProvider().invokeWebHook(requestBody).get();
-      Assertions.assertEquals("", webHookResult.getMessage());
-      Assertions.assertEquals(HttpStatus.ACCEPTED, webHookResult.getStatus());
-      Assertions.assertEquals(true, webHookResult.isSuccess());
-   }
+    WebHookResult webHookResult = getWebHookProvider().invokeWebHook(requestBody).get();
+    Assertions.assertEquals("", webHookResult.getMessage());
+    Assertions.assertEquals(HttpStatus.ACCEPTED, webHookResult.getStatus());
+    Assertions.assertEquals(true, webHookResult.isSuccess());
+  }
 
-   @Test
-   public void testRestClientResponseExceptionHandling() {
-      ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "http://localhost:4444");
-      Mockito.when(restTemplate.exchange(Mockito.anyString(),
-              Mockito.any(HttpMethod.class),
-              Mockito.any(),
-              Mockito.<Class<String>>any())).thenThrow(new RestClientResponseException(
-              "Bad request",
-              HttpStatus.BAD_REQUEST.value(),
-              anyString(),
-              Mockito.any(HttpHeaders.class),
-              any(),
-              any()));
+  @Test
+  public void testRestClientResponseExceptionHandling() {
+    ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "http://localhost:4444");
+    Mockito.when(
+            restTemplate.exchange(
+                Mockito.anyString(),
+                Mockito.any(HttpMethod.class),
+                Mockito.any(),
+                Mockito.<Class<String>>any()))
+        .thenThrow(
+            new RestClientResponseException(
+                "Bad request",
+                HttpStatus.BAD_REQUEST.value(),
+                anyString(),
+                Mockito.any(HttpHeaders.class),
+                any(),
+                any()));
 
-      WebHookResult webHookResult = getWebHookProvider().invokeWebHook(requestBody).get();
-      Assertions.assertEquals("", webHookResult.getMessage());
-      Assertions.assertEquals(HttpStatus.BAD_REQUEST, webHookResult.getStatus());
-      Assertions.assertEquals(false, webHookResult.isSuccess());
-   }
+    WebHookResult webHookResult = getWebHookProvider().invokeWebHook(requestBody).get();
+    Assertions.assertEquals("", webHookResult.getMessage());
+    Assertions.assertEquals(HttpStatus.BAD_REQUEST, webHookResult.getStatus());
+    Assertions.assertEquals(false, webHookResult.isSuccess());
+  }
 
-   @Test
-   public void testInformationalStatusCode() {
-      ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "http://localhost:4444");
-      ResponseEntity re = new ResponseEntity<>(
-              "User authorized",
-              null,
-              HttpStatus.CONTINUE);
-      Mockito.when(restTemplate.exchange(Mockito.anyString(),
-              Mockito.any(HttpMethod.class),
-              Mockito.any(),
-              Mockito.<Class<String>>any())).thenReturn(re);
+  @Test
+  public void testInformationalStatusCode() {
+    ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "http://localhost:4444");
+    ResponseEntity re = new ResponseEntity<>("User authorized", null, HttpStatus.CONTINUE);
+    Mockito.when(
+            restTemplate.exchange(
+                Mockito.anyString(),
+                Mockito.any(HttpMethod.class),
+                Mockito.any(),
+                Mockito.<Class<String>>any()))
+        .thenReturn(re);
 
-      Assertions.assertThrows(ExternalSystemError.class, () -> getWebHookProvider().invokeWebHook(requestBody));
-   }
+    Assertions.assertThrows(
+        ExternalSystemError.class, () -> getWebHookProvider().invokeWebHook(requestBody));
+  }
 
-   @Test
-   public void testRedirectionStatusCode() {
-      ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "http://localhost:4444");
-      ResponseEntity re = new ResponseEntity<>(
-              "User authorized",
-              null,
-              HttpStatus.MOVED_PERMANENTLY);
-      Mockito.when(restTemplate.exchange(Mockito.anyString(),
-              Mockito.any(HttpMethod.class),
-              Mockito.any(),
-              Mockito.<Class<String>>any())).thenReturn(re);
+  @Test
+  public void testRedirectionStatusCode() {
+    ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "http://localhost:4444");
+    ResponseEntity re = new ResponseEntity<>("User authorized", null, HttpStatus.MOVED_PERMANENTLY);
+    Mockito.when(
+            restTemplate.exchange(
+                Mockito.anyString(),
+                Mockito.any(HttpMethod.class),
+                Mockito.any(),
+                Mockito.<Class<String>>any()))
+        .thenReturn(re);
 
-      Assertions.assertThrows(ExternalSystemError.class, () -> getWebHookProvider().invokeWebHook(requestBody));
-   }
+    Assertions.assertThrows(
+        ExternalSystemError.class, () -> getWebHookProvider().invokeWebHook(requestBody));
+  }
 
-   @Test
-   public void testServiceUnavailableWithRetry() {
-      ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "http://localhost:4444");
-      ReflectionTestUtils.setField(getWebHookProvider(), "retriesOn5xxErrors", ONE_RETRY);
-      ResponseEntity re = new ResponseEntity<>(
-              "Service unavailable",
-              null,
-              HttpStatus.SERVICE_UNAVAILABLE);
-      Mockito.when(restTemplate.exchange(Mockito.anyString(),
-              Mockito.any(HttpMethod.class),
-              Mockito.any(),
-              Mockito.<Class<String>>any())).thenReturn(re);
+  @Test
+  public void testServiceUnavailableWithRetry() {
+    ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "http://localhost:4444");
+    ReflectionTestUtils.setField(getWebHookProvider(), "retriesOn5xxErrors", ONE_RETRY);
+    ResponseEntity re =
+        new ResponseEntity<>("Service unavailable", null, HttpStatus.SERVICE_UNAVAILABLE);
+    Mockito.when(
+            restTemplate.exchange(
+                Mockito.anyString(),
+                Mockito.any(HttpMethod.class),
+                Mockito.any(),
+                Mockito.<Class<String>>any()))
+        .thenReturn(re);
 
-      Assertions.assertThrows(ExternalSystemError.class, () -> getWebHookProvider().invokeWebHook(requestBody));
-      Mockito.verify(restTemplate, Mockito.times(INVOCATION_PLUS_ONE_RETRY_COUNT)).exchange(Mockito.anyString(),
-              Mockito.any(HttpMethod.class),
-              Mockito.any(),
-              Mockito.<Class<String>>any());
-   }
+    Assertions.assertThrows(
+        ExternalSystemError.class, () -> getWebHookProvider().invokeWebHook(requestBody));
+    Mockito.verify(restTemplate, Mockito.times(INVOCATION_PLUS_ONE_RETRY_COUNT))
+        .exchange(
+            Mockito.anyString(),
+            Mockito.any(HttpMethod.class),
+            Mockito.any(),
+            Mockito.<Class<String>>any());
+  }
 
-   @Test
-   public void testInternalErrorDefaultNoRetry() {
-      ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "http://localhost:4444");
-      ResponseEntity re = new ResponseEntity<>(
-              "Internal Server error",
-              null,
-              HttpStatus.INTERNAL_SERVER_ERROR);
-      Mockito.when(restTemplate.exchange(Mockito.anyString(),
-              Mockito.any(HttpMethod.class),
-              Mockito.any(),
-              Mockito.<Class<String>>any())).thenReturn(re);
+  @Test
+  public void testInternalErrorDefaultNoRetry() {
+    ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "http://localhost:4444");
+    ResponseEntity re =
+        new ResponseEntity<>("Internal Server error", null, HttpStatus.INTERNAL_SERVER_ERROR);
+    Mockito.when(
+            restTemplate.exchange(
+                Mockito.anyString(),
+                Mockito.any(HttpMethod.class),
+                Mockito.any(),
+                Mockito.<Class<String>>any()))
+        .thenReturn(re);
 
-      Assertions.assertThrows(ExternalSystemError.class, () -> getWebHookProvider().invokeWebHook(requestBody));
-      Mockito.verify(restTemplate, Mockito.times(SINGLE_INVOCATION_COUNT)).exchange(Mockito.anyString(),
-              Mockito.any(HttpMethod.class),
-              Mockito.any(),
-              Mockito.<Class<String>>any());
-   }
+    Assertions.assertThrows(
+        ExternalSystemError.class, () -> getWebHookProvider().invokeWebHook(requestBody));
+    Mockito.verify(restTemplate, Mockito.times(SINGLE_INVOCATION_COUNT))
+        .exchange(
+            Mockito.anyString(),
+            Mockito.any(HttpMethod.class),
+            Mockito.any(),
+            Mockito.<Class<String>>any());
+  }
 
-   @Test
-   public void testWebHookEndpointNotConfigured() {
-      ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "");
+  @Test
+  public void testWebHookEndpointNotConfigured() {
+    ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "");
 
-      Assertions.assertTrue(getWebHookProvider().invokeWebHook(requestBody).isEmpty());
-   }
+    Assertions.assertTrue(getWebHookProvider().invokeWebHook(requestBody).isEmpty());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/PostCreateWebHookProviderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/PostCreateWebHookProviderTest.java
@@ -8,12 +8,9 @@ package com.vmware.taurus.datajobs.webhook;
 import lombok.Getter;
 import org.mockito.InjectMocks;
 
-
 @Getter
-/**
- * See {@link BaseWebHookProviderTest} for the details of the tests.
- */
+/** See {@link BaseWebHookProviderTest} for the details of the tests. */
 public class PostCreateWebHookProviderTest extends BaseWebHookProviderTest {
-   @InjectMocks
-   private PostCreateWebHookProvider webHookProvider = new PostCreateWebHookProvider("", -1);
+  @InjectMocks
+  private PostCreateWebHookProvider webHookProvider = new PostCreateWebHookProvider("", -1);
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/PostDeleteWebHookProviderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/PostDeleteWebHookProviderTest.java
@@ -9,10 +9,8 @@ import lombok.Getter;
 import org.mockito.InjectMocks;
 
 @Getter
-/**
- * See {@link BaseWebHookProviderTest} for the details of the tests.
- */
+/** See {@link BaseWebHookProviderTest} for the details of the tests. */
 public class PostDeleteWebHookProviderTest extends BaseWebHookProviderTest {
-   @InjectMocks
-   private PostDeleteWebHookProvider webHookProvider = new PostDeleteWebHookProvider("", -1);
+  @InjectMocks
+  private PostDeleteWebHookProvider webHookProvider = new PostDeleteWebHookProvider("", -1);
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/ToApiModelConverterJobExecutionTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/ToApiModelConverterJobExecutionTest.java
@@ -18,100 +18,98 @@ import java.time.OffsetDateTime;
 
 public class ToApiModelConverterJobExecutionTest {
 
-    private static final String TEST_LOGS_URL = "http://logs/jobs?filter=job-name";
+  private static final String TEST_LOGS_URL = "http://logs/jobs?filter=job-name";
 
-    private DataJobExecution expected;
+  private DataJobExecution expected;
 
-    private com.vmware.taurus.service.model.DataJobExecution toConvert;
+  private com.vmware.taurus.service.model.DataJobExecution toConvert;
 
-    @BeforeEach
-    public void setUp() {
-        DataJobDeployment dataJobDeployment = new DataJobDeployment();
-        var schedule = new DataJobSchedule();
-        schedule.setScheduleCron("cron schedule string");
+  @BeforeEach
+  public void setUp() {
+    DataJobDeployment dataJobDeployment = new DataJobDeployment();
+    var schedule = new DataJobSchedule();
+    schedule.setScheduleCron("cron schedule string");
 
-        var resources = new DataJobResources();
-        resources.setMemoryRequest(100);
-        resources.setMemoryLimit(150);
-        resources.setCpuRequest(1.4f);
-        resources.setCpuLimit(2.5f);
+    var resources = new DataJobResources();
+    resources.setMemoryRequest(100);
+    resources.setMemoryLimit(150);
+    resources.setCpuRequest(1.4f);
+    resources.setCpuLimit(2.5f);
 
-        dataJobDeployment.setSchedule(schedule);
-        dataJobDeployment.setResources(resources);
-        dataJobDeployment.setId(DataJobMode.RELEASE.getValue());
-        dataJobDeployment.setMode(DataJobMode.RELEASE);
-        dataJobDeployment.enabled(true);
-        dataJobDeployment.setDeployedBy("test-user");
-        dataJobDeployment.setDeployedDate(OffsetDateTime.MAX);
+    dataJobDeployment.setSchedule(schedule);
+    dataJobDeployment.setResources(resources);
+    dataJobDeployment.setId(DataJobMode.RELEASE.getValue());
+    dataJobDeployment.setMode(DataJobMode.RELEASE);
+    dataJobDeployment.enabled(true);
+    dataJobDeployment.setDeployedBy("test-user");
+    dataJobDeployment.setDeployedDate(OffsetDateTime.MAX);
 
-        expected = new DataJobExecution();
-        expected.setDeployment(dataJobDeployment);
-        expected.setType(DataJobExecution.TypeEnum.SCHEDULED);
-        expected.setMessage("Message");
-        expected.setStartedBy("Started");
-        expected.setId("1234");
-        expected.setOpId("1234");
-        expected.setStartTime(OffsetDateTime.MIN);
-        expected.setEndTime(OffsetDateTime.MAX);
-        expected.setJobName("Job");
-        expected.setStatus(DataJobExecution.StatusEnum.RUNNING);
-        expected.setLogsUrl(TEST_LOGS_URL);
+    expected = new DataJobExecution();
+    expected.setDeployment(dataJobDeployment);
+    expected.setType(DataJobExecution.TypeEnum.SCHEDULED);
+    expected.setMessage("Message");
+    expected.setStartedBy("Started");
+    expected.setId("1234");
+    expected.setOpId("1234");
+    expected.setStartTime(OffsetDateTime.MIN);
+    expected.setEndTime(OffsetDateTime.MAX);
+    expected.setJobName("Job");
+    expected.setStatus(DataJobExecution.StatusEnum.RUNNING);
+    expected.setLogsUrl(TEST_LOGS_URL);
 
-        toConvert = new com.vmware.taurus.service.model.DataJobExecution();
-        toConvert.setEndTime(OffsetDateTime.MAX);
-        toConvert.setStartTime(OffsetDateTime.MIN);
-        toConvert.setType(ExecutionType.SCHEDULED);
-        toConvert.setMessage("Message");
-        toConvert.setStartedBy("Started");
-        toConvert.setId("1234");
-        toConvert.setOpId("1234");
-        toConvert.setDataJob(new DataJob());
-        toConvert.getDataJob()
-                .setName("Job");
-        toConvert.setLastDeployedBy("test-user");
-        toConvert.setLastDeployedDate(OffsetDateTime.MAX);
-        toConvert.setStatus(ExecutionStatus.RUNNING);
-        toConvert.setJobSchedule("cron schedule string");
-        toConvert.setResourcesCpuLimit(2.5f);
-        toConvert.setResourcesCpuRequest(1.4f);
-        toConvert.setResourcesMemoryRequest(100);
-        toConvert.setResourcesMemoryLimit(150);
-    }
+    toConvert = new com.vmware.taurus.service.model.DataJobExecution();
+    toConvert.setEndTime(OffsetDateTime.MAX);
+    toConvert.setStartTime(OffsetDateTime.MIN);
+    toConvert.setType(ExecutionType.SCHEDULED);
+    toConvert.setMessage("Message");
+    toConvert.setStartedBy("Started");
+    toConvert.setId("1234");
+    toConvert.setOpId("1234");
+    toConvert.setDataJob(new DataJob());
+    toConvert.getDataJob().setName("Job");
+    toConvert.setLastDeployedBy("test-user");
+    toConvert.setLastDeployedDate(OffsetDateTime.MAX);
+    toConvert.setStatus(ExecutionStatus.RUNNING);
+    toConvert.setJobSchedule("cron schedule string");
+    toConvert.setResourcesCpuLimit(2.5f);
+    toConvert.setResourcesCpuRequest(1.4f);
+    toConvert.setResourcesMemoryRequest(100);
+    toConvert.setResourcesMemoryLimit(150);
+  }
 
-    @Test
-    public void testConvertDataJobExecution() {
-        var actual = ToApiModelConverter.jobExecutionToConvert(toConvert, TEST_LOGS_URL);
-        Assertions.assertEquals(expected, actual);
-    }
+  @Test
+  public void testConvertDataJobExecution() {
+    var actual = ToApiModelConverter.jobExecutionToConvert(toConvert, TEST_LOGS_URL);
+    Assertions.assertEquals(expected, actual);
+  }
 
-    @Test
-    public void testDifferentStatus() {
-        expected.setStatus(DataJobExecution.StatusEnum.PLATFORM_ERROR);
-        toConvert.setStatus(ExecutionStatus.PLATFORM_ERROR);
-        var actual = ToApiModelConverter.jobExecutionToConvert(toConvert, TEST_LOGS_URL);
+  @Test
+  public void testDifferentStatus() {
+    expected.setStatus(DataJobExecution.StatusEnum.PLATFORM_ERROR);
+    toConvert.setStatus(ExecutionStatus.PLATFORM_ERROR);
+    var actual = ToApiModelConverter.jobExecutionToConvert(toConvert, TEST_LOGS_URL);
 
-        Assertions.assertEquals(expected, actual);
-    }
+    Assertions.assertEquals(expected, actual);
+  }
 
-    @Test
-    public void testDifferentType() {
-        expected.setType(DataJobExecution.TypeEnum.MANUAL);
-        toConvert.setType(ExecutionType.MANUAL);
-        var actual = ToApiModelConverter.jobExecutionToConvert(toConvert, TEST_LOGS_URL);
+  @Test
+  public void testDifferentType() {
+    expected.setType(DataJobExecution.TypeEnum.MANUAL);
+    toConvert.setType(ExecutionType.MANUAL);
+    var actual = ToApiModelConverter.jobExecutionToConvert(toConvert, TEST_LOGS_URL);
 
-        Assertions.assertEquals(expected, actual);
-    }
+    Assertions.assertEquals(expected, actual);
+  }
 
-    @Test
-    public void testSomeNullablePropertiesNull() {
-        expected.setEndTime(null);
-        expected.setMessage(null);
+  @Test
+  public void testSomeNullablePropertiesNull() {
+    expected.setEndTime(null);
+    expected.setMessage(null);
 
-        toConvert.setEndTime(null);
-        toConvert.setMessage(null);
-        var actual = ToApiModelConverter.jobExecutionToConvert(toConvert, TEST_LOGS_URL);
+    toConvert.setEndTime(null);
+    toConvert.setMessage(null);
+    var actual = ToApiModelConverter.jobExecutionToConvert(toConvert, TEST_LOGS_URL);
 
-        Assertions.assertEquals(expected, actual);
-    }
-
+    Assertions.assertEquals(expected, actual);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/DataJobExecutionRateCounterTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/DataJobExecutionRateCounterTest.java
@@ -27,79 +27,139 @@ import java.util.List;
 @ExtendWith(SpringExtension.class)
 public class DataJobExecutionRateCounterTest {
 
-    @Autowired
-    private JobExecutionRepository jobExecutionRepository;
+  @Autowired private JobExecutionRepository jobExecutionRepository;
 
-    @Autowired
-    private JobsRepository jobsRepository;
+  @Autowired private JobsRepository jobsRepository;
 
-    @Autowired
-    JobExecutionService jobExecutionService;
+  @Autowired JobExecutionService jobExecutionService;
 
-    private DataJob dataJob;
+  private DataJob dataJob;
 
-    @BeforeEach
-    public void setup() {
-        dataJob = RepositoryUtil.createDataJob(jobsRepository);
-    }
+  @BeforeEach
+  public void setup() {
+    dataJob = RepositoryUtil.createDataJob(jobsRepository);
+  }
 
-    @AfterEach
-    public void cleanup() {
-        jobsRepository.deleteAll();
-        jobExecutionRepository.deleteAll();
-    }
+  @AfterEach
+  public void cleanup() {
+    jobsRepository.deleteAll();
+    jobExecutionRepository.deleteAll();
+  }
 
-    @Test
-    public void testSuccessQuery_emptyExecutionsRepo_expectNoSuccess() {
-        var response = jobExecutionService.countExecutionStatuses(List.of("test-job"), List.of(ExecutionStatus.PLATFORM_ERROR, ExecutionStatus.SUCCEEDED));
-        Assertions.assertEquals(0, response.getOrDefault("test-job", new HashMap<>())
-                                                    .getOrDefault(ExecutionStatus.PLATFORM_ERROR, 0));
-        Assertions.assertEquals(0, response.getOrDefault("test-job", new HashMap<>())
-                                                    .getOrDefault(ExecutionStatus.SUCCEEDED, 0));
-    }
+  @Test
+  public void testSuccessQuery_emptyExecutionsRepo_expectNoSuccess() {
+    var response =
+        jobExecutionService.countExecutionStatuses(
+            List.of("test-job"),
+            List.of(ExecutionStatus.PLATFORM_ERROR, ExecutionStatus.SUCCEEDED));
+    Assertions.assertEquals(
+        0,
+        response
+            .getOrDefault("test-job", new HashMap<>())
+            .getOrDefault(ExecutionStatus.PLATFORM_ERROR, 0));
+    Assertions.assertEquals(
+        0,
+        response
+            .getOrDefault("test-job", new HashMap<>())
+            .getOrDefault(ExecutionStatus.SUCCEEDED, 0));
+  }
 
-    @Test
-    public void testSuccessQuery_oneFailed_expectNoSuccess() {
-        RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-id", dataJob,
-                ExecutionStatus.PLATFORM_ERROR, "test-msg", OffsetDateTime.now());
-        var response = jobExecutionService.countExecutionStatuses(List.of("test-job"), List.of(ExecutionStatus.SUCCEEDED));
-        Assertions.assertEquals(0, response.getOrDefault("test-job", new HashMap<>())
-                                                    .getOrDefault(ExecutionStatus.SUCCEEDED, 0));
-    }
+  @Test
+  public void testSuccessQuery_oneFailed_expectNoSuccess() {
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-id",
+        dataJob,
+        ExecutionStatus.PLATFORM_ERROR,
+        "test-msg",
+        OffsetDateTime.now());
+    var response =
+        jobExecutionService.countExecutionStatuses(
+            List.of("test-job"), List.of(ExecutionStatus.SUCCEEDED));
+    Assertions.assertEquals(
+        0,
+        response
+            .getOrDefault("test-job", new HashMap<>())
+            .getOrDefault(ExecutionStatus.SUCCEEDED, 0));
+  }
 
-    @Test
-    public void testFailureQuery_oneSuccessful_expectNoFailure() {
-        RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-id", dataJob,
-                ExecutionStatus.SUCCEEDED, "test-msg", OffsetDateTime.now());
+  @Test
+  public void testFailureQuery_oneSuccessful_expectNoFailure() {
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-id",
+        dataJob,
+        ExecutionStatus.SUCCEEDED,
+        "test-msg",
+        OffsetDateTime.now());
 
-        var response = jobExecutionService.countExecutionStatuses(List.of("test-job"), List.of(ExecutionStatus.PLATFORM_ERROR));
-        Assertions.assertEquals(0, response.getOrDefault("test-job", new HashMap<>())
-                                                    .getOrDefault(ExecutionStatus.PLATFORM_ERROR, 0));
-    }
+    var response =
+        jobExecutionService.countExecutionStatuses(
+            List.of("test-job"), List.of(ExecutionStatus.PLATFORM_ERROR));
+    Assertions.assertEquals(
+        0,
+        response
+            .getOrDefault("test-job", new HashMap<>())
+            .getOrDefault(ExecutionStatus.PLATFORM_ERROR, 0));
+  }
 
-    @Test
-    public void testSuccessQuery_twoSuccessful_expectTwoSuccessful() {
-        RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-id", dataJob,
-                ExecutionStatus.SUCCEEDED, "test-msg", OffsetDateTime.now());
-        RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-id2", dataJob,
-                ExecutionStatus.SUCCEEDED, "test-msg", OffsetDateTime.now());
-        RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-id3", dataJob,
-                ExecutionStatus.SUBMITTED, "test-msg", OffsetDateTime.now());
+  @Test
+  public void testSuccessQuery_twoSuccessful_expectTwoSuccessful() {
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-id",
+        dataJob,
+        ExecutionStatus.SUCCEEDED,
+        "test-msg",
+        OffsetDateTime.now());
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-id2",
+        dataJob,
+        ExecutionStatus.SUCCEEDED,
+        "test-msg",
+        OffsetDateTime.now());
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-id3",
+        dataJob,
+        ExecutionStatus.SUBMITTED,
+        "test-msg",
+        OffsetDateTime.now());
 
-        var response = jobExecutionService.countExecutionStatuses(List.of("test-job"), List.of(ExecutionStatus.SUCCEEDED));
-        Assertions.assertEquals(2, response.get("test-job").get(ExecutionStatus.SUCCEEDED));
-    }
+    var response =
+        jobExecutionService.countExecutionStatuses(
+            List.of("test-job"), List.of(ExecutionStatus.SUCCEEDED));
+    Assertions.assertEquals(2, response.get("test-job").get(ExecutionStatus.SUCCEEDED));
+  }
 
-    @Test
-    public void testFailureQuery_twoFailed_expectTwoFailed() {
-        RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-id", dataJob,
-                ExecutionStatus.PLATFORM_ERROR, "test-msg", OffsetDateTime.now());
-        RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-id2", dataJob,
-                ExecutionStatus.PLATFORM_ERROR, "test-msg", OffsetDateTime.now());
-        RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-id3", dataJob,
-                ExecutionStatus.SUBMITTED, "test-msg", OffsetDateTime.now());
+  @Test
+  public void testFailureQuery_twoFailed_expectTwoFailed() {
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-id",
+        dataJob,
+        ExecutionStatus.PLATFORM_ERROR,
+        "test-msg",
+        OffsetDateTime.now());
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-id2",
+        dataJob,
+        ExecutionStatus.PLATFORM_ERROR,
+        "test-msg",
+        OffsetDateTime.now());
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-id3",
+        dataJob,
+        ExecutionStatus.SUBMITTED,
+        "test-msg",
+        OffsetDateTime.now());
 
-        var response = jobExecutionService.countExecutionStatuses(List.of("test-job"), List.of(ExecutionStatus.PLATFORM_ERROR));
-        Assertions.assertEquals(2, response.get("test-job").get(ExecutionStatus.PLATFORM_ERROR));
-    }
+    var response =
+        jobExecutionService.countExecutionStatuses(
+            List.of("test-job"), List.of(ExecutionStatus.PLATFORM_ERROR));
+    Assertions.assertEquals(2, response.get("test-job").get(ExecutionStatus.PLATFORM_ERROR));
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/GraphQLJobsQueryServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/GraphQLJobsQueryServiceTest.java
@@ -21,25 +21,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(MockitoExtension.class)
 class GraphQLJobsQueryServiceTest {
 
-   @Mock
-   private GraphQL graphQL;
-   @Mock
-   private JsonSerializer jsonSerializer;
-   @Mock
-   private OperationContext operationContext;
+  @Mock private GraphQL graphQL;
+  @Mock private JsonSerializer jsonSerializer;
+  @Mock private OperationContext operationContext;
 
-   private GraphQLJobsQueryService queryService;
+  private GraphQLJobsQueryService queryService;
 
-   @BeforeEach
-   void beforeEach() {
-      queryService = new GraphQLJobsQueryService(graphQL, jsonSerializer, operationContext);
-   }
+  @BeforeEach
+  void beforeEach() {
+    queryService = new GraphQLJobsQueryService(graphQL, jsonSerializer, operationContext);
+  }
 
-   @Test
-   void testQueryService_whenConvertingNullString_shouldReturnEmptyMap() {
-      Map<String, Object> stringObjectMap = queryService.convertVariablesJson(null);
+  @Test
+  void testQueryService_whenConvertingNullString_shouldReturnEmptyMap() {
+    Map<String, Object> stringObjectMap = queryService.convertVariablesJson(null);
 
-      assertThat(stringObjectMap).isEmpty();
-   }
-
+    assertThat(stringObjectMap).isEmpty();
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobExecutionFilterSpecIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobExecutionFilterSpecIT.java
@@ -23,109 +23,185 @@ import java.util.List;
 @SpringBootTest(classes = ControlplaneApplication.class)
 public class JobExecutionFilterSpecIT {
 
-   @Autowired
-   private JobsRepository jobsRepository;
+  @Autowired private JobsRepository jobsRepository;
 
-   @Autowired
-   private JobExecutionRepository jobExecutionRepository;
+  @Autowired private JobExecutionRepository jobExecutionRepository;
 
-   @BeforeEach
-   public void setUp() throws Exception {
-      jobsRepository.deleteAll();
-   }
+  @BeforeEach
+  public void setUp() throws Exception {
+    jobsRepository.deleteAll();
+  }
 
-   @Test
-   public void testJobExecutionFilterSpec_filerByStatusIn_shouldReturnResult() {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+  @Test
+  public void testJobExecutionFilterSpec_filerByStatusIn_shouldReturnResult() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED);
-      DataJobExecution expectedJobExecution1 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING);
-      DataJobExecution expectedJobExecution2 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED);
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.PLATFORM_ERROR);
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED);
+    DataJobExecution expectedJobExecution1 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING);
+    DataJobExecution expectedJobExecution2 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-3",
+            actualDataJob,
+            ExecutionStatus.SUBMITTED);
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-4",
+        actualDataJob,
+        ExecutionStatus.PLATFORM_ERROR);
 
-      DataJobExecutionFilter filter = DataJobExecutionFilter.builder()
+    DataJobExecutionFilter filter =
+        DataJobExecutionFilter.builder()
             .statusIn(List.of(ExecutionStatus.RUNNING, ExecutionStatus.SUBMITTED))
             .build();
-      JobExecutionFilterSpec jobExecutionFilterSpec = new JobExecutionFilterSpec(filter);
-      var actualJobExecutions = jobExecutionRepository.findAll(jobExecutionFilterSpec);
+    JobExecutionFilterSpec jobExecutionFilterSpec = new JobExecutionFilterSpec(filter);
+    var actualJobExecutions = jobExecutionRepository.findAll(jobExecutionFilterSpec);
 
-      Assertions.assertNotNull(actualJobExecutions);
-      Assertions.assertEquals(2, actualJobExecutions.size());
-      Assertions.assertEquals(expectedJobExecution1, actualJobExecutions.get(0));
-      Assertions.assertEquals(expectedJobExecution2, actualJobExecutions.get(1));
-   }
+    Assertions.assertNotNull(actualJobExecutions);
+    Assertions.assertEquals(2, actualJobExecutions.size());
+    Assertions.assertEquals(expectedJobExecution1, actualJobExecutions.get(0));
+    Assertions.assertEquals(expectedJobExecution2, actualJobExecutions.get(1));
+  }
 
-   @Test
-   public void testJobExecutionFilterSpec_filerByStartTimeGte_shouldReturnResult() {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
-      OffsetDateTime now = OffsetDateTime.now();
+  @Test
+  public void testJobExecutionFilterSpec_filerByStartTimeGte_shouldReturnResult() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    OffsetDateTime now = OffsetDateTime.now();
 
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED, now.minusMinutes(2));
-      DataJobExecution expectedJobExecution1 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, now.minusMinutes(1));
-      DataJobExecution expectedJobExecution2 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED, now.minusMinutes(1));
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.PLATFORM_ERROR, now.minusMinutes(2));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-1",
+        actualDataJob,
+        ExecutionStatus.CANCELLED,
+        now.minusMinutes(2));
+    DataJobExecution expectedJobExecution1 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-2",
+            actualDataJob,
+            ExecutionStatus.RUNNING,
+            now.minusMinutes(1));
+    DataJobExecution expectedJobExecution2 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-3",
+            actualDataJob,
+            ExecutionStatus.SUBMITTED,
+            now.minusMinutes(1));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-4",
+        actualDataJob,
+        ExecutionStatus.PLATFORM_ERROR,
+        now.minusMinutes(2));
 
-      DataJobExecutionFilter filter = DataJobExecutionFilter.builder()
-            .startTimeGte(now.minusMinutes(1))
-            .build();
-      JobExecutionFilterSpec jobExecutionFilterSpec = new JobExecutionFilterSpec(filter);
-      var actualJobExecutions = jobExecutionRepository.findAll(jobExecutionFilterSpec);
+    DataJobExecutionFilter filter =
+        DataJobExecutionFilter.builder().startTimeGte(now.minusMinutes(1)).build();
+    JobExecutionFilterSpec jobExecutionFilterSpec = new JobExecutionFilterSpec(filter);
+    var actualJobExecutions = jobExecutionRepository.findAll(jobExecutionFilterSpec);
 
-      Assertions.assertNotNull(actualJobExecutions);
-      Assertions.assertEquals(2, actualJobExecutions.size());
-      Assertions.assertEquals(expectedJobExecution1, actualJobExecutions.get(0));
-      Assertions.assertEquals(expectedJobExecution2, actualJobExecutions.get(1));
-   }
+    Assertions.assertNotNull(actualJobExecutions);
+    Assertions.assertEquals(2, actualJobExecutions.size());
+    Assertions.assertEquals(expectedJobExecution1, actualJobExecutions.get(0));
+    Assertions.assertEquals(expectedJobExecution2, actualJobExecutions.get(1));
+  }
 
-   @Test
-   public void testJobExecutionFilterSpec_filerByEndTimeGte_shouldReturnResult() {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
-      OffsetDateTime now = OffsetDateTime.now();
+  @Test
+  public void testJobExecutionFilterSpec_filerByEndTimeGte_shouldReturnResult() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    OffsetDateTime now = OffsetDateTime.now();
 
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED, now.minusMinutes(2), now.minusMinutes(2));
-      DataJobExecution expectedJobExecution1 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, now.minusMinutes(1), now.minusMinutes(1));
-      DataJobExecution expectedJobExecution2 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED, now.minusMinutes(1), now.minusMinutes(1));
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.PLATFORM_ERROR, now.minusMinutes(2), now.minusMinutes(2));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-1",
+        actualDataJob,
+        ExecutionStatus.CANCELLED,
+        now.minusMinutes(2),
+        now.minusMinutes(2));
+    DataJobExecution expectedJobExecution1 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-2",
+            actualDataJob,
+            ExecutionStatus.RUNNING,
+            now.minusMinutes(1),
+            now.minusMinutes(1));
+    DataJobExecution expectedJobExecution2 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-3",
+            actualDataJob,
+            ExecutionStatus.SUBMITTED,
+            now.minusMinutes(1),
+            now.minusMinutes(1));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-4",
+        actualDataJob,
+        ExecutionStatus.PLATFORM_ERROR,
+        now.minusMinutes(2),
+        now.minusMinutes(2));
 
-      DataJobExecutionFilter filter = DataJobExecutionFilter.builder()
-            .endTimeGte(now.minusMinutes(1))
-            .build();
-      JobExecutionFilterSpec jobExecutionFilterSpec = new JobExecutionFilterSpec(filter);
-      var actualJobExecutions = jobExecutionRepository.findAll(jobExecutionFilterSpec);
+    DataJobExecutionFilter filter =
+        DataJobExecutionFilter.builder().endTimeGte(now.minusMinutes(1)).build();
+    JobExecutionFilterSpec jobExecutionFilterSpec = new JobExecutionFilterSpec(filter);
+    var actualJobExecutions = jobExecutionRepository.findAll(jobExecutionFilterSpec);
 
-      Assertions.assertNotNull(actualJobExecutions);
-      Assertions.assertEquals(2, actualJobExecutions.size());
-      Assertions.assertEquals(expectedJobExecution1, actualJobExecutions.get(0));
-      Assertions.assertEquals(expectedJobExecution2, actualJobExecutions.get(1));
-   }
+    Assertions.assertNotNull(actualJobExecutions);
+    Assertions.assertEquals(2, actualJobExecutions.size());
+    Assertions.assertEquals(expectedJobExecution1, actualJobExecutions.get(0));
+    Assertions.assertEquals(expectedJobExecution2, actualJobExecutions.get(1));
+  }
 
-   @Test
-   public void testJobExecutionFilterSpec_filerByAllFields_shouldReturnResult() {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
-      OffsetDateTime now = OffsetDateTime.now();
+  @Test
+  public void testJobExecutionFilterSpec_filerByAllFields_shouldReturnResult() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    OffsetDateTime now = OffsetDateTime.now();
 
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED, now.minusMinutes(2), now.minusMinutes(2));
-      DataJobExecution expectedJobExecution1 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, now.minusMinutes(1), now.minusMinutes(1));
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED, now.minusMinutes(1), now.minusMinutes(1));
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.PLATFORM_ERROR, now.minusMinutes(2), now.minusMinutes(2));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-1",
+        actualDataJob,
+        ExecutionStatus.CANCELLED,
+        now.minusMinutes(2),
+        now.minusMinutes(2));
+    DataJobExecution expectedJobExecution1 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-2",
+            actualDataJob,
+            ExecutionStatus.RUNNING,
+            now.minusMinutes(1),
+            now.minusMinutes(1));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-3",
+        actualDataJob,
+        ExecutionStatus.SUBMITTED,
+        now.minusMinutes(1),
+        now.minusMinutes(1));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-4",
+        actualDataJob,
+        ExecutionStatus.PLATFORM_ERROR,
+        now.minusMinutes(2),
+        now.minusMinutes(2));
 
-      DataJobExecutionFilter filter = DataJobExecutionFilter.builder()
+    DataJobExecutionFilter filter =
+        DataJobExecutionFilter.builder()
             .startTimeGte(now.minusMinutes(1))
             .endTimeGte(now.minusMinutes(1))
             .statusIn(List.of(ExecutionStatus.RUNNING))
             .build();
-      JobExecutionFilterSpec jobExecutionFilterSpec = new JobExecutionFilterSpec(filter);
-      var actualJobExecutions = jobExecutionRepository.findAll(jobExecutionFilterSpec);
+    JobExecutionFilterSpec jobExecutionFilterSpec = new JobExecutionFilterSpec(filter);
+    var actualJobExecutions = jobExecutionRepository.findAll(jobExecutionFilterSpec);
 
-      Assertions.assertNotNull(actualJobExecutions);
-      Assertions.assertEquals(1, actualJobExecutions.size());
-      Assertions.assertEquals(expectedJobExecution1, actualJobExecutions.get(0));
-   }
+    Assertions.assertNotNull(actualJobExecutions);
+    Assertions.assertEquals(1, actualJobExecutions.size());
+    Assertions.assertEquals(expectedJobExecution1, actualJobExecutions.get(0));
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobExecutionRepositoryIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobExecutionRepositoryIT.java
@@ -23,164 +23,200 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 
-/**
- * Integration tests of the setup of Spring Data repository for data job executions
- */
+/** Integration tests of the setup of Spring Data repository for data job executions */
 @SpringBootTest(classes = ControlplaneApplication.class)
 public class JobExecutionRepositoryIT {
 
-   @Autowired
-   private JobsRepository jobsRepository;
+  @Autowired private JobsRepository jobsRepository;
 
-   @Autowired
-   private JobExecutionRepository jobExecutionRepository;
+  @Autowired private JobExecutionRepository jobExecutionRepository;
 
-   @BeforeEach
-   public void setUp() throws Exception {
-      jobsRepository.deleteAll();
-   }
+  @BeforeEach
+  public void setUp() throws Exception {
+    jobsRepository.deleteAll();
+  }
 
-   /**
-    * Tests CRUD operations of job executions
-    */
-   @Test
-   public void testCRUD_shouldSucceed() {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+  /** Tests CRUD operations of job executions */
+  @Test
+  public void testCRUD_shouldSucceed() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-      String executionId = "test-execution-id";
-      ExecutionStatus executionStatus = ExecutionStatus.RUNNING;
-      DataJobExecution expectedJobExecution =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, executionId, actualDataJob, executionStatus);
+    String executionId = "test-execution-id";
+    ExecutionStatus executionStatus = ExecutionStatus.RUNNING;
+    DataJobExecution expectedJobExecution =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository, executionId, actualDataJob, executionStatus);
 
-      var actualJobExecution = jobExecutionRepository.findById(expectedJobExecution.getId()).get();
-      Assertions.assertEquals(expectedJobExecution, actualJobExecution);
+    var actualJobExecution = jobExecutionRepository.findById(expectedJobExecution.getId()).get();
+    Assertions.assertEquals(expectedJobExecution, actualJobExecution);
 
-      jobsRepository.deleteAll();
-      var deletedJobExecution = jobExecutionRepository.findById(expectedJobExecution.getId());
-      Assertions.assertFalse(deletedJobExecution.isPresent());
-   }
+    jobsRepository.deleteAll();
+    var deletedJobExecution = jobExecutionRepository.findById(expectedJobExecution.getId());
+    Assertions.assertFalse(deletedJobExecution.isPresent());
+  }
 
-   @Test
-   public void testFindDataJobExecutionsByDataJobName_existingDataJobExecution_shouldReturnResult() {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+  @Test
+  public void testFindDataJobExecutionsByDataJobName_existingDataJobExecution_shouldReturnResult() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-      String executionId = "test-execution-id";
-      ExecutionStatus executionStatus = ExecutionStatus.RUNNING;
-      DataJobExecution expectedJobExecution =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, executionId, actualDataJob, executionStatus);
+    String executionId = "test-execution-id";
+    ExecutionStatus executionStatus = ExecutionStatus.RUNNING;
+    DataJobExecution expectedJobExecution =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository, executionId, actualDataJob, executionStatus);
 
-      var actualJobExecutions = jobExecutionRepository.findDataJobExecutionsByDataJobName(actualDataJob.getName());
+    var actualJobExecutions =
+        jobExecutionRepository.findDataJobExecutionsByDataJobName(actualDataJob.getName());
 
-      Assertions.assertNotNull(actualJobExecutions);
-      Assertions.assertEquals(1, actualJobExecutions.size());
-      Assertions.assertEquals(expectedJobExecution, actualJobExecutions.get(0));
-   }
+    Assertions.assertNotNull(actualJobExecutions);
+    Assertions.assertEquals(1, actualJobExecutions.size());
+    Assertions.assertEquals(expectedJobExecution, actualJobExecutions.get(0));
+  }
 
-   @Test
-   public void testFindDataJobExecutionsByDataJobName_nonExistingDataJobExecution_shouldReturnEmptyResult() {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
-      var actualJobExecutions = jobExecutionRepository.findDataJobExecutionsByDataJobName(actualDataJob.getName());
+  @Test
+  public void
+      testFindDataJobExecutionsByDataJobName_nonExistingDataJobExecution_shouldReturnEmptyResult() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    var actualJobExecutions =
+        jobExecutionRepository.findDataJobExecutionsByDataJobName(actualDataJob.getName());
 
-      Assertions.assertNotNull(actualJobExecutions);
-      Assertions.assertTrue(actualJobExecutions.isEmpty());
-   }
+    Assertions.assertNotNull(actualJobExecutions);
+    Assertions.assertTrue(actualJobExecutions.isEmpty());
+  }
 
-   @Test
-   public void testFindDataJobExecutionsByDataJobNameAndStatusIn_existingDataJobExecutions_shouldReturnResult() {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+  @Test
+  public void
+      testFindDataJobExecutionsByDataJobNameAndStatusIn_existingDataJobExecutions_shouldReturnResult() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED);
-      DataJobExecution expectedJobExecution1 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING);
-      DataJobExecution expectedJobExecution2 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED);
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.PLATFORM_ERROR);
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED);
+    DataJobExecution expectedJobExecution1 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING);
+    DataJobExecution expectedJobExecution2 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-3",
+            actualDataJob,
+            ExecutionStatus.SUBMITTED);
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-4",
+        actualDataJob,
+        ExecutionStatus.PLATFORM_ERROR);
 
+    var actualJobExecutions =
+        jobExecutionRepository.findDataJobExecutionsByDataJobNameAndStatusIn(
+            actualDataJob.getName(), List.of(ExecutionStatus.RUNNING, ExecutionStatus.SUBMITTED));
 
-      var actualJobExecutions =
-            jobExecutionRepository.findDataJobExecutionsByDataJobNameAndStatusIn(
-                  actualDataJob.getName(),
-                  List.of(ExecutionStatus.RUNNING, ExecutionStatus.SUBMITTED));
+    Assertions.assertNotNull(actualJobExecutions);
+    Assertions.assertEquals(2, actualJobExecutions.size());
+    Assertions.assertEquals(expectedJobExecution1, actualJobExecutions.get(0));
+    Assertions.assertEquals(expectedJobExecution2, actualJobExecutions.get(1));
+  }
 
-      Assertions.assertNotNull(actualJobExecutions);
-      Assertions.assertEquals(2, actualJobExecutions.size());
-      Assertions.assertEquals(expectedJobExecution1, actualJobExecutions.get(0));
-      Assertions.assertEquals(expectedJobExecution2, actualJobExecutions.get(1));
-   }
+  @Test
+  void
+      testFindFirst5ByDataJobNameOrderByStartTimeDesc_existingDataJobExecutions_shouldReturnValidResult() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-   @Test
-   void testFindFirst5ByDataJobNameOrderByStartTimeDesc_existingDataJobExecutions_shouldReturnValidResult() {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED);
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING);
+    DataJobExecution expectedJobExecution3 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-3",
+            actualDataJob,
+            ExecutionStatus.SUBMITTED);
+    DataJobExecution expectedJobExecution4 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-4",
+            actualDataJob,
+            ExecutionStatus.PLATFORM_ERROR);
 
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED);
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING);
-      DataJobExecution expectedJobExecution3 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED);
-      DataJobExecution expectedJobExecution4 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.PLATFORM_ERROR);
+    Pageable pageable = PageRequest.of(0, 2, Sort.by(Sort.Order.desc("id")));
+    var actualJobExecutions =
+        jobExecutionRepository.findDataJobExecutionsByDataJobName(
+            actualDataJob.getName(), pageable);
 
+    Assertions.assertNotNull(actualJobExecutions);
+    Assertions.assertEquals(2, actualJobExecutions.size());
+    Assertions.assertEquals(expectedJobExecution4, actualJobExecutions.get(0));
+    Assertions.assertEquals(expectedJobExecution3, actualJobExecutions.get(1));
+  }
 
-      Pageable pageable = PageRequest.of(0, 2, Sort.by(Sort.Order.desc("id")));
-      var actualJobExecutions =
-            jobExecutionRepository.findDataJobExecutionsByDataJobName(actualDataJob.getName(), pageable);
+  @Test
+  void
+      testFindDataJobExecutionsByDataJobNameAndStatusIn_nonExistingDataJobExecution_shouldReturnEmptyResult() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-      Assertions.assertNotNull(actualJobExecutions);
-      Assertions.assertEquals(2, actualJobExecutions.size());
-      Assertions.assertEquals(expectedJobExecution4, actualJobExecutions.get(0));
-      Assertions.assertEquals(expectedJobExecution3, actualJobExecutions.get(1));
+    var actualJobExecutions =
+        jobExecutionRepository.findDataJobExecutionsByDataJobNameAndStatusIn(
+            actualDataJob.getName(), List.of(ExecutionStatus.RUNNING));
 
-   }
+    Assertions.assertNotNull(actualJobExecutions);
+    Assertions.assertTrue(actualJobExecutions.isEmpty());
+  }
 
-   @Test
-   void testFindDataJobExecutionsByDataJobNameAndStatusIn_nonExistingDataJobExecution_shouldReturnEmptyResult() {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+  @Test
+  public void
+      testFindDataJobExecutionsByDataJobName_existingDataJobExecution_shouldReturnResult2() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-      var actualJobExecutions =
-            jobExecutionRepository.findDataJobExecutionsByDataJobNameAndStatusIn(actualDataJob.getName(), List.of(ExecutionStatus.RUNNING));
+    String executionId = "test-execution-id";
+    ExecutionStatus executionStatus = ExecutionStatus.RUNNING;
+    DataJobExecution expectedJobExecution =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository, executionId, actualDataJob, executionStatus);
+  }
 
-      Assertions.assertNotNull(actualJobExecutions);
-      Assertions.assertTrue(actualJobExecutions.isEmpty());
-   }
+  @Test
+  void testFindFirstByDataJobNameOrderByStartTimeDesc_withNoExecutions_shouldReturnEmpty() {
+    DataJob dataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-   @Test
-   public void testFindDataJobExecutionsByDataJobName_existingDataJobExecution_shouldReturnResult2() {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    var lastExecution =
+        jobExecutionRepository.findFirstByDataJobNameOrderByStartTimeDesc(dataJob.getName());
 
-      String executionId = "test-execution-id";
-      ExecutionStatus executionStatus = ExecutionStatus.RUNNING;
-      DataJobExecution expectedJobExecution =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, executionId, actualDataJob, executionStatus);
-   }
+    Assertions.assertTrue(lastExecution.isEmpty());
+  }
 
-   @Test
-   void testFindFirstByDataJobNameOrderByStartTimeDesc_withNoExecutions_shouldReturnEmpty() {
-      DataJob dataJob = RepositoryUtil.createDataJob(jobsRepository);
+  @Test
+  void testFindFirstByDataJobNameOrderByStartTimeDesc_shouldReturnTheLastExecution() {
+    DataJob dataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-      var lastExecution = jobExecutionRepository.findFirstByDataJobNameOrderByStartTimeDesc(dataJob.getName());
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "execution1",
+        dataJob,
+        ExecutionStatus.SUCCEEDED,
+        "Success",
+        OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
+        OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "execution2",
+        dataJob,
+        ExecutionStatus.RUNNING,
+        null,
+        OffsetDateTime.of(2000, 1, 1, 4, 0, 0, 0, ZoneOffset.UTC),
+        null);
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "execution3",
+        dataJob,
+        ExecutionStatus.PLATFORM_ERROR,
+        "Platform error",
+        OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC),
+        OffsetDateTime.of(2000, 1, 1, 3, 0, 0, 0, ZoneOffset.UTC));
 
-      Assertions.assertTrue(lastExecution.isEmpty());
-   }
+    var lastExecution =
+        jobExecutionRepository.findFirstByDataJobNameOrderByStartTimeDesc(dataJob.getName());
 
-   @Test
-   void testFindFirstByDataJobNameOrderByStartTimeDesc_shouldReturnTheLastExecution() {
-      DataJob dataJob = RepositoryUtil.createDataJob(jobsRepository);
-
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository,
-              "execution1", dataJob, ExecutionStatus.SUCCEEDED, "Success",
-              OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
-              OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC));
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository,
-              "execution2", dataJob, ExecutionStatus.RUNNING, null,
-              OffsetDateTime.of(2000, 1, 1, 4, 0, 0, 0, ZoneOffset.UTC),
-              null);
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository,
-              "execution3", dataJob, ExecutionStatus.PLATFORM_ERROR, "Platform error",
-              OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC),
-              OffsetDateTime.of(2000, 1, 1, 3, 0, 0, 0, ZoneOffset.UTC));
-
-      var lastExecution = jobExecutionRepository.findFirstByDataJobNameOrderByStartTimeDesc(dataJob.getName());
-
-      Assertions.assertTrue(lastExecution.isPresent());
-      Assertions.assertEquals("execution2", lastExecution.get().getId());
-   }
+    Assertions.assertTrue(lastExecution.isPresent());
+    Assertions.assertEquals("execution2", lastExecution.get().getId());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobImageDeployerTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobImageDeployerTest.java
@@ -22,110 +22,143 @@ import java.util.Map;
 
 public class JobImageDeployerTest {
 
-    private JobImageDeployer jobImageDeployer;
-    private DataJob dataJob;
-    private JobDeployment jobDeployment;
+  private JobImageDeployer jobImageDeployer;
+  private DataJob dataJob;
+  private JobDeployment jobDeployment;
 
-    private JobCredentialsService jobCredentialsService;
-    private DataJobsKubernetesService dataJobsKubernetesService;
-    private VdkOptionsReader vdkOptionsReader;
-    private DataJobDefaultConfigurations dataJobDefaultConfigurations;
-    private DeploymentProgress deploymentProgress;
-    private KubernetesResources kubernetesResources;
-    private JobCommandProvider jobCommandProvider;
+  private JobCredentialsService jobCredentialsService;
+  private DataJobsKubernetesService dataJobsKubernetesService;
+  private VdkOptionsReader vdkOptionsReader;
+  private DataJobDefaultConfigurations dataJobDefaultConfigurations;
+  private DeploymentProgress deploymentProgress;
+  private KubernetesResources kubernetesResources;
+  private JobCommandProvider jobCommandProvider;
 
-    @BeforeEach
-    public void setUp() {
-        jobCredentialsService = Mockito.mock(JobCredentialsService.class);
-        dataJobsKubernetesService = Mockito.mock(DataJobsKubernetesService.class);
-        vdkOptionsReader = Mockito.mock(VdkOptionsReader.class);
-        dataJobDefaultConfigurations = Mockito.mock(DataJobDefaultConfigurations.class);
-        deploymentProgress = Mockito.mock(DeploymentProgress.class);
-        kubernetesResources = Mockito.mock(KubernetesResources.class);
-        jobCommandProvider = Mockito.mock(JobCommandProvider.class);
+  @BeforeEach
+  public void setUp() {
+    jobCredentialsService = Mockito.mock(JobCredentialsService.class);
+    dataJobsKubernetesService = Mockito.mock(DataJobsKubernetesService.class);
+    vdkOptionsReader = Mockito.mock(VdkOptionsReader.class);
+    dataJobDefaultConfigurations = Mockito.mock(DataJobDefaultConfigurations.class);
+    deploymentProgress = Mockito.mock(DeploymentProgress.class);
+    kubernetesResources = Mockito.mock(KubernetesResources.class);
+    jobCommandProvider = Mockito.mock(JobCommandProvider.class);
 
-        jobImageDeployer = new JobImageDeployer(jobCredentialsService, dataJobsKubernetesService, vdkOptionsReader,
-                dataJobDefaultConfigurations, deploymentProgress, kubernetesResources, jobCommandProvider);
+    jobImageDeployer =
+        new JobImageDeployer(
+            jobCredentialsService,
+            dataJobsKubernetesService,
+            vdkOptionsReader,
+            dataJobDefaultConfigurations,
+            deploymentProgress,
+            kubernetesResources,
+            jobCommandProvider);
+  }
 
+  @Test
+  public void testScheduleLabelsAnnotations() {
+    // prepare test class
+    dataJob = new DataJob();
+    dataJob.setName("TestDataJob");
+    dataJob.setJobConfig(new JobConfig());
+    dataJob.getJobConfig().setSchedule("schedule string");
+
+    jobDeployment = new JobDeployment();
+    jobDeployment.setImageName("TestImageName");
+    jobDeployment.setGitCommitSha("testVersionString");
+    jobDeployment.setEnabled(false);
+    // mock behaviour so we reach tested (private) functionality
+    Mockito.when(jobCredentialsService.getJobPrincipalName(Mockito.anyString()))
+        .thenReturn("testPrincipalString");
+    Mockito.when(vdkOptionsReader.readVdkOptions(Mockito.anyString())).thenReturn(new HashMap<>());
+    Mockito.when(dataJobDefaultConfigurations.dataJobLimits())
+        .thenReturn(new KubernetesService.Resources("1.2", "200"));
+    Mockito.when(dataJobDefaultConfigurations.dataJobRequests())
+        .thenReturn(new KubernetesService.Resources("1.5", "250"));
+    Mockito.when(kubernetesResources.dataJobInitContainerLimits())
+        .thenReturn(new KubernetesService.Resources("1.5", "200"));
+    Mockito.when(kubernetesResources.dataJobInitContainerRequests())
+        .thenReturn(new KubernetesService.Resources("1.5", "200"));
+
+    var annotationCaptor = ArgumentCaptor.forClass(Map.class);
+    var labelCaptor = ArgumentCaptor.forClass(Map.class);
+    try {
+      // capture labels from method.
+      Mockito.doNothing()
+          .when(dataJobsKubernetesService)
+          .createCronJob(
+              Mockito.anyString(),
+              Mockito.anyString(),
+              Mockito.anyMap(),
+              Mockito.anyString(),
+              Mockito.anyBoolean(),
+              Mockito.anyList(),
+              Mockito.any(),
+              Mockito.any(),
+              Mockito.any(),
+              Mockito.any(),
+              Mockito.anyList(),
+              Mockito.anyMap(),
+              Mockito.anyMap(),
+              annotationCaptor.capture(),
+              labelCaptor.capture(),
+              Mockito.anyList());
+      // execute public method.
+      jobImageDeployer.scheduleJob(dataJob, jobDeployment, false, "lastDeployedBy");
+      // verify we called the method only once.
+      Mockito.verify(dataJobsKubernetesService)
+          .createCronJob(
+              Mockito.anyString(),
+              Mockito.anyString(),
+              Mockito.anyMap(),
+              Mockito.anyString(),
+              Mockito.anyBoolean(),
+              Mockito.anyList(),
+              Mockito.any(),
+              Mockito.any(),
+              Mockito.any(),
+              Mockito.any(),
+              Mockito.anyList(),
+              Mockito.anyMap(),
+              Mockito.anyMap(),
+              Mockito.anyMap(),
+              Mockito.anyMap(),
+              Mockito.anyList());
+      // extract labels/annotations from call
+      var labels = labelCaptor.getValue();
+      var annotations = annotationCaptor.getValue();
+      // check everything was as expected
+      Assertions.assertEquals(3, labels.size(), "Expecting three labels");
+      Assertions.assertEquals(6, annotations.size(), "Expecting six annotations");
+
+      var jobName = labels.get(JobLabel.NAME.getValue());
+      var jobVersion = labels.get(JobLabel.VERSION.getValue());
+      var jobType = labels.get(JobLabel.TYPE.getValue());
+
+      Assertions.assertEquals("TestDataJob", jobName);
+      Assertions.assertEquals("testVersionString", jobVersion);
+      Assertions.assertEquals("DataJob", jobType);
+
+      var schedule = annotations.get(JobAnnotation.SCHEDULE.getValue());
+      var deployedBy = annotations.get(JobAnnotation.DEPLOYED_BY.getValue());
+      var deployedDate = annotations.get(JobAnnotation.DEPLOYED_DATE.getValue());
+      var startedBy = annotations.get(JobAnnotation.STARTED_BY.getValue());
+      var executionType = annotations.get(JobAnnotation.EXECUTION_TYPE.getValue());
+      var unscheduled = annotations.get(JobAnnotation.UNSCHEDULED.getValue());
+
+      Assertions.assertEquals("schedule string", schedule);
+      Assertions.assertEquals("lastDeployedBy", deployedBy);
+      Assertions.assertEquals(
+          OffsetDateTime.now().toString().substring(0, 10),
+          deployedDate.toString().substring(0, 10),
+          "Testing if date is the same, we cannot be precise down to the millisecond.");
+      Assertions.assertEquals("scheduled/runtime", startedBy);
+      Assertions.assertEquals("scheduled", executionType);
+      Assertions.assertEquals("false", unscheduled);
+
+    } catch (ApiException e) {
+      e.printStackTrace();
+      Assertions.fail(e);
     }
-
-    @Test
-    public void testScheduleLabelsAnnotations() {
-        //prepare test class
-        dataJob = new DataJob();
-        dataJob.setName("TestDataJob");
-        dataJob.setJobConfig(new JobConfig());
-        dataJob.getJobConfig().setSchedule("schedule string");
-
-        jobDeployment = new JobDeployment();
-        jobDeployment.setImageName("TestImageName");
-        jobDeployment.setGitCommitSha("testVersionString");
-        jobDeployment.setEnabled(false);
-        //mock behaviour so we reach tested (private) functionality
-        Mockito.when(jobCredentialsService.getJobPrincipalName(Mockito.anyString()))
-               .thenReturn("testPrincipalString");
-        Mockito.when(vdkOptionsReader.readVdkOptions(Mockito.anyString()))
-               .thenReturn(new HashMap<>());
-        Mockito.when(dataJobDefaultConfigurations.dataJobLimits())
-               .thenReturn(new KubernetesService.Resources("1.2", "200"));
-        Mockito.when(dataJobDefaultConfigurations.dataJobRequests())
-               .thenReturn(new KubernetesService.Resources("1.5", "250"));
-        Mockito.when(kubernetesResources.dataJobInitContainerLimits())
-               .thenReturn(new KubernetesService.Resources("1.5", "200"));
-        Mockito.when(kubernetesResources.dataJobInitContainerRequests())
-               .thenReturn(new KubernetesService.Resources("1.5", "200"));
-
-        var annotationCaptor = ArgumentCaptor.forClass(Map.class);
-        var labelCaptor = ArgumentCaptor.forClass(Map.class);
-        try {
-            //capture labels from method.
-            Mockito.doNothing()
-                   .when(dataJobsKubernetesService)
-                   .createCronJob(Mockito.anyString(), Mockito.anyString(), Mockito.anyMap(), Mockito.anyString(),
-                                   Mockito.anyBoolean(), Mockito.anyList(), Mockito.any(), Mockito.any(), Mockito.any(),
-                                   Mockito.any(), Mockito.anyList(), Mockito.anyMap(), Mockito.anyMap(),
-                                   annotationCaptor.capture(), labelCaptor.capture(), Mockito.anyList());
-            //execute public method.
-            jobImageDeployer.scheduleJob(dataJob, jobDeployment, false, "lastDeployedBy");
-            //verify we called the method only once.
-            Mockito.verify(dataJobsKubernetesService)
-                   .createCronJob(Mockito.anyString(), Mockito.anyString(), Mockito.anyMap(), Mockito.anyString(),
-                                   Mockito.anyBoolean(), Mockito.anyList(), Mockito.any(), Mockito.any(), Mockito.any(),
-                                   Mockito.any(), Mockito.anyList(), Mockito.anyMap(), Mockito.anyMap(), Mockito.anyMap(),
-                                   Mockito.anyMap(), Mockito.anyList());
-            //extract labels/annotations from call
-            var labels = labelCaptor.getValue();
-            var annotations = annotationCaptor.getValue();
-            //check everything was as expected
-            Assertions.assertEquals(3, labels.size(), "Expecting three labels");
-            Assertions.assertEquals(6, annotations.size(), "Expecting six annotations");
-
-            var jobName = labels.get(JobLabel.NAME.getValue());
-            var jobVersion = labels.get(JobLabel.VERSION.getValue());
-            var jobType = labels.get(JobLabel.TYPE.getValue());
-
-            Assertions.assertEquals("TestDataJob", jobName);
-            Assertions.assertEquals("testVersionString", jobVersion);
-            Assertions.assertEquals("DataJob", jobType);
-
-            var schedule = annotations.get(JobAnnotation.SCHEDULE.getValue());
-            var deployedBy = annotations.get(JobAnnotation.DEPLOYED_BY.getValue());
-            var deployedDate = annotations.get(JobAnnotation.DEPLOYED_DATE.getValue());
-            var startedBy = annotations.get(JobAnnotation.STARTED_BY.getValue());
-            var executionType = annotations.get(JobAnnotation.EXECUTION_TYPE.getValue());
-            var unscheduled = annotations.get(JobAnnotation.UNSCHEDULED.getValue());
-
-            Assertions.assertEquals("schedule string", schedule);
-            Assertions.assertEquals("lastDeployedBy", deployedBy);
-            Assertions.assertEquals(OffsetDateTime.now().toString().substring(0, 10), deployedDate.toString().substring(0, 10),
-                            "Testing if date is the same, we cannot be precise down to the millisecond.");
-            Assertions.assertEquals("scheduled/runtime", startedBy);
-            Assertions.assertEquals("scheduled", executionType);
-            Assertions.assertEquals("false", unscheduled);
-
-        } catch (ApiException e) {
-            e.printStackTrace();
-            Assertions.fail(e);
-        }
-    }
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobsRepositoryIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobsRepositoryIT.java
@@ -19,92 +19,99 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 
-/**
- * Integration tests of the setup of Spring Data repository for data jobs
- */
+/** Integration tests of the setup of Spring Data repository for data jobs */
 @SpringBootTest(classes = ControlplaneApplication.class)
 public class JobsRepositoryIT {
 
-   @Autowired
-   private JobsRepository repository;
+  @Autowired private JobsRepository repository;
 
-   @BeforeEach
-   public void setUp() throws Exception {
-      repository.deleteAll();
-   }
+  @BeforeEach
+  public void setUp() throws Exception {
+    repository.deleteAll();
+  }
 
-   /**
-    * Confirms that writing and reading jobs also covers their configuration and keeps equality overall
-    */
-   @Test
-   public void testLoadEmbedded() {
-      JobConfig config = new JobConfig();
-      config.setSchedule("schedule");
-      var entity = new DataJob("hello", config, DeploymentStatus.NONE, ExecutionStatus.USER_ERROR, "1234");
-      var savedEntity = repository.save(entity);
-      Assertions.assertEquals(entity, savedEntity);
+  /**
+   * Confirms that writing and reading jobs also covers their configuration and keeps equality
+   * overall
+   */
+  @Test
+  public void testLoadEmbedded() {
+    JobConfig config = new JobConfig();
+    config.setSchedule("schedule");
+    var entity =
+        new DataJob("hello", config, DeploymentStatus.NONE, ExecutionStatus.USER_ERROR, "1234");
+    var savedEntity = repository.save(entity);
+    Assertions.assertEquals(entity, savedEntity);
 
-      Iterable<DataJob> jobs = repository.findAll();
-      Assertions.assertEquals(entity, jobs.iterator().next());
-      Assertions.assertEquals(entity.getJobConfig(), jobs.iterator().next().getJobConfig());
-   }
+    Iterable<DataJob> jobs = repository.findAll();
+    Assertions.assertEquals(entity, jobs.iterator().next());
+    Assertions.assertEquals(entity.getJobConfig(), jobs.iterator().next().getJobConfig());
+  }
 
-   @Test
-   public void testEmptyJobConfigIsReadAsNull() {
-      var entity = new DataJob("hello", new JobConfig(), DeploymentStatus.NONE);
-      entity = repository.save(entity);
-      Assertions.assertNotNull(entity.getJobConfig());
-      entity = repository.findById("hello").get();
-      var expectedJobConfig = new JobConfig(null, null, null, null, null, null, null, null, null, null, false, null);
-      Assertions.assertEquals(entity.getJobConfig(), expectedJobConfig);
+  @Test
+  public void testEmptyJobConfigIsReadAsNull() {
+    var entity = new DataJob("hello", new JobConfig(), DeploymentStatus.NONE);
+    entity = repository.save(entity);
+    Assertions.assertNotNull(entity.getJobConfig());
+    entity = repository.findById("hello").get();
+    var expectedJobConfig =
+        new JobConfig(null, null, null, null, null, null, null, null, null, null, false, null);
+    Assertions.assertEquals(entity.getJobConfig(), expectedJobConfig);
 
-      Assertions.assertEquals(entity.getLatestJobDeploymentStatus(), DeploymentStatus.NONE);
-   }
+    Assertions.assertEquals(entity.getLatestJobDeploymentStatus(), DeploymentStatus.NONE);
+  }
 
-   @Test
-   void testUpdateDataJobEnabledByName() {
-      var entity = new DataJob("hello", new JobConfig(), DeploymentStatus.NONE);
-      entity.setEnabled(true);
-      repository.save(entity);
+  @Test
+  void testUpdateDataJobEnabledByName() {
+    var entity = new DataJob("hello", new JobConfig(), DeploymentStatus.NONE);
+    entity.setEnabled(true);
+    repository.save(entity);
 
-      repository.updateDataJobEnabledByName("hello", false);
+    repository.updateDataJobEnabledByName("hello", false);
 
-      var persistedEntity = repository.findById("hello");
-      Assertions.assertTrue(persistedEntity.isPresent());
-      Assertions.assertFalse(persistedEntity.get().getEnabled());
-   }
+    var persistedEntity = repository.findById("hello");
+    Assertions.assertTrue(persistedEntity.isPresent());
+    Assertions.assertFalse(persistedEntity.get().getEnabled());
+  }
 
-   @Test
-   void testUpdateDataJobLastExecutionByName() {
-      var entity = new DataJob("hello", new JobConfig(), DeploymentStatus.NONE);
-      entity.setLastExecutionStatus(ExecutionStatus.PLATFORM_ERROR);
-      entity.setLastExecutionEndTime(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
-      entity.setLastExecutionDuration(100);
-      repository.save(entity);
+  @Test
+  void testUpdateDataJobLastExecutionByName() {
+    var entity = new DataJob("hello", new JobConfig(), DeploymentStatus.NONE);
+    entity.setLastExecutionStatus(ExecutionStatus.PLATFORM_ERROR);
+    entity.setLastExecutionEndTime(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
+    entity.setLastExecutionDuration(100);
+    repository.save(entity);
 
-      repository.updateDataJobLastExecutionByName("hello", ExecutionStatus.SUCCEEDED,
-              OffsetDateTime.of(2000, 1, 2, 0, 0, 0, 0, ZoneOffset.UTC), 200);
+    repository.updateDataJobLastExecutionByName(
+        "hello",
+        ExecutionStatus.SUCCEEDED,
+        OffsetDateTime.of(2000, 1, 2, 0, 0, 0, 0, ZoneOffset.UTC),
+        200);
 
-      var persistedEntity = repository.findById("hello");
-      Assertions.assertTrue(persistedEntity.isPresent());
-      Assertions.assertEquals(ExecutionStatus.SUCCEEDED, persistedEntity.get().getLastExecutionStatus());
-      Assertions.assertEquals(OffsetDateTime.of(2000, 1, 2, 0, 0, 0, 0, ZoneOffset.UTC),
-              persistedEntity.get().getLastExecutionEndTime().toInstant().atOffset(ZoneOffset.UTC));
-      Assertions.assertEquals(200, persistedEntity.get().getLastExecutionDuration());
-   }
+    var persistedEntity = repository.findById("hello");
+    Assertions.assertTrue(persistedEntity.isPresent());
+    Assertions.assertEquals(
+        ExecutionStatus.SUCCEEDED, persistedEntity.get().getLastExecutionStatus());
+    Assertions.assertEquals(
+        OffsetDateTime.of(2000, 1, 2, 0, 0, 0, 0, ZoneOffset.UTC),
+        persistedEntity.get().getLastExecutionEndTime().toInstant().atOffset(ZoneOffset.UTC));
+    Assertions.assertEquals(200, persistedEntity.get().getLastExecutionDuration());
+  }
 
-   @Test
-   void testUpdateDataJobLatestTerminationStatus() {
-      var entity = new DataJob("hello", new JobConfig(), DeploymentStatus.NONE);
-      entity.setLatestJobTerminationStatus(ExecutionStatus.SUCCEEDED);
-      entity.setLatestJobExecutionId("old-id");
-      repository.save(entity);
+  @Test
+  void testUpdateDataJobLatestTerminationStatus() {
+    var entity = new DataJob("hello", new JobConfig(), DeploymentStatus.NONE);
+    entity.setLatestJobTerminationStatus(ExecutionStatus.SUCCEEDED);
+    entity.setLatestJobExecutionId("old-id");
+    repository.save(entity);
 
-      repository.updateDataJobLatestTerminationStatusByName("hello", ExecutionStatus.USER_ERROR, "new-id");
+    repository.updateDataJobLatestTerminationStatusByName(
+        "hello", ExecutionStatus.USER_ERROR, "new-id");
 
-      var persistedEntity = repository.findById("hello");
-      Assertions.assertTrue(persistedEntity.isPresent());
-      Assertions.assertEquals(ExecutionStatus.USER_ERROR, persistedEntity.get().getLatestJobTerminationStatus());
-      Assertions.assertEquals("new-id", persistedEntity.get().getLatestJobExecutionId());
-   }
+    var persistedEntity = repository.findById("hello");
+    Assertions.assertTrue(persistedEntity.isPresent());
+    Assertions.assertEquals(
+        ExecutionStatus.USER_ERROR, persistedEntity.get().getLatestJobTerminationStatus());
+    Assertions.assertEquals("new-id", persistedEntity.get().getLatestJobExecutionId());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobsServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobsServiceTest.java
@@ -36,45 +36,48 @@ import static org.mockito.Mockito.mock;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class JobsServiceTest {
 
-    @Mock
-    private JobsRepository jobsRepository;
+  @Mock private JobsRepository jobsRepository;
 
-    @Test
-    public void testCreateUpdateMissing() {
-        var testInst = createTestInstance();
-        assertThrows(NullPointerException.class, () -> testInst.createJob(null).isCompleted());
-        assertThrows(NullPointerException.class, () -> testInst.createJob(new DataJob("hello", null, null)).isCompleted());
+  @Test
+  public void testCreateUpdateMissing() {
+    var testInst = createTestInstance();
+    assertThrows(NullPointerException.class, () -> testInst.createJob(null).isCompleted());
+    assertThrows(
+        NullPointerException.class,
+        () -> testInst.createJob(new DataJob("hello", null, null)).isCompleted());
 
-        var job = new DataJob("hello", null, null);
-        doAnswer(method -> 1)
-                .when(jobsRepository).updateDataJobLatestJobDeploymentStatusByName(
-                eq(job.getName()), Mockito.any(DeploymentStatus.class));
-        assertFalse(testInst.updateJob(job));
-    }
+    var job = new DataJob("hello", null, null);
+    doAnswer(method -> 1)
+        .when(jobsRepository)
+        .updateDataJobLatestJobDeploymentStatusByName(
+            eq(job.getName()), Mockito.any(DeploymentStatus.class));
+    assertFalse(testInst.updateJob(job));
+  }
 
-    @Test
-    public void testCreateConflict() {
-        var testInst = createTestInstance();
-        var job = new DataJob("hello", new JobConfig(), null);
+  @Test
+  public void testCreateConflict() {
+    var testInst = createTestInstance();
+    var job = new DataJob("hello", new JobConfig(), null);
 
-        doAnswer(method -> job).when(jobsRepository)
-                .save(job);
-        doAnswer(method -> 1).when(jobsRepository)
-                .updateDataJobLatestJobDeploymentStatusByName(eq(job.getName()), Mockito.any(DeploymentStatus.class));
-        doAnswer(m -> Optional.of(job)).when(jobsRepository)
-                .findById(eq(job.getName()));
+    doAnswer(method -> job).when(jobsRepository).save(job);
+    doAnswer(method -> 1)
+        .when(jobsRepository)
+        .updateDataJobLatestJobDeploymentStatusByName(
+            eq(job.getName()), Mockito.any(DeploymentStatus.class));
+    doAnswer(m -> Optional.of(job)).when(jobsRepository).findById(eq(job.getName()));
 
-        assertTrue(testInst.createJob(job).isCompleted());
-        assertNotNull(testInst.getByName("hello").get().getJobConfig());
-    }
+    assertTrue(testInst.createJob(job).isCompleted());
+    assertNotNull(testInst.getByName("hello").get().getJobConfig());
+  }
 
-    private JobsService createTestInstance() {
-        return new JobsService(jobsRepository,
-                mock(DeploymentService.class),
-                mock(JobCredentialsService.class),
-                mock(WebHookRequestBodyProvider.class),
-                mock(PostCreateWebHookProvider.class),
-                mock(PostDeleteWebHookProvider.class),
-                mock(DataJobMetrics.class));
-    }
+  private JobsService createTestInstance() {
+    return new JobsService(
+        jobsRepository,
+        mock(DeploymentService.class),
+        mock(JobCredentialsService.class),
+        mock(WebHookRequestBodyProvider.class),
+        mock(PostCreateWebHookProvider.class),
+        mock(PostDeleteWebHookProvider.class),
+        mock(DataJobMetrics.class));
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
@@ -20,66 +20,86 @@ import com.vmware.taurus.exception.KubernetesException;
 
 public class KubernetesServiceCancelRunningCronJobTest {
 
-   @Test
-   public void testIsRunningJob_nullResponse_shouldThrowDataJobExecutionCannotBeCancelledException() throws ApiException {
-      KubernetesService kubernetesService = mockKubernetesService(null);
+  @Test
+  public void testIsRunningJob_nullResponse_shouldThrowDataJobExecutionCannotBeCancelledException()
+      throws ApiException {
+    KubernetesService kubernetesService = mockKubernetesService(null);
 
-      Assertions.assertThrows(DataJobExecutionCannotBeCancelledException.class, () ->
-            kubernetesService.cancelRunningCronJob("test-team", "test-job-name", "test-execution-id"));
-   }
+    Assertions.assertThrows(
+        DataJobExecutionCannotBeCancelledException.class,
+        () ->
+            kubernetesService.cancelRunningCronJob(
+                "test-team", "test-job-name", "test-execution-id"));
+  }
 
-   @Test
-   public void testIsRunningJob_notNullResponseAndNullStatus_shouldThrowDataJobExecutionCannotBeCancelledException() throws ApiException {
-      KubernetesService kubernetesService = mockKubernetesService(new V1Status().status(null));
+  @Test
+  public void
+      testIsRunningJob_notNullResponseAndNullStatus_shouldThrowDataJobExecutionCannotBeCancelledException()
+          throws ApiException {
+    KubernetesService kubernetesService = mockKubernetesService(new V1Status().status(null));
 
-      Assertions.assertThrows(DataJobExecutionCannotBeCancelledException.class, () ->
-            kubernetesService.cancelRunningCronJob("test-team", "test-job-name", "test-execution-id"));
-   }
+    Assertions.assertThrows(
+        DataJobExecutionCannotBeCancelledException.class,
+        () ->
+            kubernetesService.cancelRunningCronJob(
+                "test-team", "test-job-name", "test-execution-id"));
+  }
 
-   @Test
-   public void testIsRunningJob_notNullResponseAndStatusSuccess_shouldNotThrowException() throws ApiException {
-      KubernetesService kubernetesService = mockKubernetesService(new V1Status().status("Success"));
+  @Test
+  public void testIsRunningJob_notNullResponseAndStatusSuccess_shouldNotThrowException()
+      throws ApiException {
+    KubernetesService kubernetesService = mockKubernetesService(new V1Status().status("Success"));
 
-      Assertions.assertDoesNotThrow(() ->
-            kubernetesService.cancelRunningCronJob("test-team", "test-job-name", "test-execution-id"));
-   }
+    Assertions.assertDoesNotThrow(
+        () ->
+            kubernetesService.cancelRunningCronJob(
+                "test-team", "test-job-name", "test-execution-id"));
+  }
 
-   @Test
-   public void testIsRunningJob_notNullResponseAndStatusFailure_shouldThrowKubernetesException() throws ApiException {
-      V1Status v1Status = new V1Status()
+  @Test
+  public void testIsRunningJob_notNullResponseAndStatusFailure_shouldThrowKubernetesException()
+      throws ApiException {
+    V1Status v1Status =
+        new V1Status()
             .status("Failure")
             .reason("test-reason")
             .code(1)
             .message("test-message")
             .details(new V1StatusDetails());
-      KubernetesService kubernetesService = mockKubernetesService(v1Status);
+    KubernetesService kubernetesService = mockKubernetesService(v1Status);
 
-      Assertions.assertThrows(KubernetesException.class, () ->
-            kubernetesService.cancelRunningCronJob("test-team", "test-job-name", "test-execution-id"));
-   }
+    Assertions.assertThrows(
+        KubernetesException.class,
+        () ->
+            kubernetesService.cancelRunningCronJob(
+                "test-team", "test-job-name", "test-execution-id"));
+  }
 
-   private KubernetesService mockKubernetesService(V1Status v1Status) throws ApiException {
-      KubernetesService kubernetesService = Mockito.mock(KubernetesService.class);
-      ReflectionTestUtils.setField(kubernetesService, // inject into this object
-            "log", // assign to this field
-            Mockito.mock(Logger.class)); // object to be injected
-      Mockito.doCallRealMethod().when(kubernetesService).cancelRunningCronJob(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+  private KubernetesService mockKubernetesService(V1Status v1Status) throws ApiException {
+    KubernetesService kubernetesService = Mockito.mock(KubernetesService.class);
+    ReflectionTestUtils.setField(
+        kubernetesService, // inject into this object
+        "log", // assign to this field
+        Mockito.mock(Logger.class)); // object to be injected
+    Mockito.doCallRealMethod()
+        .when(kubernetesService)
+        .cancelRunningCronJob(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
 
-      BatchV1Api batchV1Api = Mockito.mock(BatchV1Api.class);
-      Mockito.when(batchV1Api.
-                  deleteNamespacedJob(
-                        Mockito.anyString(),
-                        Mockito.isNull(),
-                        Mockito.isNull(),
-                        Mockito.isNull(),
-                        Mockito.isNull(),
-                        Mockito.isNull(),
-                        Mockito.anyString(),
-                        Mockito.isNull()))
-            .thenReturn(v1Status);
+    BatchV1Api batchV1Api = Mockito.mock(BatchV1Api.class);
+    Mockito.when(
+            batchV1Api.deleteNamespacedJob(
+                Mockito.anyString(),
+                Mockito.isNull(),
+                Mockito.isNull(),
+                Mockito.isNull(),
+                Mockito.isNull(),
+                Mockito.isNull(),
+                Mockito.anyString(),
+                Mockito.isNull()))
+        .thenReturn(v1Status);
 
-      Mockito.when(kubernetesService.initBatchV1Api()).thenReturn(batchV1Api);
+    Mockito.when(kubernetesService.initBatchV1Api()).thenReturn(batchV1Api);
 
-      return kubernetesService;
-   }
+    return kubernetesService;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceIsRunningJobTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceIsRunningJobTest.java
@@ -19,72 +19,82 @@ import org.mockito.Mockito;
 
 public class KubernetesServiceIsRunningJobTest {
 
-   @Test
-   public void testIsRunningJob_nullResponse_shouldReturnFalse() throws ApiException {
-      assertResponseValid(null, false);
-   }
+  @Test
+  public void testIsRunningJob_nullResponse_shouldReturnFalse() throws ApiException {
+    assertResponseValid(null, false);
+  }
 
-   @Test
-   public void testIsRunningJob_emptyResponse_shouldReturnFalse() throws ApiException {
-      assertResponseValid(new V1JobList(), false);
-   }
+  @Test
+  public void testIsRunningJob_emptyResponse_shouldReturnFalse() throws ApiException {
+    assertResponseValid(new V1JobList(), false);
+  }
 
-   @Test
-   public void testIsRunningJob_oneJobWithConditionsNull_shouldReturnTrue() throws ApiException {
-      V1JobList response = new V1JobList()
-            .addItemsItem(new V1Job().status(new V1JobStatus().conditions(null)));
+  @Test
+  public void testIsRunningJob_oneJobWithConditionsNull_shouldReturnTrue() throws ApiException {
+    V1JobList response =
+        new V1JobList().addItemsItem(new V1Job().status(new V1JobStatus().conditions(null)));
 
-      assertResponseValid(response, true);
-   }
+    assertResponseValid(response, true);
+  }
 
-   @Test
-   public void testIsRunningJob_oneJobWithConditionsNotNullAndEmpty_shouldReturnTrue() throws ApiException {
-      V1JobList response = new V1JobList()
-            .addItemsItem(new V1Job().status(new V1JobStatus().conditions(Collections.emptyList())));
+  @Test
+  public void testIsRunningJob_oneJobWithConditionsNotNullAndEmpty_shouldReturnTrue()
+      throws ApiException {
+    V1JobList response =
+        new V1JobList()
+            .addItemsItem(
+                new V1Job().status(new V1JobStatus().conditions(Collections.emptyList())));
 
-      assertResponseValid(response, true);
-   }
+    assertResponseValid(response, true);
+  }
 
-   @Test
-   public void testIsRunningJob_oneJobWithConditionsNotNullAndNotEmpty_shouldReturnFalse() throws ApiException {
-      V1JobList response = new V1JobList()
-            .addItemsItem(new V1Job().status(new V1JobStatus().addConditionsItem(new V1JobCondition())));
+  @Test
+  public void testIsRunningJob_oneJobWithConditionsNotNullAndNotEmpty_shouldReturnFalse()
+      throws ApiException {
+    V1JobList response =
+        new V1JobList()
+            .addItemsItem(
+                new V1Job().status(new V1JobStatus().addConditionsItem(new V1JobCondition())));
 
-      assertResponseValid(response, false);
-   }
+    assertResponseValid(response, false);
+  }
 
-   @Test
-   public void testIsRunningJob_oneJobWithConditionsNullAndOneJobWithConditionsNotNull_shouldReturnTrue() throws ApiException {
-      V1JobList response = new V1JobList()
+  @Test
+  public void
+      testIsRunningJob_oneJobWithConditionsNullAndOneJobWithConditionsNotNull_shouldReturnTrue()
+          throws ApiException {
+    V1JobList response =
+        new V1JobList()
             .addItemsItem(new V1Job().status(new V1JobStatus().conditions(null)))
-            .addItemsItem(new V1Job().status(new V1JobStatus().addConditionsItem(new V1JobCondition())));
+            .addItemsItem(
+                new V1Job().status(new V1JobStatus().addConditionsItem(new V1JobCondition())));
 
-      assertResponseValid(response, true);
-   }
+    assertResponseValid(response, true);
+  }
 
-   private void assertResponseValid(V1JobList response, boolean expectedResult) throws ApiException {
-      KubernetesService kubernetesService = Mockito.mock(KubernetesService.class);
-      Mockito.when(kubernetesService.isRunningJob(Mockito.anyString())).thenCallRealMethod();
+  private void assertResponseValid(V1JobList response, boolean expectedResult) throws ApiException {
+    KubernetesService kubernetesService = Mockito.mock(KubernetesService.class);
+    Mockito.when(kubernetesService.isRunningJob(Mockito.anyString())).thenCallRealMethod();
 
-      BatchV1Api batchV1Api = Mockito.mock(BatchV1Api.class);
-      Mockito.when(batchV1Api
-            .listNamespacedJob(
-                  Mockito.isNull(),
-                  Mockito.isNull(),
-                  Mockito.isNull(),
-                  Mockito.isNull(),
-                  Mockito.isNull(),
-                  Mockito.anyString(),
-                  Mockito.isNull(),
-                  Mockito.isNull(),
-                  Mockito.isNull(),
-                  Mockito.isNull(),
-                  Mockito.isNull()))
-            .thenReturn(response);
+    BatchV1Api batchV1Api = Mockito.mock(BatchV1Api.class);
+    Mockito.when(
+            batchV1Api.listNamespacedJob(
+                Mockito.isNull(),
+                Mockito.isNull(),
+                Mockito.isNull(),
+                Mockito.isNull(),
+                Mockito.isNull(),
+                Mockito.anyString(),
+                Mockito.isNull(),
+                Mockito.isNull(),
+                Mockito.isNull(),
+                Mockito.isNull(),
+                Mockito.isNull()))
+        .thenReturn(response);
 
-      Mockito.when(kubernetesService.initBatchV1Api()).thenReturn(batchV1Api);
-      boolean actualResult = kubernetesService.isRunningJob("test-job");
+    Mockito.when(kubernetesService.initBatchV1Api()).thenReturn(batchV1Api);
+    boolean actualResult = kubernetesService.isRunningJob("test-job");
 
-      Assertions.assertEquals(expectedResult, actualResult);
-   }
+    Assertions.assertEquals(expectedResult, actualResult);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartJobWithArgumentsIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartJobWithArgumentsIT.java
@@ -23,136 +23,168 @@ import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 
-
 public class KubernetesServiceStartJobWithArgumentsIT {
 
-    private KubernetesService kubernetesService;
+  private KubernetesService kubernetesService;
 
-    @BeforeEach
-    public void getMockKubernetesServiceForVdkRunExtraArgsTests() throws Exception {
+  @BeforeEach
+  public void getMockKubernetesServiceForVdkRunExtraArgsTests() throws Exception {
 
-        kubernetesService = Mockito.mock(KubernetesService.class);
-        Mockito.when(kubernetesService.getK8sSupportsV1CronJob()).thenReturn(false);
-        V1beta1CronJob internalCronjobTemplate = getValidCronJobForVdkRunExtraArgsTests();
-        BatchV1beta1Api mockBatch = Mockito.mock(BatchV1beta1Api.class);
-        Mockito.when(kubernetesService.initBatchV1beta1Api()).thenReturn(mockBatch);
-        Mockito.when(mockBatch.readNamespacedCronJob(any(), any(), any())).thenReturn(internalCronjobTemplate);
-        Mockito.doNothing().when(kubernetesService).createNewJob(any(), any(), any(), any());
-        Mockito.doCallRealMethod().when(kubernetesService).startNewCronJobExecution(any(), any(), any(), any(), any(), any());
-        kubernetesService.afterPropertiesSet();
-        // We have to set this field manually which would normally get injected by Spring, since
-        // Kubernetes Service is an abstract class and a lot of the methods which depend on this field and are mocked here
-        // cannot be mocked or accessed by the extending classes since they are not public.
-        var f1 = kubernetesService.getClass().getSuperclass().getDeclaredField("jobCommandProvider");
-        f1.setAccessible(true);
-        f1.set(kubernetesService, new JobCommandProvider());
+    kubernetesService = Mockito.mock(KubernetesService.class);
+    Mockito.when(kubernetesService.getK8sSupportsV1CronJob()).thenReturn(false);
+    V1beta1CronJob internalCronjobTemplate = getValidCronJobForVdkRunExtraArgsTests();
+    BatchV1beta1Api mockBatch = Mockito.mock(BatchV1beta1Api.class);
+    Mockito.when(kubernetesService.initBatchV1beta1Api()).thenReturn(mockBatch);
+    Mockito.when(mockBatch.readNamespacedCronJob(any(), any(), any()))
+        .thenReturn(internalCronjobTemplate);
+    Mockito.doNothing().when(kubernetesService).createNewJob(any(), any(), any(), any());
+    Mockito.doCallRealMethod()
+        .when(kubernetesService)
+        .startNewCronJobExecution(any(), any(), any(), any(), any(), any());
+    kubernetesService.afterPropertiesSet();
+    // We have to set this field manually which would normally get injected by Spring, since
+    // Kubernetes Service is an abstract class and a lot of the methods which depend on this field
+    // and are mocked here
+    // cannot be mocked or accessed by the extending classes since they are not public.
+    var f1 = kubernetesService.getClass().getSuperclass().getDeclaredField("jobCommandProvider");
+    f1.setAccessible(true);
+    f1.set(kubernetesService, new JobCommandProvider());
+  }
+
+  @Test
+  public void testStartCronJobWithExtraArgumentForVdkRun() {
+
+    try {
+      ArgumentCaptor<V1JobSpec> specCaptor = ArgumentCaptor.forClass(V1JobSpec.class);
+      Map<String, Object> extraArgs = Map.of("argument1", "value1");
+      kubernetesService.startNewCronJobExecution(
+          "test-job", "test-id", new HashMap<>(), new HashMap<>(), extraArgs, "test-job");
+      Mockito.verify(kubernetesService)
+          .createNewJob(Mockito.any(), specCaptor.capture(), Mockito.any(), Mockito.any());
+      var capturedSpec = specCaptor.getValue();
+      var capturedCommand =
+          capturedSpec.getTemplate().getSpec().getContainers().get(0).getCommand().get(2);
+      // check if command arg starts correctly
+      Assertions.assertEquals(
+          "export PYTHONPATH=/usr/local/lib/python3.7/site-packages:/vdk/site-packages/ && /vdk/vdk"
+              + " run ./test-job --arguments '{\"argument1\":\"value1\"}'",
+          capturedCommand);
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assertions.fail(e.getMessage());
     }
+  }
 
-    @Test
-    public void testStartCronJobWithExtraArgumentForVdkRun() {
+  @Test
+  public void testStartCronJobWithExtraArgumentsForVdkRun() {
 
-        try {
-            ArgumentCaptor<V1JobSpec> specCaptor = ArgumentCaptor.forClass(V1JobSpec.class);
-            Map<String, Object> extraArgs = Map.of("argument1", "value1");
-            kubernetesService.startNewCronJobExecution("test-job", "test-id", new HashMap<>(), new HashMap<>(), extraArgs, "test-job");
-            Mockito.verify(kubernetesService).createNewJob(Mockito.any(), specCaptor.capture(), Mockito.any(), Mockito.any());
-            var capturedSpec = specCaptor.getValue();
-            var capturedCommand = capturedSpec.getTemplate().getSpec().getContainers().get(0).getCommand().get(2);
-            //check if command arg starts correctly
-            Assertions.assertEquals("export PYTHONPATH=/usr/local/lib/python3.7/site-packages:/vdk/" +
-                    "site-packages/ && /vdk/vdk run ./test-job --arguments '{\"argument1\":\"value1\"}'", capturedCommand);
+    try {
+      ArgumentCaptor<V1JobSpec> specCaptor = ArgumentCaptor.forClass(V1JobSpec.class);
+      Map<String, Object> extraArgs = Map.of("argument1", "value1", "argument2", "value2");
+      kubernetesService.startNewCronJobExecution(
+          "test-job", "test-id", new HashMap<>(), new HashMap<>(), extraArgs, "test-job");
+      Mockito.verify(kubernetesService)
+          .createNewJob(Mockito.any(), specCaptor.capture(), Mockito.any(), Mockito.any());
+      var capturedSpec = specCaptor.getValue();
+      var capturedCommand =
+          capturedSpec.getTemplate().getSpec().getContainers().get(0).getCommand().get(2);
+      // check if command arg starts correctly
+      Assertions.assertTrue(
+          capturedCommand.startsWith(
+              "export PYTHONPATH=/usr/local/lib/python3.7/si"
+                  + "te-packages:/vdk/site-packages/ && /vdk/vdk run ./test-job --arguments '{"),
+          "Vdk run command string invalid.");
+      // extra arguments passed as a map, print order might be different.
+      Assertions.assertTrue(
+          capturedCommand.contains("\"argument2\":\"value2\""), "Second argument not present.");
+      Assertions.assertTrue(
+          capturedCommand.contains("\"argument1\":\"value1\""), "First argument not present.");
 
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assertions.fail(e.getMessage());
-        }
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assertions.fail(e.getMessage());
     }
+  }
 
-    @Test
-    public void testStartCronJobWithExtraArgumentsForVdkRun() {
+  @Test
+  public void testStartCronJobWithNullArgumentsForVdkRun() {
 
-        try {
-            ArgumentCaptor<V1JobSpec> specCaptor = ArgumentCaptor.forClass(V1JobSpec.class);
-            Map<String, Object> extraArgs = Map.of("argument1", "value1", "argument2", "value2");
-            kubernetesService.startNewCronJobExecution("test-job", "test-id", new HashMap<>(), new HashMap<>(), extraArgs, "test-job");
-            Mockito.verify(kubernetesService).createNewJob(Mockito.any(), specCaptor.capture(), Mockito.any(), Mockito.any());
-            var capturedSpec = specCaptor.getValue();
-            var capturedCommand = capturedSpec.getTemplate().getSpec().getContainers().get(0).getCommand().get(2);
-            //check if command arg starts correctly
-            Assertions.assertTrue(capturedCommand.startsWith("export PYTHONPATH=/usr/local/lib/python3.7/si" +
-                    "te-packages:/vdk/site-packages/ && /vdk/vdk run ./test-job --arguments '{"), "Vdk run command string invalid.");
-            //extra arguments passed as a map, print order might be different.
-            Assertions.assertTrue(capturedCommand.contains("\"argument2\":\"value2\""), "Second argument not present.");
-            Assertions.assertTrue(capturedCommand.contains("\"argument1\":\"value1\""), "First argument not present.");
+    try {
+      ArgumentCaptor<V1JobSpec> specCaptor = ArgumentCaptor.forClass(V1JobSpec.class);
+      kubernetesService.startNewCronJobExecution(
+          "test-job", "test-id", new HashMap<>(), new HashMap<>(), null, "test-job");
 
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assertions.fail(e.getMessage());
-        }
+      Mockito.verify(kubernetesService)
+          .createNewJob(Mockito.any(), specCaptor.capture(), Mockito.any(), Mockito.any());
+      var capturedSpec = specCaptor.getValue();
+      var capturedCommand =
+          capturedSpec.getTemplate().getSpec().getContainers().get(0).getCommand().get(2);
+      // check if command arg hasn't changed.
+      Assertions.assertEquals(
+          "export PYTHONPATH=/usr/local/lib/python3.7/site-packages:/vdk/"
+              + "site-packages/ && /vdk/vdk run ./test-job",
+          capturedCommand);
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assertions.fail(e.getMessage());
     }
+  }
 
-    @Test
-    public void testStartCronJobWithNullArgumentsForVdkRun() {
+  @Test
+  public void testStartCronJobWithEmptyArgumentsForVdkRun() {
 
-        try {
-            ArgumentCaptor<V1JobSpec> specCaptor = ArgumentCaptor.forClass(V1JobSpec.class);
-            kubernetesService.startNewCronJobExecution("test-job", "test-id", new HashMap<>(), new HashMap<>(), null, "test-job");
+    try {
+      ArgumentCaptor<V1JobSpec> specCaptor = ArgumentCaptor.forClass(V1JobSpec.class);
+      kubernetesService.startNewCronJobExecution(
+          "test-job", "test-id", new HashMap<>(), new HashMap<>(), Map.of(), "test-job");
 
-            Mockito.verify(kubernetesService).createNewJob(Mockito.any(), specCaptor.capture(), Mockito.any(), Mockito.any());
-            var capturedSpec = specCaptor.getValue();
-            var capturedCommand = capturedSpec.getTemplate().getSpec().getContainers().get(0).getCommand().get(2);
-            //check if command arg hasn't changed.
-            Assertions.assertEquals("export PYTHONPATH=/usr/local/lib/python3.7/site-packages:/vdk/" +
-                    "site-packages/ && /vdk/vdk run ./test-job", capturedCommand);
+      Mockito.verify(kubernetesService)
+          .createNewJob(Mockito.any(), specCaptor.capture(), Mockito.any(), Mockito.any());
+      var capturedSpec = specCaptor.getValue();
+      var capturedCommand =
+          capturedSpec.getTemplate().getSpec().getContainers().get(0).getCommand().get(2);
+      // check if command arg hasn't changed.
+      Assertions.assertEquals(
+          "export PYTHONPATH=/usr/local/lib/python3.7/site-packages:/vdk/"
+              + "site-packages/ && /vdk/vdk run ./test-job",
+          capturedCommand);
 
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assertions.fail(e.getMessage());
-        }
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assertions.fail(e.getMessage());
     }
+  }
 
-    @Test
-    public void testStartCronJobWithEmptyArgumentsForVdkRun() {
-
-        try {
-            ArgumentCaptor<V1JobSpec> specCaptor = ArgumentCaptor.forClass(V1JobSpec.class);
-            kubernetesService.startNewCronJobExecution("test-job", "test-id", new HashMap<>(), new HashMap<>(), Map.of(), "test-job");
-
-            Mockito.verify(kubernetesService).createNewJob(Mockito.any(), specCaptor.capture(), Mockito.any(), Mockito.any());
-            var capturedSpec = specCaptor.getValue();
-            var capturedCommand = capturedSpec.getTemplate().getSpec().getContainers().get(0).getCommand().get(2);
-            //check if command arg hasn't changed.
-            Assertions.assertEquals("export PYTHONPATH=/usr/local/lib/python3.7/site-packages:/vdk/" +
-                    "site-packages/ && /vdk/vdk run ./test-job", capturedCommand);
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assertions.fail(e.getMessage());
-        }
+  private V1beta1CronJob getValidCronJobForVdkRunExtraArgsTests() throws Exception {
+    KubernetesService service = new DataJobsKubernetesService("default", "someConfig", false);
+    // V1betaCronJob initializing snippet copied from tests above, using reflection
+    service.afterPropertiesSet();
+    Method loadInternalV1beta1CronjobTemplate =
+        KubernetesService.class.getDeclaredMethod("loadInternalV1beta1CronjobTemplate");
+    if (loadInternalV1beta1CronjobTemplate == null) {
+      Assertions.fail("The method 'loadInternalV1beta1CronjobTemplate' does not exist.");
     }
+    loadInternalV1beta1CronjobTemplate.setAccessible(true);
+    V1beta1CronJob internalCronjobTemplate =
+        (V1beta1CronJob) loadInternalV1beta1CronjobTemplate.invoke(service);
+    var container =
+        internalCronjobTemplate
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .getContainers()
+            .get(0);
 
-    private V1beta1CronJob getValidCronJobForVdkRunExtraArgsTests() throws Exception {
-        KubernetesService service = new DataJobsKubernetesService("default", "someConfig", false);
-        // V1betaCronJob initializing snippet copied from tests above, using reflection
-        service.afterPropertiesSet();
-        Method loadInternalV1beta1CronjobTemplate = KubernetesService.class.getDeclaredMethod("loadInternalV1beta1CronjobTemplate");
-        if (loadInternalV1beta1CronjobTemplate == null) {
-            Assertions.fail("The method 'loadInternalV1beta1CronjobTemplate' does not exist.");
-        }
-        loadInternalV1beta1CronjobTemplate.setAccessible(true);
-        V1beta1CronJob internalCronjobTemplate = (V1beta1CronJob) loadInternalV1beta1CronjobTemplate.invoke(service);
-        var container = internalCronjobTemplate.getSpec()
-                .getJobTemplate()
-                .getSpec()
-                .getTemplate()
-                .getSpec()
-                .getContainers()
-                .get(0);
-
-        var newCommand = new ArrayList<>(container.getCommand());
-        newCommand.set(2, "export PYTHONPATH=/usr/local/lib/python3.7/site-packages:/vdk/site-packages/ && /vdk/vdk run ./test-job");
-        container.setCommand(newCommand);
-        return internalCronjobTemplate;
-    }
-
+    var newCommand = new ArrayList<>(container.getCommand());
+    newCommand.set(
+        2,
+        "export PYTHONPATH=/usr/local/lib/python3.7/site-packages:/vdk/site-packages/ && /vdk/vdk"
+            + " run ./test-job");
+    container.setCommand(newCommand);
+    return internalCronjobTemplate;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartNewCronJobExecutionTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartNewCronJobExecutionTest.java
@@ -22,130 +22,207 @@ import java.util.Optional;
 
 public class KubernetesServiceStartNewCronJobExecutionTest {
 
-   @Test
-   public void testStartNewCronJobExecution_nullCronJobDefinition_shouldThrowException() throws ApiException {
-      String jobName = "test-job";
-      KubernetesService kubernetesService = mockKubernetesService(jobName, null);
+  @Test
+  public void testStartNewCronJobExecution_nullCronJobDefinition_shouldThrowException()
+      throws ApiException {
+    String jobName = "test-job";
+    KubernetesService kubernetesService = mockKubernetesService(jobName, null);
 
-      Exception exception = Assertions.assertThrows(ApiException.class, () ->
-            kubernetesService.startNewCronJobExecution(jobName, "test-execution-id", Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), "test-name"));
+    Exception exception =
+        Assertions.assertThrows(
+            ApiException.class,
+            () ->
+                kubernetesService.startNewCronJobExecution(
+                    jobName,
+                    "test-execution-id",
+                    Collections.emptyMap(),
+                    Collections.emptyMap(),
+                    Collections.emptyMap(),
+                    "test-name"));
 
-      Assertions.assertEquals(String.format("K8S Cron Job '%s' does not exist or is not properly defined.", jobName), exception.getMessage());
-   }
+    Assertions.assertEquals(
+        String.format("K8S Cron Job '%s' does not exist or is not properly defined.", jobName),
+        exception.getMessage());
+  }
 
-   @Test
-   public void testStartNewCronJobExecution_incorrectCronJobDefinition_shouldThrowException() throws ApiException {
-      String jobName = "test-job";
-      V1beta1CronJob expectedResult = new V1beta1CronJob().spec(new V1beta1CronJobSpec().jobTemplate(new V1beta1JobTemplateSpec().spec(new V1JobSpec())));
-      KubernetesService kubernetesService = mockKubernetesService(jobName, expectedResult);
+  @Test
+  public void testStartNewCronJobExecution_incorrectCronJobDefinition_shouldThrowException()
+      throws ApiException {
+    String jobName = "test-job";
+    V1beta1CronJob expectedResult =
+        new V1beta1CronJob()
+            .spec(
+                new V1beta1CronJobSpec()
+                    .jobTemplate(new V1beta1JobTemplateSpec().spec(new V1JobSpec())));
+    KubernetesService kubernetesService = mockKubernetesService(jobName, expectedResult);
 
-      Exception exception = Assertions.assertThrows(ApiException.class, () ->
-            kubernetesService.startNewCronJobExecution(jobName, "dada", Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), "test-name"));
+    Exception exception =
+        Assertions.assertThrows(
+            ApiException.class,
+            () ->
+                kubernetesService.startNewCronJobExecution(
+                    jobName,
+                    "dada",
+                    Collections.emptyMap(),
+                    Collections.emptyMap(),
+                    Collections.emptyMap(),
+                    "test-name"));
 
-      Assertions.assertEquals(String.format("K8S Cron Job '%s' is not properly defined.", jobName), exception.getMessage());
-   }
+    Assertions.assertEquals(
+        String.format("K8S Cron Job '%s' is not properly defined.", jobName),
+        exception.getMessage());
+  }
 
-   @Test
-   public void testStartNewCronJobExecution_existingJobContainerEnvs_shouldSetJobContainerEnvs() throws ApiException {
-      String jobName = "test-job";
-      String executionId = "test-execution-id";
-      V1EnvVar vdkOpIdEnv = new V1EnvVar().name(JobEnvVar.VDK_OP_ID.getValue()).value("test-op-id");
-      V1EnvVar testEnv = new V1EnvVar().name("test-env-name").value("test-env-value");
-      V1beta1CronJob expectedResult = new V1beta1CronJob()
-            .spec(new V1beta1CronJobSpec()
-                  .jobTemplate(new V1beta1JobTemplateSpec()
-                        .spec(new V1JobSpec()
-                              .template(new V1PodTemplateSpec()
-                                    .spec(new V1PodSpec()
-                                          .addContainersItem(new V1Container()
-                                                .addEnvItem(testEnv)))))));
+  @Test
+  public void testStartNewCronJobExecution_existingJobContainerEnvs_shouldSetJobContainerEnvs()
+      throws ApiException {
+    String jobName = "test-job";
+    String executionId = "test-execution-id";
+    V1EnvVar vdkOpIdEnv = new V1EnvVar().name(JobEnvVar.VDK_OP_ID.getValue()).value("test-op-id");
+    V1EnvVar testEnv = new V1EnvVar().name("test-env-name").value("test-env-value");
+    V1beta1CronJob expectedResult =
+        new V1beta1CronJob()
+            .spec(
+                new V1beta1CronJobSpec()
+                    .jobTemplate(
+                        new V1beta1JobTemplateSpec()
+                            .spec(
+                                new V1JobSpec()
+                                    .template(
+                                        new V1PodTemplateSpec()
+                                            .spec(
+                                                new V1PodSpec()
+                                                    .addContainersItem(
+                                                        new V1Container().addEnvItem(testEnv)))))));
 
-      KubernetesService kubernetesService = mockKubernetesService(jobName, expectedResult);
-      kubernetesService.startNewCronJobExecution(jobName, executionId, Collections.emptyMap(), Map.of(vdkOpIdEnv.getName(), vdkOpIdEnv.getValue()), Collections.emptyMap(), "test-name");
+    KubernetesService kubernetesService = mockKubernetesService(jobName, expectedResult);
+    kubernetesService.startNewCronJobExecution(
+        jobName,
+        executionId,
+        Collections.emptyMap(),
+        Map.of(vdkOpIdEnv.getName(), vdkOpIdEnv.getValue()),
+        Collections.emptyMap(),
+        "test-name");
 
-      ArgumentCaptor<String> executionIdArgumentCaptor = ArgumentCaptor.forClass(String.class);
-      ArgumentCaptor<V1JobSpec> v1JobSpecArgumentCaptor = ArgumentCaptor.forClass(V1JobSpec.class);
+    ArgumentCaptor<String> executionIdArgumentCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<V1JobSpec> v1JobSpecArgumentCaptor = ArgumentCaptor.forClass(V1JobSpec.class);
 
-      Mockito.verify(kubernetesService, Mockito.times(1))
-            .createNewJob(executionIdArgumentCaptor.capture(),
-                  v1JobSpecArgumentCaptor.capture(),
-                  Mockito.anyMap(),
-                  Mockito.anyMap());
+    Mockito.verify(kubernetesService, Mockito.times(1))
+        .createNewJob(
+            executionIdArgumentCaptor.capture(),
+            v1JobSpecArgumentCaptor.capture(),
+            Mockito.anyMap(),
+            Mockito.anyMap());
 
-      Assertions.assertEquals(executionId, executionIdArgumentCaptor.getValue());
+    Assertions.assertEquals(executionId, executionIdArgumentCaptor.getValue());
 
-      Optional<List<V1EnvVar>> actualV1EnvVarsOptional = Optional.ofNullable(v1JobSpecArgumentCaptor.getValue())
+    Optional<List<V1EnvVar>> actualV1EnvVarsOptional =
+        Optional.ofNullable(v1JobSpecArgumentCaptor.getValue())
             .map(v1JobSpec -> v1JobSpec.getTemplate())
             .map(v1PodTemplateSpec -> v1PodTemplateSpec.getSpec())
             .map(v1PodSpec -> v1PodSpec.getContainers())
             .map(v1Containers -> v1Containers.get(0))
             .map(v1Container -> v1Container.getEnv());
-      Assertions.assertTrue(actualV1EnvVarsOptional.isPresent());
+    Assertions.assertTrue(actualV1EnvVarsOptional.isPresent());
 
-      List<V1EnvVar> actualV1EnvVars = actualV1EnvVarsOptional.get();
-      Assertions.assertEquals(2, actualV1EnvVars.size());
-      Assertions.assertTrue(actualV1EnvVars.contains(vdkOpIdEnv));
-      Assertions.assertTrue(actualV1EnvVars.contains(testEnv));
-   }
+    List<V1EnvVar> actualV1EnvVars = actualV1EnvVarsOptional.get();
+    Assertions.assertEquals(2, actualV1EnvVars.size());
+    Assertions.assertTrue(actualV1EnvVars.contains(vdkOpIdEnv));
+    Assertions.assertTrue(actualV1EnvVars.contains(testEnv));
+  }
 
-   @Test
-   public void testStartNewCronJobExecution_existingJobLabelsAndJobAnnotations_shouldKeepJobLabelsAndMergeJobAnnotations() throws ApiException {
-      String jobName = "test-job";
-      String executionId = "test-execution-id";
-      V1EnvVar vdkOpIdEnv = new V1EnvVar().name(JobEnvVar.VDK_OP_ID.getValue()).value("test-op-id");
-      String expectedAnnotationKey1 = JobAnnotation.SCHEDULE.getValue();
-      String expectedAnnotationKey2 = "test-annotation-name";
-      Map<String, String> inputAnnotations = Map.of(expectedAnnotationKey2, "test-annotation-value-1");
-      Map<String, String> expectedAnnotations = Map.of(expectedAnnotationKey1, "scheduled/runtime", expectedAnnotationKey2, "test-annotation-value-1");
+  @Test
+  public void
+      testStartNewCronJobExecution_existingJobLabelsAndJobAnnotations_shouldKeepJobLabelsAndMergeJobAnnotations()
+          throws ApiException {
+    String jobName = "test-job";
+    String executionId = "test-execution-id";
+    V1EnvVar vdkOpIdEnv = new V1EnvVar().name(JobEnvVar.VDK_OP_ID.getValue()).value("test-op-id");
+    String expectedAnnotationKey1 = JobAnnotation.SCHEDULE.getValue();
+    String expectedAnnotationKey2 = "test-annotation-name";
+    Map<String, String> inputAnnotations =
+        Map.of(expectedAnnotationKey2, "test-annotation-value-1");
+    Map<String, String> expectedAnnotations =
+        Map.of(
+            expectedAnnotationKey1,
+            "scheduled/runtime",
+            expectedAnnotationKey2,
+            "test-annotation-value-1");
 
-      V1beta1CronJob expectedResult = new V1beta1CronJob()
-            .spec(new V1beta1CronJobSpec()
-                  .jobTemplate(new V1beta1JobTemplateSpec()
-                        .metadata(new V1ObjectMeta()
-                              .putAnnotationsItem(expectedAnnotationKey1, expectedAnnotations.get(JobAnnotation.SCHEDULE.getValue()))
-                              .putAnnotationsItem(expectedAnnotationKey2, "test-annotation-value-2")
-                              .putLabelsItem("test-inline-label-name", "test-inline-label-value"))
-                        .spec(new V1JobSpec()
-                              .template(new V1PodTemplateSpec()
-                                    .spec(new V1PodSpec()
-                                          .addContainersItem(new V1Container()))))));
+    V1beta1CronJob expectedResult =
+        new V1beta1CronJob()
+            .spec(
+                new V1beta1CronJobSpec()
+                    .jobTemplate(
+                        new V1beta1JobTemplateSpec()
+                            .metadata(
+                                new V1ObjectMeta()
+                                    .putAnnotationsItem(
+                                        expectedAnnotationKey1,
+                                        expectedAnnotations.get(JobAnnotation.SCHEDULE.getValue()))
+                                    .putAnnotationsItem(
+                                        expectedAnnotationKey2, "test-annotation-value-2")
+                                    .putLabelsItem(
+                                        "test-inline-label-name", "test-inline-label-value"))
+                            .spec(
+                                new V1JobSpec()
+                                    .template(
+                                        new V1PodTemplateSpec()
+                                            .spec(
+                                                new V1PodSpec()
+                                                    .addContainersItem(new V1Container()))))));
 
-      KubernetesService kubernetesService = mockKubernetesService(jobName, expectedResult);
-      kubernetesService.startNewCronJobExecution(jobName, executionId, inputAnnotations, Map.of(vdkOpIdEnv.getName(), vdkOpIdEnv.getValue()), Collections.emptyMap(), "test-name");
+    KubernetesService kubernetesService = mockKubernetesService(jobName, expectedResult);
+    kubernetesService.startNewCronJobExecution(
+        jobName,
+        executionId,
+        inputAnnotations,
+        Map.of(vdkOpIdEnv.getName(), vdkOpIdEnv.getValue()),
+        Collections.emptyMap(),
+        "test-name");
 
-      ArgumentCaptor<String> executionIdArgumentCaptor = ArgumentCaptor.forClass(String.class);
-      ArgumentCaptor<Map> labelsArgumentCaptor = ArgumentCaptor.forClass(Map.class);
-      ArgumentCaptor<Map> annotationsArgumentCaptor = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<String> executionIdArgumentCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Map> labelsArgumentCaptor = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<Map> annotationsArgumentCaptor = ArgumentCaptor.forClass(Map.class);
 
-      Mockito.verify(kubernetesService, Mockito.times(1))
-            .createNewJob(executionIdArgumentCaptor.capture(),
-                  Mockito.any(),
-                  labelsArgumentCaptor.capture(),
-                  annotationsArgumentCaptor.capture());
+    Mockito.verify(kubernetesService, Mockito.times(1))
+        .createNewJob(
+            executionIdArgumentCaptor.capture(),
+            Mockito.any(),
+            labelsArgumentCaptor.capture(),
+            annotationsArgumentCaptor.capture());
 
-      Assertions.assertEquals(executionId, executionIdArgumentCaptor.getValue());
-      Assertions.assertNotNull(labelsArgumentCaptor.getValue());
-      Assertions.assertFalse(labelsArgumentCaptor.getValue().isEmpty());
-      Assertions.assertEquals(expectedResult.getSpec().getJobTemplate().getMetadata().getLabels(), labelsArgumentCaptor.getValue());
+    Assertions.assertEquals(executionId, executionIdArgumentCaptor.getValue());
+    Assertions.assertNotNull(labelsArgumentCaptor.getValue());
+    Assertions.assertFalse(labelsArgumentCaptor.getValue().isEmpty());
+    Assertions.assertEquals(
+        expectedResult.getSpec().getJobTemplate().getMetadata().getLabels(),
+        labelsArgumentCaptor.getValue());
 
-      Assertions.assertEquals(expectedAnnotations, annotationsArgumentCaptor.getValue());
-   }
+    Assertions.assertEquals(expectedAnnotations, annotationsArgumentCaptor.getValue());
+  }
 
-   private KubernetesService mockKubernetesService(String jobName, V1beta1CronJob result) throws ApiException {
-      KubernetesService kubernetesService = Mockito.mock(KubernetesService.class);
-      Mockito.doCallRealMethod().when(kubernetesService)
-            .startNewCronJobExecution(Mockito.anyString(), Mockito.anyString(), Mockito.anyMap(), Mockito.anyMap(), Mockito.anyMap(), Mockito.any());
+  private KubernetesService mockKubernetesService(String jobName, V1beta1CronJob result)
+      throws ApiException {
+    KubernetesService kubernetesService = Mockito.mock(KubernetesService.class);
+    Mockito.doCallRealMethod()
+        .when(kubernetesService)
+        .startNewCronJobExecution(
+            Mockito.anyString(),
+            Mockito.anyString(),
+            Mockito.anyMap(),
+            Mockito.anyMap(),
+            Mockito.anyMap(),
+            Mockito.any());
 
-      BatchV1beta1Api batchV1beta1Api = Mockito.mock(BatchV1beta1Api.class);
-      Mockito.when(batchV1beta1Api
-            .readNamespacedCronJob(
-                  Mockito.eq(jobName),
-                  Mockito.isNull(),
-                  Mockito.isNull()))
-            .thenReturn(result);
+    BatchV1beta1Api batchV1beta1Api = Mockito.mock(BatchV1beta1Api.class);
+    Mockito.when(
+            batchV1beta1Api.readNamespacedCronJob(
+                Mockito.eq(jobName), Mockito.isNull(), Mockito.isNull()))
+        .thenReturn(result);
 
-      Mockito.when(kubernetesService.initBatchV1beta1Api()).thenReturn(batchV1beta1Api);
+    Mockito.when(kubernetesService.initBatchV1beta1Api()).thenReturn(batchV1beta1Api);
 
-      return kubernetesService;
-   }
+    return kubernetesService;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -15,7 +15,6 @@ import com.vmware.taurus.service.model.JobAnnotation;
 import com.vmware.taurus.service.model.JobLabel;
 import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.openapi.models.*;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -30,410 +29,638 @@ import java.util.*;
 
 public class KubernetesServiceTest {
 
-   @Test
-   public void testCreateVDKContainer() {
+  @Test
+  public void testCreateVDKContainer() {
 
-      var vdkCommand = List.of(
+    var vdkCommand =
+        List.of(
             "/bin/bash",
             "-c",
             "cp -r /usr/local/lib/python3.7/site-packages /vdk/. && cp /usr/local/bin/vdk /vdk/.");
 
-      var volumeMount = KubernetesService.volumeMount("vdk-volume", "/vdk", false);
+    var volumeMount = KubernetesService.volumeMount("vdk-volume", "/vdk", false);
 
-      var expectedVDKContainer = new V1ContainerBuilder()
+    var expectedVDKContainer =
+        new V1ContainerBuilder()
             .withName("vdk")
             .withImage("vdk:latest")
-            .withVolumeMounts(new V1VolumeMount()
-                  .name("vdk-volume")
-                  .mountPath("/vdk")
-                  .readOnly(false))
+            .withVolumeMounts(
+                new V1VolumeMount().name("vdk-volume").mountPath("/vdk").readOnly(false))
             .withImagePullPolicy("Always")
-            .withSecurityContext(new V1SecurityContextBuilder()
-                  .withPrivileged(false)
-                  .build())
+            .withSecurityContext(new V1SecurityContextBuilder().withPrivileged(false).build())
             .withCommand(vdkCommand)
             .withArgs(List.of())
             .withEnv(List.of())
-            .withResources(new V1ResourceRequirementsBuilder()
-                  .withRequests(Map.of("cpu", new Quantity("500m"), "memory", new Quantity("1G")))
-                  .withLimits(Map.of("cpu", new Quantity("2000m"), "memory", new Quantity("1G")))
-                  .build())
+            .withResources(
+                new V1ResourceRequirementsBuilder()
+                    .withRequests(Map.of("cpu", new Quantity("500m"), "memory", new Quantity("1G")))
+                    .withLimits(Map.of("cpu", new Quantity("2000m"), "memory", new Quantity("1G")))
+                    .build())
             .build();
 
-      var actualVDKContainer = KubernetesService.container("vdk", "vdk:latest", false, Map.of(), List.of(),
-            List.of(volumeMount), "Always", new KubernetesService.Resources("500m", "1G"),
-            new KubernetesService.Resources("2000m", "1G"), null, vdkCommand);
+    var actualVDKContainer =
+        KubernetesService.container(
+            "vdk",
+            "vdk:latest",
+            false,
+            Map.of(),
+            List.of(),
+            List.of(volumeMount),
+            "Always",
+            new KubernetesService.Resources("500m", "1G"),
+            new KubernetesService.Resources("2000m", "1G"),
+            null,
+            vdkCommand);
 
-      Assertions.assertEquals(expectedVDKContainer, actualVDKContainer);
-   }
+    Assertions.assertEquals(expectedVDKContainer, actualVDKContainer);
+  }
 
-   @Test
-   public void testGetJobExecutionStatus_emptyJob_shouldReturnEmptyJobExecutionStatus() {
-      V1Job v1Job = new V1Job();
-      KubernetesService mock = Mockito.mock(KubernetesService.class);
-      Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
-      Mockito.when(mock.getTerminationStatus(v1Job)).thenReturn(Optional.empty());
-      Mockito.when(mock.getJobExecutionStatus(v1Job, null)).thenCallRealMethod();
-      Optional<KubernetesService.JobExecution> actualJobExecutionStatusOptional = mock.getJobExecutionStatus(v1Job, null);
+  @Test
+  public void testGetJobExecutionStatus_emptyJob_shouldReturnEmptyJobExecutionStatus() {
+    V1Job v1Job = new V1Job();
+    KubernetesService mock = Mockito.mock(KubernetesService.class);
+    Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
+    Mockito.when(mock.getTerminationStatus(v1Job)).thenReturn(Optional.empty());
+    Mockito.when(mock.getJobExecutionStatus(v1Job, null)).thenCallRealMethod();
+    Optional<KubernetesService.JobExecution> actualJobExecutionStatusOptional =
+        mock.getJobExecutionStatus(v1Job, null);
 
-      Assertions.assertTrue(actualJobExecutionStatusOptional.isPresent());
+    Assertions.assertTrue(actualJobExecutionStatusOptional.isPresent());
 
-      KubernetesService.JobExecution actualJobExecution = actualJobExecutionStatusOptional.get();
-      Assertions.assertNull(actualJobExecution.getExecutionId());
-      Assertions.assertNull(actualJobExecution.getJobName());
-      Assertions.assertNull(actualJobExecution.getJobVersion());
-      Assertions.assertNull(actualJobExecution.getDeployedDate());
-      Assertions.assertNull(actualJobExecution.getExecutionType());
-      Assertions.assertNull(actualJobExecution.getOpId());
-      Assertions.assertNull(actualJobExecution.getResourcesCpuRequest());
-      Assertions.assertNull(actualJobExecution.getResourcesCpuLimit());
-      Assertions.assertNull(actualJobExecution.getResourcesMemoryRequest());
-      Assertions.assertNull(actualJobExecution.getResourcesMemoryLimit());
-      Assertions.assertNull(actualJobExecution.getStartTime());
-      Assertions.assertNull(actualJobExecution.getEndTime());
-      Assertions.assertNull(actualJobExecution.getSucceeded());
-   }
+    KubernetesService.JobExecution actualJobExecution = actualJobExecutionStatusOptional.get();
+    Assertions.assertNull(actualJobExecution.getExecutionId());
+    Assertions.assertNull(actualJobExecution.getJobName());
+    Assertions.assertNull(actualJobExecution.getJobVersion());
+    Assertions.assertNull(actualJobExecution.getDeployedDate());
+    Assertions.assertNull(actualJobExecution.getExecutionType());
+    Assertions.assertNull(actualJobExecution.getOpId());
+    Assertions.assertNull(actualJobExecution.getResourcesCpuRequest());
+    Assertions.assertNull(actualJobExecution.getResourcesCpuLimit());
+    Assertions.assertNull(actualJobExecution.getResourcesMemoryRequest());
+    Assertions.assertNull(actualJobExecution.getResourcesMemoryLimit());
+    Assertions.assertNull(actualJobExecution.getStartTime());
+    Assertions.assertNull(actualJobExecution.getEndTime());
+    Assertions.assertNull(actualJobExecution.getSucceeded());
+  }
 
-   @Test
-   public void testGetJobExecutionStatus_notEmptyJob_shouldReturnNotEmptyJobExecutionStatus() {
-      String dataJobName = "test-data-job";
-      String kubernetesJobName = "test-job";
-      String jobVersion = "1234";
-      String deployedDate = "2021-06-15T08:04:33.534787Z";
-      String deployedBy = "test-user";
-      String executionType = "manual";
-      String opId = "test-op-id";
-      String cpuRequest = "1";
-      String cpuLimit = "2";
-      Integer memoryRequest = 500;
-      Integer memoryLimit = 1000;
-      OffsetDateTime startTime = OffsetDateTime.now();
-      OffsetDateTime endTime = OffsetDateTime.now();
-      Integer succeeded = 1;
+  @Test
+  public void testGetJobExecutionStatus_notEmptyJob_shouldReturnNotEmptyJobExecutionStatus() {
+    String dataJobName = "test-data-job";
+    String kubernetesJobName = "test-job";
+    String jobVersion = "1234";
+    String deployedDate = "2021-06-15T08:04:33.534787Z";
+    String deployedBy = "test-user";
+    String executionType = "manual";
+    String opId = "test-op-id";
+    String cpuRequest = "1";
+    String cpuLimit = "2";
+    Integer memoryRequest = 500;
+    Integer memoryLimit = 1000;
+    OffsetDateTime startTime = OffsetDateTime.now();
+    OffsetDateTime endTime = OffsetDateTime.now();
+    Integer succeeded = 1;
 
-      V1Job expectedJob = new V1Job()
-            .metadata(new V1ObjectMeta()
-                  .name(kubernetesJobName)
-                  .putLabelsItem(JobLabel.VERSION.getValue(), jobVersion)
-                  .putLabelsItem(JobLabel.NAME.getValue(), dataJobName)
-                  .putAnnotationsItem(JobAnnotation.DEPLOYED_DATE.getValue(), deployedDate)
-                  .putAnnotationsItem(JobAnnotation.DEPLOYED_BY.getValue(), deployedBy)
-                  .putAnnotationsItem(JobAnnotation.EXECUTION_TYPE.getValue(), executionType)
-                  .putAnnotationsItem(JobAnnotation.OP_ID.getValue(), opId))
-            .spec(new V1JobSpec()
-                  .template(new V1PodTemplateSpec()
-                        .spec(new V1PodSpec()
-                              .addContainersItem(new V1Container()
-                                    .name(dataJobName)
-                                    .resources(new V1ResourceRequirements()
-                                          .putRequestsItem("cpu", new Quantity(cpuRequest))
-                                          .putRequestsItem("memory", new Quantity(Integer.toString(memoryRequest * 1000 * 1000)))
-                                          .putLimitsItem("cpu", new Quantity(cpuLimit))
-                                          .putLimitsItem("memory", new Quantity(Integer.toString(memoryLimit * 1000 * 1000)))
-                                    )))))
-            .status(new V1JobStatus()
-                  .startTime(startTime)
-                  .completionTime(endTime)
-                  .succeeded(succeeded));
-      KubernetesService.JobStatusCondition condition = new KubernetesService.JobStatusCondition(true, "type", "reason", "message", endTime.toInstant().toEpochMilli());
+    V1Job expectedJob =
+        new V1Job()
+            .metadata(
+                new V1ObjectMeta()
+                    .name(kubernetesJobName)
+                    .putLabelsItem(JobLabel.VERSION.getValue(), jobVersion)
+                    .putLabelsItem(JobLabel.NAME.getValue(), dataJobName)
+                    .putAnnotationsItem(JobAnnotation.DEPLOYED_DATE.getValue(), deployedDate)
+                    .putAnnotationsItem(JobAnnotation.DEPLOYED_BY.getValue(), deployedBy)
+                    .putAnnotationsItem(JobAnnotation.EXECUTION_TYPE.getValue(), executionType)
+                    .putAnnotationsItem(JobAnnotation.OP_ID.getValue(), opId))
+            .spec(
+                new V1JobSpec()
+                    .template(
+                        new V1PodTemplateSpec()
+                            .spec(
+                                new V1PodSpec()
+                                    .addContainersItem(
+                                        new V1Container()
+                                            .name(dataJobName)
+                                            .resources(
+                                                new V1ResourceRequirements()
+                                                    .putRequestsItem(
+                                                        "cpu", new Quantity(cpuRequest))
+                                                    .putRequestsItem(
+                                                        "memory",
+                                                        new Quantity(
+                                                            Integer.toString(
+                                                                memoryRequest * 1000 * 1000)))
+                                                    .putLimitsItem("cpu", new Quantity(cpuLimit))
+                                                    .putLimitsItem(
+                                                        "memory",
+                                                        new Quantity(
+                                                            Integer.toString(
+                                                                memoryLimit * 1000 * 1000))))))))
+            .status(
+                new V1JobStatus()
+                    .startTime(startTime)
+                    .completionTime(endTime)
+                    .succeeded(succeeded));
+    KubernetesService.JobStatusCondition condition =
+        new KubernetesService.JobStatusCondition(
+            true, "type", "reason", "message", endTime.toInstant().toEpochMilli());
 
-      KubernetesService mock = Mockito.mock(KubernetesService.class);
-      Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
-      Mockito.when(mock.getTerminationStatus(expectedJob)).thenReturn(Optional.empty());
-      Mockito.when(mock.getJobExecutionStatus(expectedJob, condition)).thenCallRealMethod();
-      Optional<KubernetesService.JobExecution> actualJobExecutionStatusOptional = mock.getJobExecutionStatus(expectedJob, condition);
+    KubernetesService mock = Mockito.mock(KubernetesService.class);
+    Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
+    Mockito.when(mock.getTerminationStatus(expectedJob)).thenReturn(Optional.empty());
+    Mockito.when(mock.getJobExecutionStatus(expectedJob, condition)).thenCallRealMethod();
+    Optional<KubernetesService.JobExecution> actualJobExecutionStatusOptional =
+        mock.getJobExecutionStatus(expectedJob, condition);
 
-      Assertions.assertTrue(actualJobExecutionStatusOptional.isPresent());
+    Assertions.assertTrue(actualJobExecutionStatusOptional.isPresent());
 
-      KubernetesService.JobExecution actualJobExecution = actualJobExecutionStatusOptional.get();
-      Assertions.assertEquals(kubernetesJobName, actualJobExecution.getExecutionId());
-      Assertions.assertEquals(dataJobName, actualJobExecution.getJobName());
-      Assertions.assertEquals(jobVersion, actualJobExecution.getJobVersion());
-      Assertions.assertEquals(OffsetDateTime.parse(deployedDate), actualJobExecution.getDeployedDate());
-      Assertions.assertEquals(executionType, actualJobExecution.getExecutionType());
-      Assertions.assertEquals(opId, actualJobExecution.getOpId());
-      Assertions.assertEquals(Float.valueOf(cpuRequest), actualJobExecution.getResourcesCpuRequest());
-      Assertions.assertEquals(Float.valueOf(cpuLimit), actualJobExecution.getResourcesCpuLimit());
-      Assertions.assertEquals(memoryRequest, actualJobExecution.getResourcesMemoryRequest());
-      Assertions.assertEquals(memoryLimit, actualJobExecution.getResourcesMemoryLimit());
-      Assertions.assertEquals(OffsetDateTime.ofInstant(Instant.ofEpochMilli(startTime.toInstant().toEpochMilli()), ZoneOffset.UTC), actualJobExecution.getStartTime());
-      Assertions.assertEquals(OffsetDateTime.ofInstant(Instant.ofEpochMilli(endTime.toInstant().toEpochMilli()), ZoneOffset.UTC), actualJobExecution.getEndTime());
-      Assertions.assertTrue(actualJobExecution.getSucceeded());
-   }
+    KubernetesService.JobExecution actualJobExecution = actualJobExecutionStatusOptional.get();
+    Assertions.assertEquals(kubernetesJobName, actualJobExecution.getExecutionId());
+    Assertions.assertEquals(dataJobName, actualJobExecution.getJobName());
+    Assertions.assertEquals(jobVersion, actualJobExecution.getJobVersion());
+    Assertions.assertEquals(
+        OffsetDateTime.parse(deployedDate), actualJobExecution.getDeployedDate());
+    Assertions.assertEquals(executionType, actualJobExecution.getExecutionType());
+    Assertions.assertEquals(opId, actualJobExecution.getOpId());
+    Assertions.assertEquals(Float.valueOf(cpuRequest), actualJobExecution.getResourcesCpuRequest());
+    Assertions.assertEquals(Float.valueOf(cpuLimit), actualJobExecution.getResourcesCpuLimit());
+    Assertions.assertEquals(memoryRequest, actualJobExecution.getResourcesMemoryRequest());
+    Assertions.assertEquals(memoryLimit, actualJobExecution.getResourcesMemoryLimit());
+    Assertions.assertEquals(
+        OffsetDateTime.ofInstant(
+            Instant.ofEpochMilli(startTime.toInstant().toEpochMilli()), ZoneOffset.UTC),
+        actualJobExecution.getStartTime());
+    Assertions.assertEquals(
+        OffsetDateTime.ofInstant(
+            Instant.ofEpochMilli(endTime.toInstant().toEpochMilli()), ZoneOffset.UTC),
+        actualJobExecution.getEndTime());
+    Assertions.assertTrue(actualJobExecution.getSucceeded());
+  }
 
-    // Note that we are testing private functionality and mocking the surrounding methods
-    // won't do us any good. Better approach is to rely on integration tests where we can
-    // check the final outcome directly in the K8s environment.
-    @Test
-    public void testCreateV1beta1CronJobFromInternalResource() {
-        KubernetesService service = new DataJobsKubernetesService("default", "someConfig", false);
-        try {
-            // Step 1 - load and check the internal cronjob template.
-            service.afterPropertiesSet();
-            // At this point we know that the cronjob template is loaded successfully.
+  // Note that we are testing private functionality and mocking the surrounding methods
+  // won't do us any good. Better approach is to rely on integration tests where we can
+  // check the final outcome directly in the K8s environment.
+  @Test
+  public void testCreateV1beta1CronJobFromInternalResource() {
+    KubernetesService service = new DataJobsKubernetesService("default", "someConfig", false);
+    try {
+      // Step 1 - load and check the internal cronjob template.
+      service.afterPropertiesSet();
+      // At this point we know that the cronjob template is loaded successfully.
 
-            // Step 2 - check whether an empty V1beta1CronJob object is properly populated
-            //          with corresponding entries from the internal cronjob template.
-            // First we load the internal cronjob template.
-            Method loadInternalV1beta1CronjobTemplate = KubernetesService.class.getDeclaredMethod("loadInternalV1beta1CronjobTemplate");
-            if(loadInternalV1beta1CronjobTemplate == null) {
-                Assertions.fail("The method 'loadInternalV1beta1CronjobTemplate' does not exist.");
-            }
-            loadInternalV1beta1CronjobTemplate.setAccessible(true);
-            V1beta1CronJob internalCronjobTemplate = (V1beta1CronJob) loadInternalV1beta1CronjobTemplate.invoke(service);
-            // Prepare the 'v1beta1checkForMissingEntries' method.
-            Method checkForMissingEntries = KubernetesService.class.getDeclaredMethod("v1beta1checkForMissingEntries", V1beta1CronJob.class);
-            if(checkForMissingEntries == null) {
-                Assertions.fail("The method 'v1beta1checkForMissingEntries' does not exist.");
-            }
-            checkForMissingEntries.setAccessible(true);
-            V1beta1CronJob emptyCronjobToBeFixed = new V1beta1CronJob(); // Worst case scenario to test - empty cronjob.
-            checkForMissingEntries.invoke(service, emptyCronjobToBeFixed);
-            // We can't rely on equality check on root metadata/spec level, because if the internal template
-            // has missing elements, the equality check will miss them. Instead, we will check the most
-            // important elements one by one.
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata());
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata().getAnnotations());
-            Assertions.assertEquals(internalCronjobTemplate.getMetadata().getAnnotations(),
-                    emptyCronjobToBeFixed.getMetadata().getAnnotations());
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec());
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate());
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec());
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate());
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata());
-            Assertions.assertEquals(internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata().getLabels(),
-                    emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata().getLabels());
+      // Step 2 - check whether an empty V1beta1CronJob object is properly populated
+      //          with corresponding entries from the internal cronjob template.
+      // First we load the internal cronjob template.
+      Method loadInternalV1beta1CronjobTemplate =
+          KubernetesService.class.getDeclaredMethod("loadInternalV1beta1CronjobTemplate");
+      if (loadInternalV1beta1CronjobTemplate == null) {
+        Assertions.fail("The method 'loadInternalV1beta1CronjobTemplate' does not exist.");
+      }
+      loadInternalV1beta1CronjobTemplate.setAccessible(true);
+      V1beta1CronJob internalCronjobTemplate =
+          (V1beta1CronJob) loadInternalV1beta1CronjobTemplate.invoke(service);
+      // Prepare the 'v1beta1checkForMissingEntries' method.
+      Method checkForMissingEntries =
+          KubernetesService.class.getDeclaredMethod(
+              "v1beta1checkForMissingEntries", V1beta1CronJob.class);
+      if (checkForMissingEntries == null) {
+        Assertions.fail("The method 'v1beta1checkForMissingEntries' does not exist.");
+      }
+      checkForMissingEntries.setAccessible(true);
+      V1beta1CronJob emptyCronjobToBeFixed =
+          new V1beta1CronJob(); // Worst case scenario to test - empty cronjob.
+      checkForMissingEntries.invoke(service, emptyCronjobToBeFixed);
+      // We can't rely on equality check on root metadata/spec level, because if the internal
+      // template
+      // has missing elements, the equality check will miss them. Instead, we will check the most
+      // important elements one by one.
+      Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata());
+      Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata().getAnnotations());
+      Assertions.assertEquals(
+          internalCronjobTemplate.getMetadata().getAnnotations(),
+          emptyCronjobToBeFixed.getMetadata().getAnnotations());
+      Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec());
+      Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate());
+      Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec());
+      Assertions.assertNotNull(
+          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate());
+      Assertions.assertNotNull(
+          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
+      Assertions.assertNotNull(
+          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata());
+      Assertions.assertEquals(
+          internalCronjobTemplate
+              .getSpec()
+              .getJobTemplate()
+              .getSpec()
+              .getTemplate()
+              .getMetadata()
+              .getLabels(),
+          emptyCronjobToBeFixed
+              .getSpec()
+              .getJobTemplate()
+              .getSpec()
+              .getTemplate()
+              .getMetadata()
+              .getLabels());
 
-            Assertions.assertNotNull(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
-            // Step 3 - create and check the actual cronjob.
-            Method[] methods = KubernetesService.class.getDeclaredMethods();
-            // This is much easier than describing the whole method signature.
-            Optional<Method> method = Arrays.stream(methods).filter(m -> m.getName().equals("v1beta1CronJobFromTemplate")).findFirst();
-            if(method.isEmpty()) {
-                Assertions.fail("The method 'v1beta1cronJobFromTemplate' does not exist.");
-            }
-            method.get().setAccessible(true);
-            V1beta1CronJob cronjob = (V1beta1CronJob) method.get().invoke(service, "test-job-name", "test-job-schedule", true, null, null, null, Collections.EMPTY_MAP, Collections.EMPTY_MAP, Collections.EMPTY_MAP, Collections.EMPTY_MAP, List.of(""));
-            Assertions.assertEquals("test-job-name", cronjob.getMetadata().getName());
-            Assertions.assertEquals("test-job-schedule", cronjob.getSpec().getSchedule());
-            Assertions.assertEquals(true, cronjob.getSpec().getSuspend());
-            Assertions.assertEquals(Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getLabels());
-            Assertions.assertEquals(Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations());
+      Assertions.assertNotNull(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
+      // Step 3 - create and check the actual cronjob.
+      Method[] methods = KubernetesService.class.getDeclaredMethods();
+      // This is much easier than describing the whole method signature.
+      Optional<Method> method =
+          Arrays.stream(methods)
+              .filter(m -> m.getName().equals("v1beta1CronJobFromTemplate"))
+              .findFirst();
+      if (method.isEmpty()) {
+        Assertions.fail("The method 'v1beta1cronJobFromTemplate' does not exist.");
+      }
+      method.get().setAccessible(true);
+      V1beta1CronJob cronjob =
+          (V1beta1CronJob)
+              method
+                  .get()
+                  .invoke(
+                      service,
+                      "test-job-name",
+                      "test-job-schedule",
+                      true,
+                      null,
+                      null,
+                      null,
+                      Collections.EMPTY_MAP,
+                      Collections.EMPTY_MAP,
+                      Collections.EMPTY_MAP,
+                      Collections.EMPTY_MAP,
+                      List.of(""));
+      Assertions.assertEquals("test-job-name", cronjob.getMetadata().getName());
+      Assertions.assertEquals("test-job-schedule", cronjob.getSpec().getSchedule());
+      Assertions.assertEquals(true, cronjob.getSpec().getSuspend());
+      Assertions.assertEquals(
+          Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getLabels());
+      Assertions.assertEquals(
+          Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations());
 
-        } catch(Exception e) {
-            e.printStackTrace();
-            Assertions.fail(e.getMessage());
-        }
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assertions.fail(e.getMessage());
     }
+  }
 
-    @Test
-    public void testCreateV1CronJobFromInternalResource() {
-        KubernetesService service = new DataJobsKubernetesService("default", "someConfig", false);
-        try {
-            // Step 1 - load and check the internal cronjob template.
-            service.afterPropertiesSet();
-            // At this point we know that the cronjob template is loaded successfully.
+  @Test
+  public void testCreateV1CronJobFromInternalResource() {
+    KubernetesService service = new DataJobsKubernetesService("default", "someConfig", false);
+    try {
+      // Step 1 - load and check the internal cronjob template.
+      service.afterPropertiesSet();
+      // At this point we know that the cronjob template is loaded successfully.
 
-            // Step 2 - check whether an empty V1CronJob object is properly populated
-            //          with corresponding entries from the internal cronjob template.
-            // First we load the internal cronjob template.
-            Method loadInternalV1CronjobTemplate = KubernetesService.class.getDeclaredMethod("loadInternalV1CronjobTemplate");
-            if(loadInternalV1CronjobTemplate == null) {
-                Assertions.fail("The method 'loadInternalV1CronjobTemplate' does not exist.");
-            }
-            loadInternalV1CronjobTemplate.setAccessible(true);
-            V1CronJob internalCronjobTemplate = (V1CronJob) loadInternalV1CronjobTemplate.invoke(service);
-            // Prepare the 'v1checkForMissingEntries' method.
-            Method checkForMissingEntries = KubernetesService.class.getDeclaredMethod("v1checkForMissingEntries", V1CronJob.class);
-            if(checkForMissingEntries == null) {
-                Assertions.fail("The method 'v1checkForMissingEntries' does not exist.");
-            }
-            checkForMissingEntries.setAccessible(true);
-            V1CronJob emptyCronjobToBeFixed = new V1CronJob(); // Worst case scenario to test - empty cronjob.
-            checkForMissingEntries.invoke(service, emptyCronjobToBeFixed);
-            // We can't rely on equality check on root metadata/spec level, because if the internal template
-            // has missing elements, the equality check will miss them. Instead, we will check the most
-            // important elements one by one.
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata());
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata().getAnnotations());
-            Assertions.assertEquals(internalCronjobTemplate.getMetadata().getAnnotations(),
-                    emptyCronjobToBeFixed.getMetadata().getAnnotations());
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec());
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate());
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec());
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate());
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata());
-            Assertions.assertEquals(internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata().getLabels(),
-                    emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata().getLabels());
+      // Step 2 - check whether an empty V1CronJob object is properly populated
+      //          with corresponding entries from the internal cronjob template.
+      // First we load the internal cronjob template.
+      Method loadInternalV1CronjobTemplate =
+          KubernetesService.class.getDeclaredMethod("loadInternalV1CronjobTemplate");
+      if (loadInternalV1CronjobTemplate == null) {
+        Assertions.fail("The method 'loadInternalV1CronjobTemplate' does not exist.");
+      }
+      loadInternalV1CronjobTemplate.setAccessible(true);
+      V1CronJob internalCronjobTemplate = (V1CronJob) loadInternalV1CronjobTemplate.invoke(service);
+      // Prepare the 'v1checkForMissingEntries' method.
+      Method checkForMissingEntries =
+          KubernetesService.class.getDeclaredMethod("v1checkForMissingEntries", V1CronJob.class);
+      if (checkForMissingEntries == null) {
+        Assertions.fail("The method 'v1checkForMissingEntries' does not exist.");
+      }
+      checkForMissingEntries.setAccessible(true);
+      V1CronJob emptyCronjobToBeFixed =
+          new V1CronJob(); // Worst case scenario to test - empty cronjob.
+      checkForMissingEntries.invoke(service, emptyCronjobToBeFixed);
+      // We can't rely on equality check on root metadata/spec level, because if the internal
+      // template
+      // has missing elements, the equality check will miss them. Instead, we will check the most
+      // important elements one by one.
+      Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata());
+      Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata().getAnnotations());
+      Assertions.assertEquals(
+          internalCronjobTemplate.getMetadata().getAnnotations(),
+          emptyCronjobToBeFixed.getMetadata().getAnnotations());
+      Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec());
+      Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate());
+      Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec());
+      Assertions.assertNotNull(
+          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate());
+      Assertions.assertNotNull(
+          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
+      Assertions.assertNotNull(
+          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata());
+      Assertions.assertEquals(
+          internalCronjobTemplate
+              .getSpec()
+              .getJobTemplate()
+              .getSpec()
+              .getTemplate()
+              .getMetadata()
+              .getLabels(),
+          emptyCronjobToBeFixed
+              .getSpec()
+              .getJobTemplate()
+              .getSpec()
+              .getTemplate()
+              .getMetadata()
+              .getLabels());
 
-            Assertions.assertNotNull(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
-            // Step 3 - create and check the actual cronjob.
-            Method[] methods = KubernetesService.class.getDeclaredMethods();
-            // This is much easier than describing the whole method signature.
-            Optional<Method> method = Arrays.stream(methods).filter(m -> m.getName().equals("v1CronJobFromTemplate")).findFirst();
-            if(method.isEmpty()) {
-                Assertions.fail("The method 'v1cronJobFromTemplate' does not exist.");
-            }
-            method.get().setAccessible(true);
-            V1CronJob cronjob = (V1CronJob) method.get().invoke(service, "test-job-name", "test-job-schedule", true, null, null, null, Collections.EMPTY_MAP, Collections.EMPTY_MAP, Collections.EMPTY_MAP, Collections.EMPTY_MAP, List.of(""));
-            Assertions.assertEquals("test-job-name", cronjob.getMetadata().getName());
-            Assertions.assertEquals("test-job-schedule", cronjob.getSpec().getSchedule());
-            Assertions.assertEquals(true, cronjob.getSpec().getSuspend());
-            Assertions.assertEquals(Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getLabels());
-            Assertions.assertEquals(Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations());
+      Assertions.assertNotNull(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
+      // Step 3 - create and check the actual cronjob.
+      Method[] methods = KubernetesService.class.getDeclaredMethods();
+      // This is much easier than describing the whole method signature.
+      Optional<Method> method =
+          Arrays.stream(methods)
+              .filter(m -> m.getName().equals("v1CronJobFromTemplate"))
+              .findFirst();
+      if (method.isEmpty()) {
+        Assertions.fail("The method 'v1cronJobFromTemplate' does not exist.");
+      }
+      method.get().setAccessible(true);
+      V1CronJob cronjob =
+          (V1CronJob)
+              method
+                  .get()
+                  .invoke(
+                      service,
+                      "test-job-name",
+                      "test-job-schedule",
+                      true,
+                      null,
+                      null,
+                      null,
+                      Collections.EMPTY_MAP,
+                      Collections.EMPTY_MAP,
+                      Collections.EMPTY_MAP,
+                      Collections.EMPTY_MAP,
+                      List.of(""));
+      Assertions.assertEquals("test-job-name", cronjob.getMetadata().getName());
+      Assertions.assertEquals("test-job-schedule", cronjob.getSpec().getSchedule());
+      Assertions.assertEquals(true, cronjob.getSpec().getSuspend());
+      Assertions.assertEquals(
+          Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getLabels());
+      Assertions.assertEquals(
+          Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations());
 
-        } catch(Exception e) {
-            e.printStackTrace();
-            Assertions.fail(e.getMessage());
-        }
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assertions.fail(e.getMessage());
     }
+  }
 
-    @Test
-    public void testQuantityToMbConversionMegabytes() throws Exception {
-        var hundredMb = "100M";
-        testQuantityToMbConversion(100, hundredMb);
+  @Test
+  public void testQuantityToMbConversionMegabytes() throws Exception {
+    var hundredMb = "100M";
+    testQuantityToMbConversion(100, hundredMb);
 
-        var thousandMb = "1000M";
-        testQuantityToMbConversion(1000, thousandMb);
-        // this should be enough for overflow errors on the method to manifest.
-        var tenThousandMb = "10000M";
-        testQuantityToMbConversion(10000, tenThousandMb);
+    var thousandMb = "1000M";
+    testQuantityToMbConversion(1000, thousandMb);
+    // this should be enough for overflow errors on the method to manifest.
+    var tenThousandMb = "10000M";
+    testQuantityToMbConversion(10000, tenThousandMb);
 
-        var hundredThousandMb = "100000M";
-        testQuantityToMbConversion(100000, hundredThousandMb);
+    var hundredThousandMb = "100000M";
+    testQuantityToMbConversion(100000, hundredThousandMb);
+  }
 
-    }
+  @Test
+  public void testQuantityConversionGigabytes() throws Exception {
+    var oneG = "1G";
+    testQuantityToMbConversion(1000, oneG);
 
-    @Test
-    public void testQuantityConversionGigabytes() throws Exception {
-        var oneG = "1G";
-        testQuantityToMbConversion(1000, oneG);
+    var twoG = "2G";
+    testQuantityToMbConversion(2000, twoG);
+    // this should be enough for overflow errors on the method to manifest.
+    var threeG = "3G";
+    testQuantityToMbConversion(3000, threeG);
 
-        var twoG = "2G";
-        testQuantityToMbConversion(2000, twoG);
-        // this should be enough for overflow errors on the method to manifest.
-        var threeG = "3G";
-        testQuantityToMbConversion(3000, threeG);
+    var fourG = "4G";
+    testQuantityToMbConversion(4000, fourG);
 
-        var fourG = "4G";
-        testQuantityToMbConversion(4000, fourG);
+    var sixtyFourG = "64G";
+    testQuantityToMbConversion(64000, sixtyFourG);
+  }
 
-        var sixtyFourG = "64G";
-        testQuantityToMbConversion(64000, sixtyFourG);
-    }
+  @Test
+  public void testV1beta1CronJobFromTemplate_emptyImagePullSecretsList() {
+    KubernetesService mock = mockCronJobFromTemplate();
+    V1beta1CronJob v1beta1CronJob =
+        mock.v1beta1CronJobFromTemplate(
+            "",
+            "",
+            true,
+            null,
+            null,
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyList());
 
-   @Test
-   public void testV1beta1CronJobFromTemplate_emptyImagePullSecretsList() {
-      KubernetesService mock = mockCronJobFromTemplate();
-      V1beta1CronJob v1beta1CronJob = mock.v1beta1CronJobFromTemplate(
-            "", "", true,
-            null, null, null,
-            Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
-            Collections.emptyMap(), Collections.emptyList());
+    Assertions.assertNull(
+        v1beta1CronJob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .getImagePullSecrets());
+  }
 
-      Assertions.assertNull(v1beta1CronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getImagePullSecrets());
-   }
+  @Test
+  public void testV1CronJobFromTemplate_emptyImagePullSecretsList() {
+    KubernetesService mock = mockCronJobFromTemplate();
+    V1CronJob v1CronJob =
+        mock.v1CronJobFromTemplate(
+            "",
+            "",
+            true,
+            null,
+            null,
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyList());
 
-    @Test
-    public void testV1CronJobFromTemplate_emptyImagePullSecretsList() {
-        KubernetesService mock = mockCronJobFromTemplate();
-        V1CronJob v1CronJob = mock.v1CronJobFromTemplate(
-                "", "", true,
-                null, null, null,
-                Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
-                Collections.emptyMap(), Collections.emptyList());
+    Assertions.assertNull(
+        v1CronJob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .getImagePullSecrets());
+  }
 
-        Assertions.assertNull(v1CronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getImagePullSecrets());
-    }
+  @Test
+  public void testV1beta1CronJobFromTemplate_imagePullSecretsListWithEmptyValues() {
+    KubernetesService mock = mockCronJobFromTemplate();
+    V1beta1CronJob v1beta1CronJob =
+        mock.v1beta1CronJobFromTemplate(
+            "",
+            "",
+            true,
+            null,
+            null,
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            List.of("", ""));
 
-   @Test
-   public void testV1beta1CronJobFromTemplate_imagePullSecretsListWithEmptyValues() {
-      KubernetesService mock = mockCronJobFromTemplate();
-      V1beta1CronJob v1beta1CronJob = mock.v1beta1CronJobFromTemplate(
-            "", "", true,
-            null, null, null,
-            Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
-            Collections.emptyMap(), List.of("", ""));
+    Assertions.assertNull(
+        v1beta1CronJob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .getImagePullSecrets());
+  }
 
-      Assertions.assertNull(v1beta1CronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getImagePullSecrets());
-   }
+  @Test
+  public void testV1CronJobFromTemplate_imagePullSecretsListWithEmptyValues() {
+    KubernetesService mock = mockCronJobFromTemplate();
+    V1CronJob v1CronJob =
+        mock.v1CronJobFromTemplate(
+            "",
+            "",
+            true,
+            null,
+            null,
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            List.of("", ""));
 
-    @Test
-    public void testV1CronJobFromTemplate_imagePullSecretsListWithEmptyValues() {
-        KubernetesService mock = mockCronJobFromTemplate();
-        V1CronJob v1CronJob = mock.v1CronJobFromTemplate(
-                "", "", true,
-                null, null, null,
-                Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
-                Collections.emptyMap(), List.of("", ""));
+    Assertions.assertNull(
+        v1CronJob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .getImagePullSecrets());
+  }
 
-        Assertions.assertNull(v1CronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getImagePullSecrets());
-    }
+  @Test
+  public void
+      testV1beta1CronJobFromTemplate_imagePullSecretsListWithOneNonEmptyValueAndOneEmptyValue() {
+    KubernetesService mock = mockCronJobFromTemplate();
+    String secretName = "test_secret_name";
+    V1beta1CronJob v1beta1CronJob =
+        mock.v1beta1CronJobFromTemplate(
+            "",
+            "",
+            true,
+            null,
+            null,
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            List.of("", secretName));
 
-   @Test
-   public void testV1beta1CronJobFromTemplate_imagePullSecretsListWithOneNonEmptyValueAndOneEmptyValue() {
-      KubernetesService mock = mockCronJobFromTemplate();
-      String secretName = "test_secret_name";
-      V1beta1CronJob v1beta1CronJob = mock.v1beta1CronJobFromTemplate(
-            "", "", true,
-            null, null, null,
-            Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
-            Collections.emptyMap(), List.of("", secretName));
+    List<V1LocalObjectReference> actualImagePullSecrets =
+        v1beta1CronJob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .getImagePullSecrets();
 
-      List<V1LocalObjectReference> actualImagePullSecrets =
-            v1beta1CronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getImagePullSecrets();
+    Assertions.assertNotNull(actualImagePullSecrets);
+    Assertions.assertEquals(1, actualImagePullSecrets.size());
+    Assertions.assertEquals(secretName, actualImagePullSecrets.get(0).getName());
+  }
 
-      Assertions.assertNotNull(actualImagePullSecrets);
-      Assertions.assertEquals(1, actualImagePullSecrets.size());
-      Assertions.assertEquals(secretName, actualImagePullSecrets.get(0).getName());
-   }
+  @Test
+  public void testV1CronJobFromTemplate_imagePullSecretsListWithOneNonEmptyValueAndOneEmptyValue() {
+    KubernetesService mock = mockCronJobFromTemplate();
+    String secretName = "test_secret_name";
+    V1CronJob v1CronJob =
+        mock.v1CronJobFromTemplate(
+            "",
+            "",
+            true,
+            null,
+            null,
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            List.of("", secretName));
 
-    @Test
-    public void testV1CronJobFromTemplate_imagePullSecretsListWithOneNonEmptyValueAndOneEmptyValue() {
-        KubernetesService mock = mockCronJobFromTemplate();
-        String secretName = "test_secret_name";
-        V1CronJob v1CronJob = mock.v1CronJobFromTemplate(
-                "", "", true,
-                null, null, null,
-                Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
-                Collections.emptyMap(), List.of("", secretName));
+    List<V1LocalObjectReference> actualImagePullSecrets =
+        v1CronJob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .getImagePullSecrets();
 
-        List<V1LocalObjectReference> actualImagePullSecrets =
-                v1CronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getImagePullSecrets();
+    Assertions.assertNotNull(actualImagePullSecrets);
+    Assertions.assertEquals(1, actualImagePullSecrets.size());
+    Assertions.assertEquals(secretName, actualImagePullSecrets.get(0).getName());
+  }
 
-        Assertions.assertNotNull(actualImagePullSecrets);
-        Assertions.assertEquals(1, actualImagePullSecrets.size());
-        Assertions.assertEquals(secretName, actualImagePullSecrets.get(0).getName());
-    }
+  public void testQuantityToMbConversion(int expectedMb, String providedResources)
+      throws Exception {
+    var q = Quantity.fromString(providedResources);
+    var actual = KubernetesService.convertMemoryToMBs(q);
+    Assertions.assertEquals(expectedMb, actual);
+  }
 
-    public void testQuantityToMbConversion(int expectedMb, String providedResources) throws Exception {
-        var q = Quantity.fromString(providedResources);
-        var actual = KubernetesService.convertMemoryToMBs(q);
-        Assertions.assertEquals(expectedMb, actual);
-    }
+  private KubernetesService mockCronJobFromTemplate() {
+    KubernetesService mock = Mockito.mock(KubernetesService.class);
+    Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
+    Mockito.when(
+            mock.v1beta1CronJobFromTemplate(
+                anyString(),
+                anyString(),
+                anyBoolean(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                anyList()))
+        .thenCallRealMethod();
+    Mockito.when(
+            mock.v1CronJobFromTemplate(
+                anyString(),
+                anyString(),
+                anyBoolean(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                anyList()))
+        .thenCallRealMethod();
 
-    private KubernetesService mockCronJobFromTemplate() {
-       KubernetesService mock = Mockito.mock(KubernetesService.class);
-       Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
-       Mockito.when(mock.v1beta1CronJobFromTemplate(
-                   anyString(), anyString(), anyBoolean(),
-                   any(), any(), any(),
-                   any(), any(), any(),
-                   any(), anyList()))
-             .thenCallRealMethod();
-        Mockito.when(mock.v1CronJobFromTemplate(
-                anyString(), anyString(), anyBoolean(),
-                any(), any(), any(),
-                any(), any(), any(),
-                any(), anyList()))
-                .thenCallRealMethod();
+    ReflectionTestUtils.setField(
+        mock, // inject into this object
+        "log", // assign to this field
+        Mockito.mock(Logger.class)); // object to be injected
 
-       ReflectionTestUtils.setField(mock, // inject into this object
-             "log", // assign to this field
-             Mockito.mock(Logger.class)); // object to be injected
-
-       return mock;
-    }
+    return mock;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/credentials/JobCredentialsServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/credentials/JobCredentialsServiceTest.java
@@ -27,43 +27,40 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 public class JobCredentialsServiceTest {
 
-    @Mock
-    private KerberosCredentialsRepository credentialsRepository;
+  @Mock private KerberosCredentialsRepository credentialsRepository;
 
-    @Mock
-    private DataJobsKubernetesService kubernetesService;
+  @Mock private DataJobsKubernetesService kubernetesService;
 
-    @InjectMocks
-    private JobCredentialsService credentialsService;
+  @InjectMocks private JobCredentialsService credentialsService;
 
-    @BeforeEach
-    public void setup() throws Exception {
-    }
+  @BeforeEach
+  public void setup() throws Exception {}
 
-    @Test
-    public void test_createJobCredentials() throws ApiException {
-        doAnswer(a -> {
-            Optional<File> f = (Optional<File>)a.getArgument(1);
-            Files.writeString(f.get().toPath(), "keytab-data");
-            return null;
-        }).when(credentialsRepository).createPrincipal(anyString(), any());
+  @Test
+  public void test_createJobCredentials() throws ApiException {
+    doAnswer(
+            a -> {
+              Optional<File> f = (Optional<File>) a.getArgument(1);
+              Files.writeString(f.get().toPath(), "keytab-data");
+              return null;
+            })
+        .when(credentialsRepository)
+        .createPrincipal(anyString(), any());
 
-        credentialsService.createJobCredentials("test");
+    credentialsService.createJobCredentials("test");
 
-        String secretName = JobCredentialsService.getJobKeytabKubernetesSecretName("test");
-        ArgumentCaptor<Map<String, byte[]>> argCaptor = ArgumentCaptor.forClass(Map.class);
+    String secretName = JobCredentialsService.getJobKeytabKubernetesSecretName("test");
+    ArgumentCaptor<Map<String, byte[]>> argCaptor = ArgumentCaptor.forClass(Map.class);
 
-        verify(kubernetesService, only()).saveSecretData(eq(secretName), argCaptor.capture());
-        Assertions.assertTrue(argCaptor.getValue().containsKey("keytab"));
-        Assertions.assertArrayEquals("keytab-data".getBytes(), argCaptor.getValue().get("keytab"));
-    }
+    verify(kubernetesService, only()).saveSecretData(eq(secretName), argCaptor.capture());
+    Assertions.assertTrue(argCaptor.getValue().containsKey("keytab"));
+    Assertions.assertArrayEquals("keytab-data".getBytes(), argCaptor.getValue().get("keytab"));
+  }
 
-    @Test
-    public void test_deleteJobCredentials() throws ApiException {
-        credentialsService.deleteJobCredentials("job");
-        verify(kubernetesService).removeSecretData(contains("job"));
-        verify(credentialsRepository).deletePrincipal(contains("job"));
-    }
-
-
+  @Test
+  public void test_deleteJobCredentials() throws ApiException {
+    credentialsService.deleteJobCredentials("job");
+    verify(kubernetesService).removeSecretData(contains("job"));
+    verify(credentialsRepository).deletePrincipal(contains("job"));
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/credentials/KerberosCredentialsServiceTestManual.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/credentials/KerberosCredentialsServiceTestManual.java
@@ -14,34 +14,34 @@ import java.io.IOException;
 import java.util.Optional;
 
 /**
- * TODO: enable it in CICD:
- * apk --no-cache add krb5
- * + pointing to the krb5.conf
- * + using hadoop-minikdc or docker KDC server
+ * TODO: enable it in CICD: apk --no-cache add krb5 + pointing to the krb5.conf + using
+ * hadoop-minikdc or docker KDC server
  */
 public class KerberosCredentialsServiceTestManual {
 
-    @Test
-    public void test() throws IOException {
-        String kadminUser = System.getProperty("kadmin_password", "phuser/admin");
-        String kadminPassword = System.getProperty("kadmin_password");
+  @Test
+  public void test() throws IOException {
+    String kadminUser = System.getProperty("kadmin_password", "phuser/admin");
+    String kadminPassword = System.getProperty("kadmin_password");
 
-        Assumptions.assumeTrue(kadminPassword != null && !kadminPassword.isBlank(),
-                "kadmin_password is missing. Assuming test is disabled.");
+    Assumptions.assumeTrue(
+        kadminPassword != null && !kadminPassword.isBlank(),
+        "kadmin_password is missing. Assuming test is disabled.");
 
-        KerberosCredentialsRepository service = new KerberosCredentialsRepository(kadminUser, kadminPassword);
+    KerberosCredentialsRepository service =
+        new KerberosCredentialsRepository(kadminUser, kadminPassword);
 
-        File file = File.createTempFile("keytab_test", ".keytab");
-        file.deleteOnExit();
+    File file = File.createTempFile("keytab_test", ".keytab");
+    file.deleteOnExit();
 
-        String principal = "taurus-pipelines-test-user";
-        service.deletePrincipal(principal);
-        Assertions.assertFalse(service.principalExists(principal));
-        service.createPrincipal(principal, Optional.of(file));
-        Assertions.assertTrue(service.principalExists(principal));
-        Assertions.assertTrue(file.exists());
-        Assertions.assertTrue(file.length() > 0);
-        service.deletePrincipal(principal);
-        Assertions.assertFalse(service.principalExists(principal));
-    }
+    String principal = "taurus-pipelines-test-user";
+    service.deletePrincipal(principal);
+    Assertions.assertFalse(service.principalExists(principal));
+    service.createPrincipal(principal, Optional.of(file));
+    Assertions.assertTrue(service.principalExists(principal));
+    Assertions.assertTrue(file.exists());
+    Assertions.assertTrue(file.length() > 0);
+    service.deletePrincipal(principal);
+    Assertions.assertFalse(service.principalExists(principal));
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentNotificationHelperTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentNotificationHelperTest.java
@@ -23,73 +23,85 @@ import java.io.IOException;
 
 import static org.mockito.Mockito.*;
 
-
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = ControlplaneApplication.class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = ControlplaneApplication.class)
 public class DeploymentNotificationHelperTest {
-    private static final String TEST_JOB_NAME = "test-job-name";
-    private static final String TEST_JOB_SCHEDULE = "*/5 * * * *";
-    private static final String TEST_DB_DEFAULT_TYPE = "IMPALA";
-    private static final String TEST_BUILDER_JOB_NAME = "builder-test-job-name";
+  private static final String TEST_JOB_NAME = "test-job-name";
+  private static final String TEST_JOB_SCHEDULE = "*/5 * * * *";
+  private static final String TEST_DB_DEFAULT_TYPE = "IMPALA";
+  private static final String TEST_BUILDER_JOB_NAME = "builder-test-job-name";
 
-    @Autowired
-    private DeploymentNotificationHelper deploymentNotificationHelper;
+  @Autowired private DeploymentNotificationHelper deploymentNotificationHelper;
 
-    @MockBean
-    private DeploymentProgress deploymentProgress;
+  @MockBean private DeploymentProgress deploymentProgress;
 
-    @Test
-    public void deploymentNotificationHelper_fail_userError() throws IOException {
-        JobConfig jobConfig = new JobConfig();
-        jobConfig.setDbDefaultType(TEST_DB_DEFAULT_TYPE);
-        jobConfig.setSchedule(TEST_JOB_SCHEDULE);
-        jobConfig.setTeam("test-team");
+  @Test
+  public void deploymentNotificationHelper_fail_userError() throws IOException {
+    JobConfig jobConfig = new JobConfig();
+    jobConfig.setDbDefaultType(TEST_DB_DEFAULT_TYPE);
+    jobConfig.setSchedule(TEST_JOB_SCHEDULE);
+    jobConfig.setTeam("test-team");
 
-        DataJob testDataJob = new DataJob();
-        testDataJob.setName(TEST_JOB_NAME);
-        testDataJob.setJobConfig(jobConfig);
+    DataJob testDataJob = new DataJob();
+    testDataJob.setName(TEST_JOB_NAME);
+    testDataJob.setJobConfig(jobConfig);
 
-        JobDeployment testJobDeployment = new JobDeployment();
-        testJobDeployment.setDataJobName(TEST_JOB_NAME);
-        testJobDeployment.setGitCommitSha("test-git-commit-sha");
+    JobDeployment testJobDeployment = new JobDeployment();
+    testJobDeployment.setDataJobName(TEST_JOB_NAME);
+    testJobDeployment.setGitCommitSha("test-git-commit-sha");
 
-        KubernetesService.JobStatusCondition testCondition = new KubernetesService.JobStatusCondition(false,
-                "type",
-                "user-error",
-                "some-message",
-                0);
+    KubernetesService.JobStatusCondition testCondition =
+        new KubernetesService.JobStatusCondition(false, "type", "user-error", "some-message", 0);
 
-        final String BUILDER_JOB_LOGS = "INFO[0007] ARG requirements_file=requirements.txt       \n" +
-                "INFO[0007] RUN if [ -f \"$job_name/$requirements_file\" ]; then pip3 install --disable-pip-version-check -q -r \"$job_name/$requirements_file\" || ( echo \">requirements_failed<\" && exit 1 ) ; fi \n" +
-                "INFO[0007] cmd: /bin/sh                                 \n" +
-                "INFO[0007] args: [-c if [ -f \"$job_name/$requirements_file\" ]; then pip3 install --disable-pip-version-check -q -r \"$job_name/$requirements_file\" || ( echo \">requirements_failed<\" && exit 1 ) ; fi] \n" +
-                "INFO[0007] Running: [/bin/sh -c if [ -f \"$job_name/$requirements_file\" ]; then pip3 install --disable-pip-version-check -q -r \"$job_name/$requirements_file\" || ( echo \">requirements_failed<\" && exit 1 ) ; fi] \n" +
-                "ERROR: Invalid requirement: 'sqlite=\"broken\"' (from line 4 of aa-test-job/requirements.txt)\n" +
-                "Hint: = is not a valid operator. Did you mean == ?\n" +
-                ">requirements_failed<\n" +
-                "error building image: error building stage: failed to execute command: waiting for process to exit: exit status 1";
+    final String BUILDER_JOB_LOGS =
+        "INFO[0007] ARG requirements_file=requirements.txt       \n"
+            + "INFO[0007] RUN if [ -f \"$job_name/$requirements_file\" ]; then pip3 install"
+            + " --disable-pip-version-check -q -r \"$job_name/$requirements_file\" || ( echo"
+            + " \">requirements_failed<\" && exit 1 ) ; fi \n"
+            + "INFO[0007] cmd: /bin/sh                                 \n"
+            + "INFO[0007] args: [-c if [ -f \"$job_name/$requirements_file\" ]; then pip3 install"
+            + " --disable-pip-version-check -q -r \"$job_name/$requirements_file\" || ( echo"
+            + " \">requirements_failed<\" && exit 1 ) ; fi] \n"
+            + "INFO[0007] Running: [/bin/sh -c if [ -f \"$job_name/$requirements_file\" ]; then"
+            + " pip3 install --disable-pip-version-check -q -r \"$job_name/$requirements_file\" ||"
+            + " ( echo \">requirements_failed<\" && exit 1 ) ; fi] \n"
+            + "ERROR: Invalid requirement: 'sqlite=\"broken\"' (from line 4 of"
+            + " aa-test-job/requirements.txt)\n"
+            + "Hint: = is not a valid operator. Did you mean == ?\n"
+            + ">requirements_failed<\n"
+            + "error building image: error building stage: failed to execute command: waiting for"
+            + " process to exit: exit status 1";
 
-        final String requirementsError = "\" && exit 1 ) ; fi] \n" +
-                "ERROR: Invalid requirement: 'sqlite=\"broken\"' (from line 4 of aa-test-job/requirements.txt)\n" +
-                "Hint: = is not a valid operator. Did you mean == ?\n";
+    final String requirementsError =
+        "\" && exit 1 ) ; fi] \n"
+            + "ERROR: Invalid requirement: 'sqlite=\"broken\"' (from line 4 of"
+            + " aa-test-job/requirements.txt)\n"
+            + "Hint: = is not a valid operator. Did you mean == ?\n";
 
-        String errorMessage = NotificationContent.getErrorBody(
-                "Tried to deploy a data job",
-                "There has been an error while processing your requirements file: " + requirementsError,
-                "Your new/updated job was not deployed. Your job will run its latest successfully deployed version (if any) as scheduled.",
-                "Please fix the requirements file");
+    String errorMessage =
+        NotificationContent.getErrorBody(
+            "Tried to deploy a data job",
+            "There has been an error while processing your requirements file: " + requirementsError,
+            "Your new/updated job was not deployed. Your job will run its latest successfully"
+                + " deployed version (if any) as scheduled.",
+            "Please fix the requirements file");
 
-        deploymentNotificationHelper.verifyBuilderResult(TEST_BUILDER_JOB_NAME,
-                testDataJob,
-                testJobDeployment,
-                testCondition,
-                BUILDER_JOB_LOGS,
-                true);
+    deploymentNotificationHelper.verifyBuilderResult(
+        TEST_BUILDER_JOB_NAME,
+        testDataJob,
+        testJobDeployment,
+        testCondition,
+        BUILDER_JOB_LOGS,
+        true);
 
-        verify(deploymentProgress).failed(testDataJob.getJobConfig(),
-                testJobDeployment,
-                DeploymentStatus.USER_ERROR,
-                errorMessage,
-                true);
-    }
+    verify(deploymentProgress)
+        .failed(
+            testDataJob.getJobConfig(),
+            testJobDeployment,
+            DeploymentStatus.USER_ERROR,
+            errorMessage,
+            true);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
@@ -40,248 +40,380 @@ import static org.mockito.Mockito.*;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class DeploymentServiceTest {
 
-   private static final String OP_ID = "c00b40dcc9904ae6";
-   private static final String TEST_JOB_NAME = "test-job-name";
-   private static final String TEST_CRONJOB_NAME = TEST_JOB_NAME;
-   private static final String TEST_JOB_IMAGE_NAME = "test-job-image-name";
-   private static final String TEST_JOB_SCHEDULE = "*/5 * * * *";
-   private static final String TEST_BUILDER_JOB_NAME = "builder-test-job-name";
-   private static final Map<String, String> TEST_VDK_OPTS = Map.of(
-           "testOptKey", "testOptVal", "VDK_KEYTAB_PRINCIPAL", "pa__view_test-job-name_taurus");
-   private static final String TEST_PRINCIPAL_NAME = "pa__view_test-job-name_taurus";
+  private static final String OP_ID = "c00b40dcc9904ae6";
+  private static final String TEST_JOB_NAME = "test-job-name";
+  private static final String TEST_CRONJOB_NAME = TEST_JOB_NAME;
+  private static final String TEST_JOB_IMAGE_NAME = "test-job-image-name";
+  private static final String TEST_JOB_SCHEDULE = "*/5 * * * *";
+  private static final String TEST_BUILDER_JOB_NAME = "builder-test-job-name";
+  private static final Map<String, String> TEST_VDK_OPTS =
+      Map.of("testOptKey", "testOptVal", "VDK_KEYTAB_PRINCIPAL", "pa__view_test-job-name_taurus");
+  private static final String TEST_PRINCIPAL_NAME = "pa__view_test-job-name_taurus";
 
-   @Mock
-   private DataJobsKubernetesService kubernetesService;
+  @Mock private DataJobsKubernetesService kubernetesService;
 
-   @Mock
-   private DockerRegistryService dockerRegistryService;
+  @Mock private DockerRegistryService dockerRegistryService;
 
-   @Mock
-   private DataJobNotification dataJobNotification;
+  @Mock private DataJobNotification dataJobNotification;
 
-   @Mock
-   private JobImageBuilder jobImageBuilder;
+  @Mock private JobImageBuilder jobImageBuilder;
 
-   @Mock
-   private VdkOptionsReader vdkOptionsReader;
+  @Mock private VdkOptionsReader vdkOptionsReader;
 
-   @Mock
-   private DeploymentMonitor deploymentMonitor;
+  @Mock private DeploymentMonitor deploymentMonitor;
 
-   @Mock
-   private DataJobDefaultConfigurations defaultConfigurations;
+  @Mock private DataJobDefaultConfigurations defaultConfigurations;
 
-   @Mock
-   private KubernetesResources kubernetesResources;
+  @Mock private KubernetesResources kubernetesResources;
 
-   @Mock
-   private JobCredentialsService jobCredentialsService;
+  @Mock private JobCredentialsService jobCredentialsService;
 
-   @Spy
-   private JobCommandProvider jobCommandProvider; // We need this to inject it into the deployer
+  @Spy private JobCommandProvider jobCommandProvider; // We need this to inject it into the deployer
 
-   @InjectMocks
-   private DeploymentProgress deploymentProgress;
+  @InjectMocks private DeploymentProgress deploymentProgress;
 
-   @InjectMocks
-   private JobImageDeployer jobImageDeployer;
+  @InjectMocks private JobImageDeployer jobImageDeployer;
 
-   @InjectMocks
-   private DeploymentService deploymentService;
+  @InjectMocks private DeploymentService deploymentService;
 
-   @InjectMocks
-   private OperationContext operationContext;
+  @InjectMocks private OperationContext operationContext;
 
-   @Mock
-   private JobsRepository jobsRepository;
+  @Mock private JobsRepository jobsRepository;
 
-   private DataJob testDataJob;
+  private DataJob testDataJob;
 
-   @BeforeEach
-   public void setUp() {
+  @BeforeEach
+  public void setUp() {
 
-      // We use lenient here as the mocked methods are indirectly invoked by the JobImageDeployer#updateCronJob
-      // and mockito renders them unnecessary mocks and fails the tests. If we remove the lenient tests will
-      // throw NullPointerException
-      Mockito.lenient().when(kubernetesResources.builderLimits())
-              .thenReturn(new KubernetesService.Resources("1000m","1000Mi"));
-      Mockito.lenient().when(kubernetesResources.builderRequests())
-              .thenReturn(new KubernetesService.Resources("250m","250Mi"));
-      Mockito.lenient().when(kubernetesResources.dataJobInitContainerLimits())
-              .thenReturn(new KubernetesService.Resources("100m","100Mi"));
-      Mockito.lenient().when(kubernetesResources.dataJobInitContainerRequests())
-              .thenReturn(new KubernetesService.Resources("100m","100Mi"));
+    // We use lenient here as the mocked methods are indirectly invoked by the
+    // JobImageDeployer#updateCronJob
+    // and mockito renders them unnecessary mocks and fails the tests. If we remove the lenient
+    // tests will
+    // throw NullPointerException
+    Mockito.lenient()
+        .when(kubernetesResources.builderLimits())
+        .thenReturn(new KubernetesService.Resources("1000m", "1000Mi"));
+    Mockito.lenient()
+        .when(kubernetesResources.builderRequests())
+        .thenReturn(new KubernetesService.Resources("250m", "250Mi"));
+    Mockito.lenient()
+        .when(kubernetesResources.dataJobInitContainerLimits())
+        .thenReturn(new KubernetesService.Resources("100m", "100Mi"));
+    Mockito.lenient()
+        .when(kubernetesResources.dataJobInitContainerRequests())
+        .thenReturn(new KubernetesService.Resources("100m", "100Mi"));
 
-      deploymentService = new DeploymentService(dockerRegistryService,
-              deploymentProgress, jobImageBuilder, jobImageDeployer, operationContext, jobsRepository);
+    deploymentService =
+        new DeploymentService(
+            dockerRegistryService,
+            deploymentProgress,
+            jobImageBuilder,
+            jobImageDeployer,
+            operationContext,
+            jobsRepository);
 
-      Mockito.when(vdkOptionsReader.readVdkOptions(TEST_JOB_NAME)).thenReturn(TEST_VDK_OPTS);
-      Mockito.when(jobCredentialsService.getJobPrincipalName(TEST_JOB_NAME)).thenReturn(TEST_PRINCIPAL_NAME);
+    Mockito.when(vdkOptionsReader.readVdkOptions(TEST_JOB_NAME)).thenReturn(TEST_VDK_OPTS);
+    Mockito.when(jobCredentialsService.getJobPrincipalName(TEST_JOB_NAME))
+        .thenReturn(TEST_PRINCIPAL_NAME);
 
-      when(defaultConfigurations.dataJobRequests())
-              .thenReturn(new KubernetesService.Resources("500m", "1G"));
-      when(defaultConfigurations.dataJobLimits())
-              .thenReturn(new KubernetesService.Resources("2000m", "1G"));
+    when(defaultConfigurations.dataJobRequests())
+        .thenReturn(new KubernetesService.Resources("500m", "1G"));
+    when(defaultConfigurations.dataJobLimits())
+        .thenReturn(new KubernetesService.Resources("2000m", "1G"));
 
-      JobConfig jobConfig = new JobConfig();
-      jobConfig.setTeam(TestUtils.TEST_TEAM_NAME);
-      jobConfig.setSchedule(TEST_JOB_SCHEDULE);
-      testDataJob = new DataJob();
-      testDataJob.setName(TEST_JOB_NAME);
-      testDataJob.setJobConfig(jobConfig);
+    JobConfig jobConfig = new JobConfig();
+    jobConfig.setTeam(TestUtils.TEST_TEAM_NAME);
+    jobConfig.setSchedule(TEST_JOB_SCHEDULE);
+    testDataJob = new DataJob();
+    testDataJob.setName(TEST_JOB_NAME);
+    testDataJob.setJobConfig(jobConfig);
 
-      when(kubernetesService.readCronJob(TEST_CRONJOB_NAME)).thenReturn(Optional.of(TestUtils.getJobDeploymentStatus()));
-   }
+    when(kubernetesService.readCronJob(TEST_CRONJOB_NAME))
+        .thenReturn(Optional.of(TestUtils.getJobDeploymentStatus()));
+  }
 
-   @Test
-   public void updateDeployment_newDeploymentCreated() throws ApiException, IOException, InterruptedException {
-      JobDeployment jobDeployment = TestUtils.getJobDeployment();
-      jobDeployment.setDataJobName(TEST_JOB_NAME);
-      jobDeployment.setGitCommitSha("test-commit");
-      jobDeployment.setEnabled(true);
+  @Test
+  public void updateDeployment_newDeploymentCreated()
+      throws ApiException, IOException, InterruptedException {
+    JobDeployment jobDeployment = TestUtils.getJobDeployment();
+    jobDeployment.setDataJobName(TEST_JOB_NAME);
+    jobDeployment.setGitCommitSha("test-commit");
+    jobDeployment.setEnabled(true);
 
-      when(dockerRegistryService.dataJobImage(TEST_JOB_NAME, "test-commit")).thenReturn(TEST_JOB_IMAGE_NAME);
-      when(jobImageBuilder.buildImage(TEST_JOB_IMAGE_NAME, testDataJob, jobDeployment, true)).thenReturn(true);
+    when(dockerRegistryService.dataJobImage(TEST_JOB_NAME, "test-commit"))
+        .thenReturn(TEST_JOB_IMAGE_NAME);
+    when(jobImageBuilder.buildImage(TEST_JOB_IMAGE_NAME, testDataJob, jobDeployment, true))
+        .thenReturn(true);
 
-      deploymentService.updateDeployment(testDataJob, jobDeployment, true, TEST_PRINCIPAL_NAME, OP_ID);
+    deploymentService.updateDeployment(
+        testDataJob, jobDeployment, true, TEST_PRINCIPAL_NAME, OP_ID);
 
-      verify(dockerRegistryService).dataJobImage(TEST_JOB_NAME, "test-commit");
-      verify(jobImageBuilder).buildImage(TEST_JOB_IMAGE_NAME, testDataJob, jobDeployment, true);
-      verify(kubernetesService).createCronJob(eq(TEST_CRONJOB_NAME), eq(TEST_JOB_IMAGE_NAME), any(),
-            eq(TEST_JOB_SCHEDULE), eq(true), any(), any(), any(),
-              any(),
-              any(), any(), any(), any(), any(), any(), anyList());
-      verify(deploymentMonitor).recordDeploymentStatus(jobDeployment.getDataJobName(), DeploymentStatus.SUCCESS);
-      verify(dataJobNotification).notifyJobDeploySuccess(testDataJob.getJobConfig());
+    verify(dockerRegistryService).dataJobImage(TEST_JOB_NAME, "test-commit");
+    verify(jobImageBuilder).buildImage(TEST_JOB_IMAGE_NAME, testDataJob, jobDeployment, true);
+    verify(kubernetesService)
+        .createCronJob(
+            eq(TEST_CRONJOB_NAME),
+            eq(TEST_JOB_IMAGE_NAME),
+            any(),
+            eq(TEST_JOB_SCHEDULE),
+            eq(true),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyList());
+    verify(deploymentMonitor)
+        .recordDeploymentStatus(jobDeployment.getDataJobName(), DeploymentStatus.SUCCESS);
+    verify(dataJobNotification).notifyJobDeploySuccess(testDataJob.getJobConfig());
 
-      var dataJobCaptor = ArgumentCaptor.forClass(DataJob.class);
-      verify(jobsRepository).save(dataJobCaptor.capture());
-      assertEquals(true, dataJobCaptor.getValue().getEnabled());
-   }
+    var dataJobCaptor = ArgumentCaptor.forClass(DataJob.class);
+    verify(jobsRepository).save(dataJobCaptor.capture());
+    assertEquals(true, dataJobCaptor.getValue().getEnabled());
+  }
 
-   @Test
-   public void updateDeployment_existingDeploymentUpdated() throws ApiException, IOException, InterruptedException {
-      JobDeployment jobDeployment = TestUtils.getJobDeployment();
-      jobDeployment.setDataJobName(TEST_JOB_NAME);
-      jobDeployment.setGitCommitSha("test-commit");
-      jobDeployment.setEnabled(true);
-      testDataJob.setEnabled(true);
+  @Test
+  public void updateDeployment_existingDeploymentUpdated()
+      throws ApiException, IOException, InterruptedException {
+    JobDeployment jobDeployment = TestUtils.getJobDeployment();
+    jobDeployment.setDataJobName(TEST_JOB_NAME);
+    jobDeployment.setGitCommitSha("test-commit");
+    jobDeployment.setEnabled(true);
+    testDataJob.setEnabled(true);
 
-      when(dockerRegistryService.dataJobImage(TEST_JOB_NAME, "test-commit")).thenReturn(TEST_JOB_IMAGE_NAME);
-      when(jobImageBuilder.buildImage(TEST_JOB_IMAGE_NAME, testDataJob, jobDeployment, true)).thenReturn(true);
-      when(kubernetesService.listCronJobs()).thenReturn(Set.of(TEST_CRONJOB_NAME));
+    when(dockerRegistryService.dataJobImage(TEST_JOB_NAME, "test-commit"))
+        .thenReturn(TEST_JOB_IMAGE_NAME);
+    when(jobImageBuilder.buildImage(TEST_JOB_IMAGE_NAME, testDataJob, jobDeployment, true))
+        .thenReturn(true);
+    when(kubernetesService.listCronJobs()).thenReturn(Set.of(TEST_CRONJOB_NAME));
 
-      deploymentService.updateDeployment(testDataJob, jobDeployment, true, TEST_PRINCIPAL_NAME, OP_ID);
+    deploymentService.updateDeployment(
+        testDataJob, jobDeployment, true, TEST_PRINCIPAL_NAME, OP_ID);
 
-      verify(dockerRegistryService).dataJobImage(TEST_JOB_NAME, "test-commit");
-      verify(jobImageBuilder).buildImage(TEST_JOB_IMAGE_NAME, testDataJob, jobDeployment, true);
-      verify(kubernetesService).updateCronJob(eq(TEST_CRONJOB_NAME), eq(TEST_JOB_IMAGE_NAME), any(),
-            eq(TEST_JOB_SCHEDULE), eq(true), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), anyList());
-      verify(deploymentMonitor).recordDeploymentStatus(jobDeployment.getDataJobName(), DeploymentStatus.SUCCESS);
-      verify(dataJobNotification).notifyJobDeploySuccess(testDataJob.getJobConfig());
+    verify(dockerRegistryService).dataJobImage(TEST_JOB_NAME, "test-commit");
+    verify(jobImageBuilder).buildImage(TEST_JOB_IMAGE_NAME, testDataJob, jobDeployment, true);
+    verify(kubernetesService)
+        .updateCronJob(
+            eq(TEST_CRONJOB_NAME),
+            eq(TEST_JOB_IMAGE_NAME),
+            any(),
+            eq(TEST_JOB_SCHEDULE),
+            eq(true),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyList());
+    verify(deploymentMonitor)
+        .recordDeploymentStatus(jobDeployment.getDataJobName(), DeploymentStatus.SUCCESS);
+    verify(dataJobNotification).notifyJobDeploySuccess(testDataJob.getJobConfig());
 
-      verify(jobsRepository, never()).save(any());
-   }
+    verify(jobsRepository, never()).save(any());
+  }
 
+  @Test
+  public void updateDeployment_failedToBuildImage_deploymentSkipped()
+      throws ApiException, IOException, InterruptedException {
+    JobDeployment jobDeployment = TestUtils.getJobDeployment();
+    jobDeployment.setDataJobName(TEST_JOB_NAME);
+    jobDeployment.setGitCommitSha("test-commit");
+    jobDeployment.setEnabled(true);
 
-   @Test
-   public void updateDeployment_failedToBuildImage_deploymentSkipped() throws ApiException, IOException, InterruptedException {
-      JobDeployment jobDeployment = TestUtils.getJobDeployment();
-      jobDeployment.setDataJobName(TEST_JOB_NAME);
-      jobDeployment.setGitCommitSha("test-commit");
-      jobDeployment.setEnabled(true);
+    when(dockerRegistryService.dataJobImage(TEST_JOB_NAME, "test-commit"))
+        .thenReturn(TEST_JOB_IMAGE_NAME);
+    when(jobImageBuilder.buildImage(TEST_JOB_IMAGE_NAME, testDataJob, jobDeployment, true))
+        .thenReturn(false);
 
-      when(dockerRegistryService.dataJobImage(TEST_JOB_NAME, "test-commit")).thenReturn(TEST_JOB_IMAGE_NAME);
-      when(jobImageBuilder.buildImage(TEST_JOB_IMAGE_NAME, testDataJob, jobDeployment, true)).thenReturn(false);
+    deploymentService.updateDeployment(
+        testDataJob, jobDeployment, true, TEST_PRINCIPAL_NAME, OP_ID);
 
-      deploymentService.updateDeployment(testDataJob, jobDeployment, true, TEST_PRINCIPAL_NAME, OP_ID);
+    verify(dockerRegistryService).dataJobImage(TEST_JOB_NAME, "test-commit");
+    verify(jobImageBuilder).buildImage(TEST_JOB_IMAGE_NAME, testDataJob, jobDeployment, true);
+    verify(kubernetesService, never())
+        .updateCronJob(
+            anyString(),
+            anyString(),
+            any(),
+            anyString(),
+            anyBoolean(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
+    verify(kubernetesService, never())
+        .createCronJob(
+            anyString(),
+            anyString(),
+            any(),
+            anyString(),
+            anyBoolean(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
+    verify(dataJobNotification, never()).notifyJobDeploySuccess(testDataJob.getJobConfig());
+    // The builder class is responsible for sending metrics and notifications on failed build.
+    verify(deploymentMonitor, never()).recordDeploymentStatus(any(), any());
+    verify(dataJobNotification, never())
+        .notifyJobDeployError(eq(testDataJob.getJobConfig()), any(), any());
+  }
 
-      verify(dockerRegistryService).dataJobImage(TEST_JOB_NAME, "test-commit");
-      verify(jobImageBuilder).buildImage(TEST_JOB_IMAGE_NAME, testDataJob, jobDeployment, true);
-      verify(kubernetesService, never()).updateCronJob(anyString(), anyString(), any(), anyString(), anyBoolean(),
-              any(), any(), any(), any(), any(), any(), any());
-      verify(kubernetesService, never()).createCronJob(anyString(), anyString(), any(), anyString(), anyBoolean(),
-              any(), any(), any(), any(), any(), any(), any());
-      verify(dataJobNotification, never()).notifyJobDeploySuccess(testDataJob.getJobConfig());
-      // The builder class is responsible for sending metrics and notifications on failed build.
-      verify(deploymentMonitor, never()).recordDeploymentStatus(any(), any());
-      verify(dataJobNotification, never()).notifyJobDeployError(eq(testDataJob.getJobConfig()), any(), any());
-   }
+  @Test
+  public void updateDeployment_exceptionOccurred_errorNotificationSent() throws ApiException {
+    when(dockerRegistryService.dataJobImage(TEST_JOB_NAME, "test-commit"))
+        .thenThrow(new RuntimeException("test-exception"));
 
-   @Test
-   public void updateDeployment_exceptionOccurred_errorNotificationSent() throws ApiException {
-      when(dockerRegistryService.dataJobImage(TEST_JOB_NAME, "test-commit"))
-            .thenThrow(new RuntimeException("test-exception"));
+    JobDeployment jobDeployment = new JobDeployment();
+    jobDeployment.setDataJobName(TEST_JOB_NAME);
+    jobDeployment.setGitCommitSha("test-commit");
+    jobDeployment.setEnabled(true);
 
-      JobDeployment jobDeployment = new JobDeployment();
-      jobDeployment.setDataJobName(TEST_JOB_NAME);
-      jobDeployment.setGitCommitSha("test-commit");
-      jobDeployment.setEnabled(true);
+    deploymentService.updateDeployment(
+        testDataJob, jobDeployment, true, TEST_PRINCIPAL_NAME, OP_ID);
 
-      deploymentService.updateDeployment(testDataJob, jobDeployment, true, TEST_PRINCIPAL_NAME, OP_ID);
+    verify(kubernetesService, never())
+        .updateCronJob(
+            anyString(),
+            anyString(),
+            any(),
+            anyString(),
+            anyBoolean(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
+    verify(kubernetesService, never())
+        .createCronJob(
+            anyString(),
+            anyString(),
+            any(),
+            anyString(),
+            anyBoolean(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
+    verify(deploymentMonitor)
+        .recordDeploymentStatus(jobDeployment.getDataJobName(), DeploymentStatus.PLATFORM_ERROR);
+    verify(dataJobNotification).notifyJobDeployError(eq(testDataJob.getJobConfig()), any(), any());
+  }
 
-      verify(kubernetesService, never()).updateCronJob(anyString(), anyString(),  any(), anyString(), anyBoolean(),
-              any(), any(), any(), any(), any(), any(), any());
-      verify(kubernetesService, never()).createCronJob(anyString(), anyString(),  any(), anyString(), anyBoolean(),
-              any(), any(), any(), any(), any(), any(), any());
-      verify(deploymentMonitor).recordDeploymentStatus(jobDeployment.getDataJobName(), DeploymentStatus.PLATFORM_ERROR);
-      verify(dataJobNotification).notifyJobDeployError(eq(testDataJob.getJobConfig()), any(), any());
-   }
+  @Test
+  public void patchDeployment() throws ApiException {
+    JobDeployment jobDeployment = new JobDeployment();
+    jobDeployment.setDataJobTeam(testDataJob.getJobConfig().getTeam());
+    jobDeployment.setDataJobName(testDataJob.getName());
+    jobDeployment.setEnabled(true);
 
-   @Test
-   public void patchDeployment() throws ApiException {
-      JobDeployment jobDeployment = new JobDeployment();
-      jobDeployment.setDataJobTeam(testDataJob.getJobConfig().getTeam());
-      jobDeployment.setDataJobName(testDataJob.getName());
-      jobDeployment.setEnabled(true);
+    deploymentService.patchDeployment(testDataJob, jobDeployment);
 
-      deploymentService.patchDeployment(testDataJob, jobDeployment);
+    verify(kubernetesService)
+        .createCronJob(
+            eq(TEST_CRONJOB_NAME),
+            eq(TEST_JOB_IMAGE_NAME),
+            any(),
+            eq(TEST_JOB_SCHEDULE),
+            eq(true),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyList());
 
-      verify(kubernetesService).createCronJob(eq(TEST_CRONJOB_NAME), eq(TEST_JOB_IMAGE_NAME), any(),
-            eq(TEST_JOB_SCHEDULE), eq(true), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), anyList());
+    var dataJobCaptor = ArgumentCaptor.forClass(DataJob.class);
+    verify(jobsRepository).save(dataJobCaptor.capture());
+    assertEquals(true, dataJobCaptor.getValue().getEnabled());
+  }
 
-      var dataJobCaptor = ArgumentCaptor.forClass(DataJob.class);
-      verify(jobsRepository).save(dataJobCaptor.capture());
-      assertEquals(true, dataJobCaptor.getValue().getEnabled());
-   }
+  @Test
+  public void enableDeployment_sameEnabledStatus_updateSkipped() throws ApiException {
+    JobDeployment jobDeployment = new JobDeployment();
+    jobDeployment.setDataJobTeam(testDataJob.getJobConfig().getTeam());
+    jobDeployment.setDataJobName(testDataJob.getName());
+    jobDeployment.setEnabled(true);
 
-   @Test
-   public void enableDeployment_sameEnabledStatus_updateSkipped() throws ApiException {
-      JobDeployment jobDeployment = new JobDeployment();
-      jobDeployment.setDataJobTeam(testDataJob.getJobConfig().getTeam());
-      jobDeployment.setDataJobName(testDataJob.getName());
-      jobDeployment.setEnabled(true);
+    deploymentService.patchDeployment(testDataJob, jobDeployment);
 
-      deploymentService.patchDeployment(testDataJob, jobDeployment);
+    verify(kubernetesService, never())
+        .updateCronJob(
+            any(),
+            any(),
+            any(),
+            anyString(),
+            anyBoolean(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
+    verify(kubernetesService, never())
+        .createCronJob(
+            any(),
+            any(),
+            any(),
+            anyString(),
+            anyBoolean(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
+  }
 
-      verify(kubernetesService, never()).updateCronJob(any(), any(), any(), anyString(), anyBoolean(),
-              any(), any(), any(), any(), any(), any(), any());
-      verify(kubernetesService, never()).createCronJob(any(), any(), any(), anyString(), anyBoolean(),
-              any(), any(), any(), any(), any(), any(), any());
-   }
+  @Test
+  public void deleteDeployment() throws ApiException {
 
-   @Test
-   public void deleteDeployment() throws ApiException {
+    when(kubernetesService.listCronJobs()).thenReturn(Set.of(TEST_CRONJOB_NAME));
+    when(kubernetesService.readCronJob(TEST_CRONJOB_NAME))
+        .thenReturn(Optional.of(new JobDeploymentStatus()));
 
-      when(kubernetesService
-            .listCronJobs())
-            .thenReturn(Set.of(TEST_CRONJOB_NAME));
-      when(kubernetesService.readCronJob(TEST_CRONJOB_NAME)).thenReturn(Optional.of(new JobDeploymentStatus()));
+    deploymentService.deleteDeployment(TEST_JOB_NAME);
 
-      deploymentService.deleteDeployment(TEST_JOB_NAME);
+    verify(jobImageBuilder).cancelBuildingJob(TEST_JOB_NAME);
+    verify(kubernetesService).deleteCronJob(any());
+  }
 
-      verify(jobImageBuilder).cancelBuildingJob(TEST_JOB_NAME);
-      verify(kubernetesService).deleteCronJob(any());
-   }
+  @Test
+  public void deleteDeployment_notFound_skipped() throws ApiException {
+    when(kubernetesService.readCronJob(TEST_CRONJOB_NAME)).thenReturn(Optional.empty());
 
-   @Test
-   public void deleteDeployment_notFound_skipped() throws ApiException {
-      when(kubernetesService.readCronJob(TEST_CRONJOB_NAME)).thenReturn(Optional.empty());
+    deploymentService.deleteDeployment(TEST_JOB_NAME);
 
-      deploymentService.deleteDeployment(TEST_JOB_NAME);
-
-      verify(kubernetesService, never()).deleteJob(any());
-      verify(kubernetesService, never()).deleteCronJob(any());
-      verify(deploymentMonitor).recordDeploymentStatus(any(), eq(DeploymentStatus.SUCCESS));
-   }
+    verify(kubernetesService, never()).deleteJob(any());
+    verify(kubernetesService, never()).deleteCronJob(any());
+    verify(deploymentMonitor).recordDeploymentStatus(any(), eq(DeploymentStatus.SUCCESS));
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DockerImageNameTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DockerImageNameTest.java
@@ -10,28 +10,26 @@ import org.junit.jupiter.api.Test;
 
 public class DockerImageNameTest {
 
-    @Test
-    void testGetTag() {
-        Assertions.assertEquals("tag", DockerImageName.getTag("domain:5000/name:tag"));
-        Assertions.assertEquals("v1.0.1", DockerImageName.getTag("name:v1.0.1"));
-        Assertions.assertEquals("v1.0.2", DockerImageName.getTag("foo.bar/name:v1.0.2"));
-        Assertions.assertEquals("latest", DockerImageName.getTag("foo.bar/name"));
-        Assertions.assertEquals("latest", DockerImageName.getTag("domain:5000/name"));
-    }
+  @Test
+  void testGetTag() {
+    Assertions.assertEquals("tag", DockerImageName.getTag("domain:5000/name:tag"));
+    Assertions.assertEquals("v1.0.1", DockerImageName.getTag("name:v1.0.1"));
+    Assertions.assertEquals("v1.0.2", DockerImageName.getTag("foo.bar/name:v1.0.2"));
+    Assertions.assertEquals("latest", DockerImageName.getTag("foo.bar/name"));
+    Assertions.assertEquals("latest", DockerImageName.getTag("domain:5000/name"));
+  }
 
-    @Test
-    void testUpdateImageWithTag() {
-        Assertions.assertEquals("domain:5000/name:tag2",
-                DockerImageName.updateImageWithTag("domain:5000/name:tag", "tag2"));
-        Assertions.assertEquals("name:v5",
-                DockerImageName.updateImageWithTag("name:v1.0.1", "v5"));
-        Assertions.assertEquals("foo.bar/name:v6",
-                DockerImageName.updateImageWithTag("foo.bar/name:v1.0.2", "v6"));
+  @Test
+  void testUpdateImageWithTag() {
+    Assertions.assertEquals(
+        "domain:5000/name:tag2",
+        DockerImageName.updateImageWithTag("domain:5000/name:tag", "tag2"));
+    Assertions.assertEquals("name:v5", DockerImageName.updateImageWithTag("name:v1.0.1", "v5"));
+    Assertions.assertEquals(
+        "foo.bar/name:v6", DockerImageName.updateImageWithTag("foo.bar/name:v1.0.2", "v6"));
 
-        Assertions.assertEquals("name:tag",
-                DockerImageName.updateImageWithTag("name", "tag"));
-        Assertions.assertEquals("domain:5000/name:tag",
-                DockerImageName.updateImageWithTag("domain:5000/name", "tag"));
-    }
-
+    Assertions.assertEquals("name:tag", DockerImageName.updateImageWithTag("name", "tag"));
+    Assertions.assertEquals(
+        "domain:5000/name:tag", DockerImageName.updateImageWithTag("domain:5000/name", "tag"));
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
@@ -29,138 +29,192 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class JobImageBuilderTest {
-   private static final String TEST_JOB_NAME = "test-job-name";
-   private static final String TEST_IMAGE_NAME = "test-image-name";
-   private static final String TEST_BUILDER_IMAGE_NAME = "builder-test-job-name";
-   private static final String TEST_BUILDER_LOGS = "test-logs";
-   private static final String TEST_JOB_SCHEDULE = "*/5 * * * *";
-   private static final String TEST_DB_DEFAULT_TYPE = "IMPALA";
-   private static final String TEST_BUILDER_JOB_NAME = "builder-test-job-name";
+  private static final String TEST_JOB_NAME = "test-job-name";
+  private static final String TEST_IMAGE_NAME = "test-image-name";
+  private static final String TEST_BUILDER_IMAGE_NAME = "builder-test-job-name";
+  private static final String TEST_BUILDER_LOGS = "test-logs";
+  private static final String TEST_JOB_SCHEDULE = "*/5 * * * *";
+  private static final String TEST_DB_DEFAULT_TYPE = "IMPALA";
+  private static final String TEST_BUILDER_JOB_NAME = "builder-test-job-name";
 
-   @Mock
-   private ControlKubernetesService kubernetesService;
+  @Mock private ControlKubernetesService kubernetesService;
 
-   @Mock
-   private DockerRegistryService dockerRegistryService;
+  @Mock private DockerRegistryService dockerRegistryService;
 
-   @Mock
-   private DeploymentNotificationHelper notificationHelper;
+  @Mock private DeploymentNotificationHelper notificationHelper;
 
-   @Mock
-   private KubernetesResources kubernetesResources;
+  @Mock private KubernetesResources kubernetesResources;
 
-   @InjectMocks
-   private JobImageBuilder jobImageBuilder;
+  @InjectMocks private JobImageBuilder jobImageBuilder;
 
-   private DataJob testDataJob;
+  private DataJob testDataJob;
 
-   @BeforeEach
-   public void setUp() {
-      ReflectionTestUtils.setField(jobImageBuilder, "dockerRepositoryUrl", "test-docker-repository");
-      ReflectionTestUtils.setField(jobImageBuilder, "registryType", "ecr");
-      ReflectionTestUtils.setField(jobImageBuilder, "deploymentDataJobBaseImage", "python:3.7-slim");
-      ReflectionTestUtils.setField(jobImageBuilder, "builderJobExtraArgs", "");
+  @BeforeEach
+  public void setUp() {
+    ReflectionTestUtils.setField(jobImageBuilder, "dockerRepositoryUrl", "test-docker-repository");
+    ReflectionTestUtils.setField(jobImageBuilder, "registryType", "ecr");
+    ReflectionTestUtils.setField(jobImageBuilder, "deploymentDataJobBaseImage", "python:3.7-slim");
+    ReflectionTestUtils.setField(jobImageBuilder, "builderJobExtraArgs", "");
 
-      JobConfig jobConfig = new JobConfig();
-      jobConfig.setDbDefaultType(TEST_DB_DEFAULT_TYPE);
-      jobConfig.setSchedule(TEST_JOB_SCHEDULE);
-      jobConfig.setTeam("test-team");
-      testDataJob = new DataJob();
-      testDataJob.setName(TEST_JOB_NAME);
-      testDataJob.setJobConfig(jobConfig);
-   }
+    JobConfig jobConfig = new JobConfig();
+    jobConfig.setDbDefaultType(TEST_DB_DEFAULT_TYPE);
+    jobConfig.setSchedule(TEST_JOB_SCHEDULE);
+    jobConfig.setTeam("test-team");
+    testDataJob = new DataJob();
+    testDataJob.setName(TEST_JOB_NAME);
+    testDataJob.setJobConfig(jobConfig);
+  }
 
-   @Test
-   public void buildImage_notExist_success() throws InterruptedException, ApiException, IOException {
-      when(dockerRegistryService.builderImage()).thenReturn(TEST_BUILDER_IMAGE_NAME);
-      when(kubernetesService.listJobs()).thenReturn(Collections.emptySet());
-      var builderJobResult = new KubernetesService.JobStatusCondition(true, "type", "test-reason", "test-message", 0);
-      when(kubernetesService
-            .watchJob(any(), anyInt(), any()))
-            .thenReturn(builderJobResult);
+  @Test
+  public void buildImage_notExist_success() throws InterruptedException, ApiException, IOException {
+    when(dockerRegistryService.builderImage()).thenReturn(TEST_BUILDER_IMAGE_NAME);
+    when(kubernetesService.listJobs()).thenReturn(Collections.emptySet());
+    var builderJobResult =
+        new KubernetesService.JobStatusCondition(true, "type", "test-reason", "test-message", 0);
+    when(kubernetesService.watchJob(any(), anyInt(), any())).thenReturn(builderJobResult);
 
-      JobDeployment jobDeployment = new JobDeployment();
-      jobDeployment.setDataJobName(TEST_JOB_NAME);
-      jobDeployment.setGitCommitSha("test-commit");
-      jobDeployment.setEnabled(true);
+    JobDeployment jobDeployment = new JobDeployment();
+    jobDeployment.setDataJobName(TEST_JOB_NAME);
+    jobDeployment.setGitCommitSha("test-commit");
+    jobDeployment.setEnabled(true);
 
-      var result = jobImageBuilder.buildImage("test-image", testDataJob, jobDeployment, true);
+    var result = jobImageBuilder.buildImage("test-image", testDataJob, jobDeployment, true);
 
-      verify(kubernetesService).createJob(
-            eq(TEST_BUILDER_JOB_NAME), eq(TEST_BUILDER_IMAGE_NAME), eq(false), any(), any(),
-            any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong(), any());
+    verify(kubernetesService)
+        .createJob(
+            eq(TEST_BUILDER_JOB_NAME),
+            eq(TEST_BUILDER_IMAGE_NAME),
+            eq(false),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any());
 
-      verify(kubernetesService).deleteJob(TEST_BUILDER_JOB_NAME);
-      Assertions.assertTrue(result);
-   }
+    verify(kubernetesService).deleteJob(TEST_BUILDER_JOB_NAME);
+    Assertions.assertTrue(result);
+  }
 
-   @Test
-   public void buildImage_builderRunning_oldBuilderDeleted() throws InterruptedException, ApiException, IOException {
-      when(dockerRegistryService.dataJobImageExists(TEST_IMAGE_NAME)).thenReturn(false);
-      when(dockerRegistryService.builderImage()).thenReturn(TEST_BUILDER_IMAGE_NAME);
-      when(kubernetesService.listJobs()).thenReturn(Set.of(TEST_BUILDER_IMAGE_NAME), Collections.emptySet());
-      var builderJobResult = new KubernetesService.JobStatusCondition(true, "type", "test-reason", "test-message", 0);
-      when(kubernetesService
-            .watchJob(any(), anyInt(), any()))
-            .thenReturn(builderJobResult);
+  @Test
+  public void buildImage_builderRunning_oldBuilderDeleted()
+      throws InterruptedException, ApiException, IOException {
+    when(dockerRegistryService.dataJobImageExists(TEST_IMAGE_NAME)).thenReturn(false);
+    when(dockerRegistryService.builderImage()).thenReturn(TEST_BUILDER_IMAGE_NAME);
+    when(kubernetesService.listJobs())
+        .thenReturn(Set.of(TEST_BUILDER_IMAGE_NAME), Collections.emptySet());
+    var builderJobResult =
+        new KubernetesService.JobStatusCondition(true, "type", "test-reason", "test-message", 0);
+    when(kubernetesService.watchJob(any(), anyInt(), any())).thenReturn(builderJobResult);
 
-      JobDeployment jobDeployment = new JobDeployment();
-      jobDeployment.setDataJobName(TEST_JOB_NAME);
-      jobDeployment.setGitCommitSha("test-commit");
-      jobDeployment.setEnabled(true);
+    JobDeployment jobDeployment = new JobDeployment();
+    jobDeployment.setDataJobName(TEST_JOB_NAME);
+    jobDeployment.setGitCommitSha("test-commit");
+    jobDeployment.setEnabled(true);
 
-      var result = jobImageBuilder.buildImage(TEST_IMAGE_NAME, testDataJob, jobDeployment, true);
+    var result = jobImageBuilder.buildImage(TEST_IMAGE_NAME, testDataJob, jobDeployment, true);
 
-      verify(kubernetesService, times(2)).deleteJob(TEST_BUILDER_IMAGE_NAME);
-      verify(kubernetesService).createJob(
-            eq(TEST_BUILDER_JOB_NAME), eq(TEST_BUILDER_IMAGE_NAME), eq(false), any(), any(),
-            any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong(), any());
-      Assertions.assertTrue(result);
-   }
+    verify(kubernetesService, times(2)).deleteJob(TEST_BUILDER_IMAGE_NAME);
+    verify(kubernetesService)
+        .createJob(
+            eq(TEST_BUILDER_JOB_NAME),
+            eq(TEST_BUILDER_IMAGE_NAME),
+            eq(false),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any());
+    Assertions.assertTrue(result);
+  }
 
-   @Test
-   public void buildImage_imageExists_buildSkipped() throws InterruptedException, ApiException, IOException {
-      when(dockerRegistryService.dataJobImageExists(TEST_IMAGE_NAME)).thenReturn(true);
+  @Test
+  public void buildImage_imageExists_buildSkipped()
+      throws InterruptedException, ApiException, IOException {
+    when(dockerRegistryService.dataJobImageExists(TEST_IMAGE_NAME)).thenReturn(true);
 
-      JobDeployment jobDeployment = new JobDeployment();
-      jobDeployment.setDataJobName(TEST_JOB_NAME);
-      jobDeployment.setGitCommitSha("test-commit");
-      jobDeployment.setEnabled(true);
+    JobDeployment jobDeployment = new JobDeployment();
+    jobDeployment.setDataJobName(TEST_JOB_NAME);
+    jobDeployment.setGitCommitSha("test-commit");
+    jobDeployment.setEnabled(true);
 
-      var result = jobImageBuilder.buildImage(TEST_IMAGE_NAME, testDataJob, jobDeployment, true);
+    var result = jobImageBuilder.buildImage(TEST_IMAGE_NAME, testDataJob, jobDeployment, true);
 
-      verify(kubernetesService, never()).createJob(
-            anyString(), anyString(), anyBoolean(), any(), any(),
-            any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong(), anyString());
-      verify(notificationHelper, never())
-            .verifyBuilderResult(anyString(), any(), any(), any(), anyString(), anyBoolean());
-      Assertions.assertTrue(result);
-   }
+    verify(kubernetesService, never())
+        .createJob(
+            anyString(),
+            anyString(),
+            anyBoolean(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyString());
+    verify(notificationHelper, never())
+        .verifyBuilderResult(anyString(), any(), any(), any(), anyString(), anyBoolean());
+    Assertions.assertTrue(result);
+  }
 
-   @Test
-   public void buildImage_jobFailed_failure() throws InterruptedException, ApiException, IOException {
-      when(dockerRegistryService.builderImage()).thenReturn(TEST_BUILDER_IMAGE_NAME);
-      when(kubernetesService.listJobs()).thenReturn(Collections.emptySet());
-      var builderJobResult = new KubernetesService.JobStatusCondition(false, "type", "test-reason", "test-message", 0);
-      when(kubernetesService
-            .watchJob(any(), anyInt(), any()))
-            .thenReturn(builderJobResult);
-      when(kubernetesService.getPodLogs(TEST_BUILDER_JOB_NAME)).thenReturn(TEST_BUILDER_LOGS);
+  @Test
+  public void buildImage_jobFailed_failure()
+      throws InterruptedException, ApiException, IOException {
+    when(dockerRegistryService.builderImage()).thenReturn(TEST_BUILDER_IMAGE_NAME);
+    when(kubernetesService.listJobs()).thenReturn(Collections.emptySet());
+    var builderJobResult =
+        new KubernetesService.JobStatusCondition(false, "type", "test-reason", "test-message", 0);
+    when(kubernetesService.watchJob(any(), anyInt(), any())).thenReturn(builderJobResult);
+    when(kubernetesService.getPodLogs(TEST_BUILDER_JOB_NAME)).thenReturn(TEST_BUILDER_LOGS);
 
-      JobDeployment jobDeployment = new JobDeployment();
-      jobDeployment.setDataJobName(TEST_JOB_NAME);
-      jobDeployment.setGitCommitSha("test-commit");
-      jobDeployment.setEnabled(true);
+    JobDeployment jobDeployment = new JobDeployment();
+    jobDeployment.setDataJobName(TEST_JOB_NAME);
+    jobDeployment.setGitCommitSha("test-commit");
+    jobDeployment.setEnabled(true);
 
-      var result = jobImageBuilder.buildImage("test-image", testDataJob, jobDeployment, true);
+    var result = jobImageBuilder.buildImage("test-image", testDataJob, jobDeployment, true);
 
-      verify(kubernetesService).createJob(
-            eq(TEST_BUILDER_JOB_NAME), eq(TEST_BUILDER_IMAGE_NAME), eq(false), any(), any(),
-            any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong(), any());
+    verify(kubernetesService)
+        .createJob(
+            eq(TEST_BUILDER_JOB_NAME),
+            eq(TEST_BUILDER_IMAGE_NAME),
+            eq(false),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any());
 
-
-      // verify(kubernetesService).deleteJob(TEST_BUILDER_JOB_NAME); // not called in case of an error
-      verify(notificationHelper).verifyBuilderResult(TEST_BUILDER_JOB_NAME, testDataJob, jobDeployment, builderJobResult, TEST_BUILDER_LOGS, true);
-      Assertions.assertFalse(result);
-   }
+    // verify(kubernetesService).deleteJob(TEST_BUILDER_JOB_NAME); // not called in case of an error
+    verify(notificationHelper)
+        .verifyBuilderResult(
+            TEST_BUILDER_JOB_NAME,
+            testDataJob,
+            jobDeployment,
+            builderJobResult,
+            TEST_BUILDER_LOGS,
+            true);
+    Assertions.assertFalse(result);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageDeployerTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageDeployerTest.java
@@ -36,138 +36,185 @@ import static org.mockito.Mockito.*;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class JobImageDeployerTest {
 
-   private static final String TEST_JOB_NAME = "test-job-name";
-   private static final String TEST_CRONJOB_NAME = TEST_JOB_NAME;
-   private static final String TEST_JOB_IMAGE_NAME = "test-job-image-name";
-   private static final String TEST_JOB_SCHEDULE = "*/5 * * * *";
-   private static final String TEST_BUILDER_JOB_NAME = "builder-test-job-name";
-   private static final Map<String, String> TEST_VDK_OPTS = Map.of(
-           "testOptKey", "testOptVal", "VDK_KEYTAB_PRINCIPAL", "pa__view_test-job-name_taurus");
-   private static final String TEST_PRINCIPAL_NAME = "pa__view_test-job-name_taurus";
+  private static final String TEST_JOB_NAME = "test-job-name";
+  private static final String TEST_CRONJOB_NAME = TEST_JOB_NAME;
+  private static final String TEST_JOB_IMAGE_NAME = "test-job-image-name";
+  private static final String TEST_JOB_SCHEDULE = "*/5 * * * *";
+  private static final String TEST_BUILDER_JOB_NAME = "builder-test-job-name";
+  private static final Map<String, String> TEST_VDK_OPTS =
+      Map.of("testOptKey", "testOptVal", "VDK_KEYTAB_PRINCIPAL", "pa__view_test-job-name_taurus");
+  private static final String TEST_PRINCIPAL_NAME = "pa__view_test-job-name_taurus";
 
-   @Mock
-   private DataJobsKubernetesService kubernetesService;
+  @Mock private DataJobsKubernetesService kubernetesService;
 
-   @Mock
-   private VdkOptionsReader vdkOptionsReader;
+  @Mock private VdkOptionsReader vdkOptionsReader;
 
-   @Mock
-   private DeploymentProgress deploymentProgress;
+  @Mock private DeploymentProgress deploymentProgress;
 
-   @Mock
-   private DataJobDefaultConfigurations defaultConfigurations;
+  @Mock private DataJobDefaultConfigurations defaultConfigurations;
 
-   @Mock
-   private JobCredentialsService jobCredentialsService;
+  @Mock private JobCredentialsService jobCredentialsService;
 
-   @Mock
-   private KubernetesResources kubernetesResources;
+  @Mock private KubernetesResources kubernetesResources;
 
-   @Spy
-   private JobCommandProvider jobCommandProvider; // We need this to inject it into the deployer
+  @Spy private JobCommandProvider jobCommandProvider; // We need this to inject it into the deployer
 
-   @InjectMocks
-   private JobImageDeployer jobImageDeployer;
+  @InjectMocks private JobImageDeployer jobImageDeployer;
 
-   private DataJob testDataJob;
+  private DataJob testDataJob;
 
+  @BeforeEach
+  public void setUp() {
 
-   @BeforeEach
-   public void setUp() {
+    // We use lenient here as the mocked methods are indirectly invoked by the
+    // JobImageDeployer#updateCronJob
+    // and mockito renders them unnecessary mocks and fails the tests. If we remove the lenient
+    // tests will
+    // throw NullPointerException
+    Mockito.lenient()
+        .when(kubernetesResources.builderLimits())
+        .thenReturn(new KubernetesService.Resources("1000m", "1000Mi"));
+    Mockito.lenient()
+        .when(kubernetesResources.builderRequests())
+        .thenReturn(new KubernetesService.Resources("250m", "250Mi"));
+    Mockito.lenient()
+        .when(kubernetesResources.dataJobInitContainerLimits())
+        .thenReturn(new KubernetesService.Resources("100m", "100Mi"));
+    Mockito.lenient()
+        .when(kubernetesResources.dataJobInitContainerRequests())
+        .thenReturn(new KubernetesService.Resources("100m", "100Mi"));
 
-      // We use lenient here as the mocked methods are indirectly invoked by the JobImageDeployer#updateCronJob
-      // and mockito renders them unnecessary mocks and fails the tests. If we remove the lenient tests will
-      // throw NullPointerException
-      Mockito.lenient().when(kubernetesResources.builderLimits())
-              .thenReturn(new KubernetesService.Resources("1000m","1000Mi"));
-      Mockito.lenient().when(kubernetesResources.builderRequests())
-              .thenReturn(new KubernetesService.Resources("250m","250Mi"));
-      Mockito.lenient().when(kubernetesResources.dataJobInitContainerLimits())
-              .thenReturn(new KubernetesService.Resources("100m","100Mi"));
-      Mockito.lenient().when(kubernetesResources.dataJobInitContainerRequests())
-              .thenReturn(new KubernetesService.Resources("100m","100Mi"));
+    Mockito.when(vdkOptionsReader.readVdkOptions(TEST_JOB_NAME)).thenReturn(TEST_VDK_OPTS);
+    Mockito.when(jobCredentialsService.getJobPrincipalName(TEST_JOB_NAME))
+        .thenReturn(TEST_PRINCIPAL_NAME);
 
-      Mockito.when(vdkOptionsReader.readVdkOptions(TEST_JOB_NAME)).thenReturn(TEST_VDK_OPTS);
-      Mockito.when(jobCredentialsService.getJobPrincipalName(TEST_JOB_NAME)).thenReturn(TEST_PRINCIPAL_NAME);
+    when(defaultConfigurations.dataJobRequests())
+        .thenReturn(new KubernetesService.Resources("500m", "1G"));
+    when(defaultConfigurations.dataJobLimits())
+        .thenReturn(new KubernetesService.Resources("2000m", "1G"));
 
-      when(defaultConfigurations.dataJobRequests())
-              .thenReturn(new KubernetesService.Resources("500m", "1G"));
-      when(defaultConfigurations.dataJobLimits())
-              .thenReturn(new KubernetesService.Resources("2000m", "1G"));
+    JobConfig jobConfig = new JobConfig();
+    jobConfig.setSchedule(TEST_JOB_SCHEDULE);
+    testDataJob = new DataJob();
+    testDataJob.setName(TEST_JOB_NAME);
+    testDataJob.setJobConfig(jobConfig);
+  }
 
-      JobConfig jobConfig = new JobConfig();
-      jobConfig.setSchedule(TEST_JOB_SCHEDULE);
-      testDataJob = new DataJob();
-      testDataJob.setName(TEST_JOB_NAME);
-      testDataJob.setJobConfig(jobConfig);
-   }
+  @Test
+  public void test_scheduleJobMonitoring() throws ApiException, IOException, InterruptedException {
+    JobDeployment jobDeployment = new JobDeployment();
+    jobDeployment.setDataJobName(TEST_JOB_NAME);
+    jobDeployment.setGitCommitSha("test-commit");
+    jobDeployment.setEnabled(true);
+    jobDeployment.setImageName("image");
 
-   @Test
-   public void test_scheduleJobMonitoring() throws ApiException, IOException, InterruptedException {
-      JobDeployment jobDeployment = new JobDeployment();
-      jobDeployment.setDataJobName(TEST_JOB_NAME);
-      jobDeployment.setGitCommitSha("test-commit");
-      jobDeployment.setEnabled(true);
-      jobDeployment.setImageName("image");
+    when(kubernetesService.listCronJobs()).thenReturn(Set.of(TEST_CRONJOB_NAME));
+    doThrow(
+            new ApiException(
+                "foo",
+                422,
+                Collections.emptyMap(),
+                "{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"CronJob.batch"
+                    + " \\\"foo\\\" is invalid: spec.schedule: Invalid value: \\\"a * * * *\\\":"
+                    + " Failed to parse int from a: strconv.Atoi: parsing \\\"a\\\": invalid"
+                    + " syntax\",\"reason\":"
+                    + "\"Invalid\",\"details\":{\"name\":\"foo\",\"group\":\"batch\",\"kind\":\"CronJob\",\"causes\":[{\"reason\":\"FieldValueInvalid\",\"message\":\"Invalid"
+                    + " value: \\\"a * * * *\\\": Failed to parse int from a: strconv.Atoi: parsing"
+                    + " \\\"a\\\": invalid syntax\",\"field\":\"spec.schedule\"}]},\"code\":422}"))
+        .when(kubernetesService)
+        .updateCronJob(
+            anyString(),
+            anyString(),
+            anyMap(),
+            anyString(),
+            anyBoolean(),
+            anyList(),
+            any(KubernetesService.Resources.class),
+            any(KubernetesService.Resources.class),
+            any(V1Container.class),
+            any(V1Container.class),
+            any(List.class),
+            anyMap(),
+            anyMap(),
+            anyMap(),
+            anyMap(),
+            anyList());
 
-      when(kubernetesService.listCronJobs()).thenReturn(Set.of(TEST_CRONJOB_NAME));
-      doThrow(new ApiException("foo", 422, Collections.emptyMap(), "{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{}," +
-              "\"status\":\"Failure\",\"message\":\"CronJob.batch " +
-              "\\\"foo\\\" is invalid: spec.schedule: Invalid value: \\\"a * * * *\\\": " +
-              "Failed to parse int from a: strconv.Atoi: parsing \\\"a\\\": invalid syntax\",\"reason\":" +
-              "\"Invalid\",\"details\":{\"name\":\"foo\",\"group\":\"batch\",\"kind\":\"CronJob\",\"causes\":" +
-              "[{\"reason\":\"FieldValueInvalid\",\"message\":\"Invalid value: \\\"a * * * *\\\": Failed to parse int from a:" +
-              " strconv.Atoi: parsing \\\"a\\\": invalid syntax\",\"field\":\"spec.schedule\"}]},\"code\":422}"))
-              .when(kubernetesService)
-              .updateCronJob(anyString(), anyString(), anyMap(), anyString(), anyBoolean(), anyList(), any(KubernetesService.Resources.class),
-                      any(KubernetesService.Resources.class), any(V1Container.class), any(V1Container.class), any(List.class), anyMap(), anyMap(), anyMap(), anyMap(), anyList());
+    jobImageDeployer.scheduleJob(testDataJob, jobDeployment, true, TEST_PRINCIPAL_NAME);
+    verify(deploymentProgress)
+        .failed(any(), any(), eq(DeploymentStatus.USER_ERROR), anyString(), anyBoolean());
+  }
 
-      jobImageDeployer.scheduleJob(testDataJob, jobDeployment, true, TEST_PRINCIPAL_NAME);
-      verify(deploymentProgress).failed(any(), any(), eq(DeploymentStatus.USER_ERROR), anyString(), anyBoolean());
-   }
+  /** Test that the job container name is the same as the data job name. */
+  @Test
+  public void testJobContainerName() throws ApiException {
+    var jobDeployment = new JobDeployment();
+    jobDeployment.setDataJobName(TEST_JOB_NAME);
+    jobDeployment.setGitCommitSha("test-commit");
+    jobDeployment.setEnabled(true);
+    jobDeployment.setImageName("image");
 
-   /**
-    * Test that the job container name is the same as the data job name.
-    */
-   @Test
-   public void testJobContainerName() throws ApiException {
-      var jobDeployment = new JobDeployment();
-      jobDeployment.setDataJobName(TEST_JOB_NAME);
-      jobDeployment.setGitCommitSha("test-commit");
-      jobDeployment.setEnabled(true);
-      jobDeployment.setImageName("image");
+    jobImageDeployer.scheduleJob(testDataJob, jobDeployment, true, TEST_PRINCIPAL_NAME);
 
-      jobImageDeployer.scheduleJob(testDataJob, jobDeployment, true, TEST_PRINCIPAL_NAME);
+    ArgumentCaptor<V1Container> containerCaptor = ArgumentCaptor.forClass(V1Container.class);
+    verify(kubernetesService)
+        .createCronJob(
+            anyString(),
+            anyString(),
+            anyMap(),
+            anyString(),
+            anyBoolean(),
+            anyList(),
+            any(KubernetesService.Resources.class),
+            any(KubernetesService.Resources.class),
+            containerCaptor.capture(),
+            any(V1Container.class),
+            anyList(),
+            anyMap(),
+            anyMap(),
+            anyMap(),
+            anyMap(),
+            anyList());
+    var jobContainer = containerCaptor.getValue();
+    Assertions.assertEquals(testDataJob.getName(), jobContainer.getName());
+  }
 
-      ArgumentCaptor<V1Container> containerCaptor = ArgumentCaptor.forClass(V1Container.class);
-      verify(kubernetesService).createCronJob(anyString(), anyString(), anyMap(), anyString(), anyBoolean(),
-              anyList(), any(KubernetesService.Resources.class), any(KubernetesService.Resources.class),
-              containerCaptor.capture(), any(V1Container.class), anyList(), anyMap(), anyMap(), anyMap(), anyMap(), anyList());
-      var jobContainer = containerCaptor.getValue();
-      Assertions.assertEquals(testDataJob.getName(), jobContainer.getName());
-   }
+  @Test
+  public void testJobNoSchedule() throws ApiException {
+    JobConfig jobConfig = new JobConfig();
+    jobConfig.setSchedule("");
+    testDataJob = new DataJob();
+    testDataJob.setName(TEST_JOB_NAME);
+    testDataJob.setJobConfig(jobConfig);
 
-   @Test
-   public void testJobNoSchedule() throws ApiException {
-      JobConfig jobConfig = new JobConfig();
-      jobConfig.setSchedule("");
-      testDataJob = new DataJob();
-      testDataJob.setName(TEST_JOB_NAME);
-      testDataJob.setJobConfig(jobConfig);
+    var jobDeployment = new JobDeployment();
+    jobDeployment.setDataJobName(TEST_JOB_NAME);
+    jobDeployment.setGitCommitSha("test-commit");
+    jobDeployment.setEnabled(true);
+    jobDeployment.setImageName("image");
 
-      var jobDeployment = new JobDeployment();
-      jobDeployment.setDataJobName(TEST_JOB_NAME);
-      jobDeployment.setGitCommitSha("test-commit");
-      jobDeployment.setEnabled(true);
-      jobDeployment.setImageName("image");
+    jobImageDeployer.scheduleJob(testDataJob, jobDeployment, true, TEST_PRINCIPAL_NAME);
 
-      jobImageDeployer.scheduleJob(testDataJob, jobDeployment, true, TEST_PRINCIPAL_NAME);
-
-      ArgumentCaptor<String> scheduleCaptor = ArgumentCaptor.forClass(String.class);
-      verify(kubernetesService).createCronJob(anyString(), anyString(), anyMap(), scheduleCaptor.capture(), anyBoolean(),
-              anyList(), any(KubernetesService.Resources.class), any(KubernetesService.Resources.class),
-              any(V1Container.class), any(V1Container.class), anyList(), anyMap(), anyMap(), anyMap(), anyMap(), anyList());
-      Assertions.assertEquals("0 0 30 2 *", scheduleCaptor.getValue());
-      Assertions.assertEquals("", testDataJob.getJobConfig().getSchedule());
-   }
+    ArgumentCaptor<String> scheduleCaptor = ArgumentCaptor.forClass(String.class);
+    verify(kubernetesService)
+        .createCronJob(
+            anyString(),
+            anyString(),
+            anyMap(),
+            scheduleCaptor.capture(),
+            anyBoolean(),
+            anyList(),
+            any(KubernetesService.Resources.class),
+            any(KubernetesService.Resources.class),
+            any(V1Container.class),
+            any(V1Container.class),
+            anyList(),
+            anyMap(),
+            anyMap(),
+            anyMap(),
+            anyMap(),
+            anyList());
+    Assertions.assertEquals("0 0 30 2 *", scheduleCaptor.getValue());
+    Assertions.assertEquals("", testDataJob.getJobConfig().getSchedule());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/VdkOptionsReaderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/VdkOptionsReaderTest.java
@@ -12,33 +12,34 @@ import java.util.Map;
 
 public class VdkOptionsReaderTest {
 
-   private static final String VDK_INFLUX_DB_PASSWORD_KEY = "VDK_INFLUX_DB_PASSWORD";
-   private static final String VDK_REDSHIFT_HOST_KEY = "VDK_REDSHIFT_HOST";
-   private static final String VDK_REDSHIFT_NAME_KEY = "VDK_REDSHIFT_NAME";
-   private static final String VDK_RESOURCE_LIMIT_MEMORY_MB_KEY = "VDK_RESOURCE_LIMIT_MEMORY_MB";
-   private static final String VDK_RESOURCE_LIMIT_DISK_MB_KEY = "VDK_RESOURCE_LIMIT_DISK_MB";
+  private static final String VDK_INFLUX_DB_PASSWORD_KEY = "VDK_INFLUX_DB_PASSWORD";
+  private static final String VDK_REDSHIFT_HOST_KEY = "VDK_REDSHIFT_HOST";
+  private static final String VDK_REDSHIFT_NAME_KEY = "VDK_REDSHIFT_NAME";
+  private static final String VDK_RESOURCE_LIMIT_MEMORY_MB_KEY = "VDK_RESOURCE_LIMIT_MEMORY_MB";
+  private static final String VDK_RESOURCE_LIMIT_DISK_MB_KEY = "VDK_RESOURCE_LIMIT_DISK_MB";
 
-   private VdkOptionsReader vdkOptionsReader = new VdkOptionsReader("src/test/resources/vdk_options/test_vdk_options.ini");
+  private VdkOptionsReader vdkOptionsReader =
+      new VdkOptionsReader("src/test/resources/vdk_options/test_vdk_options.ini");
 
-   @Test
-   public void readVdkOptions_defaultOptions() {
-      Map<String, String> vdkOptions = vdkOptionsReader.readVdkOptions("unconfigured-job-name");
+  @Test
+  public void readVdkOptions_defaultOptions() {
+    Map<String, String> vdkOptions = vdkOptionsReader.readVdkOptions("unconfigured-job-name");
 
-      Assertions.assertEquals(3, vdkOptions.size());
-      Assertions.assertEquals("influx-db-pass", vdkOptions.get(VDK_INFLUX_DB_PASSWORD_KEY));
-      Assertions.assertEquals("rs-host", vdkOptions.get(VDK_REDSHIFT_HOST_KEY));
-      Assertions.assertEquals("rs-name", vdkOptions.get(VDK_REDSHIFT_NAME_KEY));
-   }
+    Assertions.assertEquals(3, vdkOptions.size());
+    Assertions.assertEquals("influx-db-pass", vdkOptions.get(VDK_INFLUX_DB_PASSWORD_KEY));
+    Assertions.assertEquals("rs-host", vdkOptions.get(VDK_REDSHIFT_HOST_KEY));
+    Assertions.assertEquals("rs-name", vdkOptions.get(VDK_REDSHIFT_NAME_KEY));
+  }
 
-   @Test
-   public void readVdkOptions_customJobOptions() {
-      Map<String, String> vdkOptions = vdkOptionsReader.readVdkOptions("example");
+  @Test
+  public void readVdkOptions_customJobOptions() {
+    Map<String, String> vdkOptions = vdkOptionsReader.readVdkOptions("example");
 
-      Assertions.assertEquals(5, vdkOptions.size());
-      Assertions.assertEquals("influx-db-pass", vdkOptions.get(VDK_INFLUX_DB_PASSWORD_KEY));
-      Assertions.assertEquals("rs-host", vdkOptions.get(VDK_REDSHIFT_HOST_KEY));
-      Assertions.assertEquals("rs-name", vdkOptions.get(VDK_REDSHIFT_NAME_KEY));
-      Assertions.assertEquals("10000", vdkOptions.get(VDK_RESOURCE_LIMIT_MEMORY_MB_KEY));
-      Assertions.assertEquals("5000", vdkOptions.get(VDK_RESOURCE_LIMIT_DISK_MB_KEY));
-   }
+    Assertions.assertEquals(5, vdkOptions.size());
+    Assertions.assertEquals("influx-db-pass", vdkOptions.get(VDK_INFLUX_DB_PASSWORD_KEY));
+    Assertions.assertEquals("rs-host", vdkOptions.get(VDK_REDSHIFT_HOST_KEY));
+    Assertions.assertEquals("rs-name", vdkOptions.get(VDK_REDSHIFT_NAME_KEY));
+    Assertions.assertEquals("10000", vdkOptions.get(VDK_RESOURCE_LIMIT_MEMORY_MB_KEY));
+    Assertions.assertEquals("5000", vdkOptions.get(VDK_RESOURCE_LIMIT_DISK_MB_KEY));
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionLogsUrlBuilderIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionLogsUrlBuilderIT.java
@@ -24,173 +24,192 @@ import com.vmware.taurus.service.model.JobConfig;
 @SpringBootTest(classes = ControlplaneApplication.class)
 public class JobExecutionLogsUrlBuilderIT {
 
-   private static final String TEST_EXECUTION_ID = "test-job-name-1634127142";
-   private static final String TEST_JOB_NAME = "test-job-name";
-   private static final String TEST_OP_ID = "test-op-id-1634127142";
-   private static final OffsetDateTime TEST_START_TIME = OffsetDateTime.now();
-   private static final OffsetDateTime TEST_END_TIME = OffsetDateTime.now().plusMinutes(10);
+  private static final String TEST_EXECUTION_ID = "test-job-name-1634127142";
+  private static final String TEST_JOB_NAME = "test-job-name";
+  private static final String TEST_OP_ID = "test-op-id-1634127142";
+  private static final OffsetDateTime TEST_START_TIME = OffsetDateTime.now();
+  private static final OffsetDateTime TEST_END_TIME = OffsetDateTime.now().plusMinutes(10);
 
-   private static final String LOGS_URL_TEMPLATE =
-         "https://log-insight-base-url/li/query/stream?query=%C2%A7%C2%A7%C2%A7AND%C" +
-               "2%A7%C2%A7%C2%A7%C2%A7{0}%C2%A7{1}%C2%A7true%C2%A7COUNT%C2%A7*%C2%A7" +
-               "timestamp%C2%A7pageSortPreference:%7B%22sortBy%22%3A%22-{2}-{3}-" +
-               "ingest_timestamp%22%2C%22sortOrder%22%3A%22DESC%22%7D%C2%A7" +
-               "alertDefList:%5B%5D%C2%A7partitions:%C2%A7%C2%A7text:CONTAINS:{4}*";
+  private static final String LOGS_URL_TEMPLATE =
+      "https://log-insight-base-url/li/query/stream?query=%C2%A7%C2%A7%C2%A7AND%C"
+          + "2%A7%C2%A7%C2%A7%C2%A7{0}%C2%A7{1}%C2%A7true%C2%A7COUNT%C2%A7*%C2%A7"
+          + "timestamp%C2%A7pageSortPreference:%7B%22sortBy%22%3A%22-{2}-{3}-"
+          + "ingest_timestamp%22%2C%22sortOrder%22%3A%22DESC%22%7D%C2%A7"
+          + "alertDefList:%5B%5D%C2%A7partitions:%C2%A7%C2%A7text:CONTAINS:{4}*";
 
-   private static final String LOGS_URL_TEMPLATE_RAW =
-         MessageFormat.format(
-               LOGS_URL_TEMPLATE,
-               buildVarPlaceholder(JobExecutionLogsUrlBuilder.START_TIME_VAR),
-               buildVarPlaceholder(JobExecutionLogsUrlBuilder.END_TIME_VAR),
-               buildVarPlaceholder(JobExecutionLogsUrlBuilder.JOB_NAME_VAR),
-               buildVarPlaceholder(JobExecutionLogsUrlBuilder.OP_ID_VAR),
-               buildVarPlaceholder(JobExecutionLogsUrlBuilder.EXECUTION_ID_VAR));
+  private static final String LOGS_URL_TEMPLATE_RAW =
+      MessageFormat.format(
+          LOGS_URL_TEMPLATE,
+          buildVarPlaceholder(JobExecutionLogsUrlBuilder.START_TIME_VAR),
+          buildVarPlaceholder(JobExecutionLogsUrlBuilder.END_TIME_VAR),
+          buildVarPlaceholder(JobExecutionLogsUrlBuilder.JOB_NAME_VAR),
+          buildVarPlaceholder(JobExecutionLogsUrlBuilder.OP_ID_VAR),
+          buildVarPlaceholder(JobExecutionLogsUrlBuilder.EXECUTION_ID_VAR));
 
-   @Autowired
-   private JobExecutionLogsUrlBuilder logsUrlBuilder;
+  @Autowired private JobExecutionLogsUrlBuilder logsUrlBuilder;
 
-   @Test
-   public void testBuild_allParamsAndDataFormatUnix_shouldReturnLogsUrl() {
-      String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix(0, 0);
-      assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, expectedLogsUrl);
-   }
+  @Test
+  public void testBuild_allParamsAndDataFormatUnix_shouldReturnLogsUrl() {
+    String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix(0, 0);
+    assertLogsUrlValid(
+        LOGS_URL_TEMPLATE_RAW, JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, expectedLogsUrl);
+  }
 
-   @Test
-   public void testBuild_allParamsAndDataFormatUnixAndPositiveOffset_shouldReturnLogsUrl() {
-      String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix(1000, 2000);
-      assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, expectedLogsUrl);
-   }
+  @Test
+  public void testBuild_allParamsAndDataFormatUnixAndPositiveOffset_shouldReturnLogsUrl() {
+    String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix(1000, 2000);
+    assertLogsUrlValid(
+        LOGS_URL_TEMPLATE_RAW, JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, expectedLogsUrl);
+  }
 
-   @Test
-   public void testBuild_allParamsAndDataFormatUnixAndNegativeOffset_shouldReturnLogsUrl() {
-      String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix(-1000, -2000);
-      assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, expectedLogsUrl);
-   }
+  @Test
+  public void testBuild_allParamsAndDataFormatUnixAndNegativeOffset_shouldReturnLogsUrl() {
+    String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix(-1000, -2000);
+    assertLogsUrlValid(
+        LOGS_URL_TEMPLATE_RAW, JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, expectedLogsUrl);
+  }
 
-   @Test
-   public void testBuild_allParamsAndDataFormatIso_shouldReturnLogsUrl() {
-      String expectedLogsUrl = buildExpectedLogsUrlDateFormatIso(0, 0);
-      assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, JobExecutionLogsUrlBuilder.ISO_DATE_FORMAT, expectedLogsUrl);
-   }
+  @Test
+  public void testBuild_allParamsAndDataFormatIso_shouldReturnLogsUrl() {
+    String expectedLogsUrl = buildExpectedLogsUrlDateFormatIso(0, 0);
+    assertLogsUrlValid(
+        LOGS_URL_TEMPLATE_RAW, JobExecutionLogsUrlBuilder.ISO_DATE_FORMAT, expectedLogsUrl);
+  }
 
-   @Test
-   public void testBuild_allParamsAndDataFormatIsoAndPositiveOffset_shouldReturnLogsUrl() {
-      String expectedLogsUrl = buildExpectedLogsUrlDateFormatIso(1000, 2000);
-      assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, JobExecutionLogsUrlBuilder.ISO_DATE_FORMAT, expectedLogsUrl);
-   }
+  @Test
+  public void testBuild_allParamsAndDataFormatIsoAndPositiveOffset_shouldReturnLogsUrl() {
+    String expectedLogsUrl = buildExpectedLogsUrlDateFormatIso(1000, 2000);
+    assertLogsUrlValid(
+        LOGS_URL_TEMPLATE_RAW, JobExecutionLogsUrlBuilder.ISO_DATE_FORMAT, expectedLogsUrl);
+  }
 
-   @Test
-   public void testBuild_allParamsAndDataFormatIsoAndNegativeOffset_shouldReturnLogsUrl() {
-      String expectedLogsUrl = buildExpectedLogsUrlDateFormatIso(-1000, -2000);
-      assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, JobExecutionLogsUrlBuilder.ISO_DATE_FORMAT, expectedLogsUrl);
-   }
+  @Test
+  public void testBuild_allParamsAndDataFormatIsoAndNegativeOffset_shouldReturnLogsUrl() {
+    String expectedLogsUrl = buildExpectedLogsUrlDateFormatIso(-1000, -2000);
+    assertLogsUrlValid(
+        LOGS_URL_TEMPLATE_RAW, JobExecutionLogsUrlBuilder.ISO_DATE_FORMAT, expectedLogsUrl);
+  }
 
-   @Test
-   public void testBuild_extraParamAndDataFormatUnix_shouldReturnLogsUrl() {
-      String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix(0, 0) + "{{abc}}";
-      assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW + "{{abc}}", JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, expectedLogsUrl);
-   }
+  @Test
+  public void testBuild_extraParamAndDataFormatUnix_shouldReturnLogsUrl() {
+    String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix(0, 0) + "{{abc}}";
+    assertLogsUrlValid(
+        LOGS_URL_TEMPLATE_RAW + "{{abc}}",
+        JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT,
+        expectedLogsUrl);
+  }
 
-   @Test
-   public void testBuild_partialParamsAndDataFormatUnix_shouldReturnLogsUrl() {
-      String logsUrlRaw = MessageFormat.format(
+  @Test
+  public void testBuild_partialParamsAndDataFormatUnix_shouldReturnLogsUrl() {
+    String logsUrlRaw =
+        MessageFormat.format(
             LOGS_URL_TEMPLATE,
             buildVarPlaceholder(JobExecutionLogsUrlBuilder.START_TIME_VAR),
             buildVarPlaceholder(JobExecutionLogsUrlBuilder.END_TIME_VAR),
             buildVarPlaceholder(JobExecutionLogsUrlBuilder.JOB_NAME_VAR),
             buildVarPlaceholder(JobExecutionLogsUrlBuilder.OP_ID_VAR),
             "");
-      String expectedLogsUrl = MessageFormat.format(LOGS_URL_TEMPLATE,
+    String expectedLogsUrl =
+        MessageFormat.format(
+            LOGS_URL_TEMPLATE,
             String.valueOf(TEST_START_TIME.toInstant().toEpochMilli()),
             String.valueOf(TEST_END_TIME.toInstant().toEpochMilli()),
             TEST_JOB_NAME,
             TEST_OP_ID,
             "");
 
-      assertLogsUrlValid(logsUrlRaw, JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, expectedLogsUrl);
-   }
+    assertLogsUrlValid(logsUrlRaw, JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, expectedLogsUrl);
+  }
 
-   @Test
-   public void testBuild_emptyLogsUrlTemplate_shouldReturnEmptyLogsUrl() {
-      assertLogsUrlValid("", JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, "");
-   }
+  @Test
+  public void testBuild_emptyLogsUrlTemplate_shouldReturnEmptyLogsUrl() {
+    assertLogsUrlValid("", JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, "");
+  }
 
-   @Test
-   public void testBuild_nullLogsUrlTemplate_shouldReturnEmptyLogsUrl() {
-      assertLogsUrlValid(null, JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, "");
-   }
+  @Test
+  public void testBuild_nullLogsUrlTemplate_shouldReturnEmptyLogsUrl() {
+    assertLogsUrlValid(null, JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, "");
+  }
 
-   @Test
-   public void testBuild_nullLogsUrlDateFormat_shouldReturnLogsUrlWithDateFormatUnix() {
-      String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix(0, 0);
-      assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, null, expectedLogsUrl);
-   }
+  @Test
+  public void testBuild_nullLogsUrlDateFormat_shouldReturnLogsUrlWithDateFormatUnix() {
+    String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix(0, 0);
+    assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, null, expectedLogsUrl);
+  }
 
-   @Test
-   public void testBuild_emptyLogsUrlDateFormat_shouldReturnLogsUrlWithDateFormatUnix() {
-      String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix(0, 0);
-      assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, "", expectedLogsUrl);
-   }
+  @Test
+  public void testBuild_emptyLogsUrlDateFormat_shouldReturnLogsUrlWithDateFormatUnix() {
+    String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix(0, 0);
+    assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, "", expectedLogsUrl);
+  }
 
-   @Test
-   public void testBuild_noExecutionEndTime_shouldReturnLogsUrlWithEndTimeInTheFuture() {
-      // making sure that start time, current time and end time are differnet to reduce chance of false positives
-      var currentTime = TEST_START_TIME.plusMinutes(1);
-      ReflectionTestUtils.setField(logsUrlBuilder, "clock", Clock.fixed(currentTime.toInstant(), currentTime.getOffset()));
+  @Test
+  public void testBuild_noExecutionEndTime_shouldReturnLogsUrlWithEndTimeInTheFuture() {
+    // making sure that start time, current time and end time are differnet to reduce chance of
+    // false positives
+    var currentTime = TEST_START_TIME.plusMinutes(1);
+    ReflectionTestUtils.setField(
+        logsUrlBuilder, "clock", Clock.fixed(currentTime.toInstant(), currentTime.getOffset()));
 
-      String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix(0, 0, currentTime);
-      assertLogsUrlValid(LOGS_URL_TEMPLATE_RAW, JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, expectedLogsUrl, null);
-   }
+    String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix(0, 0, currentTime);
+    assertLogsUrlValid(
+        LOGS_URL_TEMPLATE_RAW, JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT, expectedLogsUrl, null);
+  }
 
-   private static String buildVarPlaceholder(String var) {
-      return JobExecutionLogsUrlBuilder.VAR_PREFIX + var + JobExecutionLogsUrlBuilder.VAR_SUFFIX;
-   }
+  private static String buildVarPlaceholder(String var) {
+    return JobExecutionLogsUrlBuilder.VAR_PREFIX + var + JobExecutionLogsUrlBuilder.VAR_SUFFIX;
+  }
 
-   private Instant getDateTime(OffsetDateTime dateTime, long offset) {
-      return dateTime.toInstant().plusSeconds(offset);
-   }
+  private Instant getDateTime(OffsetDateTime dateTime, long offset) {
+    return dateTime.toInstant().plusSeconds(offset);
+  }
 
-   private String buildExpectedLogsUrlDateFormatUnix(long startTimeOffset, long endTimeOffset, OffsetDateTime endTime) {
-      ReflectionTestUtils.setField(logsUrlBuilder, "startTimeOffsetSeconds", startTimeOffset);
-      ReflectionTestUtils.setField(logsUrlBuilder, "endTimeOffsetSeconds", endTimeOffset);
+  private String buildExpectedLogsUrlDateFormatUnix(
+      long startTimeOffset, long endTimeOffset, OffsetDateTime endTime) {
+    ReflectionTestUtils.setField(logsUrlBuilder, "startTimeOffsetSeconds", startTimeOffset);
+    ReflectionTestUtils.setField(logsUrlBuilder, "endTimeOffsetSeconds", endTimeOffset);
 
-      return MessageFormat.format(
-              LOGS_URL_TEMPLATE,
-              String.valueOf(getDateTime(TEST_START_TIME, startTimeOffset).toEpochMilli()),
-              String.valueOf(getDateTime(endTime, endTimeOffset).toEpochMilli()),
-              TEST_JOB_NAME,
-              TEST_OP_ID,
-              TEST_EXECUTION_ID);
-   }
+    return MessageFormat.format(
+        LOGS_URL_TEMPLATE,
+        String.valueOf(getDateTime(TEST_START_TIME, startTimeOffset).toEpochMilli()),
+        String.valueOf(getDateTime(endTime, endTimeOffset).toEpochMilli()),
+        TEST_JOB_NAME,
+        TEST_OP_ID,
+        TEST_EXECUTION_ID);
+  }
 
-   private String buildExpectedLogsUrlDateFormatUnix(long startTimeOffset, long endTimeOffset) {
-      return  buildExpectedLogsUrlDateFormatUnix(startTimeOffset, endTimeOffset, TEST_END_TIME);
-   }
+  private String buildExpectedLogsUrlDateFormatUnix(long startTimeOffset, long endTimeOffset) {
+    return buildExpectedLogsUrlDateFormatUnix(startTimeOffset, endTimeOffset, TEST_END_TIME);
+  }
 
-   private String buildExpectedLogsUrlDateFormatIso(long startTimeOffset, long endTimeOffset) {
-      ReflectionTestUtils.setField(logsUrlBuilder, "startTimeOffsetSeconds", startTimeOffset);
-      ReflectionTestUtils.setField(logsUrlBuilder, "endTimeOffsetSeconds", endTimeOffset);
+  private String buildExpectedLogsUrlDateFormatIso(long startTimeOffset, long endTimeOffset) {
+    ReflectionTestUtils.setField(logsUrlBuilder, "startTimeOffsetSeconds", startTimeOffset);
+    ReflectionTestUtils.setField(logsUrlBuilder, "endTimeOffsetSeconds", endTimeOffset);
 
-      return MessageFormat.format(
-            LOGS_URL_TEMPLATE,
-            getDateTime(TEST_START_TIME, startTimeOffset).toString(),
-            getDateTime(TEST_END_TIME, endTimeOffset).toString(),
-            TEST_JOB_NAME,
-            TEST_OP_ID,
-            TEST_EXECUTION_ID);
-   }
+    return MessageFormat.format(
+        LOGS_URL_TEMPLATE,
+        getDateTime(TEST_START_TIME, startTimeOffset).toString(),
+        getDateTime(TEST_END_TIME, endTimeOffset).toString(),
+        TEST_JOB_NAME,
+        TEST_OP_ID,
+        TEST_EXECUTION_ID);
+  }
 
+  private void assertLogsUrlValid(
+      String logsUrlTemplate, String logsUrlDateFormat, String expectedLogsUrl) {
+    assertLogsUrlValid(logsUrlTemplate, logsUrlDateFormat, expectedLogsUrl, TEST_END_TIME);
+  }
 
-   private void assertLogsUrlValid(String logsUrlTemplate, String logsUrlDateFormat, String expectedLogsUrl) {
-      assertLogsUrlValid(logsUrlTemplate, logsUrlDateFormat, expectedLogsUrl, TEST_END_TIME);
-   }
+  private void assertLogsUrlValid(
+      String logsUrlTemplate,
+      String logsUrlDateFormat,
+      String expectedLogsUrl,
+      OffsetDateTime executionEndTime) {
+    ReflectionTestUtils.setField(logsUrlBuilder, "template", logsUrlTemplate);
+    ReflectionTestUtils.setField(logsUrlBuilder, "dateFormat", logsUrlDateFormat);
 
-   private void assertLogsUrlValid(String logsUrlTemplate, String logsUrlDateFormat, String expectedLogsUrl, OffsetDateTime executionEndTime) {
-      ReflectionTestUtils.setField(logsUrlBuilder, "template", logsUrlTemplate);
-      ReflectionTestUtils.setField(logsUrlBuilder, "dateFormat", logsUrlDateFormat);
-
-      DataJobExecution execution = DataJobExecution
-            .builder()
+    DataJobExecution execution =
+        DataJobExecution.builder()
             .id(TEST_EXECUTION_ID)
             .dataJob(new DataJob(TEST_JOB_NAME, new JobConfig()))
             .opId(TEST_OP_ID)
@@ -198,7 +217,7 @@ public class JobExecutionLogsUrlBuilderIT {
             .endTime(executionEndTime)
             .build();
 
-      String actualLogsUrl = logsUrlBuilder.build(execution);
-      Assertions.assertEquals(expectedLogsUrl, actualLogsUrl);
-   }
+    String actualLogsUrl = logsUrlBuilder.build(execution);
+    Assertions.assertEquals(expectedLogsUrl, actualLogsUrl);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionResultManagerTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionResultManagerTest.java
@@ -19,346 +19,401 @@ import java.time.OffsetDateTime;
 
 public class JobExecutionResultManagerTest {
 
-   @Test
-   public void testGetResult_succeededTrueAndNullTerminationMessage_shouldReturnMessage() {
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder().succeeded(true).podTerminationMessage(null).build();
-      ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
+  @Test
+  public void testGetResult_succeededTrueAndNullTerminationMessage_shouldReturnMessage() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .succeeded(true)
+            .podTerminationMessage(null)
+            .build();
+    ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
 
-      Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualTerminationMessage.getExecutionStatus());
-      Assertions.assertEquals("", actualTerminationMessage.getVdkVersion());
-   }
+    Assertions.assertEquals(
+        ExecutionStatus.SUCCEEDED, actualTerminationMessage.getExecutionStatus());
+    Assertions.assertEquals("", actualTerminationMessage.getVdkVersion());
+  }
 
-   @Test
-   public void testGetResult_succeededFalseAndNullTerminationMessage_shouldReturnMessage() {
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder().succeeded(false).podTerminationMessage(null).build();
-      ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
+  @Test
+  public void testGetResult_succeededFalseAndNullTerminationMessage_shouldReturnMessage() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .succeeded(false)
+            .podTerminationMessage(null)
+            .build();
+    ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
 
-      Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualTerminationMessage.getExecutionStatus());
-      Assertions.assertEquals("", actualTerminationMessage.getVdkVersion());
-   }
+    Assertions.assertEquals(
+        ExecutionStatus.PLATFORM_ERROR, actualTerminationMessage.getExecutionStatus());
+    Assertions.assertEquals("", actualTerminationMessage.getVdkVersion());
+  }
 
+  @Test
+  public void
+      testGetResult_succeededNullAndNullTerminationMessage_shouldReturnTerminationStatusNone() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .succeeded(null)
+            .startTime(OffsetDateTime.now())
+            .podTerminationMessage(null)
+            .build();
 
-   @Test
-   public void testGetResult_succeededNullAndNullTerminationMessage_shouldReturnTerminationStatusNone() {
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder()
-                  .succeeded(null)
-                  .startTime(OffsetDateTime.now())
-                  .podTerminationMessage(null)
-                  .build();
+    ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(ExecutionStatus.RUNNING, actualResult.getExecutionStatus());
+  }
 
-      ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
-      Assertions.assertEquals(ExecutionStatus.RUNNING, actualResult.getExecutionStatus());
-   }
+  @Test
+  public void testGetResult_succeededTrueAndEmptyTerminationMessage_shouldReturnMessage() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder().succeeded(true).podTerminationMessage("").build();
+    ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
 
-   @Test
-   public void testGetResult_succeededTrueAndEmptyTerminationMessage_shouldReturnMessage() {
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder().succeeded(true).podTerminationMessage("").build();
-      ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(
+        ExecutionStatus.SUCCEEDED, actualTerminationMessage.getExecutionStatus());
+    Assertions.assertEquals("", actualTerminationMessage.getVdkVersion());
+  }
 
-      Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualTerminationMessage.getExecutionStatus());
-      Assertions.assertEquals("", actualTerminationMessage.getVdkVersion());
-   }
+  @Test
+  public void testGetResult_succeededFalseAndEmptyTerminationMessage_shouldReturnMessage() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder().succeeded(false).podTerminationMessage("").build();
+    ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
 
-   @Test
-   public void testGetResult_succeededFalseAndEmptyTerminationMessage_shouldReturnMessage() {
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder().succeeded(false).podTerminationMessage("").build();
-      ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(
+        ExecutionStatus.PLATFORM_ERROR, actualTerminationMessage.getExecutionStatus());
+    Assertions.assertEquals("", actualTerminationMessage.getVdkVersion());
+  }
 
-      Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualTerminationMessage.getExecutionStatus());
-      Assertions.assertEquals("", actualTerminationMessage.getVdkVersion());
-   }
+  @Test
+  public void
+      testGetResult_succeededNullAndEmptyTerminationMessage_shouldReturnTerminationStatusNone() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .succeeded(null)
+            .startTime(OffsetDateTime.now())
+            .podTerminationMessage("")
+            .build();
 
-   @Test
-   public void testGetResult_succeededNullAndEmptyTerminationMessage_shouldReturnTerminationStatusNone() {
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder()
-                  .succeeded(null)
-                  .startTime(OffsetDateTime.now())
-                  .podTerminationMessage("")
-                  .build();
+    ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(ExecutionStatus.RUNNING, actualResult.getExecutionStatus());
+  }
 
-      ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
-      Assertions.assertEquals(ExecutionStatus.RUNNING, actualResult.getExecutionStatus());
-   }
+  @Test
+  public void testGetResult_succeededTrueAndNotExistingTerminationMessage_shouldReturnMessage() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .succeeded(true)
+            .podTerminationMessage("not-existing-termination-message")
+            .build();
+    ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
 
-   @Test
-   public void testGetResult_succeededTrueAndNotExistingTerminationMessage_shouldReturnMessage() {
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder().succeeded(true).podTerminationMessage("not-existing-termination-message").build();
-      ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(
+        ExecutionStatus.PLATFORM_ERROR, actualTerminationMessage.getExecutionStatus());
+    Assertions.assertEquals("", actualTerminationMessage.getVdkVersion());
+  }
 
-      Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualTerminationMessage.getExecutionStatus());
-      Assertions.assertEquals("", actualTerminationMessage.getVdkVersion());
-   }
+  @Test
+  public void testGetResult_succeededFalseAndNotExistingTerminationMessage_shouldReturnMessage() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .succeeded(false)
+            .podTerminationMessage("not-existing-termination-message")
+            .build();
+    ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
 
-   @Test
-   public void testGetResult_succeededFalseAndNotExistingTerminationMessage_shouldReturnMessage() {
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder().succeeded(false).podTerminationMessage("not-existing-termination-message").build();
-      ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(
+        ExecutionStatus.PLATFORM_ERROR,
+        actualTerminationMessage.getExecutionStatus()); // TODO OR platform error
+    Assertions.assertEquals("", actualTerminationMessage.getVdkVersion());
+  }
 
-      Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualTerminationMessage.getExecutionStatus()); // TODO OR platform error
-      Assertions.assertEquals("", actualTerminationMessage.getVdkVersion());
-   }
+  @Test
+  public void testGetResult_succeededNullAndNotExistingTerminationMessage_shouldReturnMessage() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .succeeded(null)
+            .startTime(OffsetDateTime.now())
+            .podTerminationMessage("not-existing-termination-message")
+            .build();
+    ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
 
-   @Test
-   public void testGetResult_succeededNullAndNotExistingTerminationMessage_shouldReturnMessage() {
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder()
-                  .succeeded(null)
-                  .startTime(OffsetDateTime.now())
-                  .podTerminationMessage("not-existing-termination-message")
-                  .build();
-      ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(ExecutionStatus.RUNNING, actualTerminationMessage.getExecutionStatus());
+    Assertions.assertEquals("", actualTerminationMessage.getVdkVersion());
+  }
 
-      Assertions.assertEquals(ExecutionStatus.RUNNING, actualTerminationMessage.getExecutionStatus());
-      Assertions.assertEquals("", actualTerminationMessage.getVdkVersion());
-   }
+  @Test
+  public void testGetResult_jsonTerminationMessage_shouldReturnMessage() {
+    ExecutionStatus expectedTerminationStatus = ExecutionStatus.USER_ERROR;
+    String vdkVersion = "1.2.3";
+    JsonObject expectedTerminationMessage = new JsonObject();
+    expectedTerminationMessage.addProperty(
+        JobExecutionResultManager.TERMINATION_MESSAGE_ATTRIBUTE_STATUS,
+        expectedTerminationStatus.getPodStatus());
+    expectedTerminationMessage.addProperty(
+        JobExecutionResultManager.TERMINATION_MESSAGE_ATTRIBUTE_VDK_VERSION, vdkVersion);
 
-   @Test
-   public void testGetResult_jsonTerminationMessage_shouldReturnMessage() {
-      ExecutionStatus expectedTerminationStatus = ExecutionStatus.USER_ERROR;
-      String vdkVersion = "1.2.3";
-      JsonObject expectedTerminationMessage = new JsonObject();
-      expectedTerminationMessage.addProperty(JobExecutionResultManager.TERMINATION_MESSAGE_ATTRIBUTE_STATUS, expectedTerminationStatus.getPodStatus());
-      expectedTerminationMessage.addProperty(JobExecutionResultManager.TERMINATION_MESSAGE_ATTRIBUTE_VDK_VERSION, vdkVersion);
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .succeeded(false)
+            .podTerminationMessage(expectedTerminationMessage.toString())
+            .build();
+    ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
 
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution
-                  .builder()
-                  .succeeded(false)
-                  .podTerminationMessage(expectedTerminationMessage.toString())
-                  .build();
-      ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(
+        expectedTerminationStatus, actualTerminationMessage.getExecutionStatus());
+    Assertions.assertEquals(vdkVersion, actualTerminationMessage.getVdkVersion());
+  }
 
-      Assertions.assertEquals(expectedTerminationStatus, actualTerminationMessage.getExecutionStatus());
-      Assertions.assertEquals(vdkVersion, actualTerminationMessage.getVdkVersion());
-   }
+  @Test
+  public void testGetResult_stringTerminationMessage_shouldReturnMessage() {
+    ExecutionStatus expectedTerminationStatus = ExecutionStatus.USER_ERROR;
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .succeeded(false)
+            .podTerminationMessage(expectedTerminationStatus.getPodStatus())
+            .build();
 
-   @Test
-   public void testGetResult_stringTerminationMessage_shouldReturnMessage() {
-      ExecutionStatus expectedTerminationStatus = ExecutionStatus.USER_ERROR;
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution
-                  .builder()
-                  .succeeded(false)
-                  .podTerminationMessage(expectedTerminationStatus.getPodStatus())
-                  .build();
+    ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(
+        expectedTerminationStatus, actualTerminationMessage.getExecutionStatus());
+  }
 
-      ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
-      Assertions.assertEquals(expectedTerminationStatus, actualTerminationMessage.getExecutionStatus());
-   }
+  @Test
+  public void
+      testGetResult_succeededTrueAndTerminationMessageUserError_shouldReturnTerminationStatusSuccess() {
+    ExecutionStatus expectedExecutionStatus = ExecutionStatus.USER_ERROR;
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .succeeded(true)
+            .podTerminationMessage(expectedExecutionStatus.getPodStatus())
+            .build();
 
-   @Test
-   public void testGetResult_succeededTrueAndTerminationMessageUserError_shouldReturnTerminationStatusSuccess() {
-      ExecutionStatus expectedExecutionStatus = ExecutionStatus.USER_ERROR;
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder().succeeded(true).podTerminationMessage(expectedExecutionStatus.getPodStatus()).build();
+    ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(expectedExecutionStatus, actualResult.getExecutionStatus());
+  }
 
-      ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
-      Assertions.assertEquals(expectedExecutionStatus, actualResult.getExecutionStatus());
-   }
+  @Test
+  public void
+      testGetResult_succeededFalseAndTerminationMessageUserError_shouldReturnTerminationStatusSuccess() {
+    ExecutionStatus expectedExecutionStatus = ExecutionStatus.USER_ERROR;
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .succeeded(false)
+            .podTerminationMessage(expectedExecutionStatus.getPodStatus())
+            .build();
 
-   @Test
-   public void testGetResult_succeededFalseAndTerminationMessageUserError_shouldReturnTerminationStatusSuccess() {
-      ExecutionStatus expectedExecutionStatus = ExecutionStatus.USER_ERROR;
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder().succeeded(false).podTerminationMessage(expectedExecutionStatus.getPodStatus()).build();
+    ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(expectedExecutionStatus, actualResult.getExecutionStatus());
+  }
 
-      ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
-      Assertions.assertEquals(expectedExecutionStatus, actualResult.getExecutionStatus());
-   }
+  @Test
+  public void
+      testGetResult_succeededNullAndTerminationMessageUserError_shouldReturnTerminationStatusSuccess() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .succeeded(null)
+            .startTime(OffsetDateTime.now())
+            .podTerminationMessage(ExecutionStatus.USER_ERROR.getPodStatus())
+            .build();
 
-   @Test
-   public void testGetResult_succeededNullAndTerminationMessageUserError_shouldReturnTerminationStatusSuccess() {
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder()
-                  .succeeded(null)
-                  .startTime(OffsetDateTime.now())
-                  .podTerminationMessage(ExecutionStatus.USER_ERROR.getPodStatus())
-                  .build();
+    ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(ExecutionStatus.RUNNING, actualResult.getExecutionStatus());
+  }
 
-      ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
-      Assertions.assertEquals(ExecutionStatus.RUNNING, actualResult.getExecutionStatus());
-   }
+  @Test
+  public void
+      testGetResult_succeededTrueAndTerminationMessagePlatformError_shouldReturnTerminationStatusSuccess() {
+    ExecutionStatus expectedExecutionStatus = ExecutionStatus.PLATFORM_ERROR;
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .succeeded(true)
+            .podTerminationMessage(expectedExecutionStatus.getPodStatus())
+            .build();
 
-   @Test
-   public void testGetResult_succeededTrueAndTerminationMessagePlatformError_shouldReturnTerminationStatusSuccess() {
-      ExecutionStatus expectedExecutionStatus = ExecutionStatus.PLATFORM_ERROR;
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder().succeeded(true).podTerminationMessage(expectedExecutionStatus.getPodStatus()).build();
+    ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(expectedExecutionStatus, actualResult.getExecutionStatus());
+  }
 
-      ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
-      Assertions.assertEquals(expectedExecutionStatus, actualResult.getExecutionStatus());
-   }
+  @Test
+  public void
+      testGetResult_succeededFalseAndTerminationMessagePlatformError_shouldReturnTerminationStatusSuccess() {
+    ExecutionStatus expectedExecutionStatus = ExecutionStatus.PLATFORM_ERROR;
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .succeeded(false)
+            .podTerminationMessage(expectedExecutionStatus.getPodStatus())
+            .build();
 
-   @Test
-   public void testGetResult_succeededFalseAndTerminationMessagePlatformError_shouldReturnTerminationStatusSuccess() {
-      ExecutionStatus expectedExecutionStatus = ExecutionStatus.PLATFORM_ERROR;
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder().succeeded(false).podTerminationMessage(expectedExecutionStatus.getPodStatus()).build();
+    ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(expectedExecutionStatus, actualResult.getExecutionStatus());
+  }
 
-      ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
-      Assertions.assertEquals(expectedExecutionStatus, actualResult.getExecutionStatus());
-   }
+  @Test
+  public void
+      testGetResult_succeededNullAndTerminationMessagePlatformError_shouldReturnTerminationStatusSuccess() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .succeeded(null)
+            .startTime(OffsetDateTime.now())
+            .podTerminationMessage(ExecutionStatus.PLATFORM_ERROR.getPodStatus())
+            .build();
 
-   @Test
-   public void testGetResult_succeededNullAndTerminationMessagePlatformError_shouldReturnTerminationStatusSuccess() {
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder()
-                  .succeeded(null)
-                  .startTime(OffsetDateTime.now())
-                  .podTerminationMessage(ExecutionStatus.PLATFORM_ERROR.getPodStatus())
-                  .build();
+    ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(ExecutionStatus.RUNNING, actualResult.getExecutionStatus());
+  }
 
-      ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
-      Assertions.assertEquals(ExecutionStatus.RUNNING, actualResult.getExecutionStatus());
-   }
+  @Test
+  public void
+      testGetResult_emptyTerminationMessageAndExecutionStatusSucceeded_shouldReturnTerminationStatusSuccess() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder().succeeded(true).podTerminationMessage("").build();
 
-   @Test
-   public void testGetResult_emptyTerminationMessageAndExecutionStatusSucceeded_shouldReturnTerminationStatusSuccess() {
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder().succeeded(true).podTerminationMessage("").build();
+    ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualResult.getExecutionStatus());
+  }
 
-      ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
-      Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualResult.getExecutionStatus());
-   }
+  @Test
+  public void
+      testGetResult_emptyTerminationMessageAndExecutionStatusFailed_shouldReturnTerminationStatusPlatformError() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder().succeeded(false).podTerminationMessage("").build();
 
-   @Test
-   public void testGetResult_emptyTerminationMessageAndExecutionStatusFailed_shouldReturnTerminationStatusPlatformError() {
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder().succeeded(false).podTerminationMessage("").build();
+    ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualResult.getExecutionStatus());
+  }
 
-      ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
-      Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualResult.getExecutionStatus());
-   }
+  @Test
+  public void
+      testGetResult_executionSucceededNullAndStartTimeNull_shouldReturnExecutionStatusSubmitted() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder().succeeded(null).startTime(null).build();
+    ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
 
-   @Test
-   public void testGetResult_executionSucceededNullAndStartTimeNull_shouldReturnExecutionStatusSubmitted() {
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder().succeeded(null).startTime(null).build();
-      ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(ExecutionStatus.SUBMITTED, actualResult.getExecutionStatus());
+  }
 
-      Assertions.assertEquals(ExecutionStatus.SUBMITTED, actualResult.getExecutionStatus());
-   }
+  @Test
+  public void
+      testGetResult_executionSucceededNullAndStartTimeNotNull_shouldReturnExecutionStatusRunning() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .succeeded(null)
+            .startTime(OffsetDateTime.now())
+            .build();
+    ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
 
-   @Test
-   public void testGetResult_executionSucceededNullAndStartTimeNotNull_shouldReturnExecutionStatusRunning() {
-      KubernetesService.JobExecution jobExecution =
-              KubernetesService.JobExecution.builder().succeeded(null).startTime(OffsetDateTime.now()).build();
-      ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(ExecutionStatus.RUNNING, actualResult.getExecutionStatus());
+  }
 
-      Assertions.assertEquals(ExecutionStatus.RUNNING, actualResult.getExecutionStatus());
-   }
+  @Test
+  public void testGetResult_executionSucceededTrue_shouldReturnExecutionStatusSucceeded() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder().succeeded(true).build();
+    ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
 
-   @Test
-   public void testGetResult_executionSucceededTrue_shouldReturnExecutionStatusSucceeded() {
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder().succeeded(true).build();
-      ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualResult.getExecutionStatus());
+  }
 
-      Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualResult.getExecutionStatus());
-   }
+  @Test
+  public void testGetResult_executionSucceededFalse_shouldReturnExecutionStatusFailed() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder().succeeded(false).build();
+    ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
 
-   @Test
-   public void testGetResult_executionSucceededFalse_shouldReturnExecutionStatusFailed() {
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder().succeeded(false).build();
-      ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualResult.getExecutionStatus());
+  }
 
-      Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualResult.getExecutionStatus());
-   }
+  @Test
+  public void
+      testGetResult_executionStatusSucceededAndTerminationStatusUserError_shouldReturnExecutionStatusFailed() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .succeeded(true)
+            .podTerminationMessage(ExecutionStatus.USER_ERROR.getPodStatus())
+            .build();
 
-   @Test
-   public void testGetResult_executionStatusSucceededAndTerminationStatusUserError_shouldReturnExecutionStatusFailed() {
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder()
-                  .succeeded(true)
-                  .podTerminationMessage(ExecutionStatus.USER_ERROR.getPodStatus())
-                  .build();
+    ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(ExecutionStatus.USER_ERROR, actualResult.getExecutionStatus());
+  }
 
-      ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
-      Assertions.assertEquals(ExecutionStatus.USER_ERROR, actualResult.getExecutionStatus());
-   }
+  @Test
+  public void
+      testGetResult_executionStatusSucceededAndTerminationStatusSkipped_shouldReturnExecutionStatusSkipped() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .succeeded(true)
+            .podTerminationMessage(ExecutionStatus.SKIPPED.getPodStatus())
+            .build();
 
-   @Test
-   public void testGetResult_executionStatusSucceededAndTerminationStatusSkipped_shouldReturnExecutionStatusSkipped() {
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder()
-                  .succeeded(true)
-                  .podTerminationMessage(ExecutionStatus.SKIPPED.getPodStatus())
-                  .build();
+    ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(ExecutionStatus.SKIPPED, actualResult.getExecutionStatus());
+  }
 
-      ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
-      Assertions.assertEquals(ExecutionStatus.SKIPPED, actualResult.getExecutionStatus());
-   }
+  @Test
+  public void
+      testGetResult_succeededTrueAndTerminationStatusPlatformError_shouldReturnExecutionStatusPlatformError() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .succeeded(true)
+            .podTerminationMessage(ExecutionStatus.PLATFORM_ERROR.getPodStatus())
+            .build();
 
-   @Test
-   public void testGetResult_succeededTrueAndTerminationStatusPlatformError_shouldReturnExecutionStatusPlatformError() {
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder()
-                  .succeeded(true)
-                  .podTerminationMessage(ExecutionStatus.PLATFORM_ERROR.getPodStatus())
-                  .build();
+    ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualResult.getExecutionStatus());
+  }
 
-      ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
-      Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualResult.getExecutionStatus());
-   }
+  @Test
+  public void
+      testGetResult_succeededFalseAndTerminationStatusPlatformError_shouldReturnExecutionStatusPlatformError() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .succeeded(false)
+            .podTerminationMessage(ExecutionStatus.PLATFORM_ERROR.getPodStatus())
+            .build();
 
-   @Test
-   public void testGetResult_succeededFalseAndTerminationStatusPlatformError_shouldReturnExecutionStatusPlatformError() {
-      KubernetesService.JobExecution jobExecution =
-            KubernetesService.JobExecution.builder()
-                  .succeeded(false)
-                  .podTerminationMessage(ExecutionStatus.PLATFORM_ERROR.getPodStatus())
-                  .build();
+    ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualResult.getExecutionStatus());
+  }
 
-      ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
-      Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualResult.getExecutionStatus());
-   }
+  @Test
+  void
+      testGetResult_terminationMessageNullAndExecutionStatusFailedAndTerminationReasonDeadlineExceeded_shouldReturnTerminationStatusUserError() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .podTerminationMessage(null)
+            .succeeded(false)
+            .jobTerminationReason(JobExecutionResultManager.TERMINATION_REASON_DEADLINE_EXCEEDED)
+            .build();
 
-   @Test
-   void testGetResult_terminationMessageNullAndExecutionStatusFailedAndTerminationReasonDeadlineExceeded_shouldReturnTerminationStatusUserError() {
-      KubernetesService.JobExecution jobExecution =
-              KubernetesService.JobExecution.builder()
-                      .podTerminationMessage(null)
-                      .succeeded(false)
-                      .jobTerminationReason(JobExecutionResultManager.TERMINATION_REASON_DEADLINE_EXCEEDED)
-                      .build();
+    ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(ExecutionStatus.USER_ERROR, actualResult.getExecutionStatus());
+  }
 
-      ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
-      Assertions.assertEquals(ExecutionStatus.USER_ERROR, actualResult.getExecutionStatus());
-   }
+  @Test
+  void
+      testGetResult_terminationMessageNullAndExecutionStatusFailedAndTerminationReasonAny_shouldReturnTerminationStatusUserError() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .podTerminationMessage(null)
+            .succeeded(false)
+            .jobTerminationReason("SomeReason")
+            .build();
 
-   @Test
-   void testGetResult_terminationMessageNullAndExecutionStatusFailedAndTerminationReasonAny_shouldReturnTerminationStatusUserError() {
-      KubernetesService.JobExecution jobExecution =
-              KubernetesService.JobExecution.builder()
-                      .podTerminationMessage(null)
-                      .succeeded(false)
-                      .jobTerminationReason("SomeReason")
-                      .build();
+    ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualResult.getExecutionStatus());
+  }
 
-      ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
-      Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualResult.getExecutionStatus());
-   }
+  @Test
+  void
+      testGetResult_terminationMessageNullAndExecutionStatusFailedAndTerminationReasonOutOfMemory_shouldReturnTerminationStatusUserError() {
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
+            .podTerminationMessage(null)
+            .succeeded(false)
+            .jobTerminationReason("Some Reason")
+            .containerTerminationReason(JobExecutionResultManager.TERMINATION_REASON_OUT_OF_MEMORY)
+            .build();
 
-   @Test
-   void testGetResult_terminationMessageNullAndExecutionStatusFailedAndTerminationReasonOutOfMemory_shouldReturnTerminationStatusUserError() {
-      KubernetesService.JobExecution jobExecution =
-              KubernetesService.JobExecution.builder()
-                      .podTerminationMessage(null)
-                      .succeeded(false)
-                      .jobTerminationReason("Some Reason")
-                      .containerTerminationReason(JobExecutionResultManager.TERMINATION_REASON_OUT_OF_MEMORY)
-                      .build();
-
-      ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
-      Assertions.assertEquals(ExecutionStatus.USER_ERROR, actualResult.getExecutionStatus());
-   }
+    ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
+    Assertions.assertEquals(ExecutionStatus.USER_ERROR, actualResult.getExecutionStatus());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceCancelExecutionIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceCancelExecutionIT.java
@@ -32,112 +32,135 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @SpringBootTest(classes = ControlplaneApplication.class)
 public class JobExecutionServiceCancelExecutionIT {
 
-    @Autowired
-    private JobsRepository jobsRepository;
+  @Autowired private JobsRepository jobsRepository;
 
-    @Autowired
-    private JobExecutionRepository jobExecutionRepository;
+  @Autowired private JobExecutionRepository jobExecutionRepository;
 
-    @Autowired
-    private JobExecutionService jobExecutionService;
+  @Autowired private JobExecutionService jobExecutionService;
 
-    @MockBean
-    private DataJobsKubernetesService dataJobsKubernetesService;
+  @MockBean private DataJobsKubernetesService dataJobsKubernetesService;
 
-    private DataJob testJob;
+  private DataJob testJob;
 
-    @BeforeEach
-    public void populateDb() {
-        JobConfig config = new JobConfig();
-        config.setSchedule("schedule");
-        config.setTeam("test-team");
-        testJob = new DataJob("testJob", config);
+  @BeforeEach
+  public void populateDb() {
+    JobConfig config = new JobConfig();
+    config.setSchedule("schedule");
+    config.setTeam("test-team");
+    testJob = new DataJob("testJob", config);
 
-        jobsRepository.save(testJob);
-    }
+    jobsRepository.save(testJob);
+  }
 
-    @AfterEach
-    public void cleanDbAfterTests() {
-        jobExecutionRepository.deleteAll();
-        jobsRepository.deleteAll();
-    }
+  @AfterEach
+  public void cleanDbAfterTests() {
+    jobExecutionRepository.deleteAll();
+    jobsRepository.deleteAll();
+  }
 
-    @Test
-    public void testCancelRunningExecution() throws ApiException {
+  @Test
+  public void testCancelRunningExecution() throws ApiException {
 
-        String jobExecutionId = "test-job-id";
-        RepositoryUtil.createDataJobExecution(jobExecutionRepository, jobExecutionId, testJob, ExecutionStatus.RUNNING);
-        Mockito.doNothing().when(dataJobsKubernetesService).cancelRunningCronJob(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+    String jobExecutionId = "test-job-id";
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository, jobExecutionId, testJob, ExecutionStatus.RUNNING);
+    Mockito.doNothing()
+        .when(dataJobsKubernetesService)
+        .cancelRunningCronJob(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
 
-        jobExecutionService.cancelDataJobExecution("test-team", "testJob", jobExecutionId);
-        var execution = jobExecutionRepository.findById(jobExecutionId).get();
+    jobExecutionService.cancelDataJobExecution("test-team", "testJob", jobExecutionId);
+    var execution = jobExecutionRepository.findById(jobExecutionId).get();
 
-        Assertions.assertEquals(ExecutionStatus.CANCELLED, execution.getStatus());
-        Assertions.assertTrue(jobExecutionRepository.findAll().size() == 1, "Expecting the size of executions to remain 1.");
-    }
+    Assertions.assertEquals(ExecutionStatus.CANCELLED, execution.getStatus());
+    Assertions.assertTrue(
+        jobExecutionRepository.findAll().size() == 1,
+        "Expecting the size of executions to remain 1.");
+  }
 
-    @Test
-    public void testCancelFinishedExecution() {
-        String jobExecutionId = "test-job-id";
-        RepositoryUtil.createDataJobExecution(jobExecutionRepository, jobExecutionId, testJob, ExecutionStatus.SUCCEEDED);
+  @Test
+  public void testCancelFinishedExecution() {
+    String jobExecutionId = "test-job-id";
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository, jobExecutionId, testJob, ExecutionStatus.SUCCEEDED);
 
-        var actualException = Assertions.assertThrows(DataJobExecutionCannotBeCancelledException.class,
-                () -> jobExecutionService.cancelDataJobExecution("test-team", "testJob", jobExecutionId));
+    var actualException =
+        Assertions.assertThrows(
+            DataJobExecutionCannotBeCancelledException.class,
+            () ->
+                jobExecutionService.cancelDataJobExecution("test-team", "testJob", jobExecutionId));
 
-        var exceptionMessage = actualException.getMessage();
-        Assertions.assertTrue(exceptionMessage.contains("Specified data job execution is not in running or submitted state."),
-                "Unexpected exception message content.");
-        Assertions.assertEquals(HttpStatus.BAD_REQUEST, actualException.getHttpStatus());
-    }
+    var exceptionMessage = actualException.getMessage();
+    Assertions.assertTrue(
+        exceptionMessage.contains(
+            "Specified data job execution is not in running or submitted state."),
+        "Unexpected exception message content.");
+    Assertions.assertEquals(HttpStatus.BAD_REQUEST, actualException.getHttpStatus());
+  }
 
-    @Test
-    public void testCancelNonExistingDataJob() {
+  @Test
+  public void testCancelNonExistingDataJob() {
 
-        var actualException = Assertions.assertThrows(DataJobExecutionCannotBeCancelledException.class,
-                () -> jobExecutionService.cancelDataJobExecution("test-team", "nonExistentDataJob", null));
+    var actualException =
+        Assertions.assertThrows(
+            DataJobExecutionCannotBeCancelledException.class,
+            () ->
+                jobExecutionService.cancelDataJobExecution(
+                    "test-team", "nonExistentDataJob", null));
 
-        var exceptionMessage = actualException.getMessage();
-        Assertions.assertTrue(exceptionMessage.contains("Specified Data Job for Team does not exist."),
-                "Unexpected exception message content.");
-        Assertions.assertEquals(HttpStatus.NOT_FOUND, actualException.getHttpStatus());
-    }
+    var exceptionMessage = actualException.getMessage();
+    Assertions.assertTrue(
+        exceptionMessage.contains("Specified Data Job for Team does not exist."),
+        "Unexpected exception message content.");
+    Assertions.assertEquals(HttpStatus.NOT_FOUND, actualException.getHttpStatus());
+  }
 
-    @Test
-    public void testCancelNonExistingDataJobExecution() {
-        var actualException = Assertions.assertThrows(DataJobExecutionCannotBeCancelledException.class,
-                () -> jobExecutionService.cancelDataJobExecution("test-team", "testJob", "nonExistingExecId"));
+  @Test
+  public void testCancelNonExistingDataJobExecution() {
+    var actualException =
+        Assertions.assertThrows(
+            DataJobExecutionCannotBeCancelledException.class,
+            () ->
+                jobExecutionService.cancelDataJobExecution(
+                    "test-team", "testJob", "nonExistingExecId"));
 
-        var exceptionMessage = actualException.getMessage();
-        Assertions.assertTrue(exceptionMessage.contains("Specified data job execution does not exist."),
-                "Unexpected exception message content.");
-        Assertions.assertEquals(HttpStatus.NOT_FOUND, actualException.getHttpStatus());
-    }
+    var exceptionMessage = actualException.getMessage();
+    Assertions.assertTrue(
+        exceptionMessage.contains("Specified data job execution does not exist."),
+        "Unexpected exception message content.");
+    Assertions.assertEquals(HttpStatus.NOT_FOUND, actualException.getHttpStatus());
+  }
 
-    @Test
-    public void testCancelExecutionK8SException() throws ApiException {
-        String jobExecutionId = "test-job-id";
-        RepositoryUtil.createDataJobExecution(jobExecutionRepository, jobExecutionId, testJob, ExecutionStatus.SUBMITTED);
+  @Test
+  public void testCancelExecutionK8SException() throws ApiException {
+    String jobExecutionId = "test-job-id";
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository, jobExecutionId, testJob, ExecutionStatus.SUBMITTED);
 
-        Mockito.doThrow(new ApiException()).when(dataJobsKubernetesService).cancelRunningCronJob(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
-        var actualException = Assertions.assertThrows(KubernetesException.class,
-                () -> jobExecutionService.cancelDataJobExecution("test-team", "testJob", jobExecutionId));
+    Mockito.doThrow(new ApiException())
+        .when(dataJobsKubernetesService)
+        .cancelRunningCronJob(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+    var actualException =
+        Assertions.assertThrows(
+            KubernetesException.class,
+            () ->
+                jobExecutionService.cancelDataJobExecution("test-team", "testJob", jobExecutionId));
 
-        var exceptionMessage = actualException.getMessage();
-        Assertions.assertTrue(exceptionMessage.contains("Cannot cancel a Data Job 'testJob' execution with execution id 'test-job-id'"),
-                "Unexpected exception message content.");
-    }
+    var exceptionMessage = actualException.getMessage();
+    Assertions.assertTrue(
+        exceptionMessage.contains(
+            "Cannot cancel a Data Job 'testJob' execution with execution id 'test-job-id'"),
+        "Unexpected exception message content.");
+  }
 
-    @Test
-    public void testExceptionObjectNullTolerant() {
-        var exception = new DataJobExecutionCannotBeCancelledException(null, null);
-        var message = exception.getMessage();
-        var status = exception.getHttpStatus();
+  @Test
+  public void testExceptionObjectNullTolerant() {
+    var exception = new DataJobExecutionCannotBeCancelledException(null, null);
+    var message = exception.getMessage();
+    var status = exception.getHttpStatus();
 
-        Assertions.assertNotNull(message);
-        Assertions.assertNotNull(status);
-        Assertions.assertTrue(exception.getMessage().contains("Unknown cause"));
-        Assertions.assertEquals(HttpStatus.BAD_REQUEST, status);
-
-    }
-
+    Assertions.assertNotNull(message);
+    Assertions.assertNotNull(status);
+    Assertions.assertTrue(exception.getMessage().contains("Unknown cause"));
+    Assertions.assertEquals(HttpStatus.BAD_REQUEST, status);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceListExecutionsIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceListExecutionsIT.java
@@ -36,144 +36,127 @@ import static com.vmware.taurus.service.execution.JobExecutionServiceUtil.assert
 @SpringBootTest(classes = ControlplaneApplication.class)
 public class JobExecutionServiceListExecutionsIT {
 
-    @Autowired
-    private JobExecutionRepository jobExecutionRepository;
+  @Autowired private JobExecutionRepository jobExecutionRepository;
 
-    @Autowired
-    private JobsRepository jobsRepository;
+  @Autowired private JobsRepository jobsRepository;
 
-    @Autowired
-    private JobExecutionService jobExecutionService;
+  @Autowired private JobExecutionService jobExecutionService;
 
-    @MockBean
-    private DataJobsKubernetesService dataJobsKubernetesService;
+  @MockBean private DataJobsKubernetesService dataJobsKubernetesService;
 
-    @BeforeEach
-    public void cleanDatabase() {
-        jobsRepository.deleteAll();
-    }
+  @BeforeEach
+  public void cleanDatabase() {
+    jobsRepository.deleteAll();
+  }
 
-    @Test
-    public void testListJobExecutions_nonExistingDataJob_shouldThrowException() {
-        Assertions.assertThrows(DataJobNotFoundException.class, () ->
-              jobExecutionService.listJobExecutions("test-team","test-job",  null));
-    }
+  @Test
+  public void testListJobExecutions_nonExistingDataJob_shouldThrowException() {
+    Assertions.assertThrows(
+        DataJobNotFoundException.class,
+        () -> jobExecutionService.listJobExecutions("test-team", "test-job", null));
+  }
 
-    @Test
-    public void testReadJobExecution_nonExistingDataJobExecution_shouldReturnEmptyList() {
-        DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+  @Test
+  public void testReadJobExecution_nonExistingDataJobExecution_shouldReturnEmptyList() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-        List<DataJobExecution> dataJobExecutions = jobExecutionService.listJobExecutions(
-              actualDataJob.getJobConfig().getTeam(),
-              actualDataJob.getName(),
-              null);
-        Assertions.assertTrue(dataJobExecutions.isEmpty());
-    }
+    List<DataJobExecution> dataJobExecutions =
+        jobExecutionService.listJobExecutions(
+            actualDataJob.getJobConfig().getTeam(), actualDataJob.getName(), null);
+    Assertions.assertTrue(dataJobExecutions.isEmpty());
+  }
 
-    @Test
-    public void testReadJobExecution_existingDataJobExecutionAndNullStatus_shouldReturnResult() {
-        DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
-        com.vmware.taurus.service.model.DataJobExecution expectedDataJobExecution = RepositoryUtil.createDataJobExecution(
-              jobExecutionRepository,
-              "test-id",
-              actualDataJob,
-              ExecutionStatus.RUNNING);
-
-        List<DataJobExecution> actualDataJobExecutions = jobExecutionService.listJobExecutions(
-              actualDataJob.getJobConfig().getTeam(),
-              actualDataJob.getName(),
-              null);
-
-        assertDataJobExecutionListValid(expectedDataJobExecution, actualDataJobExecutions);
-    }
-
-    @Test
-    public void testListJobExecutions_notValidExecutionStatus_shouldThrowException() {
-        RepositoryUtil.createDataJob(jobsRepository);
-
-        Assertions.assertThrows(DataJobExecutionStatusNotValidException.class, () ->
-              jobExecutionService.listJobExecutions("test-team","test-job", List.of("not-valid-status")));
-    }
-
-    @Test
-    public void testReadJobExecution_existingDataJobExecutionAndRunningJobInK8S_shouldReturnRunningExecutions() throws ApiException {
-        DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+  @Test
+  public void testReadJobExecution_existingDataJobExecutionAndNullStatus_shouldReturnResult() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    com.vmware.taurus.service.model.DataJobExecution expectedDataJobExecution =
         RepositoryUtil.createDataJobExecution(
-              jobExecutionRepository,
-              "test-id-1",
-              actualDataJob,
-              ExecutionStatus.CANCELLED);
+            jobExecutionRepository, "test-id", actualDataJob, ExecutionStatus.RUNNING);
 
-        com.vmware.taurus.service.model.DataJobExecution expectedDataJobExecution1 = RepositoryUtil.createDataJobExecution(
-              jobExecutionRepository,
-              "test-id-2",
-              actualDataJob,
-              ExecutionStatus.RUNNING);
+    List<DataJobExecution> actualDataJobExecutions =
+        jobExecutionService.listJobExecutions(
+            actualDataJob.getJobConfig().getTeam(), actualDataJob.getName(), null);
 
-        com.vmware.taurus.service.model.DataJobExecution expectedDataJobExecution2 = RepositoryUtil.createDataJobExecution(
-              jobExecutionRepository,
-              "test-id-3",
-              actualDataJob,
-              ExecutionStatus.SUBMITTED);
+    assertDataJobExecutionListValid(expectedDataJobExecution, actualDataJobExecutions);
+  }
 
+  @Test
+  public void testListJobExecutions_notValidExecutionStatus_shouldThrowException() {
+    RepositoryUtil.createDataJob(jobsRepository);
+
+    Assertions.assertThrows(
+        DataJobExecutionStatusNotValidException.class,
+        () ->
+            jobExecutionService.listJobExecutions(
+                "test-team", "test-job", List.of("not-valid-status")));
+  }
+
+  @Test
+  public void
+      testReadJobExecution_existingDataJobExecutionAndRunningJobInK8S_shouldReturnRunningExecutions()
+          throws ApiException {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository, "test-id-1", actualDataJob, ExecutionStatus.CANCELLED);
+
+    com.vmware.taurus.service.model.DataJobExecution expectedDataJobExecution1 =
         RepositoryUtil.createDataJobExecution(
-              jobExecutionRepository,
-              "test-id-4",
-              actualDataJob,
-              ExecutionStatus.SUCCEEDED);
+            jobExecutionRepository, "test-id-2", actualDataJob, ExecutionStatus.RUNNING);
 
-        Mockito.when(dataJobsKubernetesService.isRunningJob(actualDataJob.getName())).thenReturn(true);
-
-        List<DataJobExecution> actualDataJobExecutions =
-              jobExecutionService.listJobExecutions(
-                    actualDataJob.getJobConfig().getTeam(),
-                    actualDataJob.getName(),
-                    List.of(DataJobExecution.StatusEnum.RUNNING.getValue(), DataJobExecution.StatusEnum.SUBMITTED.getValue()));
-
-        Assertions.assertNotNull(actualDataJobExecutions);
-        Assertions.assertEquals(2, actualDataJobExecutions.size());
-
-        assertDataJobExecutionValid(expectedDataJobExecution1,  actualDataJobExecutions.get(0));
-        assertDataJobExecutionValid(expectedDataJobExecution2,  actualDataJobExecutions.get(1));
-    }
-
-    @Test
-    public void testReadJobExecution_existingDataJobExecutionAndNotRunningJobInK8S_shouldNotReturnRunningExecutions() throws ApiException {
-        DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    com.vmware.taurus.service.model.DataJobExecution expectedDataJobExecution2 =
         RepositoryUtil.createDataJobExecution(
-              jobExecutionRepository,
-              "test-id-1",
-              actualDataJob,
-              ExecutionStatus.CANCELLED);
+            jobExecutionRepository, "test-id-3", actualDataJob, ExecutionStatus.SUBMITTED);
 
-       RepositoryUtil.createDataJobExecution(
-              jobExecutionRepository,
-              "test-id-2",
-              actualDataJob,
-              ExecutionStatus.RUNNING);
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository, "test-id-4", actualDataJob, ExecutionStatus.SUCCEEDED);
 
-        com.vmware.taurus.service.model.DataJobExecution expectedDataJobExecution1 = RepositoryUtil.createDataJobExecution(
-              jobExecutionRepository,
-              "test-id-3",
-              actualDataJob,
-              ExecutionStatus.SUBMITTED);
+    Mockito.when(dataJobsKubernetesService.isRunningJob(actualDataJob.getName())).thenReturn(true);
 
+    List<DataJobExecution> actualDataJobExecutions =
+        jobExecutionService.listJobExecutions(
+            actualDataJob.getJobConfig().getTeam(),
+            actualDataJob.getName(),
+            List.of(
+                DataJobExecution.StatusEnum.RUNNING.getValue(),
+                DataJobExecution.StatusEnum.SUBMITTED.getValue()));
+
+    Assertions.assertNotNull(actualDataJobExecutions);
+    Assertions.assertEquals(2, actualDataJobExecutions.size());
+
+    assertDataJobExecutionValid(expectedDataJobExecution1, actualDataJobExecutions.get(0));
+    assertDataJobExecutionValid(expectedDataJobExecution2, actualDataJobExecutions.get(1));
+  }
+
+  @Test
+  public void
+      testReadJobExecution_existingDataJobExecutionAndNotRunningJobInK8S_shouldNotReturnRunningExecutions()
+          throws ApiException {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository, "test-id-1", actualDataJob, ExecutionStatus.CANCELLED);
+
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository, "test-id-2", actualDataJob, ExecutionStatus.RUNNING);
+
+    com.vmware.taurus.service.model.DataJobExecution expectedDataJobExecution1 =
         RepositoryUtil.createDataJobExecution(
-              jobExecutionRepository,
-              "test-id-4",
-              actualDataJob,
-              ExecutionStatus.SUCCEEDED);
+            jobExecutionRepository, "test-id-3", actualDataJob, ExecutionStatus.SUBMITTED);
 
-        Mockito.when(dataJobsKubernetesService.isRunningJob(actualDataJob.getName())).thenReturn(false);
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository, "test-id-4", actualDataJob, ExecutionStatus.SUCCEEDED);
 
-        List<DataJobExecution> actualDataJobExecutions =
-              jobExecutionService.listJobExecutions(
-                    actualDataJob.getJobConfig().getTeam(),
-                    actualDataJob.getName(),
-                    List.of(DataJobExecution.StatusEnum.SUBMITTED.getValue(), DataJobExecution.StatusEnum.RUNNING.getValue()));
+    Mockito.when(dataJobsKubernetesService.isRunningJob(actualDataJob.getName())).thenReturn(false);
 
-        Assertions.assertNotNull(actualDataJobExecutions);
-        Assertions.assertEquals(1, actualDataJobExecutions.size());
-        assertDataJobExecutionValid(expectedDataJobExecution1,  actualDataJobExecutions.get(0));
-    }
+    List<DataJobExecution> actualDataJobExecutions =
+        jobExecutionService.listJobExecutions(
+            actualDataJob.getJobConfig().getTeam(),
+            actualDataJob.getName(),
+            List.of(
+                DataJobExecution.StatusEnum.SUBMITTED.getValue(),
+                DataJobExecution.StatusEnum.RUNNING.getValue()));
+
+    Assertions.assertNotNull(actualDataJobExecutions);
+    Assertions.assertEquals(1, actualDataJobExecutions.size());
+    assertDataJobExecutionValid(expectedDataJobExecution1, actualDataJobExecutions.get(0));
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceReadExecutionIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceReadExecutionIT.java
@@ -25,49 +25,49 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @SpringBootTest(classes = ControlplaneApplication.class)
 public class JobExecutionServiceReadExecutionIT {
 
-    @Autowired
-    private JobExecutionRepository jobExecutionRepository;
+  @Autowired private JobExecutionRepository jobExecutionRepository;
 
-    @Autowired
-    private JobsRepository jobsRepository;
+  @Autowired private JobsRepository jobsRepository;
 
-    @Autowired
-    private JobExecutionService jobExecutionService;
+  @Autowired private JobExecutionService jobExecutionService;
 
-    @BeforeEach
-    public void cleanDatabase() {
-        jobsRepository.deleteAll();
-    }
+  @BeforeEach
+  public void cleanDatabase() {
+    jobsRepository.deleteAll();
+  }
 
-    @Test
-    public void testReadJobExecution_existingDataJobExecution_shouldReturnExecution() {
-        DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
-        com.vmware.taurus.service.model.DataJobExecution expectedDataJobExecution = RepositoryUtil.createDataJobExecution(
-              jobExecutionRepository,
-              "test-id",
-              actualDataJob,
-              ExecutionStatus.RUNNING);
+  @Test
+  public void testReadJobExecution_existingDataJobExecution_shouldReturnExecution() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    com.vmware.taurus.service.model.DataJobExecution expectedDataJobExecution =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository, "test-id", actualDataJob, ExecutionStatus.RUNNING);
 
-        var actualDataJobExecution = jobExecutionService.readJobExecution(
-              actualDataJob.getJobConfig().getTeam(),
-              actualDataJob.getName(),
-              expectedDataJobExecution.getId());
+    var actualDataJobExecution =
+        jobExecutionService.readJobExecution(
+            actualDataJob.getJobConfig().getTeam(),
+            actualDataJob.getName(),
+            expectedDataJobExecution.getId());
 
-        JobExecutionServiceUtil.assertDataJobExecutionValid(expectedDataJobExecution, actualDataJobExecution);
-    }
+    JobExecutionServiceUtil.assertDataJobExecutionValid(
+        expectedDataJobExecution, actualDataJobExecution);
+  }
 
-    @Test
-    public void testReadJobExecution_nonExistingDataJob_shouldThrowException() {
-        Assertions.assertThrows(DataJobNotFoundException.class, () ->
-              jobExecutionService.readJobExecution("test-team","test-job", "test-execution-id"));
-    }
+  @Test
+  public void testReadJobExecution_nonExistingDataJob_shouldThrowException() {
+    Assertions.assertThrows(
+        DataJobNotFoundException.class,
+        () -> jobExecutionService.readJobExecution("test-team", "test-job", "test-execution-id"));
+  }
 
-    @Test
-    public void testReadJobExecution_nonExistingDataJobExecution_shouldThrowException() {
-        DataJob dataJob = RepositoryUtil.createDataJob(jobsRepository);
+  @Test
+  public void testReadJobExecution_nonExistingDataJobExecution_shouldThrowException() {
+    DataJob dataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-        Assertions.assertThrows(DataJobExecutionNotFoundException.class, () ->
-              jobExecutionService.readJobExecution(
-                    dataJob.getJobConfig().getTeam(), dataJob.getName(), "test-id"));
-    }
+    Assertions.assertThrows(
+        DataJobExecutionNotFoundException.class,
+        () ->
+            jobExecutionService.readJobExecution(
+                dataJob.getJobConfig().getTeam(), dataJob.getName(), "test-id"));
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceSyncExecutionIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceSyncExecutionIT.java
@@ -29,165 +29,308 @@ import com.vmware.taurus.service.model.ExecutionStatus;
 @SpringBootTest(classes = ControlplaneApplication.class)
 public class JobExecutionServiceSyncExecutionIT {
 
-   @Autowired
-   private JobsRepository jobsRepository;
+  @Autowired private JobsRepository jobsRepository;
 
-   @Autowired
-   private JobExecutionRepository jobExecutionRepository;
+  @Autowired private JobExecutionRepository jobExecutionRepository;
 
-   @Autowired
-   private JobExecutionService jobExecutionService;
+  @Autowired private JobExecutionService jobExecutionService;
 
-   @AfterEach
-   public void cleanUp() {
-      jobsRepository.deleteAll();
-   }
+  @AfterEach
+  public void cleanUp() {
+    jobsRepository.deleteAll();
+  }
 
-   @Test
-   public void testSyncJobExecutionStatuses_fourRunningExecutionsWithStartTimeBefore5min_shouldSyncTwoExecutions() {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+  @Test
+  public void
+      testSyncJobExecutionStatuses_fourRunningExecutionsWithStartTimeBefore5min_shouldSyncTwoExecutions() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution1 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
-      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution3 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.SUBMITTED, OffsetDateTime.now().minusMinutes(5));
+    com.vmware.taurus.service.model.DataJobExecution expectedJobExecution1 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-1",
+            actualDataJob,
+            ExecutionStatus.RUNNING,
+            OffsetDateTime.now().minusMinutes(5));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-2",
+        actualDataJob,
+        ExecutionStatus.RUNNING,
+        OffsetDateTime.now().minusMinutes(5));
+    com.vmware.taurus.service.model.DataJobExecution expectedJobExecution3 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-3",
+            actualDataJob,
+            ExecutionStatus.RUNNING,
+            OffsetDateTime.now().minusMinutes(5));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-4",
+        actualDataJob,
+        ExecutionStatus.SUBMITTED,
+        OffsetDateTime.now().minusMinutes(5));
 
-      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsBeforeSync = findRunningDataJobExecutions(actualDataJob.getName());
+    List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsBeforeSync =
+        findRunningDataJobExecutions(actualDataJob.getName());
 
-      Assert.assertEquals(4, dataJobExecutionsBeforeSync.size());
-      jobExecutionService.syncJobExecutionStatuses(List.of(expectedJobExecution1.getId(), expectedJobExecution3.getId()));
+    Assert.assertEquals(4, dataJobExecutionsBeforeSync.size());
+    jobExecutionService.syncJobExecutionStatuses(
+        List.of(expectedJobExecution1.getId(), expectedJobExecution3.getId()));
 
-      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsAfterSync = findRunningDataJobExecutions(actualDataJob.getName());
+    List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsAfterSync =
+        findRunningDataJobExecutions(actualDataJob.getName());
 
-      Assert.assertEquals(2, dataJobExecutionsAfterSync.size());
-      Assert.assertEquals(expectedJobExecution1.getId(), dataJobExecutionsAfterSync.get(0).getId());
-      Assert.assertEquals(expectedJobExecution3.getId(), dataJobExecutionsAfterSync.get(1).getId());
-   }
+    Assert.assertEquals(2, dataJobExecutionsAfterSync.size());
+    Assert.assertEquals(expectedJobExecution1.getId(), dataJobExecutionsAfterSync.get(0).getId());
+    Assert.assertEquals(expectedJobExecution3.getId(), dataJobExecutionsAfterSync.get(1).getId());
+  }
 
-   @Test
-   public void testSyncJobExecutionStatuses_twoRunningExecutionsWithStartTimeBefore2minAndTwoWithStartTimeBefore5min_shouldSyncOneExecutions() {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+  @Test
+  public void
+      testSyncJobExecutionStatuses_twoRunningExecutionsWithStartTimeBefore2minAndTwoWithStartTimeBefore5min_shouldSyncOneExecutions() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution1 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
-      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution2 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(2));
-      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution3 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED, OffsetDateTime.now().minusMinutes(2));
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.SUBMITTED, OffsetDateTime.now().minusMinutes(5));
+    com.vmware.taurus.service.model.DataJobExecution expectedJobExecution1 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-1",
+            actualDataJob,
+            ExecutionStatus.RUNNING,
+            OffsetDateTime.now().minusMinutes(5));
+    com.vmware.taurus.service.model.DataJobExecution expectedJobExecution2 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-2",
+            actualDataJob,
+            ExecutionStatus.RUNNING,
+            OffsetDateTime.now().minusMinutes(2));
+    com.vmware.taurus.service.model.DataJobExecution expectedJobExecution3 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-3",
+            actualDataJob,
+            ExecutionStatus.SUBMITTED,
+            OffsetDateTime.now().minusMinutes(2));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-4",
+        actualDataJob,
+        ExecutionStatus.SUBMITTED,
+        OffsetDateTime.now().minusMinutes(5));
 
-      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsBeforeSync = findRunningDataJobExecutions(actualDataJob.getName());
+    List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsBeforeSync =
+        findRunningDataJobExecutions(actualDataJob.getName());
 
-      Assert.assertEquals(4, dataJobExecutionsBeforeSync.size());
-      jobExecutionService.syncJobExecutionStatuses(List.of(expectedJobExecution1.getId(), expectedJobExecution3.getId()));
+    Assert.assertEquals(4, dataJobExecutionsBeforeSync.size());
+    jobExecutionService.syncJobExecutionStatuses(
+        List.of(expectedJobExecution1.getId(), expectedJobExecution3.getId()));
 
-      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsAfterSync = findRunningDataJobExecutions(actualDataJob.getName());
+    List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsAfterSync =
+        findRunningDataJobExecutions(actualDataJob.getName());
 
-      Assert.assertEquals(3, dataJobExecutionsAfterSync.size());
-      Assert.assertEquals(expectedJobExecution1.getId(), dataJobExecutionsAfterSync.get(0).getId());
-      Assert.assertEquals(expectedJobExecution2.getId(), dataJobExecutionsAfterSync.get(1).getId());
-      Assert.assertEquals(expectedJobExecution3.getId(), dataJobExecutionsAfterSync.get(2).getId());
-   }
+    Assert.assertEquals(3, dataJobExecutionsAfterSync.size());
+    Assert.assertEquals(expectedJobExecution1.getId(), dataJobExecutionsAfterSync.get(0).getId());
+    Assert.assertEquals(expectedJobExecution2.getId(), dataJobExecutionsAfterSync.get(1).getId());
+    Assert.assertEquals(expectedJobExecution3.getId(), dataJobExecutionsAfterSync.get(2).getId());
+  }
 
-   @Test
-   public void testSyncJobExecutionStatuses_fourRunningExecutionsWithStartTimeBefore5min_shouldSyncFourExecutions() {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+  @Test
+  public void
+      testSyncJobExecutionStatuses_fourRunningExecutionsWithStartTimeBefore5min_shouldSyncFourExecutions() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution1 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
-      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution3 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED, OffsetDateTime.now().minusMinutes(5));
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.SUBMITTED, OffsetDateTime.now().minusMinutes(5));
+    com.vmware.taurus.service.model.DataJobExecution expectedJobExecution1 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-1",
+            actualDataJob,
+            ExecutionStatus.RUNNING,
+            OffsetDateTime.now().minusMinutes(5));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-2",
+        actualDataJob,
+        ExecutionStatus.RUNNING,
+        OffsetDateTime.now().minusMinutes(5));
+    com.vmware.taurus.service.model.DataJobExecution expectedJobExecution3 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-3",
+            actualDataJob,
+            ExecutionStatus.SUBMITTED,
+            OffsetDateTime.now().minusMinutes(5));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-4",
+        actualDataJob,
+        ExecutionStatus.SUBMITTED,
+        OffsetDateTime.now().minusMinutes(5));
 
-      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsBeforeSync = findRunningDataJobExecutions(actualDataJob.getName());
+    List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsBeforeSync =
+        findRunningDataJobExecutions(actualDataJob.getName());
 
-      Assert.assertEquals(4, dataJobExecutionsBeforeSync.size());
-      jobExecutionService.syncJobExecutionStatuses(Collections.emptyList());
+    Assert.assertEquals(4, dataJobExecutionsBeforeSync.size());
+    jobExecutionService.syncJobExecutionStatuses(Collections.emptyList());
 
-      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsAfterSync = findRunningDataJobExecutions(actualDataJob.getName());
+    List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsAfterSync =
+        findRunningDataJobExecutions(actualDataJob.getName());
 
-      Assert.assertEquals(0, dataJobExecutionsAfterSync.size());
-   }
+    Assert.assertEquals(0, dataJobExecutionsAfterSync.size());
+  }
 
-   @Test
-   public void testSyncJobExecutionStatuses_fourRunningExecutionsWithStartTimeBefore5min_shouldNotSyncAnyExecutions() {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+  @Test
+  public void
+      testSyncJobExecutionStatuses_fourRunningExecutionsWithStartTimeBefore5min_shouldNotSyncAnyExecutions() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution1 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
-      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution2 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
-      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution3 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED, OffsetDateTime.now().minusMinutes(5));
-      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution4 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.SUBMITTED, OffsetDateTime.now().minusMinutes(5));
+    com.vmware.taurus.service.model.DataJobExecution expectedJobExecution1 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-1",
+            actualDataJob,
+            ExecutionStatus.RUNNING,
+            OffsetDateTime.now().minusMinutes(5));
+    com.vmware.taurus.service.model.DataJobExecution expectedJobExecution2 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-2",
+            actualDataJob,
+            ExecutionStatus.RUNNING,
+            OffsetDateTime.now().minusMinutes(5));
+    com.vmware.taurus.service.model.DataJobExecution expectedJobExecution3 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-3",
+            actualDataJob,
+            ExecutionStatus.SUBMITTED,
+            OffsetDateTime.now().minusMinutes(5));
+    com.vmware.taurus.service.model.DataJobExecution expectedJobExecution4 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-4",
+            actualDataJob,
+            ExecutionStatus.SUBMITTED,
+            OffsetDateTime.now().minusMinutes(5));
 
-      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsBeforeSync = findRunningDataJobExecutions(actualDataJob.getName());
+    List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsBeforeSync =
+        findRunningDataJobExecutions(actualDataJob.getName());
 
-      Assert.assertEquals(4, dataJobExecutionsBeforeSync.size());
-      jobExecutionService.syncJobExecutionStatuses(List.of(
+    Assert.assertEquals(4, dataJobExecutionsBeforeSync.size());
+    jobExecutionService.syncJobExecutionStatuses(
+        List.of(
             expectedJobExecution1.getId(),
             expectedJobExecution2.getId(),
             expectedJobExecution3.getId(),
             expectedJobExecution4.getId()));
 
-      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsAfterSync = findRunningDataJobExecutions(actualDataJob.getName());
+    List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsAfterSync =
+        findRunningDataJobExecutions(actualDataJob.getName());
 
-      Assert.assertEquals(4, dataJobExecutionsAfterSync.size());
-   }
+    Assert.assertEquals(4, dataJobExecutionsAfterSync.size());
+  }
 
-   @Test
-   public void testSyncJobExecutionStatuses_fourRunningExecutionsWithStartTimeBefore5minAndNullRunningExecutionsIds_shouldNotSyncAnyExecutions() {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+  @Test
+  public void
+      testSyncJobExecutionStatuses_fourRunningExecutionsWithStartTimeBefore5minAndNullRunningExecutionsIds_shouldNotSyncAnyExecutions() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED, OffsetDateTime.now().minusMinutes(5));
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.SUBMITTED, OffsetDateTime.now().minusMinutes(5));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-1",
+        actualDataJob,
+        ExecutionStatus.RUNNING,
+        OffsetDateTime.now().minusMinutes(5));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-2",
+        actualDataJob,
+        ExecutionStatus.RUNNING,
+        OffsetDateTime.now().minusMinutes(5));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-3",
+        actualDataJob,
+        ExecutionStatus.SUBMITTED,
+        OffsetDateTime.now().minusMinutes(5));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-4",
+        actualDataJob,
+        ExecutionStatus.SUBMITTED,
+        OffsetDateTime.now().minusMinutes(5));
 
-      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsBeforeSync = findRunningDataJobExecutions(actualDataJob.getName());
+    List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsBeforeSync =
+        findRunningDataJobExecutions(actualDataJob.getName());
 
-      Assert.assertEquals(4, dataJobExecutionsBeforeSync.size());
-      jobExecutionService.syncJobExecutionStatuses(null);
+    Assert.assertEquals(4, dataJobExecutionsBeforeSync.size());
+    jobExecutionService.syncJobExecutionStatuses(null);
 
-      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsAfterSync = findRunningDataJobExecutions(actualDataJob.getName());
+    List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsAfterSync =
+        findRunningDataJobExecutions(actualDataJob.getName());
 
-      Assert.assertEquals(4, dataJobExecutionsAfterSync.size());
-   }
+    Assert.assertEquals(4, dataJobExecutionsAfterSync.size());
+  }
 
-   @Test
-   public void testSyncJobExecutionStatuses_twoRunningExecutionsWithStartTimeBefore5minAndTwoFinishedExecutionsWithStartTimeBefore5min_shouldSyncOneExecutions() {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+  @Test
+  public void
+      testSyncJobExecutionStatuses_twoRunningExecutionsWithStartTimeBefore5minAndTwoFinishedExecutionsWithStartTimeBefore5min_shouldSyncOneExecutions() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution1 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.SUCCEEDED, OffsetDateTime.now().minusMinutes(5));
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.SUCCEEDED, OffsetDateTime.now().minusMinutes(5));
-      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution3 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
-      com.vmware.taurus.service.model.DataJobExecution expectedJobExecution4 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.RUNNING, OffsetDateTime.now().minusMinutes(5));
+    com.vmware.taurus.service.model.DataJobExecution expectedJobExecution1 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-1",
+            actualDataJob,
+            ExecutionStatus.SUCCEEDED,
+            OffsetDateTime.now().minusMinutes(5));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-2",
+        actualDataJob,
+        ExecutionStatus.SUCCEEDED,
+        OffsetDateTime.now().minusMinutes(5));
+    com.vmware.taurus.service.model.DataJobExecution expectedJobExecution3 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-3",
+            actualDataJob,
+            ExecutionStatus.RUNNING,
+            OffsetDateTime.now().minusMinutes(5));
+    com.vmware.taurus.service.model.DataJobExecution expectedJobExecution4 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-4",
+            actualDataJob,
+            ExecutionStatus.RUNNING,
+            OffsetDateTime.now().minusMinutes(5));
 
-      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsBeforeSync = findRunningDataJobExecutions(actualDataJob.getName());
+    List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsBeforeSync =
+        findRunningDataJobExecutions(actualDataJob.getName());
 
-      Assert.assertEquals(2, dataJobExecutionsBeforeSync.size());
-      Assert.assertEquals(expectedJobExecution3.getId(), dataJobExecutionsBeforeSync.get(0).getId());
-      Assert.assertEquals(expectedJobExecution4.getId(), dataJobExecutionsBeforeSync.get(1).getId());
+    Assert.assertEquals(2, dataJobExecutionsBeforeSync.size());
+    Assert.assertEquals(expectedJobExecution3.getId(), dataJobExecutionsBeforeSync.get(0).getId());
+    Assert.assertEquals(expectedJobExecution4.getId(), dataJobExecutionsBeforeSync.get(1).getId());
 
-      jobExecutionService.syncJobExecutionStatuses(List.of(expectedJobExecution1.getId(), expectedJobExecution3.getId()));
-      List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsAfterSync = findRunningDataJobExecutions(actualDataJob.getName());
+    jobExecutionService.syncJobExecutionStatuses(
+        List.of(expectedJobExecution1.getId(), expectedJobExecution3.getId()));
+    List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsAfterSync =
+        findRunningDataJobExecutions(actualDataJob.getName());
 
-      Assert.assertEquals(1, dataJobExecutionsAfterSync.size());
-      Assert.assertEquals(expectedJobExecution3.getId(), dataJobExecutionsAfterSync.get(0).getId());
+    Assert.assertEquals(1, dataJobExecutionsAfterSync.size());
+    Assert.assertEquals(expectedJobExecution3.getId(), dataJobExecutionsAfterSync.get(0).getId());
 
-      DataJobExecution actualFinishedExecution = jobExecutionRepository.findById(expectedJobExecution4.getId()).get();
-      Assert.assertEquals("Status is set by VDK Control Service", actualFinishedExecution.getMessage());
-      Assert.assertNotNull(actualFinishedExecution.getEndTime());
-   }
+    DataJobExecution actualFinishedExecution =
+        jobExecutionRepository.findById(expectedJobExecution4.getId()).get();
+    Assert.assertEquals(
+        "Status is set by VDK Control Service", actualFinishedExecution.getMessage());
+    Assert.assertNotNull(actualFinishedExecution.getEndTime());
+  }
 
-   private List<com.vmware.taurus.service.model.DataJobExecution> findRunningDataJobExecutions(String dataJobName) {
-      return jobExecutionRepository.findDataJobExecutionsByDataJobNameAndStatusIn(dataJobName, List.of(ExecutionStatus.SUBMITTED, ExecutionStatus.RUNNING));
-   }
+  private List<com.vmware.taurus.service.model.DataJobExecution> findRunningDataJobExecutions(
+      String dataJobName) {
+    return jobExecutionRepository.findDataJobExecutionsByDataJobNameAndStatusIn(
+        dataJobName, List.of(ExecutionStatus.SUBMITTED, ExecutionStatus.RUNNING));
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceUpdateExecutionIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceUpdateExecutionIT.java
@@ -33,124 +33,119 @@ import com.vmware.taurus.service.model.ExecutionResult;
 @SpringBootTest(classes = ControlplaneApplication.class)
 public class JobExecutionServiceUpdateExecutionIT {
 
-   @Autowired
-   private JobsRepository jobsRepository;
+  @Autowired private JobsRepository jobsRepository;
 
-   @Autowired
-   private JobExecutionService jobExecutionService;
+  @Autowired private JobExecutionService jobExecutionService;
 
-   @Autowired
-   private JobExecutionRepository jobExecutionRepository;
+  @Autowired private JobExecutionRepository jobExecutionRepository;
 
-   @AfterEach
-   public void cleanUp() {
-      jobsRepository.deleteAll();
-   }
+  @AfterEach
+  public void cleanUp() {
+    jobsRepository.deleteAll();
+  }
 
-   @Test
-   public void testUpdateJobExecution_statusFinishedAndTerminationMessageUserError_shouldRecordExecutionStatusFailed() {
-      String actualTerminationStatus = ExecutionStatus.USER_ERROR.getPodStatus();
-      String actualVdkVersion = "1.2.3";
-      String actualTerminationMessage = getTerminationMessageJson(actualTerminationStatus, actualVdkVersion);
-      Boolean actualExecutionSucceeded = true;
-      DataJobExecution.StatusEnum expectedJobExecutionStatus = DataJobExecution.StatusEnum.USER_ERROR;
+  @Test
+  public void
+      testUpdateJobExecution_statusFinishedAndTerminationMessageUserError_shouldRecordExecutionStatusFailed() {
+    String actualTerminationStatus = ExecutionStatus.USER_ERROR.getPodStatus();
+    String actualVdkVersion = "1.2.3";
+    String actualTerminationMessage =
+        getTerminationMessageJson(actualTerminationStatus, actualVdkVersion);
+    Boolean actualExecutionSucceeded = true;
+    DataJobExecution.StatusEnum expectedJobExecutionStatus = DataJobExecution.StatusEnum.USER_ERROR;
 
-      // Termination message as Json
-      testUpdateJobExecution(
-            actualExecutionSucceeded,
-            actualTerminationMessage,
-            expectedJobExecutionStatus,
-            actualTerminationStatus,
-            actualVdkVersion);
+    // Termination message as Json
+    testUpdateJobExecution(
+        actualExecutionSucceeded,
+        actualTerminationMessage,
+        expectedJobExecutionStatus,
+        actualTerminationStatus,
+        actualVdkVersion);
 
-      // Termination message as String
-      testUpdateJobExecution(
-            actualExecutionSucceeded,
-            actualTerminationStatus,
-            expectedJobExecutionStatus,
-            null,
-            "");
-   }
+    // Termination message as String
+    testUpdateJobExecution(
+        actualExecutionSucceeded, actualTerminationStatus, expectedJobExecutionStatus, null, "");
+  }
 
-   @Test
-   public void testUpdateJobExecution_statusFinishedAndTerminationMessagePlatformError_shouldRecordExecutionStatusFailed() {
-      String actualTerminationStatus = ExecutionStatus.PLATFORM_ERROR.getPodStatus();
-      String actualVdkVersion = "1.2.3";
-      String actualTerminationMessage = getTerminationMessageJson(actualTerminationStatus, actualVdkVersion);
-      Boolean actualExecutionSucceeded = true;
-      DataJobExecution.StatusEnum expectedJobExecutionStatus = DataJobExecution.StatusEnum.PLATFORM_ERROR;
+  @Test
+  public void
+      testUpdateJobExecution_statusFinishedAndTerminationMessagePlatformError_shouldRecordExecutionStatusFailed() {
+    String actualTerminationStatus = ExecutionStatus.PLATFORM_ERROR.getPodStatus();
+    String actualVdkVersion = "1.2.3";
+    String actualTerminationMessage =
+        getTerminationMessageJson(actualTerminationStatus, actualVdkVersion);
+    Boolean actualExecutionSucceeded = true;
+    DataJobExecution.StatusEnum expectedJobExecutionStatus =
+        DataJobExecution.StatusEnum.PLATFORM_ERROR;
 
-      // Termination message as Json
-      testUpdateJobExecution(
-            actualExecutionSucceeded,
-            actualTerminationMessage,
-            expectedJobExecutionStatus,
-            actualTerminationStatus,
-            actualVdkVersion);
+    // Termination message as Json
+    testUpdateJobExecution(
+        actualExecutionSucceeded,
+        actualTerminationMessage,
+        expectedJobExecutionStatus,
+        actualTerminationStatus,
+        actualVdkVersion);
 
-      // Termination message as String
-      testUpdateJobExecution(
-            actualExecutionSucceeded,
-            actualTerminationStatus,
-            expectedJobExecutionStatus,
-            null,
-            "");
-   }
+    // Termination message as String
+    testUpdateJobExecution(
+        actualExecutionSucceeded, actualTerminationStatus, expectedJobExecutionStatus, null, "");
+  }
 
-   @Test
-   public void testUpdateJobExecution_statusFinishedAndTerminationMessageSkipped_shouldRecordExecutionStatusSkipped() {
-      String actualTerminationStatus = ExecutionStatus.SKIPPED.getPodStatus();
-      String actualVdkVersion = "1.2.3";
-      String actualTerminationMessage = getTerminationMessageJson(actualTerminationStatus, actualVdkVersion);
-      Boolean actualExecutionSucceeded = true;
-      DataJobExecution.StatusEnum expectedJobExecutionStatus = DataJobExecution.StatusEnum.SKIPPED;
+  @Test
+  public void
+      testUpdateJobExecution_statusFinishedAndTerminationMessageSkipped_shouldRecordExecutionStatusSkipped() {
+    String actualTerminationStatus = ExecutionStatus.SKIPPED.getPodStatus();
+    String actualVdkVersion = "1.2.3";
+    String actualTerminationMessage =
+        getTerminationMessageJson(actualTerminationStatus, actualVdkVersion);
+    Boolean actualExecutionSucceeded = true;
+    DataJobExecution.StatusEnum expectedJobExecutionStatus = DataJobExecution.StatusEnum.SKIPPED;
 
-      // Termination message as Json
-      testUpdateJobExecution(
-            actualExecutionSucceeded,
-            actualTerminationMessage,
-            expectedJobExecutionStatus,
-            "Skipping job execution due to another parallel running execution.",
-            actualVdkVersion);
+    // Termination message as Json
+    testUpdateJobExecution(
+        actualExecutionSucceeded,
+        actualTerminationMessage,
+        expectedJobExecutionStatus,
+        "Skipping job execution due to another parallel running execution.",
+        actualVdkVersion);
 
-      // Termination message as String
-      testUpdateJobExecution(
-            actualExecutionSucceeded,
-            actualTerminationStatus,
-            expectedJobExecutionStatus,
-            "Skipping job execution due to another parallel running execution.",
-            "");
-   }
+    // Termination message as String
+    testUpdateJobExecution(
+        actualExecutionSucceeded,
+        actualTerminationStatus,
+        expectedJobExecutionStatus,
+        "Skipping job execution due to another parallel running execution.",
+        "");
+  }
 
-   @Test
-   public void testUpdateJobExecution_statusFinishedAndTerminationMessageSuccess_shouldRecordExecutionStatusFinish() {
-      String actualTerminationStatus = ExecutionStatus.SUCCEEDED.getPodStatus();
-      String actualVdkVersion = "1.2.3";
-      String actualTerminationMessage = getTerminationMessageJson(actualTerminationStatus, actualVdkVersion);
-      Boolean actualExecutionSucceeded = true;
-      DataJobExecution.StatusEnum expectedJobExecutionStatus = DataJobExecution.StatusEnum.SUCCEEDED;
+  @Test
+  public void
+      testUpdateJobExecution_statusFinishedAndTerminationMessageSuccess_shouldRecordExecutionStatusFinish() {
+    String actualTerminationStatus = ExecutionStatus.SUCCEEDED.getPodStatus();
+    String actualVdkVersion = "1.2.3";
+    String actualTerminationMessage =
+        getTerminationMessageJson(actualTerminationStatus, actualVdkVersion);
+    Boolean actualExecutionSucceeded = true;
+    DataJobExecution.StatusEnum expectedJobExecutionStatus = DataJobExecution.StatusEnum.SUCCEEDED;
 
-      // Termination message as Json
-      testUpdateJobExecution(
-            actualExecutionSucceeded,
-            actualTerminationMessage,
-            expectedJobExecutionStatus,
-            actualTerminationStatus,
-            actualVdkVersion);
+    // Termination message as Json
+    testUpdateJobExecution(
+        actualExecutionSucceeded,
+        actualTerminationMessage,
+        expectedJobExecutionStatus,
+        actualTerminationStatus,
+        actualVdkVersion);
 
-      // Termination message as String
-      testUpdateJobExecution(
-            actualExecutionSucceeded,
-            actualTerminationStatus,
-            expectedJobExecutionStatus,
-            null,
-            "");
-   }
+    // Termination message as String
+    testUpdateJobExecution(
+        actualExecutionSucceeded, actualTerminationStatus, expectedJobExecutionStatus, null, "");
+  }
 
-   @Test
-   void testSetOomError_fromUserError_shouldHaveExecutionOomError() {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
-      KubernetesService.JobExecution expectedJobExecution = createJobExecution(
+  @Test
+  void testSetOomError_fromUserError_shouldHaveExecutionOomError() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    KubernetesService.JobExecution expectedJobExecution =
+        createJobExecution(
             actualDataJob,
             false,
             null,
@@ -158,20 +153,24 @@ public class JobExecutionServiceUpdateExecutionIT {
             OffsetDateTime.now(),
             JobExecutionResultManager.TERMINATION_REASON_OUT_OF_MEMORY);
 
-      DataJobExecution actualJobExecution = jobExecutionService.readJobExecution(
+    DataJobExecution actualJobExecution =
+        jobExecutionService.readJobExecution(
             actualDataJob.getJobConfig().getTeam(),
             actualDataJob.getName(),
             expectedJobExecution.getExecutionId());
 
-      Assert.assertNotNull(actualJobExecution.getStartTime());
-      Assert.assertEquals(DataJobExecution.StatusEnum.USER_ERROR, actualJobExecution.getStatus());
-      Assert.assertEquals("Out of memory error on the K8S pod. Please optimize your data job.", actualJobExecution.getMessage());
-   }
+    Assert.assertNotNull(actualJobExecution.getStartTime());
+    Assert.assertEquals(DataJobExecution.StatusEnum.USER_ERROR, actualJobExecution.getStatus());
+    Assert.assertEquals(
+        "Out of memory error on the K8S pod. Please optimize your data job.",
+        actualJobExecution.getMessage());
+  }
 
-   @Test
-   void testSetOomError_fromUserError_shouldNotHaveExecutionOomError() {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
-      KubernetesService.JobExecution expectedJobExecution = createJobExecution(
+  @Test
+  void testSetOomError_fromUserError_shouldNotHaveExecutionOomError() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    KubernetesService.JobExecution expectedJobExecution =
+        createJobExecution(
             actualDataJob,
             false,
             "User error",
@@ -179,46 +178,47 @@ public class JobExecutionServiceUpdateExecutionIT {
             OffsetDateTime.now(),
             "Not OOM user error.");
 
-      DataJobExecution actualJobExecution = jobExecutionService.readJobExecution(
+    DataJobExecution actualJobExecution =
+        jobExecutionService.readJobExecution(
             actualDataJob.getJobConfig().getTeam(),
             actualDataJob.getName(),
             expectedJobExecution.getExecutionId());
 
-      Assert.assertNotNull(actualJobExecution.getStartTime());
-      Assert.assertEquals(DataJobExecution.StatusEnum.USER_ERROR, actualJobExecution.getStatus());
-      Assert.assertEquals("User error", actualJobExecution.getMessage());
-   }
+    Assert.assertNotNull(actualJobExecution.getStartTime());
+    Assert.assertEquals(DataJobExecution.StatusEnum.USER_ERROR, actualJobExecution.getStatus());
+    Assert.assertEquals("User error", actualJobExecution.getMessage());
+  }
 
-   @Test
-   void testUpdateJobExecution_withoutStartTime_shouldRecordExecutionStartTimeNow() {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
-      KubernetesService.JobExecution expectedJobExecution = createJobExecution(
-            actualDataJob,
-            null,
-            null,
-            null,
-            null,
-            null);
-      DataJobExecution actualJobExecution = jobExecutionService.readJobExecution(
+  @Test
+  void testUpdateJobExecution_withoutStartTime_shouldRecordExecutionStartTimeNow() {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    KubernetesService.JobExecution expectedJobExecution =
+        createJobExecution(actualDataJob, null, null, null, null, null);
+    DataJobExecution actualJobExecution =
+        jobExecutionService.readJobExecution(
             actualDataJob.getJobConfig().getTeam(),
             actualDataJob.getName(),
             expectedJobExecution.getExecutionId());
 
-      Assert.assertNotNull(actualJobExecution.getStartTime());
-      // Start time should be close to the current time (within 10 seconds) because it is set to the current time when null
-      Assert.assertTrue(Duration.between(OffsetDateTime.now(), actualJobExecution.getStartTime()).toMillis() < 10000);
-      Assert.assertEquals(DataJobExecution.StatusEnum.SUBMITTED, actualJobExecution.getStatus());
-   }
+    Assert.assertNotNull(actualJobExecution.getStartTime());
+    // Start time should be close to the current time (within 10 seconds) because it is set to the
+    // current time when null
+    Assert.assertTrue(
+        Duration.between(OffsetDateTime.now(), actualJobExecution.getStartTime()).toMillis()
+            < 10000);
+    Assert.assertEquals(DataJobExecution.StatusEnum.SUBMITTED, actualJobExecution.getStatus());
+  }
 
-   private KubernetesService.JobExecution createJobExecution(
-         DataJob dataJob,
-         Boolean succeeded,
-         String terminationMessage,
-         OffsetDateTime startTime,
-         OffsetDateTime endTime,
-         String containerTerminationMessage) {
+  private KubernetesService.JobExecution createJobExecution(
+      DataJob dataJob,
+      Boolean succeeded,
+      String terminationMessage,
+      OffsetDateTime startTime,
+      OffsetDateTime endTime,
+      String containerTerminationMessage) {
 
-      KubernetesService.JobExecution jobExecution = KubernetesService.JobExecution.builder()
+    KubernetesService.JobExecution jobExecution =
+        KubernetesService.JobExecution.builder()
             .succeeded(succeeded)
             .opId("test_op_id")
             .executionId("test_execution_id_" + new Random().nextInt())
@@ -237,149 +237,184 @@ public class JobExecutionServiceUpdateExecutionIT {
             .podTerminationMessage(terminationMessage)
             .containerTerminationReason(containerTerminationMessage)
             .build();
-      ExecutionResult executionResult = JobExecutionResultManager.getResult(jobExecution);
-      jobExecutionService.updateJobExecution(dataJob, jobExecution, executionResult);
+    ExecutionResult executionResult = JobExecutionResultManager.getResult(jobExecution);
+    jobExecutionService.updateJobExecution(dataJob, jobExecution, executionResult);
 
-      return jobExecution;
-   }
+    return jobExecution;
+  }
 
-   private void testUpdateJobExecution(
-         Boolean actualExecutionSucceeded,
-         String actualTerminationMessage,
-         DataJobExecution.StatusEnum expectedJobExecutionStatus,
-         String expectedJobExecutionMessage,
-         String expectedVdkVersion) {
+  private void testUpdateJobExecution(
+      Boolean actualExecutionSucceeded,
+      String actualTerminationMessage,
+      DataJobExecution.StatusEnum expectedJobExecutionStatus,
+      String expectedJobExecutionMessage,
+      String expectedVdkVersion) {
 
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
-      KubernetesService.JobExecution expectedJobExecution = createJobExecution(
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    KubernetesService.JobExecution expectedJobExecution =
+        createJobExecution(
             actualDataJob,
             actualExecutionSucceeded,
             actualTerminationMessage,
             OffsetDateTime.now(),
             OffsetDateTime.now(),
             "");
-      DataJobExecution actualJobExecution = jobExecutionService.readJobExecution(
+    DataJobExecution actualJobExecution =
+        jobExecutionService.readJobExecution(
             actualDataJob.getJobConfig().getTeam(),
             actualDataJob.getName(),
             expectedJobExecution.getExecutionId());
 
-      assertDataJobExecutionValid(
-            expectedJobExecution,
-            expectedJobExecutionStatus,
-            expectedJobExecutionMessage != null ?
-                  expectedJobExecutionMessage :
-                  expectedJobExecution.getPodTerminationMessage(),
-            actualJobExecution,
-            expectedVdkVersion);
-   }
+    assertDataJobExecutionValid(
+        expectedJobExecution,
+        expectedJobExecutionStatus,
+        expectedJobExecutionMessage != null
+            ? expectedJobExecutionMessage
+            : expectedJobExecution.getPodTerminationMessage(),
+        actualJobExecution,
+        expectedVdkVersion);
+  }
 
-   private void assertDataJobExecutionValid(
-         KubernetesService.JobExecution expectedJobExecution,
-         DataJobExecution.StatusEnum expectedJobStatus,
-         String expectedMessage,
-         DataJobExecution actualJobExecution,
-         String expectedVdkVersion) {
+  private void assertDataJobExecutionValid(
+      KubernetesService.JobExecution expectedJobExecution,
+      DataJobExecution.StatusEnum expectedJobStatus,
+      String expectedMessage,
+      DataJobExecution actualJobExecution,
+      String expectedVdkVersion) {
 
-      Assert.assertEquals(expectedJobExecution.getExecutionId(), actualJobExecution.getId());
-      Assert.assertEquals(expectedJobExecution.getExecutionType(), actualJobExecution.getType().toString());
-      Assert.assertEquals(expectedJobExecution.getJobName(), actualJobExecution.getJobName());
-      Assert.assertEquals(expectedJobExecution.getJobVersion(), actualJobExecution.getDeployment().getJobVersion());
-      Assert.assertEquals(expectedMessage, actualJobExecution.getMessage());
-      Assert.assertEquals(expectedJobStatus, actualJobExecution.getStatus());
-      Assert.assertEquals(expectedJobExecution.getOpId(), actualJobExecution.getOpId());
-      Assert.assertEquals(expectedJobExecution.getStartTime(), actualJobExecution.getStartTime());
-      Assert.assertEquals(expectedJobExecution.getEndTime(), actualJobExecution.getEndTime());
-      Assert.assertEquals(expectedJobExecution.getJobSchedule(), actualJobExecution.getDeployment().getSchedule().getScheduleCron());
-      Assert.assertEquals(expectedJobExecution.getResourcesCpuLimit(), actualJobExecution.getDeployment().getResources().getCpuLimit());
-      Assert.assertEquals(expectedJobExecution.getResourcesCpuRequest(), actualJobExecution.getDeployment().getResources().getCpuRequest());
-      Assert.assertEquals(expectedJobExecution.getResourcesMemoryLimit(), actualJobExecution.getDeployment().getResources().getMemoryLimit());
-      Assert.assertEquals(expectedJobExecution.getResourcesMemoryRequest(), actualJobExecution.getDeployment().getResources().getMemoryRequest());
-      Assert.assertEquals(expectedJobExecution.getDeployedDate(), actualJobExecution.getDeployment().getDeployedDate());
-      Assert.assertEquals(expectedJobExecution.getDeployedBy(), actualJobExecution.getDeployment().getDeployedBy());
-      Assert.assertEquals(expectedVdkVersion, actualJobExecution.getDeployment().getVdkVersion());
-   }
+    Assert.assertEquals(expectedJobExecution.getExecutionId(), actualJobExecution.getId());
+    Assert.assertEquals(
+        expectedJobExecution.getExecutionType(), actualJobExecution.getType().toString());
+    Assert.assertEquals(expectedJobExecution.getJobName(), actualJobExecution.getJobName());
+    Assert.assertEquals(
+        expectedJobExecution.getJobVersion(), actualJobExecution.getDeployment().getJobVersion());
+    Assert.assertEquals(expectedMessage, actualJobExecution.getMessage());
+    Assert.assertEquals(expectedJobStatus, actualJobExecution.getStatus());
+    Assert.assertEquals(expectedJobExecution.getOpId(), actualJobExecution.getOpId());
+    Assert.assertEquals(expectedJobExecution.getStartTime(), actualJobExecution.getStartTime());
+    Assert.assertEquals(expectedJobExecution.getEndTime(), actualJobExecution.getEndTime());
+    Assert.assertEquals(
+        expectedJobExecution.getJobSchedule(),
+        actualJobExecution.getDeployment().getSchedule().getScheduleCron());
+    Assert.assertEquals(
+        expectedJobExecution.getResourcesCpuLimit(),
+        actualJobExecution.getDeployment().getResources().getCpuLimit());
+    Assert.assertEquals(
+        expectedJobExecution.getResourcesCpuRequest(),
+        actualJobExecution.getDeployment().getResources().getCpuRequest());
+    Assert.assertEquals(
+        expectedJobExecution.getResourcesMemoryLimit(),
+        actualJobExecution.getDeployment().getResources().getMemoryLimit());
+    Assert.assertEquals(
+        expectedJobExecution.getResourcesMemoryRequest(),
+        actualJobExecution.getDeployment().getResources().getMemoryRequest());
+    Assert.assertEquals(
+        expectedJobExecution.getDeployedDate(),
+        actualJobExecution.getDeployment().getDeployedDate());
+    Assert.assertEquals(
+        expectedJobExecution.getDeployedBy(), actualJobExecution.getDeployment().getDeployedBy());
+    Assert.assertEquals(expectedVdkVersion, actualJobExecution.getDeployment().getVdkVersion());
+  }
 
-   @Test
-   public void testUpdateJobExecution_DbStatusSubmittedAndUpdateStatusRunning_UpdateExpected() {
-      //control test which makes sure the status gets updated if in submitted
-      testUpdateJobExecutionWithPreviousStatusInDatabase(ExecutionStatus.SUBMITTED, null, ExecutionStatus.RUNNING);
-   }
+  @Test
+  public void testUpdateJobExecution_DbStatusSubmittedAndUpdateStatusRunning_UpdateExpected() {
+    // control test which makes sure the status gets updated if in submitted
+    testUpdateJobExecutionWithPreviousStatusInDatabase(
+        ExecutionStatus.SUBMITTED, null, ExecutionStatus.RUNNING);
+  }
 
-   @Test
-   public void testUpdateJobExecution_DbStatusRunningAndUpdateStatusFinished_UpdateExpected() {
-      //control test which makes sure the status gets updated if in running
-      testUpdateJobExecutionWithPreviousStatusInDatabase(ExecutionStatus.RUNNING, true, ExecutionStatus.SUCCEEDED);
-   }
+  @Test
+  public void testUpdateJobExecution_DbStatusRunningAndUpdateStatusFinished_UpdateExpected() {
+    // control test which makes sure the status gets updated if in running
+    testUpdateJobExecutionWithPreviousStatusInDatabase(
+        ExecutionStatus.RUNNING, true, ExecutionStatus.SUCCEEDED);
+  }
 
-   @Test
-   public void testUpdateJobExecution_DbStatusSucceededAndUpdateStatusRunning_NoUpdateExpected() {
-      //test which makes sure the status doesn't get updated if in finished
-      testUpdateJobExecutionWithPreviousStatusInDatabase(ExecutionStatus.SUCCEEDED, null, ExecutionStatus.SUCCEEDED);
-   }
+  @Test
+  public void testUpdateJobExecution_DbStatusSucceededAndUpdateStatusRunning_NoUpdateExpected() {
+    // test which makes sure the status doesn't get updated if in finished
+    testUpdateJobExecutionWithPreviousStatusInDatabase(
+        ExecutionStatus.SUCCEEDED, null, ExecutionStatus.SUCCEEDED);
+  }
 
-   @Test
-   public void testUpdateJobExecution_DbStatusCancelledAndUpdateStatusRunning_NoUpdateExpected() {
-      //test which makes sure the status doesn't get updated if in cancelled
-      testUpdateJobExecutionWithPreviousStatusInDatabase(ExecutionStatus.CANCELLED, null, ExecutionStatus.CANCELLED);
-   }
+  @Test
+  public void testUpdateJobExecution_DbStatusCancelledAndUpdateStatusRunning_NoUpdateExpected() {
+    // test which makes sure the status doesn't get updated if in cancelled
+    testUpdateJobExecutionWithPreviousStatusInDatabase(
+        ExecutionStatus.CANCELLED, null, ExecutionStatus.CANCELLED);
+  }
 
-   @Test
-   public void testUpdateJobExecution_DbStatusSkippedAndUpdateStatusRunning_NoUpdateExpected() {
-      //test which makes sure the status doesn't get updated if in skipped
-      testUpdateJobExecutionWithPreviousStatusInDatabase(ExecutionStatus.SKIPPED, null, ExecutionStatus.SKIPPED);
-   }
+  @Test
+  public void testUpdateJobExecution_DbStatusSkippedAndUpdateStatusRunning_NoUpdateExpected() {
+    // test which makes sure the status doesn't get updated if in skipped
+    testUpdateJobExecutionWithPreviousStatusInDatabase(
+        ExecutionStatus.SKIPPED, null, ExecutionStatus.SKIPPED);
+  }
 
-   @Test
-   public void testUpdateJobExecution_DbStatusPlatformErrorAndUpdateStatusRunning_NoUpdateExpected() {
-      //test which checks that status gets updated if in PLATFORM_ERROR. Retries on errors are common and status could change.
-      testUpdateJobExecutionWithPreviousStatusInDatabase(ExecutionStatus.PLATFORM_ERROR, null, ExecutionStatus.RUNNING);
-   }
+  @Test
+  public void
+      testUpdateJobExecution_DbStatusPlatformErrorAndUpdateStatusRunning_NoUpdateExpected() {
+    // test which checks that status gets updated if in PLATFORM_ERROR. Retries on errors are common
+    // and status could change.
+    testUpdateJobExecutionWithPreviousStatusInDatabase(
+        ExecutionStatus.PLATFORM_ERROR, null, ExecutionStatus.RUNNING);
+  }
 
-   /**
-    * Helper method which tests if a data job execution status changes through the updateJobExecutionMethod when
-    * a data job already has an execution status written to the database. Writes a status to a data job
-    * execution and then attempts to update it with the provided status. Checks if status matches the expectedStatus
-    * param.
-    *
-    * @param statusPresentInDb the "previous" execution status
-    * @param attemptedStatusChange the attempted change execution status
-    * @param expectedStatus the expected execution status
-    */
-   private void testUpdateJobExecutionWithPreviousStatusInDatabase(ExecutionStatus statusPresentInDb,
-                                                                   Boolean attemptedStatusChange,
-                                                                   ExecutionStatus expectedStatus) {
-      var actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
-      var execution = RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-id", actualDataJob, statusPresentInDb);
+  /**
+   * Helper method which tests if a data job execution status changes through the
+   * updateJobExecutionMethod when a data job already has an execution status written to the
+   * database. Writes a status to a data job execution and then attempts to update it with the
+   * provided status. Checks if status matches the expectedStatus param.
+   *
+   * @param statusPresentInDb the "previous" execution status
+   * @param attemptedStatusChange the attempted change execution status
+   * @param expectedStatus the expected execution status
+   */
+  private void testUpdateJobExecutionWithPreviousStatusInDatabase(
+      ExecutionStatus statusPresentInDb,
+      Boolean attemptedStatusChange,
+      ExecutionStatus expectedStatus) {
+    var actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    var execution =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository, "test-id", actualDataJob, statusPresentInDb);
 
-      KubernetesService.JobExecution attemptedExecutionUpdate = KubernetesService.JobExecution.builder()
-              .succeeded(attemptedStatusChange)
-              .opId(execution.getOpId())
-              .executionId(execution.getId())
-              .executionType("manual")
-              .jobName(actualDataJob.getName())
-              .jobVersion("test_job_version")
-              .jobSchedule("test_job_schedule")
-              .startTime(OffsetDateTime.now())
-              .endTime(OffsetDateTime.now())
-              .resourcesCpuLimit(1f)
-              .resourcesCpuRequest(1f)
-              .resourcesMemoryLimit(1)
-              .resourcesMemoryRequest(1)
-              .deployedBy("test_deployed_by")
-              .deployedDate(OffsetDateTime.now())
-              .podTerminationMessage(expectedStatus.getPodStatus()).build();
-      ExecutionResult executionResult = JobExecutionResultManager.getResult(attemptedExecutionUpdate);
-      jobExecutionService.updateJobExecution(actualDataJob, attemptedExecutionUpdate, executionResult);
-      var actualJobExecution = jobExecutionRepository.findById(attemptedExecutionUpdate.getExecutionId()).get();
+    KubernetesService.JobExecution attemptedExecutionUpdate =
+        KubernetesService.JobExecution.builder()
+            .succeeded(attemptedStatusChange)
+            .opId(execution.getOpId())
+            .executionId(execution.getId())
+            .executionType("manual")
+            .jobName(actualDataJob.getName())
+            .jobVersion("test_job_version")
+            .jobSchedule("test_job_schedule")
+            .startTime(OffsetDateTime.now())
+            .endTime(OffsetDateTime.now())
+            .resourcesCpuLimit(1f)
+            .resourcesCpuRequest(1f)
+            .resourcesMemoryLimit(1)
+            .resourcesMemoryRequest(1)
+            .deployedBy("test_deployed_by")
+            .deployedDate(OffsetDateTime.now())
+            .podTerminationMessage(expectedStatus.getPodStatus())
+            .build();
+    ExecutionResult executionResult = JobExecutionResultManager.getResult(attemptedExecutionUpdate);
+    jobExecutionService.updateJobExecution(
+        actualDataJob, attemptedExecutionUpdate, executionResult);
+    var actualJobExecution =
+        jobExecutionRepository.findById(attemptedExecutionUpdate.getExecutionId()).get();
 
-      Assertions.assertEquals(expectedStatus, actualJobExecution.getStatus());
-   }
+    Assertions.assertEquals(expectedStatus, actualJobExecution.getStatus());
+  }
 
-   private static String getTerminationMessageJson(String actualTerminationStatus, String vdkVersion) {
-      JsonObject actualTerminationMessageJson = new JsonObject();
-      actualTerminationMessageJson.addProperty(JobExecutionResultManager.TERMINATION_MESSAGE_ATTRIBUTE_STATUS, actualTerminationStatus);
-      actualTerminationMessageJson.addProperty(JobExecutionResultManager.TERMINATION_MESSAGE_ATTRIBUTE_VDK_VERSION, vdkVersion);
+  private static String getTerminationMessageJson(
+      String actualTerminationStatus, String vdkVersion) {
+    JsonObject actualTerminationMessageJson = new JsonObject();
+    actualTerminationMessageJson.addProperty(
+        JobExecutionResultManager.TERMINATION_MESSAGE_ATTRIBUTE_STATUS, actualTerminationStatus);
+    actualTerminationMessageJson.addProperty(
+        JobExecutionResultManager.TERMINATION_MESSAGE_ATTRIBUTE_VDK_VERSION, vdkVersion);
 
-      return actualTerminationMessageJson.toString();
-   }
+    return actualTerminationMessageJson.toString();
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceUtil.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceUtil.java
@@ -15,36 +15,60 @@ import java.util.List;
 
 public class JobExecutionServiceUtil {
 
-   public static void assertDataJobExecutionListValid(com.vmware.taurus.service.model.DataJobExecution expectedDataJobExecution, List<DataJobExecution> actualDataJobExecutions) {
-      Assertions.assertNotNull(actualDataJobExecutions);
-      Assertions.assertFalse(actualDataJobExecutions.isEmpty());
+  public static void assertDataJobExecutionListValid(
+      com.vmware.taurus.service.model.DataJobExecution expectedDataJobExecution,
+      List<DataJobExecution> actualDataJobExecutions) {
+    Assertions.assertNotNull(actualDataJobExecutions);
+    Assertions.assertFalse(actualDataJobExecutions.isEmpty());
 
-      DataJobExecution actualDataJobExecution = actualDataJobExecutions.get(0);
-      assertDataJobExecutionValid(expectedDataJobExecution, actualDataJobExecution);
-   }
+    DataJobExecution actualDataJobExecution = actualDataJobExecutions.get(0);
+    assertDataJobExecutionValid(expectedDataJobExecution, actualDataJobExecution);
+  }
 
-   public static void assertDataJobExecutionValid(com.vmware.taurus.service.model.DataJobExecution expectedDataJobExecution, DataJobExecution actualDataJobExecution) {
-      Assertions.assertEquals(expectedDataJobExecution.getId(), actualDataJobExecution.getId());
-      Assertions.assertEquals(expectedDataJobExecution.getDataJob().getName(), actualDataJobExecution.getJobName());
-      Assertions.assertEquals(ToApiModelConverter.convertTypeEnum(expectedDataJobExecution.getType()), actualDataJobExecution.getType());
-      Assertions.assertEquals(ToApiModelConverter.convertStatusEnum(expectedDataJobExecution.getStatus()), actualDataJobExecution.getStatus());
-      Assertions.assertEquals(expectedDataJobExecution.getOpId(), actualDataJobExecution.getOpId());
-      Assertions.assertEquals(expectedDataJobExecution.getMessage(), actualDataJobExecution.getMessage());
-      Assertions.assertEquals(expectedDataJobExecution.getStartedBy(), actualDataJobExecution.getStartedBy());
-      Assertions.assertEquals(expectedDataJobExecution.getStartTime(), actualDataJobExecution.getStartTime());
-      Assertions.assertEquals(expectedDataJobExecution.getEndTime(), actualDataJobExecution.getEndTime());
+  public static void assertDataJobExecutionValid(
+      com.vmware.taurus.service.model.DataJobExecution expectedDataJobExecution,
+      DataJobExecution actualDataJobExecution) {
+    Assertions.assertEquals(expectedDataJobExecution.getId(), actualDataJobExecution.getId());
+    Assertions.assertEquals(
+        expectedDataJobExecution.getDataJob().getName(), actualDataJobExecution.getJobName());
+    Assertions.assertEquals(
+        ToApiModelConverter.convertTypeEnum(expectedDataJobExecution.getType()),
+        actualDataJobExecution.getType());
+    Assertions.assertEquals(
+        ToApiModelConverter.convertStatusEnum(expectedDataJobExecution.getStatus()),
+        actualDataJobExecution.getStatus());
+    Assertions.assertEquals(expectedDataJobExecution.getOpId(), actualDataJobExecution.getOpId());
+    Assertions.assertEquals(
+        expectedDataJobExecution.getMessage(), actualDataJobExecution.getMessage());
+    Assertions.assertEquals(
+        expectedDataJobExecution.getStartedBy(), actualDataJobExecution.getStartedBy());
+    Assertions.assertEquals(
+        expectedDataJobExecution.getStartTime(), actualDataJobExecution.getStartTime());
+    Assertions.assertEquals(
+        expectedDataJobExecution.getEndTime(), actualDataJobExecution.getEndTime());
 
-      DataJobDeployment actualDeployment = actualDataJobExecution.getDeployment();
-      Assertions.assertNotNull(actualDeployment);
-      Assertions.assertEquals(expectedDataJobExecution.getJobSchedule(), actualDeployment.getSchedule().getScheduleCron());
-      Assertions.assertEquals(expectedDataJobExecution.getVdkVersion(), actualDeployment.getVdkVersion());
-      Assertions.assertEquals(expectedDataJobExecution.getJobVersion(), actualDeployment.getJobVersion());
+    DataJobDeployment actualDeployment = actualDataJobExecution.getDeployment();
+    Assertions.assertNotNull(actualDeployment);
+    Assertions.assertEquals(
+        expectedDataJobExecution.getJobSchedule(),
+        actualDeployment.getSchedule().getScheduleCron());
+    Assertions.assertEquals(
+        expectedDataJobExecution.getVdkVersion(), actualDeployment.getVdkVersion());
+    Assertions.assertEquals(
+        expectedDataJobExecution.getJobVersion(), actualDeployment.getJobVersion());
 
-      DataJobResources actualDeploymentResources = actualDeployment.getResources();
-      Assertions.assertNotNull(actualDeploymentResources);
-      Assertions.assertEquals(expectedDataJobExecution.getResourcesCpuRequest(), actualDeploymentResources.getCpuRequest());
-      Assertions.assertEquals(expectedDataJobExecution.getResourcesCpuLimit(), actualDeploymentResources.getCpuLimit());
-      Assertions.assertEquals(expectedDataJobExecution.getResourcesMemoryRequest(), actualDeploymentResources.getMemoryRequest());
-      Assertions.assertEquals(expectedDataJobExecution.getResourcesMemoryLimit(), actualDeploymentResources.getMemoryLimit());
-   }
+    DataJobResources actualDeploymentResources = actualDeployment.getResources();
+    Assertions.assertNotNull(actualDeploymentResources);
+    Assertions.assertEquals(
+        expectedDataJobExecution.getResourcesCpuRequest(),
+        actualDeploymentResources.getCpuRequest());
+    Assertions.assertEquals(
+        expectedDataJobExecution.getResourcesCpuLimit(), actualDeploymentResources.getCpuLimit());
+    Assertions.assertEquals(
+        expectedDataJobExecution.getResourcesMemoryRequest(),
+        actualDeploymentResources.getMemoryRequest());
+    Assertions.assertEquals(
+        expectedDataJobExecution.getResourcesMemoryLimit(),
+        actualDeploymentResources.getMemoryLimit());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/ExecutionDataFetcherFindAllAndBuildResponseIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/ExecutionDataFetcherFindAllAndBuildResponseIT.java
@@ -39,480 +39,673 @@ import static org.mockito.Mockito.when;
 @SpringBootTest(classes = ControlplaneApplication.class)
 public class ExecutionDataFetcherFindAllAndBuildResponseIT {
 
-   @Autowired
-   private JobsRepository jobsRepository;
-
-   @Autowired
-   private JobExecutionRepository jobExecutionRepository;
-
-   @Autowired
-   private ExecutionDataFetcher executionDataFetcher;
-
-   @Mock
-   private DataFetchingEnvironment dataFetchingEnvironment;
-
-   @Mock
-   private Map<String, Object> filterRaw;
-
-   @Mock
-   private Map<String, Object> orderRaw;
-
-   @BeforeEach
-   public void setUp() throws Exception {
-      jobsRepository.deleteAll();
-   }
-
-   @Test
-   public void testFindAllAndBuildResponse_withoutFilters_shouldReturnResult() throws Exception {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
-
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED);
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING);
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED);
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.PLATFORM_ERROR);
-
-      when(dataFetchingEnvironment.getArguments()).thenReturn(Collections.emptyMap());
-
-      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
-      DataJobPage response = (DataJobPage)allAndBuildResponse.get(dataFetchingEnvironment);
-      List<Object> actualJobExecutions = response.getContent();
-
-      Assertions.assertNotNull(actualJobExecutions);
-      Assertions.assertEquals(4, actualJobExecutions.size());
-   }
-
-   @Test
-   public void testFindAllAndBuildResponse_filerByStatusIn_shouldReturnResult() throws Exception {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
-
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED);
-      DataJobExecution expectedJobExecution1 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING);
-      DataJobExecution expectedJobExecution2 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED);
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.PLATFORM_ERROR);
-
-      when(filterRaw.get(DataJobExecutionFilter.STATUS_IN_FIELD)).thenReturn(List.of(
-            com.vmware.taurus.controlplane.model.data.DataJobExecution.StatusEnum.RUNNING.toString(),
-            com.vmware.taurus.controlplane.model.data.DataJobExecution.StatusEnum.SUBMITTED.toString()));
-      when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(
-              FILTER_FIELD, filterRaw
-      ));
-
-      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
-      DataJobPage response = (DataJobPage)allAndBuildResponse.get(dataFetchingEnvironment);
-      List<Object> actualJobExecutions = response.getContent();
-
-      Assertions.assertNotNull(actualJobExecutions);
-      Assertions.assertEquals(2, actualJobExecutions.size());
-
-      assertExecutionsEquals(expectedJobExecution1, actualJobExecutions.get(0));
-      assertExecutionsEquals(expectedJobExecution2, actualJobExecutions.get(1));
-   }
-
-   @Test
-   public void testFindAllAndBuildResponse_filerByStartTimeGte_shouldReturnResult() throws Exception {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
-      OffsetDateTime now = OffsetDateTime.now();
-
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED, now.minusMinutes(2));
-      DataJobExecution expectedJobExecution1 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, now.minusMinutes(1));
-      DataJobExecution expectedJobExecution2 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED, now.minusMinutes(1));
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.PLATFORM_ERROR, now.minusMinutes(2));
-
-      when(filterRaw.get(DataJobExecutionFilter.START_TIME_GTE_FIELD)).thenReturn(now.minusMinutes(1));
-      when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(
-              FILTER_FIELD, filterRaw
-      ));
-
-      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
-      DataJobPage response = (DataJobPage)allAndBuildResponse.get(dataFetchingEnvironment);
-      List<Object> actualJobExecutions = response.getContent();
-
-      Assertions.assertNotNull(actualJobExecutions);
-      Assertions.assertEquals(2, actualJobExecutions.size());
-
-      assertExecutionsEquals(expectedJobExecution1, actualJobExecutions.get(0));
-      assertExecutionsEquals(expectedJobExecution2, actualJobExecutions.get(1));
-   }
-
-   @Test
-   public void testFindAllAndBuildResponse_filerByEndTimeGte_shouldReturnResult() throws Exception {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
-      OffsetDateTime now = OffsetDateTime.now();
-
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED, now.minusMinutes(2), now.minusMinutes(2));
-      DataJobExecution expectedJobExecution1 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, now.minusMinutes(1), now.minusMinutes(1));
-      DataJobExecution expectedJobExecution2 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED, now.minusMinutes(1), now.minusMinutes(1));
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.PLATFORM_ERROR, now.minusMinutes(2), now.minusMinutes(2));
-
-      when(filterRaw.get(DataJobExecutionFilter.END_TIME_GTE_FIELD)).thenReturn(now.minusMinutes(1));
-      when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(
-              FILTER_FIELD, filterRaw
-      ));
-
-      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
-      DataJobPage response = (DataJobPage)allAndBuildResponse.get(dataFetchingEnvironment);
-      List<Object> actualJobExecutions = response.getContent();
-
-      Assertions.assertNotNull(actualJobExecutions);
-      Assertions.assertEquals(2, actualJobExecutions.size());
-
-      assertExecutionsEquals(expectedJobExecution1, actualJobExecutions.get(0));
-      assertExecutionsEquals(expectedJobExecution2, actualJobExecutions.get(1));
-   }
-
-   @Test
-   public void testFindAllAndBuildResponse_filerByAllFields_shouldReturnResult() throws Exception {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
-      OffsetDateTime now = OffsetDateTime.now();
-
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED, now.minusMinutes(2), now.minusMinutes(2));
-      DataJobExecution expectedJobExecution1 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, now.minusMinutes(1), now.minusMinutes(1));
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED, now.minusMinutes(1), now.minusMinutes(1));
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.PLATFORM_ERROR, now.minusMinutes(2), now.minusMinutes(2));
-
-      when(filterRaw.get(DataJobExecutionFilter.START_TIME_GTE_FIELD)).thenReturn(now.minusMinutes(1));
-      when(filterRaw.get(DataJobExecutionFilter.END_TIME_GTE_FIELD)).thenReturn(now.minusMinutes(1));
-      when(filterRaw.get(DataJobExecutionFilter.STATUS_IN_FIELD)).thenReturn(List.of(
-            com.vmware.taurus.controlplane.model.data.DataJobExecution.StatusEnum.RUNNING.toString()));
-
-      when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(
-              FILTER_FIELD, filterRaw
-      ));
-
-      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
-      DataJobPage response = (DataJobPage)allAndBuildResponse.get(dataFetchingEnvironment);
-      List<Object> actualJobExecutions = response.getContent();
-
-      Assertions.assertNotNull(actualJobExecutions);
-      Assertions.assertEquals(1, actualJobExecutions.size());
-
-      assertExecutionsEquals(expectedJobExecution1, actualJobExecutions.get(0));
-   }
-
-   @Test
-   public void testFindAllAndBuildResponse_orderByEndTime_shouldReturnResult() throws Exception {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
-
-      DataJobExecution expectedJobExecution1 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED);
-      DataJobExecution expectedJobExecution2 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING);
-      DataJobExecution expectedJobExecution3 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED);
-      DataJobExecution expectedJobExecution4 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.PLATFORM_ERROR);
-
-      when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(
-              ORDER_FIELD, orderRaw
-      ));
-      when(orderRaw.get(DataJobExecutionOrder.PROPERTY_FIELD)).thenReturn("startTime");
-      when(orderRaw.get(DataJobExecutionOrder.DIRECTION_FIELD)).thenReturn("DESC");
-
-      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
-      DataJobPage response = (DataJobPage)allAndBuildResponse.get(dataFetchingEnvironment);
-      List<Object> actualJobExecutions = response.getContent();
-
-      Assertions.assertNotNull(actualJobExecutions);
-      Assertions.assertEquals(4, actualJobExecutions.size());
-
-      assertExecutionsEquals(expectedJobExecution1, actualJobExecutions.get(3));
-      assertExecutionsEquals(expectedJobExecution2, actualJobExecutions.get(2));
-      assertExecutionsEquals(expectedJobExecution3, actualJobExecutions.get(1));
-      assertExecutionsEquals(expectedJobExecution4, actualJobExecutions.get(0));
-   }
-
-   @Test
-   public void testFindAllAndBuildResponse_orderWithoutProperty_shouldReturnResult() {
-      when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(
-              PAGE_NUMBER_FIELD, 1,
-              PAGE_SIZE_FIELD, 3,
-              ORDER_FIELD, orderRaw
-      ));
-      when(orderRaw.get(DataJobExecutionOrder.PROPERTY_FIELD)).thenReturn("startTime");
-
-      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
-
-      Assertions.assertThrows(GraphQLException.class, () -> allAndBuildResponse.get(dataFetchingEnvironment));
-   }
-
-   @Test
-   public void testFindAllAndBuildResponse_orderWithoutDirection_shouldReturnResult() {
-      when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(
-              PAGE_NUMBER_FIELD, 1,
-              PAGE_SIZE_FIELD, 3,
-              ORDER_FIELD, orderRaw
-      ));
-      when(orderRaw.get(DataJobExecutionOrder.DIRECTION_FIELD)).thenReturn("DESC");
-
-      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
-
-      Assertions.assertThrows(GraphQLException.class, () -> allAndBuildResponse.get(dataFetchingEnvironment));
-   }
-
-   @Test
-   public void testFindAllAndBuildResponse_withPageNumberAndPageSize_shouldReturnResult() throws Exception {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
-
-      DataJobExecution expectedJobExecution1 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED);
-      DataJobExecution expectedJobExecution2 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING);
-      DataJobExecution expectedJobExecution3 =
-            RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED);
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob, ExecutionStatus.PLATFORM_ERROR);
-
-      when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(
-              PAGE_NUMBER_FIELD, 1,
-              PAGE_SIZE_FIELD, 3
-      ));
-
-      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
-      DataJobPage response = (DataJobPage)allAndBuildResponse.get(dataFetchingEnvironment);
-      List<Object> actualJobExecutions = response.getContent();
-
-      Assertions.assertNotNull(actualJobExecutions);
-      Assertions.assertEquals(3, actualJobExecutions.size());
-
-      assertExecutionsEquals(expectedJobExecution1, actualJobExecutions.get(0));
-      assertExecutionsEquals(expectedJobExecution2, actualJobExecutions.get(1));
-      assertExecutionsEquals(expectedJobExecution3, actualJobExecutions.get(2));
-   }
-
-   @Test
-   public void testFindAllAndBuildResponse_withPageNumber_shouldReturnResult() {
-      when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(
-              PAGE_NUMBER_FIELD, 1
-      ));
-
-      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
-
-      Assertions.assertThrows(GraphQLException.class, () -> allAndBuildResponse.get(dataFetchingEnvironment));
-   }
-
-   @Test
-   public void testFindAllAndBuildResponse_withPageSize_shouldReturnResult() {
-      when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(
-              PAGE_SIZE_FIELD, 1
-      ));
-
-      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
-
-      Assertions.assertThrows(GraphQLException.class, () -> allAndBuildResponse.get(dataFetchingEnvironment));
-   }
-
-   @Test
-   public void testFindAllAndBuildResponse_orderByJobName_shouldReturnResult() throws Exception {
-
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository, "a");
-      DataJob actualDataJob2 = RepositoryUtil.createDataJob(jobsRepository, "b");
-      DataJob actualDataJob3 = RepositoryUtil.createDataJob(jobsRepository, "c");
-      DataJob actualDataJob4 = RepositoryUtil.createDataJob(jobsRepository, "d");
-
-      var expectedJobExecution1 = RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob4, ExecutionStatus.SUCCEEDED);
-      var expectedJobExecution2 = RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.SUCCEEDED);
-      var expectedJobExecution3 = RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-3", actualDataJob3, ExecutionStatus.SUCCEEDED);
-      var expectedJobExecution4 = RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-4", actualDataJob2, ExecutionStatus.SUCCEEDED);
-
-      when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(
-              ORDER_FIELD, orderRaw
-      ));
-      when(orderRaw.get(DataJobExecutionOrder.PROPERTY_FIELD)).thenReturn("jobName");
-      when(orderRaw.get(DataJobExecutionOrder.DIRECTION_FIELD)).thenReturn("DESC");
-
-      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
-      DataJobPage response = (DataJobPage)allAndBuildResponse.get(dataFetchingEnvironment);
-      List<Object> actualJobExecutions = response.getContent();
-
-      Assertions.assertEquals(4, actualJobExecutions.size());
-      //check sort order by job name is DESC
-      assertExecutionsEquals(expectedJobExecution1, actualJobExecutions.get(0));
-      assertExecutionsEquals(expectedJobExecution3, actualJobExecutions.get(1));
-      assertExecutionsEquals(expectedJobExecution4, actualJobExecutions.get(2));
-      assertExecutionsEquals(expectedJobExecution2, actualJobExecutions.get(3));
-
-   }
-
-   @Test
-   public void testFindAllAndBuildResponse_filterByJobName_shouldReturnResult() throws Exception {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository, "job-one");
-      DataJob actualDataJob2 = RepositoryUtil.createDataJob(jobsRepository, "job-two");
-
-      OffsetDateTime now = OffsetDateTime.now();
-
-      var expectedExecution = RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED, now.minusMinutes(2), now.minusMinutes(2));
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob2, ExecutionStatus.RUNNING, now.minusMinutes(1), now.minusMinutes(1));
-
-      when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(
-              FILTER_FIELD, filterRaw
-      ));
-      when(filterRaw.get(DataJobExecutionFilter.JOB_NAME_IN_FIELD)).thenReturn(List.of(actualDataJob.getName()));
-
-      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
-      DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
-      List<Object> actualJobExecutions = response.getContent();
-
-      Assertions.assertEquals(1, actualJobExecutions.size());
-      assertExecutionsEquals(expectedExecution, actualJobExecutions.get(0));
-   }
-
-   @Test
-   public void testFindAllAndBuildResponse_filterByEndTimeLte_shouldNotReturnResult() throws Exception {
-
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
-      OffsetDateTime now = OffsetDateTime.now();
-
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED, now.minusMinutes(2), now.minusMinutes(2));
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, now.minusMinutes(1), now.minusMinutes(1));
-
-      when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(
-              FILTER_FIELD, filterRaw
-      ));
-      when(filterRaw.get(DataJobExecutionFilter.END_TIME_LTE_FIELD)).thenReturn(OffsetDateTime.now().minusDays(2));
-
-      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
-      DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
-      List<Object> actualJobExecutions = response.getContent();
-
-      Assertions.assertEquals(0, actualJobExecutions.size());
-   }
-
-   @Test
-   public void testFindAllAndBuildResponse_filterByEndTimeLte_shouldReturnResult() throws Exception {
-
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
-      OffsetDateTime now = OffsetDateTime.now();
-
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED, now.minusMinutes(2), now.minusMinutes(2));
-      var expected = RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, now, now.minusDays(4));
-
-      when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(
-              FILTER_FIELD, filterRaw
-      ));
-      when(filterRaw.get(DataJobExecutionFilter.END_TIME_LTE_FIELD)).thenReturn(OffsetDateTime.now().minusDays(2));
-
-      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
-      DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
-      List<Object> actualJobExecutions = response.getContent();
-
-      Assertions.assertEquals(1, actualJobExecutions.size());
-      assertExecutionsEquals(expected, actualJobExecutions.get(0));
-   }
-
-   @Test
-   public void testFindAllAndBuildResponse_filterByStartTimeLte_shouldNotReturnResult() throws Exception {
-
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
-      OffsetDateTime now = OffsetDateTime.now();
-
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED, now.minusDays(3), now.minusMinutes(2));
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, now.minusDays(3), now.minusMinutes(1));
-
-      when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(
-              FILTER_FIELD, filterRaw
-      ));
-      when(filterRaw.get(DataJobExecutionFilter.START_TIME_LTE_FIELD)).thenReturn(OffsetDateTime.now().minusDays(4));
-
-      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
-      DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
-      List<Object> actualJobExecutions = response.getContent();
-
-      Assertions.assertEquals(0, actualJobExecutions.size());
-   }
-
-   @Test
-   public void testFindAllAndBuildResponse_filterByStartTimeLte_shouldReturnResult() throws Exception {
-
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
-      OffsetDateTime now = OffsetDateTime.now();
-
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED, now.minusMinutes(2), now.minusMinutes(2));
-      var expected = RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING, now.minusDays(3), now);
-
-      when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(
-              FILTER_FIELD, filterRaw
-      ));
-      when(filterRaw.get(DataJobExecutionFilter.START_TIME_LTE_FIELD)).thenReturn(OffsetDateTime.now().minusDays(2));
-
-      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
-      DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
-      List<Object> actualJobExecutions = response.getContent();
-
-      Assertions.assertEquals(1, actualJobExecutions.size());
-      assertExecutionsEquals(expected, actualJobExecutions.get(0));
-   }
-
-   @Test
-   public void testFindAllAndBuildResponse_filterByJobTeam_shouldNotReturnResult() throws Exception {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository, "test-job", "test-team");
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-id123", actualDataJob, ExecutionStatus.SUCCEEDED);
-
-      when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(
-            FILTER_FIELD, filterRaw
-      ));
-      when(filterRaw.get(DataJobExecutionFilter.TEAM_NAME_IN_FIELD)).thenReturn(List.of("other-test-team"));
-
-      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
-      DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
-      List<Object> actualJobExecutions = response.getContent();
-
-      Assertions.assertEquals(0, actualJobExecutions.size());
-   }
-
-   @Test
-   public void testFindAllAndBuildResponse_filterByJobTeam_shouldReturnResult() throws Exception {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository, "test-job", "test-team");
-      var expected = RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-id123", actualDataJob, ExecutionStatus.SUCCEEDED);
-
-      when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(
-            FILTER_FIELD, filterRaw
-      ));
-      when(filterRaw.get(DataJobExecutionFilter.TEAM_NAME_IN_FIELD)).thenReturn(List.of(actualDataJob.getJobConfig().getTeam()));
-
-      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
-      DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
-      List<Object> actualJobExecutions = response.getContent();
-
-      Assertions.assertEquals(1, actualJobExecutions.size());
-      assertExecutionsEquals(expected, actualJobExecutions.get(0));
-   }
-
-   @Test
-   public void testFindAllAndBuildResponse_filterByJobTeam_shouldReturnMultipleResults() throws Exception {
-      DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository, "test-job", "test-team");
-      DataJob actualDataJob2 = RepositoryUtil.createDataJob(jobsRepository, "test-job2", "test-team");
-      DataJob actualDataJob3 = RepositoryUtil.createDataJob(jobsRepository, "test-job3", "other-test-team");
-
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-id1234", actualDataJob, ExecutionStatus.SUCCEEDED);
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-id1235", actualDataJob2, ExecutionStatus.SUCCEEDED);
-      RepositoryUtil.createDataJobExecution(jobExecutionRepository, "test-id1236", actualDataJob3, ExecutionStatus.SUCCEEDED);
-
-
-      when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(
-            FILTER_FIELD, filterRaw
-      ));
-      when(filterRaw.get(DataJobExecutionFilter.TEAM_NAME_IN_FIELD)).thenReturn(List.of(actualDataJob.getJobConfig().getTeam()));
-
-      DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
-      DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
-      List<Object> actualJobExecutions = response.getContent();
-      // Expecting two executions from data jobs with the same team.
-      Assertions.assertEquals(2, actualJobExecutions.size());
-   }
-
-   private void assertExecutionsEquals(DataJobExecution expectedJobExecution, Object actualJobExecutionObject) {
-      com.vmware.taurus.controlplane.model.data.DataJobExecution actualJobExecution =
-            (com.vmware.taurus.controlplane.model.data.DataJobExecution)actualJobExecutionObject;
-
-      Assertions.assertEquals(expectedJobExecution.getId(), actualJobExecution.getId());
-      Assertions.assertEquals(expectedJobExecution.getStartTime(), actualJobExecution.getStartTime());
-      Assertions.assertEquals(expectedJobExecution.getEndTime(), actualJobExecution.getEndTime());
-      Assertions.assertEquals(expectedJobExecution.getJobVersion(), actualJobExecution.getDeployment().getJobVersion());
-   }
+  @Autowired private JobsRepository jobsRepository;
+
+  @Autowired private JobExecutionRepository jobExecutionRepository;
+
+  @Autowired private ExecutionDataFetcher executionDataFetcher;
+
+  @Mock private DataFetchingEnvironment dataFetchingEnvironment;
+
+  @Mock private Map<String, Object> filterRaw;
+
+  @Mock private Map<String, Object> orderRaw;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    jobsRepository.deleteAll();
+  }
+
+  @Test
+  public void testFindAllAndBuildResponse_withoutFilters_shouldReturnResult() throws Exception {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED);
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING);
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository, "test-execution-id-3", actualDataJob, ExecutionStatus.SUBMITTED);
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-4",
+        actualDataJob,
+        ExecutionStatus.PLATFORM_ERROR);
+
+    when(dataFetchingEnvironment.getArguments()).thenReturn(Collections.emptyMap());
+
+    DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+    DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
+    List<Object> actualJobExecutions = response.getContent();
+
+    Assertions.assertNotNull(actualJobExecutions);
+    Assertions.assertEquals(4, actualJobExecutions.size());
+  }
+
+  @Test
+  public void testFindAllAndBuildResponse_filerByStatusIn_shouldReturnResult() throws Exception {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository, "test-execution-id-1", actualDataJob, ExecutionStatus.CANCELLED);
+    DataJobExecution expectedJobExecution1 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING);
+    DataJobExecution expectedJobExecution2 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-3",
+            actualDataJob,
+            ExecutionStatus.SUBMITTED);
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-4",
+        actualDataJob,
+        ExecutionStatus.PLATFORM_ERROR);
+
+    when(filterRaw.get(DataJobExecutionFilter.STATUS_IN_FIELD))
+        .thenReturn(
+            List.of(
+                com.vmware.taurus.controlplane.model.data.DataJobExecution.StatusEnum.RUNNING
+                    .toString(),
+                com.vmware.taurus.controlplane.model.data.DataJobExecution.StatusEnum.SUBMITTED
+                    .toString()));
+    when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(FILTER_FIELD, filterRaw));
+
+    DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+    DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
+    List<Object> actualJobExecutions = response.getContent();
+
+    Assertions.assertNotNull(actualJobExecutions);
+    Assertions.assertEquals(2, actualJobExecutions.size());
+
+    assertExecutionsEquals(expectedJobExecution1, actualJobExecutions.get(0));
+    assertExecutionsEquals(expectedJobExecution2, actualJobExecutions.get(1));
+  }
+
+  @Test
+  public void testFindAllAndBuildResponse_filerByStartTimeGte_shouldReturnResult()
+      throws Exception {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    OffsetDateTime now = OffsetDateTime.now();
+
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-1",
+        actualDataJob,
+        ExecutionStatus.CANCELLED,
+        now.minusMinutes(2));
+    DataJobExecution expectedJobExecution1 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-2",
+            actualDataJob,
+            ExecutionStatus.RUNNING,
+            now.minusMinutes(1));
+    DataJobExecution expectedJobExecution2 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-3",
+            actualDataJob,
+            ExecutionStatus.SUBMITTED,
+            now.minusMinutes(1));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-4",
+        actualDataJob,
+        ExecutionStatus.PLATFORM_ERROR,
+        now.minusMinutes(2));
+
+    when(filterRaw.get(DataJobExecutionFilter.START_TIME_GTE_FIELD))
+        .thenReturn(now.minusMinutes(1));
+    when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(FILTER_FIELD, filterRaw));
+
+    DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+    DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
+    List<Object> actualJobExecutions = response.getContent();
+
+    Assertions.assertNotNull(actualJobExecutions);
+    Assertions.assertEquals(2, actualJobExecutions.size());
+
+    assertExecutionsEquals(expectedJobExecution1, actualJobExecutions.get(0));
+    assertExecutionsEquals(expectedJobExecution2, actualJobExecutions.get(1));
+  }
+
+  @Test
+  public void testFindAllAndBuildResponse_filerByEndTimeGte_shouldReturnResult() throws Exception {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    OffsetDateTime now = OffsetDateTime.now();
+
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-1",
+        actualDataJob,
+        ExecutionStatus.CANCELLED,
+        now.minusMinutes(2),
+        now.minusMinutes(2));
+    DataJobExecution expectedJobExecution1 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-2",
+            actualDataJob,
+            ExecutionStatus.RUNNING,
+            now.minusMinutes(1),
+            now.minusMinutes(1));
+    DataJobExecution expectedJobExecution2 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-3",
+            actualDataJob,
+            ExecutionStatus.SUBMITTED,
+            now.minusMinutes(1),
+            now.minusMinutes(1));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-4",
+        actualDataJob,
+        ExecutionStatus.PLATFORM_ERROR,
+        now.minusMinutes(2),
+        now.minusMinutes(2));
+
+    when(filterRaw.get(DataJobExecutionFilter.END_TIME_GTE_FIELD)).thenReturn(now.minusMinutes(1));
+    when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(FILTER_FIELD, filterRaw));
+
+    DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+    DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
+    List<Object> actualJobExecutions = response.getContent();
+
+    Assertions.assertNotNull(actualJobExecutions);
+    Assertions.assertEquals(2, actualJobExecutions.size());
+
+    assertExecutionsEquals(expectedJobExecution1, actualJobExecutions.get(0));
+    assertExecutionsEquals(expectedJobExecution2, actualJobExecutions.get(1));
+  }
+
+  @Test
+  public void testFindAllAndBuildResponse_filerByAllFields_shouldReturnResult() throws Exception {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    OffsetDateTime now = OffsetDateTime.now();
+
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-1",
+        actualDataJob,
+        ExecutionStatus.CANCELLED,
+        now.minusMinutes(2),
+        now.minusMinutes(2));
+    DataJobExecution expectedJobExecution1 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-2",
+            actualDataJob,
+            ExecutionStatus.RUNNING,
+            now.minusMinutes(1),
+            now.minusMinutes(1));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-3",
+        actualDataJob,
+        ExecutionStatus.SUBMITTED,
+        now.minusMinutes(1),
+        now.minusMinutes(1));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-4",
+        actualDataJob,
+        ExecutionStatus.PLATFORM_ERROR,
+        now.minusMinutes(2),
+        now.minusMinutes(2));
+
+    when(filterRaw.get(DataJobExecutionFilter.START_TIME_GTE_FIELD))
+        .thenReturn(now.minusMinutes(1));
+    when(filterRaw.get(DataJobExecutionFilter.END_TIME_GTE_FIELD)).thenReturn(now.minusMinutes(1));
+    when(filterRaw.get(DataJobExecutionFilter.STATUS_IN_FIELD))
+        .thenReturn(
+            List.of(
+                com.vmware.taurus.controlplane.model.data.DataJobExecution.StatusEnum.RUNNING
+                    .toString()));
+
+    when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(FILTER_FIELD, filterRaw));
+
+    DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+    DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
+    List<Object> actualJobExecutions = response.getContent();
+
+    Assertions.assertNotNull(actualJobExecutions);
+    Assertions.assertEquals(1, actualJobExecutions.size());
+
+    assertExecutionsEquals(expectedJobExecution1, actualJobExecutions.get(0));
+  }
+
+  @Test
+  public void testFindAllAndBuildResponse_orderByEndTime_shouldReturnResult() throws Exception {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+
+    DataJobExecution expectedJobExecution1 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-1",
+            actualDataJob,
+            ExecutionStatus.CANCELLED);
+    DataJobExecution expectedJobExecution2 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING);
+    DataJobExecution expectedJobExecution3 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-3",
+            actualDataJob,
+            ExecutionStatus.SUBMITTED);
+    DataJobExecution expectedJobExecution4 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-4",
+            actualDataJob,
+            ExecutionStatus.PLATFORM_ERROR);
+
+    when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(ORDER_FIELD, orderRaw));
+    when(orderRaw.get(DataJobExecutionOrder.PROPERTY_FIELD)).thenReturn("startTime");
+    when(orderRaw.get(DataJobExecutionOrder.DIRECTION_FIELD)).thenReturn("DESC");
+
+    DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+    DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
+    List<Object> actualJobExecutions = response.getContent();
+
+    Assertions.assertNotNull(actualJobExecutions);
+    Assertions.assertEquals(4, actualJobExecutions.size());
+
+    assertExecutionsEquals(expectedJobExecution1, actualJobExecutions.get(3));
+    assertExecutionsEquals(expectedJobExecution2, actualJobExecutions.get(2));
+    assertExecutionsEquals(expectedJobExecution3, actualJobExecutions.get(1));
+    assertExecutionsEquals(expectedJobExecution4, actualJobExecutions.get(0));
+  }
+
+  @Test
+  public void testFindAllAndBuildResponse_orderWithoutProperty_shouldReturnResult() {
+    when(dataFetchingEnvironment.getArguments())
+        .thenReturn(
+            Map.of(
+                PAGE_NUMBER_FIELD, 1,
+                PAGE_SIZE_FIELD, 3,
+                ORDER_FIELD, orderRaw));
+    when(orderRaw.get(DataJobExecutionOrder.PROPERTY_FIELD)).thenReturn("startTime");
+
+    DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+
+    Assertions.assertThrows(
+        GraphQLException.class, () -> allAndBuildResponse.get(dataFetchingEnvironment));
+  }
+
+  @Test
+  public void testFindAllAndBuildResponse_orderWithoutDirection_shouldReturnResult() {
+    when(dataFetchingEnvironment.getArguments())
+        .thenReturn(
+            Map.of(
+                PAGE_NUMBER_FIELD, 1,
+                PAGE_SIZE_FIELD, 3,
+                ORDER_FIELD, orderRaw));
+    when(orderRaw.get(DataJobExecutionOrder.DIRECTION_FIELD)).thenReturn("DESC");
+
+    DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+
+    Assertions.assertThrows(
+        GraphQLException.class, () -> allAndBuildResponse.get(dataFetchingEnvironment));
+  }
+
+  @Test
+  public void testFindAllAndBuildResponse_withPageNumberAndPageSize_shouldReturnResult()
+      throws Exception {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+
+    DataJobExecution expectedJobExecution1 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-1",
+            actualDataJob,
+            ExecutionStatus.CANCELLED);
+    DataJobExecution expectedJobExecution2 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository, "test-execution-id-2", actualDataJob, ExecutionStatus.RUNNING);
+    DataJobExecution expectedJobExecution3 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-3",
+            actualDataJob,
+            ExecutionStatus.SUBMITTED);
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-4",
+        actualDataJob,
+        ExecutionStatus.PLATFORM_ERROR);
+
+    when(dataFetchingEnvironment.getArguments())
+        .thenReturn(
+            Map.of(
+                PAGE_NUMBER_FIELD, 1,
+                PAGE_SIZE_FIELD, 3));
+
+    DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+    DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
+    List<Object> actualJobExecutions = response.getContent();
+
+    Assertions.assertNotNull(actualJobExecutions);
+    Assertions.assertEquals(3, actualJobExecutions.size());
+
+    assertExecutionsEquals(expectedJobExecution1, actualJobExecutions.get(0));
+    assertExecutionsEquals(expectedJobExecution2, actualJobExecutions.get(1));
+    assertExecutionsEquals(expectedJobExecution3, actualJobExecutions.get(2));
+  }
+
+  @Test
+  public void testFindAllAndBuildResponse_withPageNumber_shouldReturnResult() {
+    when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(PAGE_NUMBER_FIELD, 1));
+
+    DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+
+    Assertions.assertThrows(
+        GraphQLException.class, () -> allAndBuildResponse.get(dataFetchingEnvironment));
+  }
+
+  @Test
+  public void testFindAllAndBuildResponse_withPageSize_shouldReturnResult() {
+    when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(PAGE_SIZE_FIELD, 1));
+
+    DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+
+    Assertions.assertThrows(
+        GraphQLException.class, () -> allAndBuildResponse.get(dataFetchingEnvironment));
+  }
+
+  @Test
+  public void testFindAllAndBuildResponse_orderByJobName_shouldReturnResult() throws Exception {
+
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository, "a");
+    DataJob actualDataJob2 = RepositoryUtil.createDataJob(jobsRepository, "b");
+    DataJob actualDataJob3 = RepositoryUtil.createDataJob(jobsRepository, "c");
+    DataJob actualDataJob4 = RepositoryUtil.createDataJob(jobsRepository, "d");
+
+    var expectedJobExecution1 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-1",
+            actualDataJob4,
+            ExecutionStatus.SUCCEEDED);
+    var expectedJobExecution2 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-2",
+            actualDataJob,
+            ExecutionStatus.SUCCEEDED);
+    var expectedJobExecution3 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-3",
+            actualDataJob3,
+            ExecutionStatus.SUCCEEDED);
+    var expectedJobExecution4 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-4",
+            actualDataJob2,
+            ExecutionStatus.SUCCEEDED);
+
+    when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(ORDER_FIELD, orderRaw));
+    when(orderRaw.get(DataJobExecutionOrder.PROPERTY_FIELD)).thenReturn("jobName");
+    when(orderRaw.get(DataJobExecutionOrder.DIRECTION_FIELD)).thenReturn("DESC");
+
+    DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+    DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
+    List<Object> actualJobExecutions = response.getContent();
+
+    Assertions.assertEquals(4, actualJobExecutions.size());
+    // check sort order by job name is DESC
+    assertExecutionsEquals(expectedJobExecution1, actualJobExecutions.get(0));
+    assertExecutionsEquals(expectedJobExecution3, actualJobExecutions.get(1));
+    assertExecutionsEquals(expectedJobExecution4, actualJobExecutions.get(2));
+    assertExecutionsEquals(expectedJobExecution2, actualJobExecutions.get(3));
+  }
+
+  @Test
+  public void testFindAllAndBuildResponse_filterByJobName_shouldReturnResult() throws Exception {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository, "job-one");
+    DataJob actualDataJob2 = RepositoryUtil.createDataJob(jobsRepository, "job-two");
+
+    OffsetDateTime now = OffsetDateTime.now();
+
+    var expectedExecution =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-1",
+            actualDataJob,
+            ExecutionStatus.CANCELLED,
+            now.minusMinutes(2),
+            now.minusMinutes(2));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-2",
+        actualDataJob2,
+        ExecutionStatus.RUNNING,
+        now.minusMinutes(1),
+        now.minusMinutes(1));
+
+    when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(FILTER_FIELD, filterRaw));
+    when(filterRaw.get(DataJobExecutionFilter.JOB_NAME_IN_FIELD))
+        .thenReturn(List.of(actualDataJob.getName()));
+
+    DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+    DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
+    List<Object> actualJobExecutions = response.getContent();
+
+    Assertions.assertEquals(1, actualJobExecutions.size());
+    assertExecutionsEquals(expectedExecution, actualJobExecutions.get(0));
+  }
+
+  @Test
+  public void testFindAllAndBuildResponse_filterByEndTimeLte_shouldNotReturnResult()
+      throws Exception {
+
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    OffsetDateTime now = OffsetDateTime.now();
+
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-1",
+        actualDataJob,
+        ExecutionStatus.CANCELLED,
+        now.minusMinutes(2),
+        now.minusMinutes(2));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-2",
+        actualDataJob,
+        ExecutionStatus.RUNNING,
+        now.minusMinutes(1),
+        now.minusMinutes(1));
+
+    when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(FILTER_FIELD, filterRaw));
+    when(filterRaw.get(DataJobExecutionFilter.END_TIME_LTE_FIELD))
+        .thenReturn(OffsetDateTime.now().minusDays(2));
+
+    DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+    DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
+    List<Object> actualJobExecutions = response.getContent();
+
+    Assertions.assertEquals(0, actualJobExecutions.size());
+  }
+
+  @Test
+  public void testFindAllAndBuildResponse_filterByEndTimeLte_shouldReturnResult() throws Exception {
+
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    OffsetDateTime now = OffsetDateTime.now();
+
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-1",
+        actualDataJob,
+        ExecutionStatus.CANCELLED,
+        now.minusMinutes(2),
+        now.minusMinutes(2));
+    var expected =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-2",
+            actualDataJob,
+            ExecutionStatus.RUNNING,
+            now,
+            now.minusDays(4));
+
+    when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(FILTER_FIELD, filterRaw));
+    when(filterRaw.get(DataJobExecutionFilter.END_TIME_LTE_FIELD))
+        .thenReturn(OffsetDateTime.now().minusDays(2));
+
+    DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+    DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
+    List<Object> actualJobExecutions = response.getContent();
+
+    Assertions.assertEquals(1, actualJobExecutions.size());
+    assertExecutionsEquals(expected, actualJobExecutions.get(0));
+  }
+
+  @Test
+  public void testFindAllAndBuildResponse_filterByStartTimeLte_shouldNotReturnResult()
+      throws Exception {
+
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    OffsetDateTime now = OffsetDateTime.now();
+
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-1",
+        actualDataJob,
+        ExecutionStatus.CANCELLED,
+        now.minusDays(3),
+        now.minusMinutes(2));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-2",
+        actualDataJob,
+        ExecutionStatus.RUNNING,
+        now.minusDays(3),
+        now.minusMinutes(1));
+
+    when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(FILTER_FIELD, filterRaw));
+    when(filterRaw.get(DataJobExecutionFilter.START_TIME_LTE_FIELD))
+        .thenReturn(OffsetDateTime.now().minusDays(4));
+
+    DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+    DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
+    List<Object> actualJobExecutions = response.getContent();
+
+    Assertions.assertEquals(0, actualJobExecutions.size());
+  }
+
+  @Test
+  public void testFindAllAndBuildResponse_filterByStartTimeLte_shouldReturnResult()
+      throws Exception {
+
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+    OffsetDateTime now = OffsetDateTime.now();
+
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "test-execution-id-1",
+        actualDataJob,
+        ExecutionStatus.CANCELLED,
+        now.minusMinutes(2),
+        now.minusMinutes(2));
+    var expected =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "test-execution-id-2",
+            actualDataJob,
+            ExecutionStatus.RUNNING,
+            now.minusDays(3),
+            now);
+
+    when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(FILTER_FIELD, filterRaw));
+    when(filterRaw.get(DataJobExecutionFilter.START_TIME_LTE_FIELD))
+        .thenReturn(OffsetDateTime.now().minusDays(2));
+
+    DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+    DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
+    List<Object> actualJobExecutions = response.getContent();
+
+    Assertions.assertEquals(1, actualJobExecutions.size());
+    assertExecutionsEquals(expected, actualJobExecutions.get(0));
+  }
+
+  @Test
+  public void testFindAllAndBuildResponse_filterByJobTeam_shouldNotReturnResult() throws Exception {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository, "test-job", "test-team");
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository, "test-id123", actualDataJob, ExecutionStatus.SUCCEEDED);
+
+    when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(FILTER_FIELD, filterRaw));
+    when(filterRaw.get(DataJobExecutionFilter.TEAM_NAME_IN_FIELD))
+        .thenReturn(List.of("other-test-team"));
+
+    DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+    DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
+    List<Object> actualJobExecutions = response.getContent();
+
+    Assertions.assertEquals(0, actualJobExecutions.size());
+  }
+
+  @Test
+  public void testFindAllAndBuildResponse_filterByJobTeam_shouldReturnResult() throws Exception {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository, "test-job", "test-team");
+    var expected =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository, "test-id123", actualDataJob, ExecutionStatus.SUCCEEDED);
+
+    when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(FILTER_FIELD, filterRaw));
+    when(filterRaw.get(DataJobExecutionFilter.TEAM_NAME_IN_FIELD))
+        .thenReturn(List.of(actualDataJob.getJobConfig().getTeam()));
+
+    DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+    DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
+    List<Object> actualJobExecutions = response.getContent();
+
+    Assertions.assertEquals(1, actualJobExecutions.size());
+    assertExecutionsEquals(expected, actualJobExecutions.get(0));
+  }
+
+  @Test
+  public void testFindAllAndBuildResponse_filterByJobTeam_shouldReturnMultipleResults()
+      throws Exception {
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository, "test-job", "test-team");
+    DataJob actualDataJob2 = RepositoryUtil.createDataJob(jobsRepository, "test-job2", "test-team");
+    DataJob actualDataJob3 =
+        RepositoryUtil.createDataJob(jobsRepository, "test-job3", "other-test-team");
+
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository, "test-id1234", actualDataJob, ExecutionStatus.SUCCEEDED);
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository, "test-id1235", actualDataJob2, ExecutionStatus.SUCCEEDED);
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository, "test-id1236", actualDataJob3, ExecutionStatus.SUCCEEDED);
+
+    when(dataFetchingEnvironment.getArguments()).thenReturn(Map.of(FILTER_FIELD, filterRaw));
+    when(filterRaw.get(DataJobExecutionFilter.TEAM_NAME_IN_FIELD))
+        .thenReturn(List.of(actualDataJob.getJobConfig().getTeam()));
+
+    DataFetcher<Object> allAndBuildResponse = executionDataFetcher.findAllAndBuildResponse();
+    DataJobPage response = (DataJobPage) allAndBuildResponse.get(dataFetchingEnvironment);
+    List<Object> actualJobExecutions = response.getContent();
+    // Expecting two executions from data jobs with the same team.
+    Assertions.assertEquals(2, actualJobExecutions.size());
+  }
+
+  private void assertExecutionsEquals(
+      DataJobExecution expectedJobExecution, Object actualJobExecutionObject) {
+    com.vmware.taurus.controlplane.model.data.DataJobExecution actualJobExecution =
+        (com.vmware.taurus.controlplane.model.data.DataJobExecution) actualJobExecutionObject;
+
+    Assertions.assertEquals(expectedJobExecution.getId(), actualJobExecution.getId());
+    Assertions.assertEquals(expectedJobExecution.getStartTime(), actualJobExecution.getStartTime());
+    Assertions.assertEquals(expectedJobExecution.getEndTime(), actualJobExecution.getEndTime());
+    Assertions.assertEquals(
+        expectedJobExecution.getJobVersion(), actualJobExecution.getDeployment().getJobVersion());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/ExecutionDataFetcherStatusCountTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/ExecutionDataFetcherStatusCountTest.java
@@ -31,72 +31,90 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class ExecutionDataFetcherStatusCountTest {
 
-   ExecutionDataFetcher executionDataFetcher;
+  ExecutionDataFetcher executionDataFetcher;
 
-   @Mock
-   DataFetchingEnvironment dataFetchingEnvironment;
+  @Mock DataFetchingEnvironment dataFetchingEnvironment;
 
-   @Mock
-   DataFetchingFieldSelectionSet dataFetchingFieldSelectionSet;
+  @Mock DataFetchingFieldSelectionSet dataFetchingFieldSelectionSet;
 
-   @Mock
-   JobExecutionService jobExecutionService;
+  @Mock JobExecutionService jobExecutionService;
 
-   @Mock
-   JobExecutionRepository jobExecutionRepository;
+  @Mock JobExecutionRepository jobExecutionRepository;
 
-   @Mock
-   JobExecutionLogsUrlBuilder jobExecutionLogsUrlBuilder;
+  @Mock JobExecutionLogsUrlBuilder jobExecutionLogsUrlBuilder;
 
-   @BeforeEach
-   public void init() {
-      executionDataFetcher = new ExecutionDataFetcher(jobExecutionRepository, jobExecutionService, jobExecutionLogsUrlBuilder);
-   }
+  @BeforeEach
+  public void init() {
+    executionDataFetcher =
+        new ExecutionDataFetcher(
+            jobExecutionRepository, jobExecutionService, jobExecutionLogsUrlBuilder);
+  }
 
-   @Test
-   void testDataFetcherStatusCount_emptyExecutions() {
-      when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-      lenient().when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT_SUCCESSFUL_EXECUTIONS.getPath())).thenReturn(true);
-      lenient().when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT_FAILED_EXECUTIONS.getPath())).thenReturn(true);
-      when(jobExecutionService.countExecutionStatuses(any(), any())).thenReturn(Map.of());
-      var testJob = new V2DataJob();
-      var deployment = new V2DataJobDeployment();
+  @Test
+  void testDataFetcherStatusCount_emptyExecutions() {
+    when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
+    lenient()
+        .when(
+            dataFetchingFieldSelectionSet.contains(
+                JobFieldStrategyBy.DEPLOYMENT_SUCCESSFUL_EXECUTIONS.getPath()))
+        .thenReturn(true);
+    lenient()
+        .when(
+            dataFetchingFieldSelectionSet.contains(
+                JobFieldStrategyBy.DEPLOYMENT_FAILED_EXECUTIONS.getPath()))
+        .thenReturn(true);
+    when(jobExecutionService.countExecutionStatuses(any(), any())).thenReturn(Map.of());
+    var testJob = new V2DataJob();
+    var deployment = new V2DataJobDeployment();
 
-      testJob.setJobName("test-job");
-      testJob.setDeployments(List.of(deployment));
+    testJob.setJobName("test-job");
+    testJob.setDeployments(List.of(deployment));
 
-      var result = executionDataFetcher.populateStatusCounts(List.of(testJob), dataFetchingEnvironment);
-      assertEquals(0, result.get(0).getDeployments().get(0).getSuccessfulExecutions());
-      assertEquals(0, result.get(0).getDeployments().get(0).getFailedExecutions());
-   }
+    var result =
+        executionDataFetcher.populateStatusCounts(List.of(testJob), dataFetchingEnvironment);
+    assertEquals(0, result.get(0).getDeployments().get(0).getSuccessfulExecutions());
+    assertEquals(0, result.get(0).getDeployments().get(0).getFailedExecutions());
+  }
 
-   @Test
-   void testDataFetcherStatusCount_twoFailedExecutions() {
-      when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-      lenient().when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT_FAILED_EXECUTIONS.getPath())).thenReturn(true);
-      when(jobExecutionService.countExecutionStatuses(any(), any())).thenReturn(Map.of("test-job", Map.of(ExecutionStatus.PLATFORM_ERROR, 2)));
-      var testJob = new V2DataJob();
-      var deployment = new V2DataJobDeployment();
+  @Test
+  void testDataFetcherStatusCount_twoFailedExecutions() {
+    when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
+    lenient()
+        .when(
+            dataFetchingFieldSelectionSet.contains(
+                JobFieldStrategyBy.DEPLOYMENT_FAILED_EXECUTIONS.getPath()))
+        .thenReturn(true);
+    when(jobExecutionService.countExecutionStatuses(any(), any()))
+        .thenReturn(Map.of("test-job", Map.of(ExecutionStatus.PLATFORM_ERROR, 2)));
+    var testJob = new V2DataJob();
+    var deployment = new V2DataJobDeployment();
 
-      testJob.setJobName("test-job");
-      testJob.setDeployments(List.of(deployment));
+    testJob.setJobName("test-job");
+    testJob.setDeployments(List.of(deployment));
 
-      var result = executionDataFetcher.populateStatusCounts(List.of(testJob), dataFetchingEnvironment);
-      assertEquals(2, result.get(0).getDeployments().get(0).getFailedExecutions());
-   }
+    var result =
+        executionDataFetcher.populateStatusCounts(List.of(testJob), dataFetchingEnvironment);
+    assertEquals(2, result.get(0).getDeployments().get(0).getFailedExecutions());
+  }
 
-   @Test
-   void testDataFetcherStatusCount_twoSuccessfulExecutions() {
-      when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-      lenient().when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT_SUCCESSFUL_EXECUTIONS.getPath())).thenReturn(true);
-      when(jobExecutionService.countExecutionStatuses(any(), any())).thenReturn(Map.of("test-job", Map.of(ExecutionStatus.SUCCEEDED, 2)));
-      var testJob = new V2DataJob();
-      var deployment = new V2DataJobDeployment();
+  @Test
+  void testDataFetcherStatusCount_twoSuccessfulExecutions() {
+    when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
+    lenient()
+        .when(
+            dataFetchingFieldSelectionSet.contains(
+                JobFieldStrategyBy.DEPLOYMENT_SUCCESSFUL_EXECUTIONS.getPath()))
+        .thenReturn(true);
+    when(jobExecutionService.countExecutionStatuses(any(), any()))
+        .thenReturn(Map.of("test-job", Map.of(ExecutionStatus.SUCCEEDED, 2)));
+    var testJob = new V2DataJob();
+    var deployment = new V2DataJobDeployment();
 
-      testJob.setJobName("test-job");
-      testJob.setDeployments(List.of(deployment));
+    testJob.setJobName("test-job");
+    testJob.setDeployments(List.of(deployment));
 
-      var result = executionDataFetcher.populateStatusCounts(List.of(testJob), dataFetchingEnvironment);
-      assertEquals(2, result.get(0).getDeployments().get(0).getSuccessfulExecutions());
-   }
+    var result =
+        executionDataFetcher.populateStatusCounts(List.of(testJob), dataFetchingEnvironment);
+    assertEquals(2, result.get(0).getDeployments().get(0).getSuccessfulExecutions());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/ExecutionDataFetcherTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/ExecutionDataFetcherTest.java
@@ -48,135 +48,145 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class ExecutionDataFetcherTest {
 
-   private ExecutionDataFetcher executionDataFetcher;
-   @Mock
-   private JobExecutionRepository jobExecutionRepository;
-   @Mock
-   private DataFetchingEnvironment dataFetchingEnvironment;
-   @Mock
-   private DataFetchingFieldSelectionSet dataFetchingFieldSelectionSet;
-   @Mock
-   private SelectedField selectedField;
-   @Mock
-   private JobExecutionService jobExecutionService;
-   @Mock
-   private JobExecutionLogsUrlBuilder jobExecutionLogsUrlBuilder;
+  private ExecutionDataFetcher executionDataFetcher;
+  @Mock private JobExecutionRepository jobExecutionRepository;
+  @Mock private DataFetchingEnvironment dataFetchingEnvironment;
+  @Mock private DataFetchingFieldSelectionSet dataFetchingFieldSelectionSet;
+  @Mock private SelectedField selectedField;
+  @Mock private JobExecutionService jobExecutionService;
+  @Mock private JobExecutionLogsUrlBuilder jobExecutionLogsUrlBuilder;
 
-   @BeforeEach
-   public void init() {
-      executionDataFetcher = new ExecutionDataFetcher(jobExecutionRepository, jobExecutionService, jobExecutionLogsUrlBuilder);
-   }
+  @BeforeEach
+  public void init() {
+    executionDataFetcher =
+        new ExecutionDataFetcher(
+            jobExecutionRepository, jobExecutionService, jobExecutionLogsUrlBuilder);
+  }
 
-   @Test
-   void testDataFetcherOfJobs_whenInvalidExecutionPageNumberIsProvided_shouldThrowException() {
-      when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-      when(dataFetchingFieldSelectionSet.getField(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
-            .thenReturn(selectedField);
-      Map<String, Object> executionArgs = new HashMap<>();
-      executionArgs.put("pageNumber", 0);
-      executionArgs.put("pageSize", 25);
-      when(selectedField.getArguments()).thenReturn(executionArgs);
-      List<V2DataJob> v2DataJobs = mockListOfV2DataJobs();
+  @Test
+  void testDataFetcherOfJobs_whenInvalidExecutionPageNumberIsProvided_shouldThrowException() {
+    when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
+    when(dataFetchingFieldSelectionSet.getField(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
+        .thenReturn(selectedField);
+    Map<String, Object> executionArgs = new HashMap<>();
+    executionArgs.put("pageNumber", 0);
+    executionArgs.put("pageSize", 25);
+    when(selectedField.getArguments()).thenReturn(executionArgs);
+    List<V2DataJob> v2DataJobs = mockListOfV2DataJobs();
 
-      assertThrows(GraphQLException.class, () -> executionDataFetcher.populateExecutions(v2DataJobs, dataFetchingEnvironment));
-   }
+    assertThrows(
+        GraphQLException.class,
+        () -> executionDataFetcher.populateExecutions(v2DataJobs, dataFetchingEnvironment));
+  }
 
-   @Test
-   void testDataFetcherOfJobs_whenInvalidExecutionPageSizeIsProvided_shouldThrowException() {
-      when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-      when(dataFetchingFieldSelectionSet.getField(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
-            .thenReturn(selectedField);
-      Map<String, Object> executionArgs = new HashMap<>();
-      executionArgs.put("pageNumber", 1);
-      executionArgs.put("pageSize", 0);
-      when(selectedField.getArguments()).thenReturn(executionArgs);
-      List<V2DataJob> v2DataJobs = mockListOfV2DataJobs();
+  @Test
+  void testDataFetcherOfJobs_whenInvalidExecutionPageSizeIsProvided_shouldThrowException() {
+    when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
+    when(dataFetchingFieldSelectionSet.getField(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
+        .thenReturn(selectedField);
+    Map<String, Object> executionArgs = new HashMap<>();
+    executionArgs.put("pageNumber", 1);
+    executionArgs.put("pageSize", 0);
+    when(selectedField.getArguments()).thenReturn(executionArgs);
+    List<V2DataJob> v2DataJobs = mockListOfV2DataJobs();
 
-      assertThrows(GraphQLException.class, () -> executionDataFetcher.populateExecutions(v2DataJobs, dataFetchingEnvironment));
-   }
+    assertThrows(
+        GraphQLException.class,
+        () -> executionDataFetcher.populateExecutions(v2DataJobs, dataFetchingEnvironment));
+  }
 
-   @Test
-   void testDataFetcherOfJobs_whenRequestIncludesExecutions_shouldInvokeExecutions() {
-      when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-      when(dataFetchingFieldSelectionSet.getField(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
-            .thenReturn(selectedField);
-      Map<String, Object> executionArgs = new HashMap<>();
-      executionArgs.put("pageNumber", 1);
-      executionArgs.put("pageSize", 25);
-      when(selectedField.getArguments()).thenReturn(executionArgs);
-      List<V2DataJob> v2DataJobs = mockListOfV2DataJobs();
-      when(jobExecutionRepository.findAll(any(Specification.class), any(Pageable.class)))
-              .thenReturn(new PageImpl<DataJobExecution>(Collections.emptyList()));
+  @Test
+  void testDataFetcherOfJobs_whenRequestIncludesExecutions_shouldInvokeExecutions() {
+    when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
+    when(dataFetchingFieldSelectionSet.getField(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
+        .thenReturn(selectedField);
+    Map<String, Object> executionArgs = new HashMap<>();
+    executionArgs.put("pageNumber", 1);
+    executionArgs.put("pageSize", 25);
+    when(selectedField.getArguments()).thenReturn(executionArgs);
+    List<V2DataJob> v2DataJobs = mockListOfV2DataJobs();
+    when(jobExecutionRepository.findAll(any(Specification.class), any(Pageable.class)))
+        .thenReturn(new PageImpl<DataJobExecution>(Collections.emptyList()));
 
-      List<V2DataJob> result = executionDataFetcher.populateExecutions(v2DataJobs, dataFetchingEnvironment);
+    List<V2DataJob> result =
+        executionDataFetcher.populateExecutions(v2DataJobs, dataFetchingEnvironment);
 
-      assertEquals(3, result.size());
-      verify(jobExecutionRepository, times(2)).findAll(any(Specification.class), any(Pageable.class));
-   }
+    assertEquals(3, result.size());
+    verify(jobExecutionRepository, times(2)).findAll(any(Specification.class), any(Pageable.class));
+  }
 
-   @Test
-   void testDataFetcherOfJobs_whenUnsupportedOrderInExecutionOperation_shouldThrowException() {
-      when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-      when(dataFetchingFieldSelectionSet.getField(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
-            .thenReturn(selectedField);
-      Map<String, Object> executionArgs = new HashMap<>();
-      executionArgs.put("pageNumber", 1);
-      executionArgs.put("pageSize", 25);
+  @Test
+  void testDataFetcherOfJobs_whenUnsupportedOrderInExecutionOperation_shouldThrowException() {
+    when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
+    when(dataFetchingFieldSelectionSet.getField(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
+        .thenReturn(selectedField);
+    Map<String, Object> executionArgs = new HashMap<>();
+    executionArgs.put("pageNumber", 1);
+    executionArgs.put("pageSize", 25);
 
-      executionArgs.put("order", Map.of(
-              DataJobExecutionOrder.PROPERTY_FIELD, UUID.randomUUID().toString(),
-              DataJobExecutionOrder.DIRECTION_FIELD, Sort.Direction.ASC));
-      when(selectedField.getArguments()).thenReturn(executionArgs);
-      List<V2DataJob> v2DataJobs = mockListOfV2DataJobs();
+    executionArgs.put(
+        "order",
+        Map.of(
+            DataJobExecutionOrder.PROPERTY_FIELD,
+            UUID.randomUUID().toString(),
+            DataJobExecutionOrder.DIRECTION_FIELD,
+            Sort.Direction.ASC));
+    when(selectedField.getArguments()).thenReturn(executionArgs);
+    List<V2DataJob> v2DataJobs = mockListOfV2DataJobs();
 
-      assertThrows(GraphQLException.class, () -> executionDataFetcher.populateExecutions(v2DataJobs, dataFetchingEnvironment));
-   }
+    assertThrows(
+        GraphQLException.class,
+        () -> executionDataFetcher.populateExecutions(v2DataJobs, dataFetchingEnvironment));
+  }
 
-   @Test
-   void testDataFetcherOfJobs_whenJobNameInIsSpecified_shouldThrowException() {
-      when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-      when(dataFetchingFieldSelectionSet.getField(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
-              .thenReturn(selectedField);
-      Map<String, Object> executionArgs = new HashMap<>();
-      executionArgs.put("pageNumber", 1);
-      executionArgs.put("pageSize", 25);
-      executionArgs.put("filter", Map.of(
-              DataJobExecutionFilter.JOB_NAME_IN_FIELD, List.of("any-job")));
-      when(selectedField.getArguments()).thenReturn(executionArgs);
-      List<V2DataJob> v2DataJobs = mockListOfV2DataJobs();
+  @Test
+  void testDataFetcherOfJobs_whenJobNameInIsSpecified_shouldThrowException() {
+    when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
+    when(dataFetchingFieldSelectionSet.getField(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
+        .thenReturn(selectedField);
+    Map<String, Object> executionArgs = new HashMap<>();
+    executionArgs.put("pageNumber", 1);
+    executionArgs.put("pageSize", 25);
+    executionArgs.put(
+        "filter", Map.of(DataJobExecutionFilter.JOB_NAME_IN_FIELD, List.of("any-job")));
+    when(selectedField.getArguments()).thenReturn(executionArgs);
+    List<V2DataJob> v2DataJobs = mockListOfV2DataJobs();
 
-      assertThrows(GraphQLException.class, () -> executionDataFetcher.populateExecutions(v2DataJobs, dataFetchingEnvironment));
-   }
+    assertThrows(
+        GraphQLException.class,
+        () -> executionDataFetcher.populateExecutions(v2DataJobs, dataFetchingEnvironment));
+  }
 
-   static List<V2DataJob> mockListOfV2DataJobs() {
-      List<V2DataJob> dataJobs = new ArrayList<>();
+  static List<V2DataJob> mockListOfV2DataJobs() {
+    List<V2DataJob> dataJobs = new ArrayList<>();
 
-      dataJobs.add(mockSampleDataJob("sample-job-1", "Import SQL", true));
-      dataJobs.add(mockSampleDataJob("sample-job-2", "Dump SQL", true));
-      dataJobs.add(mockSampleDataJob("sample-job-3", "Delete users", false));
+    dataJobs.add(mockSampleDataJob("sample-job-1", "Import SQL", true));
+    dataJobs.add(mockSampleDataJob("sample-job-2", "Dump SQL", true));
+    dataJobs.add(mockSampleDataJob("sample-job-3", "Delete users", false));
 
-      return dataJobs;
-   }
+    return dataJobs;
+  }
 
-   static V2DataJob mockSampleDataJob(String jobName, String description, boolean includeDeployment) {
-      V2DataJob dataJob = new V2DataJob();
-      V2DataJobConfig jobConfig = new V2DataJobConfig();
-      jobConfig.setSchedule(new V2DataJobSchedule());
-      jobConfig.setDescription(description);
-      dataJob.setConfig(jobConfig);
-      if (includeDeployment) {
-         dataJob.setDeployments(Collections.singletonList(mockSampleDeployment(jobName)));
-      }
-      dataJob.setJobName(jobName);
+  static V2DataJob mockSampleDataJob(
+      String jobName, String description, boolean includeDeployment) {
+    V2DataJob dataJob = new V2DataJob();
+    V2DataJobConfig jobConfig = new V2DataJobConfig();
+    jobConfig.setSchedule(new V2DataJobSchedule());
+    jobConfig.setDescription(description);
+    dataJob.setConfig(jobConfig);
+    if (includeDeployment) {
+      dataJob.setDeployments(Collections.singletonList(mockSampleDeployment(jobName)));
+    }
+    dataJob.setJobName(jobName);
 
-      return dataJob;
-   }
+    return dataJob;
+  }
 
-   static V2DataJobDeployment mockSampleDeployment(String jobName) {
-      V2DataJobDeployment status = new V2DataJobDeployment();
-      status.setEnabled(true);
-      status.setId(jobName + "-latest");
-      status.setMode(DataJobMode.RELEASE);
-      return status;
-   }
+  static V2DataJobDeployment mockSampleDeployment(String jobName) {
+    V2DataJobDeployment status = new V2DataJobDeployment();
+    status.setEnabled(true);
+    status.setId(jobName + "-latest");
+    status.setMode(DataJobMode.RELEASE);
+    return status;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLDataFetchersTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLDataFetchersTest.java
@@ -58,368 +58,424 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class GraphQLDataFetchersTest {
 
-   @Mock
-   private ExecutionDataFetcher executionDataFetcher;
-
-   @Mock
-   private JobsRepository jobsRepository;
-
-   @Mock
-   private DeploymentService deploymentService;
-
-   @Mock
-   private DataFetchingEnvironment dataFetchingEnvironment;
-
-   @Mock
-   private DataFetchingFieldSelectionSet dataFetchingFieldSelectionSet;
-
-   private DataFetcher<Object> findDataJobs;
-
-   @BeforeEach
-   public void before() {
-      JobFieldStrategyFactory strategyFactory = new JobFieldStrategyFactory(collectSupportedFieldStrategies());
-      GraphQLDataFetchers graphQLDataFetchers = new GraphQLDataFetchers(strategyFactory, jobsRepository, deploymentService, executionDataFetcher);
-      findDataJobs = graphQLDataFetchers.findAllAndBuildDataJobPage();
-   }
-
-   @Test
-   void testDataFetcherOfJobs_whenGettingFullList_shouldReturnAllDataJobs() throws Exception {
-      when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
-      when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(10);
-      when(jobsRepository.findAll()).thenReturn(mockListOfDataJobs());
-      when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-      when(dataFetchingFieldSelectionSet.contains(not(eq(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath())))).thenReturn(true);
-      when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath())).thenReturn(false);
-
-      DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
-
-      assertThat(dataJobPage.getContent().size()).isEqualTo(3);
-   }
-
-   @Test
-   void testDataFetcherOfJobs_whenGettingPagedResult_shouldReturnPagedJobs() throws Exception {
-      when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(2);
-      when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(2);
-      when(jobsRepository.findAll()).thenReturn(mockListOfDataJobs());
-      when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-      when(dataFetchingFieldSelectionSet.contains(not(eq(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath())))).thenReturn(true);
-      when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath())).thenReturn(false);
-
-      DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
-
-      assertThat(dataJobPage.getContent().size()).isEqualTo(1);
-      V2DataJob dataJob = (V2DataJob) dataJobPage.getContent().get(0);
-      assertThat(dataJob.getJobName()).isEqualTo("sample-job-3");
-   }
-
-   @Test
-   void testDataFetcherOfJobs_whenSupportedFieldProvidedWithSorting_shouldReturnJobList() throws Exception {
-      when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
-      when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(10);
-      when(dataFetchingEnvironment.getArgument("search")).thenReturn(null);
-      when(jobsRepository.findAll()).thenReturn(mockListOfDataJobs());
-      when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-      when(dataFetchingEnvironment.getArgument("filter")).thenReturn(constructFilter(
-            Filter.of("jobName", "sample-job", Sort.Direction.DESC)
-      ));
-
-      DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
-
-      assertThat(dataJobPage.getContent().size()).isEqualTo(3);
-      V2DataJob dataJob = (V2DataJob) dataJobPage.getContent().get(0);
-      assertThat(dataJob.getJobName()).isEqualTo("sample-job-3");
-   }
-
-
-
-   @Test
-   void testDataFetcherOfJobs_whenSearchingSpecificJob_shouldReturnSearchedJob() throws Exception {
-      when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
-      when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(10);
-      when(dataFetchingEnvironment.getArgument("search")).thenReturn("sample-job-2");
-      when(jobsRepository.findAll()).thenReturn(mockListOfDataJobs());
-      when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-      when(dataFetchingFieldSelectionSet.contains(not(eq(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath())))).thenReturn(true);
-      when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath())).thenReturn(false);
-
-      DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
-
-      assertThat(dataJobPage.getContent().size()).isEqualTo(1);
-      V2DataJob dataJob = (V2DataJob) dataJobPage.getContent().get(0);
-      assertThat(dataJob.getJobName()).isEqualTo("sample-job-2");
-   }
-
-   @Test
-   void testDataFetcherOfJobs_whenSearchingByPattern_shouldReturnMatchingJobs() throws Exception {
-      when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
-      when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(10);
-      when(dataFetchingEnvironment.getArgument("search")).thenReturn("sample-job-2");
-      when(jobsRepository.findAll()).thenReturn(mockListOfDataJobs());
-      when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-      when(dataFetchingFieldSelectionSet.contains(not(eq(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath())))).thenReturn(true);
-      when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath())).thenReturn(false);
-
-      DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
-
-      assertThat(dataJobPage.getContent().size()).isEqualTo(1);
-      V2DataJob dataJob = (V2DataJob) dataJobPage.getContent().get(0);
-      assertThat(dataJob.getJobName()).isEqualTo("sample-job-2");
-   }
-
-   @Test
-   void testDataFetcherOfJobs_whenInvalidPageSizeIsProvided_shouldThrowException() {
-      when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
-      when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(0);
-
-      assertThrows(GraphQLException.class, () -> {
-         findDataJobs.get(dataFetchingEnvironment);
-      });
-   }
-
-   @Test
-   void testDataFetcherOfJobs_whenInvalidPageNumberIsProvided_shouldThrowException() {
-      when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(0);
-      when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(1);
-
-      assertThrows(GraphQLException.class, () -> {
-         findDataJobs.get(dataFetchingEnvironment);
-      });
-   }
-
-   @Test
-   void testDataFetcherOfJobs_whenValidPageNumberIsProvided_shouldNotThrowException() {
-      when(jobsRepository.findAll()).thenReturn(mockListOfDataJobs());
-      when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-      when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
-      when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(100);
-
-      assertDoesNotThrow(() -> {
-         findDataJobs.get(dataFetchingEnvironment);
-      });
-   }
-
-   @Test
-   void testPopulateDeployments() throws Exception {
-      when(jobsRepository.findAll()).thenReturn(mockListOfDataJobsWithLastExecution());
-      when(deploymentService.readDeployments()).thenReturn(mockListOfDeployments());
-      when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
-      when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(100);
-      when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-      when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT.getPath())).thenReturn(true);
-
-      DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
-
-      assertThat(dataJobPage.getContent()).hasSize(5);
-      var job1 = (V2DataJob)dataJobPage.getContent().get(0);
-      assertThat(job1.getDeployments()).hasSize(1);
-      assertThat(job1.getDeployments().get(0).getLastExecutionStatus()).isEqualTo(DataJobExecution.StatusEnum.PLATFORM_ERROR);
-      assertThat(job1.getDeployments().get(0).getLastExecutionTime()).isEqualTo(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
-      assertThat(job1.getDeployments().get(0).getLastExecutionDuration()).isEqualTo(1000);
-      var job2 = (V2DataJob)dataJobPage.getContent().get(1);
-      assertThat(job2.getDeployments()).hasSize(1);
-      assertThat(job2.getDeployments().get(0).getLastExecutionStatus()).isNull();
-      assertThat(job2.getDeployments().get(0).getLastExecutionTime()).isNull();
-      assertThat(job2.getDeployments().get(0).getLastExecutionDuration()).isNull();
-   }
-
-   @Test
-   void testFilterByLastExecutionStatus() throws Exception {
-      when(jobsRepository.findAll()).thenReturn(mockListOfDataJobsWithLastExecution());
-      when(deploymentService.readDeployments()).thenReturn(mockListOfDeployments());
-      when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
-      when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(100);
-      when(dataFetchingEnvironment.getArgument("search")).thenReturn(null);
-      when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-      when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT.getPath())).thenReturn(true);
-      when(dataFetchingEnvironment.getArgument("filter")).thenReturn(constructFilter(
-              Filter.of("deployments.lastExecutionStatus", DataJobExecution.StatusEnum.SUCCEEDED.getValue(), null)
-      ));
-
-      DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
-
-      assertThat(dataJobPage.getContent()).hasSize(1);
-   }
-
-   @Test
-   void testSortingByLastExecutionStatus() throws Exception {
-      when(jobsRepository.findAll()).thenReturn(mockListOfDataJobsWithLastExecution());
-      when(deploymentService.readDeployments()).thenReturn(mockListOfDeployments());
-      when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
-      when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(100);
-      when(dataFetchingEnvironment.getArgument("search")).thenReturn(null);
-      when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-      when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT.getPath())).thenReturn(true);
-      when(dataFetchingEnvironment.getArgument("filter")).thenReturn(constructFilter(
-              Filter.of("deployments.lastExecutionStatus", null, Sort.Direction.ASC)
-      ));
-
-      DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
-
-      var lastExecutionStatuses = dataJobPage.getContent().stream()
-              .map(job -> ((V2DataJob)job).getDeployments().get(0).getLastExecutionStatus())
-              .map(status -> status != null ? status.getValue() : null)
-              .collect(Collectors.toList());
-      assertThat(lastExecutionStatuses).hasSize(5);
-      assertThat(lastExecutionStatuses.get(0)).isNull();
-      assertThat(lastExecutionStatuses.get(1)).isNull();
-      assertThat(lastExecutionStatuses.get(2)).isEqualTo(DataJobExecution.StatusEnum.PLATFORM_ERROR.getValue());
-      assertThat(lastExecutionStatuses.get(3)).isEqualTo(DataJobExecution.StatusEnum.PLATFORM_ERROR.getValue());
-      assertThat(lastExecutionStatuses.get(4)).isEqualTo(DataJobExecution.StatusEnum.SUCCEEDED.getValue());
-   }
-
-   @Test
-   void testSortingByLastExecutionTime() throws Exception {
-      when(jobsRepository.findAll()).thenReturn(mockListOfDataJobsWithLastExecution());
-      when(deploymentService.readDeployments()).thenReturn(mockListOfDeployments());
-      when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
-      when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(100);
-      when(dataFetchingEnvironment.getArgument("search")).thenReturn(null);
-      when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-      when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT.getPath())).thenReturn(true);
-      when(dataFetchingEnvironment.getArgument("filter")).thenReturn(constructFilter(
-              Filter.of("deployments.lastExecutionTime", null, Sort.Direction.ASC)
-      ));
-
-      DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
-
-      var lastExecutionTimes = dataJobPage.getContent().stream()
-              .map(job -> ((V2DataJob)job).getDeployments().get(0).getLastExecutionTime())
-              .collect(Collectors.toList());
-      assertThat(lastExecutionTimes).hasSize(5);
-      assertThat(lastExecutionTimes.get(0)).isNull();
-      assertThat(lastExecutionTimes.get(1)).isNull();
-      assertThat(lastExecutionTimes.get(2)).isEqualTo(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
-      assertThat(lastExecutionTimes.get(3)).isEqualTo(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
-      assertThat(lastExecutionTimes.get(4)).isEqualTo(OffsetDateTime.of(2000, 1, 3, 0, 0, 0, 0, ZoneOffset.UTC));
-   }
-
-   @Test
-   void testSortingByLastExecutionDuration() throws Exception {
-      when(jobsRepository.findAll()).thenReturn(mockListOfDataJobsWithLastExecution());
-      when(deploymentService.readDeployments()).thenReturn(mockListOfDeployments());
-      when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
-      when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(100);
-      when(dataFetchingEnvironment.getArgument("search")).thenReturn(null);
-      when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-      when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT.getPath())).thenReturn(true);
-      when(dataFetchingEnvironment.getArgument("filter")).thenReturn(constructFilter(
-              Filter.of("deployments.lastExecutionDuration", null, Sort.Direction.DESC)
-      ));
-
-      DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
-
-      var lastExecutionTimes = dataJobPage.getContent().stream()
-              .map(job -> ((V2DataJob)job).getDeployments().get(0).getLastExecutionDuration())
-              .collect(Collectors.toList());
-      assertThat(lastExecutionTimes).hasSize(5);
-      assertThat(lastExecutionTimes.get(0)).isEqualTo(1000);
-      assertThat(lastExecutionTimes.get(1)).isEqualTo(1000);
-      assertThat(lastExecutionTimes.get(2)).isEqualTo(0);
-      assertThat(lastExecutionTimes.get(3)).isNull();
-      assertThat(lastExecutionTimes.get(4)).isNull();
-   }
-
-
-   private List<JobDeploymentStatus> mockListOfDeployments() {
-      List<JobDeploymentStatus> jobDeployments = new ArrayList<>();
-
-      jobDeployments.add(mockSampleDeployment("sample-job-1", true));
-      jobDeployments.add(mockSampleDeployment("sample-job-2", false));
-      jobDeployments.add(mockSampleDeployment("sample-job-3", true));
-      jobDeployments.add(mockSampleDeployment("sample-job-4", true));
-      jobDeployments.add(mockSampleDeployment("sample-job-5", true));
-
-      return jobDeployments;
-   }
-
-   private List<DataJob> mockListOfDataJobs() {
-      List<DataJob> dataJobs = new ArrayList<>();
-
-      dataJobs.add(mockSampleDataJob("sample-job-1", "Import SQL", "5 12 * * *"));
-      dataJobs.add(mockSampleDataJob("sample-job-2", "Dump SQL", "0 22 * * 1-5"));
-      dataJobs.add(mockSampleDataJob("sample-job-3", "Delete users", "0 4 8-14 * *"));
-
-      return dataJobs;
-   }
-
-   private List<DataJob> mockListOfDataJobsWithLastExecution() {
-      List<DataJob> dataJobs = new ArrayList<>();
-
-      dataJobs.add(mockSampleDataJob("sample-job-1", "Import SQL", "5 12 * * *",
-              ExecutionStatus.PLATFORM_ERROR, OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC), 1000));
-      dataJobs.add(mockSampleDataJob("sample-job-2", "Dump SQL", "0 22 * * 1-5"));
-      dataJobs.add(mockSampleDataJob("sample-job-3", "Import SQL", "5 12 * * *",
-              ExecutionStatus.PLATFORM_ERROR, OffsetDateTime.of(2000, 1, 3, 0, 0, 0, 0, ZoneOffset.UTC), null));
-      dataJobs.add(mockSampleDataJob("sample-job-4", "Import SQL", "5 12 * * *",
-              ExecutionStatus.SUCCEEDED, null, 0));
-      dataJobs.add(mockSampleDataJob("sample-job-5", "Import SQL", "5 12 * * *",
-              null, OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC), 1000));
-
-      return dataJobs;
-   }
-
-   private DataJob mockSampleDataJob(String jobName, String description, String schedule) {
-      return mockSampleDataJob(jobName, description, schedule, null, null, null);
-   }
-
-   private DataJob mockSampleDataJob(String jobName,
-                                     String description,
-                                     String schedule,
-                                     ExecutionStatus lastExecutionStatus,
-                                     OffsetDateTime lastExecutionEndTime,
-                                     Integer lastExecutionDuration) {
-      DataJob dataJob = new DataJob();
-      JobConfig jobConfig = new JobConfig();
-      jobConfig.setSchedule(schedule);
-      jobConfig.setDescription(description);
-      dataJob.setJobConfig(jobConfig);
-      dataJob.setName(jobName);
-      dataJob.setLastExecutionStatus(lastExecutionStatus);
-      dataJob.setLastExecutionEndTime(lastExecutionEndTime);
-      dataJob.setLastExecutionDuration(lastExecutionDuration);
-
-      return dataJob;
-   }
-
-   private JobDeploymentStatus mockSampleDeployment(String jobName, boolean enabled) {
-      JobDeploymentStatus status = new JobDeploymentStatus();
-      status.setEnabled(enabled);
-      status.setDataJobName(jobName);
-      status.setCronJobName(jobName+"-latest");
-      status.setMode("release");
-      return status;
-   }
-
-   static ArrayList<LinkedHashMap<String, String>> constructFilter(Filter ... filters) {
-      ArrayList<LinkedHashMap<String, String>> rawFilters = new ArrayList<>();
-      Arrays.stream(filters).forEach(filter -> {
-         LinkedHashMap<String, String> map = new LinkedHashMap<>();
-
-         map.put("property", filter.getProperty());
-         map.put("pattern", filter.getPattern());
-         if (filter.getSort() != null) {
-            map.put("sort", filter.getSort().toString());
-         }
-
-         rawFilters.add(map);
-      });
-
-      return rawFilters;
-   }
-
-   private Set<FieldStrategy<V2DataJob>> collectSupportedFieldStrategies() {
-      Set<FieldStrategy<V2DataJob>> strategies = new HashSet<>();
-
-      strategies.add(new JobFieldStrategyByDescription());
-      strategies.add(new JobFieldStrategyByName());
-      strategies.add(new JobFieldStrategyByNextRun());
-      strategies.add(new JobFieldStrategyByScheduleCron());
-      strategies.add(new JobFieldStrategyBySourceUrl("gitlab.com/demo-data-jobs.git", "main", true));
-      strategies.add(new JobFieldStrategyByTeam());
-      strategies.add(new JobFieldStrategyByLastExecutionStatus());
-      strategies.add(new JobFieldStrategyByLastExecutionTime());
-      strategies.add(new JobFieldStrategyByLastExecutionDuration());
-
-      return strategies;
-   }
+  @Mock private ExecutionDataFetcher executionDataFetcher;
+
+  @Mock private JobsRepository jobsRepository;
+
+  @Mock private DeploymentService deploymentService;
+
+  @Mock private DataFetchingEnvironment dataFetchingEnvironment;
+
+  @Mock private DataFetchingFieldSelectionSet dataFetchingFieldSelectionSet;
+
+  private DataFetcher<Object> findDataJobs;
+
+  @BeforeEach
+  public void before() {
+    JobFieldStrategyFactory strategyFactory =
+        new JobFieldStrategyFactory(collectSupportedFieldStrategies());
+    GraphQLDataFetchers graphQLDataFetchers =
+        new GraphQLDataFetchers(
+            strategyFactory, jobsRepository, deploymentService, executionDataFetcher);
+    findDataJobs = graphQLDataFetchers.findAllAndBuildDataJobPage();
+  }
+
+  @Test
+  void testDataFetcherOfJobs_whenGettingFullList_shouldReturnAllDataJobs() throws Exception {
+    when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
+    when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(10);
+    when(jobsRepository.findAll()).thenReturn(mockListOfDataJobs());
+    when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
+    when(dataFetchingFieldSelectionSet.contains(
+            not(eq(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))))
+        .thenReturn(true);
+    when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
+        .thenReturn(false);
+
+    DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
+
+    assertThat(dataJobPage.getContent().size()).isEqualTo(3);
+  }
+
+  @Test
+  void testDataFetcherOfJobs_whenGettingPagedResult_shouldReturnPagedJobs() throws Exception {
+    when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(2);
+    when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(2);
+    when(jobsRepository.findAll()).thenReturn(mockListOfDataJobs());
+    when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
+    when(dataFetchingFieldSelectionSet.contains(
+            not(eq(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))))
+        .thenReturn(true);
+    when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
+        .thenReturn(false);
+
+    DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
+
+    assertThat(dataJobPage.getContent().size()).isEqualTo(1);
+    V2DataJob dataJob = (V2DataJob) dataJobPage.getContent().get(0);
+    assertThat(dataJob.getJobName()).isEqualTo("sample-job-3");
+  }
+
+  @Test
+  void testDataFetcherOfJobs_whenSupportedFieldProvidedWithSorting_shouldReturnJobList()
+      throws Exception {
+    when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
+    when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(10);
+    when(dataFetchingEnvironment.getArgument("search")).thenReturn(null);
+    when(jobsRepository.findAll()).thenReturn(mockListOfDataJobs());
+    when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
+    when(dataFetchingEnvironment.getArgument("filter"))
+        .thenReturn(constructFilter(Filter.of("jobName", "sample-job", Sort.Direction.DESC)));
+
+    DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
+
+    assertThat(dataJobPage.getContent().size()).isEqualTo(3);
+    V2DataJob dataJob = (V2DataJob) dataJobPage.getContent().get(0);
+    assertThat(dataJob.getJobName()).isEqualTo("sample-job-3");
+  }
+
+  @Test
+  void testDataFetcherOfJobs_whenSearchingSpecificJob_shouldReturnSearchedJob() throws Exception {
+    when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
+    when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(10);
+    when(dataFetchingEnvironment.getArgument("search")).thenReturn("sample-job-2");
+    when(jobsRepository.findAll()).thenReturn(mockListOfDataJobs());
+    when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
+    when(dataFetchingFieldSelectionSet.contains(
+            not(eq(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))))
+        .thenReturn(true);
+    when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
+        .thenReturn(false);
+
+    DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
+
+    assertThat(dataJobPage.getContent().size()).isEqualTo(1);
+    V2DataJob dataJob = (V2DataJob) dataJobPage.getContent().get(0);
+    assertThat(dataJob.getJobName()).isEqualTo("sample-job-2");
+  }
+
+  @Test
+  void testDataFetcherOfJobs_whenSearchingByPattern_shouldReturnMatchingJobs() throws Exception {
+    when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
+    when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(10);
+    when(dataFetchingEnvironment.getArgument("search")).thenReturn("sample-job-2");
+    when(jobsRepository.findAll()).thenReturn(mockListOfDataJobs());
+    when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
+    when(dataFetchingFieldSelectionSet.contains(
+            not(eq(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))))
+        .thenReturn(true);
+    when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
+        .thenReturn(false);
+
+    DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
+
+    assertThat(dataJobPage.getContent().size()).isEqualTo(1);
+    V2DataJob dataJob = (V2DataJob) dataJobPage.getContent().get(0);
+    assertThat(dataJob.getJobName()).isEqualTo("sample-job-2");
+  }
+
+  @Test
+  void testDataFetcherOfJobs_whenInvalidPageSizeIsProvided_shouldThrowException() {
+    when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
+    when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(0);
+
+    assertThrows(
+        GraphQLException.class,
+        () -> {
+          findDataJobs.get(dataFetchingEnvironment);
+        });
+  }
+
+  @Test
+  void testDataFetcherOfJobs_whenInvalidPageNumberIsProvided_shouldThrowException() {
+    when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(0);
+    when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(1);
+
+    assertThrows(
+        GraphQLException.class,
+        () -> {
+          findDataJobs.get(dataFetchingEnvironment);
+        });
+  }
+
+  @Test
+  void testDataFetcherOfJobs_whenValidPageNumberIsProvided_shouldNotThrowException() {
+    when(jobsRepository.findAll()).thenReturn(mockListOfDataJobs());
+    when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
+    when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
+    when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(100);
+
+    assertDoesNotThrow(
+        () -> {
+          findDataJobs.get(dataFetchingEnvironment);
+        });
+  }
+
+  @Test
+  void testPopulateDeployments() throws Exception {
+    when(jobsRepository.findAll()).thenReturn(mockListOfDataJobsWithLastExecution());
+    when(deploymentService.readDeployments()).thenReturn(mockListOfDeployments());
+    when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
+    when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(100);
+    when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
+    when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT.getPath()))
+        .thenReturn(true);
+
+    DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
+
+    assertThat(dataJobPage.getContent()).hasSize(5);
+    var job1 = (V2DataJob) dataJobPage.getContent().get(0);
+    assertThat(job1.getDeployments()).hasSize(1);
+    assertThat(job1.getDeployments().get(0).getLastExecutionStatus())
+        .isEqualTo(DataJobExecution.StatusEnum.PLATFORM_ERROR);
+    assertThat(job1.getDeployments().get(0).getLastExecutionTime())
+        .isEqualTo(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
+    assertThat(job1.getDeployments().get(0).getLastExecutionDuration()).isEqualTo(1000);
+    var job2 = (V2DataJob) dataJobPage.getContent().get(1);
+    assertThat(job2.getDeployments()).hasSize(1);
+    assertThat(job2.getDeployments().get(0).getLastExecutionStatus()).isNull();
+    assertThat(job2.getDeployments().get(0).getLastExecutionTime()).isNull();
+    assertThat(job2.getDeployments().get(0).getLastExecutionDuration()).isNull();
+  }
+
+  @Test
+  void testFilterByLastExecutionStatus() throws Exception {
+    when(jobsRepository.findAll()).thenReturn(mockListOfDataJobsWithLastExecution());
+    when(deploymentService.readDeployments()).thenReturn(mockListOfDeployments());
+    when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
+    when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(100);
+    when(dataFetchingEnvironment.getArgument("search")).thenReturn(null);
+    when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
+    when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT.getPath()))
+        .thenReturn(true);
+    when(dataFetchingEnvironment.getArgument("filter"))
+        .thenReturn(
+            constructFilter(
+                Filter.of(
+                    "deployments.lastExecutionStatus",
+                    DataJobExecution.StatusEnum.SUCCEEDED.getValue(),
+                    null)));
+
+    DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
+
+    assertThat(dataJobPage.getContent()).hasSize(1);
+  }
+
+  @Test
+  void testSortingByLastExecutionStatus() throws Exception {
+    when(jobsRepository.findAll()).thenReturn(mockListOfDataJobsWithLastExecution());
+    when(deploymentService.readDeployments()).thenReturn(mockListOfDeployments());
+    when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
+    when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(100);
+    when(dataFetchingEnvironment.getArgument("search")).thenReturn(null);
+    when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
+    when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT.getPath()))
+        .thenReturn(true);
+    when(dataFetchingEnvironment.getArgument("filter"))
+        .thenReturn(
+            constructFilter(
+                Filter.of("deployments.lastExecutionStatus", null, Sort.Direction.ASC)));
+
+    DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
+
+    var lastExecutionStatuses =
+        dataJobPage.getContent().stream()
+            .map(job -> ((V2DataJob) job).getDeployments().get(0).getLastExecutionStatus())
+            .map(status -> status != null ? status.getValue() : null)
+            .collect(Collectors.toList());
+    assertThat(lastExecutionStatuses).hasSize(5);
+    assertThat(lastExecutionStatuses.get(0)).isNull();
+    assertThat(lastExecutionStatuses.get(1)).isNull();
+    assertThat(lastExecutionStatuses.get(2))
+        .isEqualTo(DataJobExecution.StatusEnum.PLATFORM_ERROR.getValue());
+    assertThat(lastExecutionStatuses.get(3))
+        .isEqualTo(DataJobExecution.StatusEnum.PLATFORM_ERROR.getValue());
+    assertThat(lastExecutionStatuses.get(4))
+        .isEqualTo(DataJobExecution.StatusEnum.SUCCEEDED.getValue());
+  }
+
+  @Test
+  void testSortingByLastExecutionTime() throws Exception {
+    when(jobsRepository.findAll()).thenReturn(mockListOfDataJobsWithLastExecution());
+    when(deploymentService.readDeployments()).thenReturn(mockListOfDeployments());
+    when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
+    when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(100);
+    when(dataFetchingEnvironment.getArgument("search")).thenReturn(null);
+    when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
+    when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT.getPath()))
+        .thenReturn(true);
+    when(dataFetchingEnvironment.getArgument("filter"))
+        .thenReturn(
+            constructFilter(Filter.of("deployments.lastExecutionTime", null, Sort.Direction.ASC)));
+
+    DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
+
+    var lastExecutionTimes =
+        dataJobPage.getContent().stream()
+            .map(job -> ((V2DataJob) job).getDeployments().get(0).getLastExecutionTime())
+            .collect(Collectors.toList());
+    assertThat(lastExecutionTimes).hasSize(5);
+    assertThat(lastExecutionTimes.get(0)).isNull();
+    assertThat(lastExecutionTimes.get(1)).isNull();
+    assertThat(lastExecutionTimes.get(2))
+        .isEqualTo(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
+    assertThat(lastExecutionTimes.get(3))
+        .isEqualTo(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
+    assertThat(lastExecutionTimes.get(4))
+        .isEqualTo(OffsetDateTime.of(2000, 1, 3, 0, 0, 0, 0, ZoneOffset.UTC));
+  }
+
+  @Test
+  void testSortingByLastExecutionDuration() throws Exception {
+    when(jobsRepository.findAll()).thenReturn(mockListOfDataJobsWithLastExecution());
+    when(deploymentService.readDeployments()).thenReturn(mockListOfDeployments());
+    when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
+    when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(100);
+    when(dataFetchingEnvironment.getArgument("search")).thenReturn(null);
+    when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
+    when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT.getPath()))
+        .thenReturn(true);
+    when(dataFetchingEnvironment.getArgument("filter"))
+        .thenReturn(
+            constructFilter(
+                Filter.of("deployments.lastExecutionDuration", null, Sort.Direction.DESC)));
+
+    DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
+
+    var lastExecutionTimes =
+        dataJobPage.getContent().stream()
+            .map(job -> ((V2DataJob) job).getDeployments().get(0).getLastExecutionDuration())
+            .collect(Collectors.toList());
+    assertThat(lastExecutionTimes).hasSize(5);
+    assertThat(lastExecutionTimes.get(0)).isEqualTo(1000);
+    assertThat(lastExecutionTimes.get(1)).isEqualTo(1000);
+    assertThat(lastExecutionTimes.get(2)).isEqualTo(0);
+    assertThat(lastExecutionTimes.get(3)).isNull();
+    assertThat(lastExecutionTimes.get(4)).isNull();
+  }
+
+  private List<JobDeploymentStatus> mockListOfDeployments() {
+    List<JobDeploymentStatus> jobDeployments = new ArrayList<>();
+
+    jobDeployments.add(mockSampleDeployment("sample-job-1", true));
+    jobDeployments.add(mockSampleDeployment("sample-job-2", false));
+    jobDeployments.add(mockSampleDeployment("sample-job-3", true));
+    jobDeployments.add(mockSampleDeployment("sample-job-4", true));
+    jobDeployments.add(mockSampleDeployment("sample-job-5", true));
+
+    return jobDeployments;
+  }
+
+  private List<DataJob> mockListOfDataJobs() {
+    List<DataJob> dataJobs = new ArrayList<>();
+
+    dataJobs.add(mockSampleDataJob("sample-job-1", "Import SQL", "5 12 * * *"));
+    dataJobs.add(mockSampleDataJob("sample-job-2", "Dump SQL", "0 22 * * 1-5"));
+    dataJobs.add(mockSampleDataJob("sample-job-3", "Delete users", "0 4 8-14 * *"));
+
+    return dataJobs;
+  }
+
+  private List<DataJob> mockListOfDataJobsWithLastExecution() {
+    List<DataJob> dataJobs = new ArrayList<>();
+
+    dataJobs.add(
+        mockSampleDataJob(
+            "sample-job-1",
+            "Import SQL",
+            "5 12 * * *",
+            ExecutionStatus.PLATFORM_ERROR,
+            OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
+            1000));
+    dataJobs.add(mockSampleDataJob("sample-job-2", "Dump SQL", "0 22 * * 1-5"));
+    dataJobs.add(
+        mockSampleDataJob(
+            "sample-job-3",
+            "Import SQL",
+            "5 12 * * *",
+            ExecutionStatus.PLATFORM_ERROR,
+            OffsetDateTime.of(2000, 1, 3, 0, 0, 0, 0, ZoneOffset.UTC),
+            null));
+    dataJobs.add(
+        mockSampleDataJob(
+            "sample-job-4", "Import SQL", "5 12 * * *", ExecutionStatus.SUCCEEDED, null, 0));
+    dataJobs.add(
+        mockSampleDataJob(
+            "sample-job-5",
+            "Import SQL",
+            "5 12 * * *",
+            null,
+            OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
+            1000));
+
+    return dataJobs;
+  }
+
+  private DataJob mockSampleDataJob(String jobName, String description, String schedule) {
+    return mockSampleDataJob(jobName, description, schedule, null, null, null);
+  }
+
+  private DataJob mockSampleDataJob(
+      String jobName,
+      String description,
+      String schedule,
+      ExecutionStatus lastExecutionStatus,
+      OffsetDateTime lastExecutionEndTime,
+      Integer lastExecutionDuration) {
+    DataJob dataJob = new DataJob();
+    JobConfig jobConfig = new JobConfig();
+    jobConfig.setSchedule(schedule);
+    jobConfig.setDescription(description);
+    dataJob.setJobConfig(jobConfig);
+    dataJob.setName(jobName);
+    dataJob.setLastExecutionStatus(lastExecutionStatus);
+    dataJob.setLastExecutionEndTime(lastExecutionEndTime);
+    dataJob.setLastExecutionDuration(lastExecutionDuration);
+
+    return dataJob;
+  }
+
+  private JobDeploymentStatus mockSampleDeployment(String jobName, boolean enabled) {
+    JobDeploymentStatus status = new JobDeploymentStatus();
+    status.setEnabled(enabled);
+    status.setDataJobName(jobName);
+    status.setCronJobName(jobName + "-latest");
+    status.setMode("release");
+    return status;
+  }
+
+  static ArrayList<LinkedHashMap<String, String>> constructFilter(Filter... filters) {
+    ArrayList<LinkedHashMap<String, String>> rawFilters = new ArrayList<>();
+    Arrays.stream(filters)
+        .forEach(
+            filter -> {
+              LinkedHashMap<String, String> map = new LinkedHashMap<>();
+
+              map.put("property", filter.getProperty());
+              map.put("pattern", filter.getPattern());
+              if (filter.getSort() != null) {
+                map.put("sort", filter.getSort().toString());
+              }
+
+              rawFilters.add(map);
+            });
+
+    return rawFilters;
+  }
+
+  private Set<FieldStrategy<V2DataJob>> collectSupportedFieldStrategies() {
+    Set<FieldStrategy<V2DataJob>> strategies = new HashSet<>();
+
+    strategies.add(new JobFieldStrategyByDescription());
+    strategies.add(new JobFieldStrategyByName());
+    strategies.add(new JobFieldStrategyByNextRun());
+    strategies.add(new JobFieldStrategyByScheduleCron());
+    strategies.add(new JobFieldStrategyBySourceUrl("gitlab.com/demo-data-jobs.git", "main", true));
+    strategies.add(new JobFieldStrategyByTeam());
+    strategies.add(new JobFieldStrategyByLastExecutionStatus());
+    strategies.add(new JobFieldStrategyByLastExecutionTime());
+    strategies.add(new JobFieldStrategyByLastExecutionDuration());
+
+    return strategies;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLJobTeamFetcherIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLJobTeamFetcherIT.java
@@ -21,87 +21,90 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = ControlplaneApplication.class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = ControlplaneApplication.class)
 @AutoConfigureMockMvc(addFilters = false)
 public class GraphQLJobTeamFetcherIT {
 
-   @Autowired
-   JobsRepository jobsRepository;
+  @Autowired JobsRepository jobsRepository;
 
-   @Autowired
-   private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
-   @AfterEach
-   public void cleanup() {
-      jobsRepository.deleteAll();
-   }
+  @AfterEach
+  public void cleanup() {
+    jobsRepository.deleteAll();
+  }
 
-   private static String getJobsUri(String teamName) {
-      return "/data-jobs/for-team/" + teamName + "/jobs";
-   }
+  private static String getJobsUri(String teamName) {
+    return "/data-jobs/for-team/" + teamName + "/jobs";
+  }
 
-   private static String getQuery(String jobTeam) {
-      return "{\n" +
-            "  jobs(\n" +
-            "    pageNumber: 1\n" +
-            "    pageSize: 100\n" +
-            "    filter: [\n" +
-            "      { property: \"config.team\", pattern: \"" + jobTeam + "\", sort: ASC }\n" +
-            "      { property: \"jobName\", sort: ASC }\n" +
-            "    ]\n" +
-            "  ) {\n" +
-            "    content {\n" +
-            "      jobName\n" +
-            "      config {\n" +
-            "        team\n" +
-            "        description\n" +
-            "        schedule {\n" +
-            "          scheduleCron\n" +
-            "        }\n" +
-            "      }\n" +
-            "      deployments {\n" +
-            "        enabled\n" +
-            "        status\n" +
-            "      }\n" +
-            "    }\n" +
-            "  }\n" +
-            "}";
-   }
+  private static String getQuery(String jobTeam) {
+    return "{\n"
+        + "  jobs(\n"
+        + "    pageNumber: 1\n"
+        + "    pageSize: 100\n"
+        + "    filter: [\n"
+        + "      { property: \"config.team\", pattern: \""
+        + jobTeam
+        + "\", sort: ASC }\n"
+        + "      { property: \"jobName\", sort: ASC }\n"
+        + "    ]\n"
+        + "  ) {\n"
+        + "    content {\n"
+        + "      jobName\n"
+        + "      config {\n"
+        + "        team\n"
+        + "        description\n"
+        + "        schedule {\n"
+        + "          scheduleCron\n"
+        + "        }\n"
+        + "      }\n"
+        + "      deployments {\n"
+        + "        enabled\n"
+        + "        status\n"
+        + "      }\n"
+        + "    }\n"
+        + "  }\n"
+        + "}";
+  }
 
-   @Test
-   public void testRetrieveJobNameWithParentheses() throws Exception {
-      testJobApiRetrievalWithTeamName("VIDA (Eco-system)");
-   }
+  @Test
+  public void testRetrieveJobNameWithParentheses() throws Exception {
+    testJobApiRetrievalWithTeamName("VIDA (Eco-system)");
+  }
 
-   @Test
-   public void testRetrieveJobNameWithoutParentheses() throws Exception {
-      testJobApiRetrievalWithTeamName("VIDA");
-   }
+  @Test
+  public void testRetrieveJobNameWithoutParentheses() throws Exception {
+    testJobApiRetrievalWithTeamName("VIDA");
+  }
 
-   /**
-    * Re-usable test that creates a data job with a given
-    * team name and attempts to retrieve it via the graphQL
-    * API
-    *
-    * @param jobTeam - the team name.
-    * @throws Exception
-    */
-   private void testJobApiRetrievalWithTeamName(String jobTeam) throws Exception {
-      createJobWithTeam(jobTeam);
-      mockMvc.perform(MockMvcRequestBuilders.get(getJobsUri(jobTeam))
-                  .queryParam("query", getQuery(jobTeam))
-                  .with(user("test")))
-            .andExpect(status().is(200))
-            .andExpect(jsonPath("$.data.content[0].jobName").value("test-job"))
-            .andExpect(jsonPath("$.data.content[0].config.team").value(jobTeam));
-   }
+  /**
+   * Re-usable test that creates a data job with a given team name and attempts to retrieve it via
+   * the graphQL API
+   *
+   * @param jobTeam - the team name.
+   * @throws Exception
+   */
+  private void testJobApiRetrievalWithTeamName(String jobTeam) throws Exception {
+    createJobWithTeam(jobTeam);
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(getJobsUri(jobTeam))
+                .queryParam("query", getQuery(jobTeam))
+                .with(user("test")))
+        .andExpect(status().is(200))
+        .andExpect(jsonPath("$.data.content[0].jobName").value("test-job"))
+        .andExpect(jsonPath("$.data.content[0].config.team").value(jobTeam));
+  }
 
-   private void createJobWithTeam(String jobTeam) {
-      DataJob dataJob = new DataJob();
-      JobConfig jobConfig = new JobConfig();
-      jobConfig.setTeam(jobTeam);
-      dataJob.setName("test-job");
-      dataJob.setJobConfig(jobConfig);
-      jobsRepository.save(dataJob);
-   }
+  private void createJobWithTeam(String jobTeam) {
+    DataJob dataJob = new DataJob();
+    JobConfig jobConfig = new JobConfig();
+    jobConfig.setTeam(jobTeam);
+    dataJob.setName("test-job");
+    dataJob.setJobConfig(jobConfig);
+    jobsRepository.save(dataJob);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/JobFieldStrategyFactoryTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/JobFieldStrategyFactoryTest.java
@@ -23,34 +23,36 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(SpringExtension.class)
 class JobFieldStrategyFactoryTest {
 
-   private final JobFieldStrategyByName jobFieldStrategyByName = new JobFieldStrategyByName();
-   private final JobFieldStrategyByDescription jobFieldStrategyByDescription = new JobFieldStrategyByDescription();
-   private final Set<FieldStrategy<V2DataJob>> strategies = new HashSet<>();
+  private final JobFieldStrategyByName jobFieldStrategyByName = new JobFieldStrategyByName();
+  private final JobFieldStrategyByDescription jobFieldStrategyByDescription =
+      new JobFieldStrategyByDescription();
+  private final Set<FieldStrategy<V2DataJob>> strategies = new HashSet<>();
 
-   @BeforeEach
-   public void beforeEach() {
-      strategies.add(jobFieldStrategyByName);
-      strategies.add(jobFieldStrategyByDescription);
-   }
+  @BeforeEach
+  public void beforeEach() {
+    strategies.add(jobFieldStrategyByName);
+    strategies.add(jobFieldStrategyByDescription);
+  }
 
-   @Test
-   void testStrategies_whenSearchingForValidStrategy_shouldReturnValidStrategy() {
-      JobFieldStrategyFactory factory = new JobFieldStrategyFactory(strategies);
+  @Test
+  void testStrategies_whenSearchingForValidStrategy_shouldReturnValidStrategy() {
+    JobFieldStrategyFactory factory = new JobFieldStrategyFactory(strategies);
 
-      FieldStrategy<V2DataJob> strategy = factory.findStrategy(jobFieldStrategyByDescription.getStrategyName());
+    FieldStrategy<V2DataJob> strategy =
+        factory.findStrategy(jobFieldStrategyByDescription.getStrategyName());
 
-      assertThat(strategy).isEqualTo(jobFieldStrategyByDescription);
-   }
+    assertThat(strategy).isEqualTo(jobFieldStrategyByDescription);
+  }
 
-   @Test
-   void testStrategies_whenGettingAllStrategies_shouldReturnStrategiesMap() {
-      JobFieldStrategyFactory factory = new JobFieldStrategyFactory(strategies);
+  @Test
+  void testStrategies_whenGettingAllStrategies_shouldReturnStrategiesMap() {
+    JobFieldStrategyFactory factory = new JobFieldStrategyFactory(strategies);
 
-      Map<JobFieldStrategyBy, FieldStrategy<V2DataJob>> strategyMap = factory.getStrategies();
+    Map<JobFieldStrategyBy, FieldStrategy<V2DataJob>> strategyMap = factory.getStrategies();
 
-      assertThat(strategyMap)
-            .hasSize(2)
-            .containsKey(jobFieldStrategyByName.getStrategyName())
-            .containsKey(jobFieldStrategyByDescription.getStrategyName());
-   }
+    assertThat(strategyMap)
+        .hasSize(2)
+        .containsKey(jobFieldStrategyByName.getStrategyName())
+        .containsKey(jobFieldStrategyByDescription.getStrategyName());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByContactTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByContactTest.java
@@ -21,113 +21,122 @@ import java.util.function.Predicate;
 
 public class JobFieldStrategyByContactTest {
 
-   private final JobFieldStrategyByDataJobContacts strategyByDataJobContacts = new JobFieldStrategyByDataJobContacts();
+  private final JobFieldStrategyByDataJobContacts strategyByDataJobContacts =
+      new JobFieldStrategyByDataJobContacts();
 
-   @Test
-   public void testDataJobContactsStrategy_whenGettingStrategyName_shouldBeSpecific() {
-      Assertions.assertTrue(strategyByDataJobContacts.getStrategyName().equals(JobFieldStrategyBy.DATA_JOB_CONTACTS));
-   }
+  @Test
+  public void testDataJobContactsStrategy_whenGettingStrategyName_shouldBeSpecific() {
+    Assertions.assertTrue(
+        strategyByDataJobContacts.getStrategyName().equals(JobFieldStrategyBy.DATA_JOB_CONTACTS));
+  }
 
-   @Test
-   public void testDataJobContactsStrategy_testEmptyContacts_shouldBeEqual() {
-      Criteria<V2DataJob> baseCriteria = new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
-      Filter filter = new Filter("contacts", null, Sort.Direction.ASC);
+  @Test
+  public void testDataJobContactsStrategy_testEmptyContacts_shouldBeEqual() {
+    Criteria<V2DataJob> baseCriteria =
+        new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
+    Filter filter = new Filter("contacts", null, Sort.Direction.ASC);
 
-      V2DataJob a = createDummyJob(new DataJobContacts());
-      V2DataJob b = createDummyJob(new DataJobContacts());
+    V2DataJob a = createDummyJob(new DataJobContacts());
+    V2DataJob b = createDummyJob(new DataJobContacts());
 
-      Criteria<V2DataJob> v2DataJobCriteria = strategyByDataJobContacts.computeFilterCriteria(baseCriteria, filter);
+    Criteria<V2DataJob> v2DataJobCriteria =
+        strategyByDataJobContacts.computeFilterCriteria(baseCriteria, filter);
 
-      Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(a));
-      Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(b));
-      Assertions.assertEquals(0, v2DataJobCriteria.getComparator().compare(a, b));
-   }
+    Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(a));
+    Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(b));
+    Assertions.assertEquals(0, v2DataJobCriteria.getComparator().compare(a, b));
+  }
 
-   @Test
-   public void testDataJobContactsStrategy_testNonEmptyContacts_shouldBeEqual() {
-      Criteria<V2DataJob> baseCriteria = new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
-      Filter filter = new Filter("contacts", null, Sort.Direction.ASC);
+  @Test
+  public void testDataJobContactsStrategy_testNonEmptyContacts_shouldBeEqual() {
+    Criteria<V2DataJob> baseCriteria =
+        new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
+    Filter filter = new Filter("contacts", null, Sort.Direction.ASC);
 
-      var contactA = new DataJobContacts();
-      var contactB = new DataJobContacts();
+    var contactA = new DataJobContacts();
+    var contactB = new DataJobContacts();
 
-      contactA.setNotifiedOnJobDeploy(List.of("non-empty"));
-      contactB.setNotifiedOnJobFailureUserError(List.of("non-empty"));
+    contactA.setNotifiedOnJobDeploy(List.of("non-empty"));
+    contactB.setNotifiedOnJobFailureUserError(List.of("non-empty"));
 
-      V2DataJob a = createDummyJob(contactA);
-      V2DataJob b = createDummyJob(contactB);
+    V2DataJob a = createDummyJob(contactA);
+    V2DataJob b = createDummyJob(contactB);
 
-      Criteria<V2DataJob> v2DataJobCriteria = strategyByDataJobContacts.computeFilterCriteria(baseCriteria, filter);
+    Criteria<V2DataJob> v2DataJobCriteria =
+        strategyByDataJobContacts.computeFilterCriteria(baseCriteria, filter);
 
-      Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(a));
-      Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(b));
-      Assertions.assertEquals(0, v2DataJobCriteria.getComparator().compare(a, b));
-   }
+    Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(a));
+    Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(b));
+    Assertions.assertEquals(0, v2DataJobCriteria.getComparator().compare(a, b));
+  }
 
-   @Test
-   public void testDataJobContactsStrategy_testEmptyNonEmptyContacts_shouldBeGreater() {
-      Criteria<V2DataJob> baseCriteria = new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
-      Filter filter = new Filter("contacts", null, Sort.Direction.ASC);
+  @Test
+  public void testDataJobContactsStrategy_testEmptyNonEmptyContacts_shouldBeGreater() {
+    Criteria<V2DataJob> baseCriteria =
+        new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
+    Filter filter = new Filter("contacts", null, Sort.Direction.ASC);
 
-      var contactA = new DataJobContacts();
-      var contactB = new DataJobContacts();
+    var contactA = new DataJobContacts();
+    var contactB = new DataJobContacts();
 
-      contactA.setNotifiedOnJobDeploy(List.of("non-empty"));
+    contactA.setNotifiedOnJobDeploy(List.of("non-empty"));
 
-      V2DataJob a = createDummyJob(contactA);
-      V2DataJob b = createDummyJob(contactB);
+    V2DataJob a = createDummyJob(contactA);
+    V2DataJob b = createDummyJob(contactB);
 
-      Criteria<V2DataJob> v2DataJobCriteria = strategyByDataJobContacts.computeFilterCriteria(baseCriteria, filter);
+    Criteria<V2DataJob> v2DataJobCriteria =
+        strategyByDataJobContacts.computeFilterCriteria(baseCriteria, filter);
 
-      Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(a));
-      Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(b));
-      Assertions.assertEquals(1, v2DataJobCriteria.getComparator().compare(a, b));
-   }
+    Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(a));
+    Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(b));
+    Assertions.assertEquals(1, v2DataJobCriteria.getComparator().compare(a, b));
+  }
 
-   @Test
-   public void testDataJobContactsStrategy_testEmptyNonEmptyContacts_shouldBeLess() {
-      Criteria<V2DataJob> baseCriteria = new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
-      Filter filter = new Filter("contacts", null, Sort.Direction.ASC);
+  @Test
+  public void testDataJobContactsStrategy_testEmptyNonEmptyContacts_shouldBeLess() {
+    Criteria<V2DataJob> baseCriteria =
+        new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
+    Filter filter = new Filter("contacts", null, Sort.Direction.ASC);
 
-      var contactA = new DataJobContacts();
-      var contactB = new DataJobContacts();
+    var contactA = new DataJobContacts();
+    var contactB = new DataJobContacts();
 
-      contactB.setNotifiedOnJobFailureUserError(List.of("non-empty"));
+    contactB.setNotifiedOnJobFailureUserError(List.of("non-empty"));
 
-      V2DataJob a = createDummyJob(contactA);
-      V2DataJob b = createDummyJob(contactB);
+    V2DataJob a = createDummyJob(contactA);
+    V2DataJob b = createDummyJob(contactB);
 
-      Criteria<V2DataJob> v2DataJobCriteria = strategyByDataJobContacts.computeFilterCriteria(baseCriteria, filter);
+    Criteria<V2DataJob> v2DataJobCriteria =
+        strategyByDataJobContacts.computeFilterCriteria(baseCriteria, filter);
 
-      Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(a));
-      Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(b));
-      Assertions.assertEquals(-1, v2DataJobCriteria.getComparator().compare(a, b));
-   }
+    Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(a));
+    Assertions.assertTrue(v2DataJobCriteria.getPredicate().test(b));
+    Assertions.assertEquals(-1, v2DataJobCriteria.getComparator().compare(a, b));
+  }
 
-   @Test
-   void testJobContactsStrategy_whenComputingProvidedSearch_shouldReturnValidPredicate() {
-      Predicate<V2DataJob> predicate = strategyByDataJobContacts.computeSearchCriteria("some random string");
+  @Test
+  void testJobContactsStrategy_whenComputingProvidedSearch_shouldReturnValidPredicate() {
+    Predicate<V2DataJob> predicate =
+        strategyByDataJobContacts.computeSearchCriteria("some random string");
 
-      var contactA = new DataJobContacts();
-      var contactB = new DataJobContacts();
+    var contactA = new DataJobContacts();
+    var contactB = new DataJobContacts();
 
-      contactB.setNotifiedOnJobFailureUserError(List.of("non-empty"));
+    contactB.setNotifiedOnJobFailureUserError(List.of("non-empty"));
 
-      V2DataJob a = createDummyJob(contactA);
-      V2DataJob b = createDummyJob(contactB);
+    V2DataJob a = createDummyJob(contactA);
+    V2DataJob b = createDummyJob(contactB);
 
-      Assertions.assertTrue(predicate.test(a));
-      Assertions.assertTrue(predicate.test(b));
+    Assertions.assertTrue(predicate.test(a));
+    Assertions.assertTrue(predicate.test(b));
+  }
 
-   }
-
-   private V2DataJob createDummyJob(DataJobContacts contacts) {
-      V2DataJob job = new V2DataJob();
-      V2DataJobConfig config = new V2DataJobConfig();
-      config.setDescription("desc");
-      config.setContacts(contacts);
-      job.setConfig(config);
-      return job;
-   }
-
+  private V2DataJob createDummyJob(DataJobContacts contacts) {
+    V2DataJob job = new V2DataJob();
+    V2DataJobConfig config = new V2DataJobConfig();
+    config.setDescription("desc");
+    config.setContacts(contacts);
+    job.setConfig(config);
+    return job;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByDeploymentStatusTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByDeploymentStatusTest.java
@@ -22,109 +22,124 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class JobFieldStrategyByDeploymentStatusTest {
 
-   private final JobFieldStrategyByDeploymentStatus strategyByDeploymentStatus = new JobFieldStrategyByDeploymentStatus();
+  private final JobFieldStrategyByDeploymentStatus strategyByDeploymentStatus =
+      new JobFieldStrategyByDeploymentStatus();
 
-   @Test
-   void testJobDeploymentStatusStrategy_whenGettingStrategyName_shouldBeSpecific() {
-      assertThat(strategyByDeploymentStatus.getStrategyName()).isEqualTo(JobFieldStrategyBy.DEPLOYMENT_ENABLED);
-   }
+  @Test
+  void testJobDeploymentStatusStrategy_whenGettingStrategyName_shouldBeSpecific() {
+    assertThat(strategyByDeploymentStatus.getStrategyName())
+        .isEqualTo(JobFieldStrategyBy.DEPLOYMENT_ENABLED);
+  }
 
-   @Test
-   void testJobDeploymentStatusStrategy_whenAlteringFieldData_shouldNotModifyState() {
-      V2DataJob dataJob = createDummyJob(JobFieldStrategyByDeploymentStatus.DeploymentStatus.ENABLED);
+  @Test
+  void testJobDeploymentStatusStrategy_whenAlteringFieldData_shouldNotModifyState() {
+    V2DataJob dataJob = createDummyJob(JobFieldStrategyByDeploymentStatus.DeploymentStatus.ENABLED);
 
-      strategyByDeploymentStatus.alterFieldData(dataJob);
+    strategyByDeploymentStatus.alterFieldData(dataJob);
 
-      assertThat(dataJob.getDeployments().get(0).getEnabled()).isTrue();
-   }
+    assertThat(dataJob.getDeployments().get(0).getEnabled()).isTrue();
+  }
 
+  @Test
+  void
+      testJobDeploymentStatusStrategy_whenComputingValidCriteriaWithoutFilter_shouldReturnValidCriteria() {
+    Criteria<V2DataJob> baseCriteria =
+        new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
+    Filter baseFilter = new Filter("random", null, Sort.Direction.DESC);
+    V2DataJob a = createDummyJob(JobFieldStrategyByDeploymentStatus.DeploymentStatus.ENABLED);
+    V2DataJob b = createDummyJob(JobFieldStrategyByDeploymentStatus.DeploymentStatus.DISABLED);
 
-   @Test
-   void testJobDeploymentStatusStrategy_whenComputingValidCriteriaWithoutFilter_shouldReturnValidCriteria() {
-      Criteria<V2DataJob> baseCriteria = new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
-      Filter baseFilter = new Filter("random", null, Sort.Direction.DESC);
-      V2DataJob a = createDummyJob(JobFieldStrategyByDeploymentStatus.DeploymentStatus.ENABLED);
-      V2DataJob b = createDummyJob(JobFieldStrategyByDeploymentStatus.DeploymentStatus.DISABLED);
+    Criteria<V2DataJob> v2DataJobCriteria =
+        strategyByDeploymentStatus.computeFilterCriteria(baseCriteria, baseFilter);
 
-      Criteria<V2DataJob> v2DataJobCriteria = strategyByDeploymentStatus.computeFilterCriteria(baseCriteria, baseFilter);
+    assertThat(v2DataJobCriteria.getPredicate().test(a)).isTrue();
+    assertThat(v2DataJobCriteria.getComparator().compare(a, b)).isPositive();
+  }
 
-      assertThat(v2DataJobCriteria.getPredicate().test(a)).isTrue();
-      assertThat(v2DataJobCriteria.getComparator().compare(a, b)).isPositive();
-   }
+  @Test
+  void
+      testJobDeploymentStatusStrategy_whenComputingValidCriteriaWithFilter_shouldReturnValidCriteria() {
+    Criteria<V2DataJob> baseCriteria =
+        new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
 
-   @Test
-   void testJobDeploymentStatusStrategy_whenComputingValidCriteriaWithFilter_shouldReturnValidCriteria() {
-      Criteria<V2DataJob> baseCriteria = new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
+    V2DataJob a = createDummyJob(JobFieldStrategyByDeploymentStatus.DeploymentStatus.ENABLED);
+    V2DataJob b = createDummyJob(JobFieldStrategyByDeploymentStatus.DeploymentStatus.DISABLED);
+    V2DataJob c = createDummyJob(JobFieldStrategyByDeploymentStatus.DeploymentStatus.NOT_DEPLOYED);
 
-      V2DataJob a = createDummyJob(JobFieldStrategyByDeploymentStatus.DeploymentStatus.ENABLED);
-      V2DataJob b = createDummyJob(JobFieldStrategyByDeploymentStatus.DeploymentStatus.DISABLED);
-      V2DataJob c = createDummyJob(JobFieldStrategyByDeploymentStatus.DeploymentStatus.NOT_DEPLOYED);
+    Filter enabledFilter = new Filter("deployments.status", "enabled", Sort.Direction.ASC);
+    Criteria<V2DataJob> criteriaForEnabledJobs =
+        strategyByDeploymentStatus.computeFilterCriteria(baseCriteria, enabledFilter);
 
-      Filter enabledFilter = new Filter("deployments.status", "enabled", Sort.Direction.ASC);
-      Criteria<V2DataJob> criteriaForEnabledJobs = strategyByDeploymentStatus.computeFilterCriteria(baseCriteria, enabledFilter);
+    assertThat(criteriaForEnabledJobs.getPredicate().test(a)).isTrue();
+    assertThat(criteriaForEnabledJobs.getPredicate().test(b)).isFalse();
+    assertThat(criteriaForEnabledJobs.getPredicate().test(c)).isFalse();
+    assertThat(criteriaForEnabledJobs.getComparator().compare(a, b)).isNegative();
+    assertThat(criteriaForEnabledJobs.getComparator().compare(c, b)).isPositive();
+    assertThat(criteriaForEnabledJobs.getComparator().compare(a, c)).isNegative();
 
-      assertThat(criteriaForEnabledJobs.getPredicate().test(a)).isTrue();
-      assertThat(criteriaForEnabledJobs.getPredicate().test(b)).isFalse();
-      assertThat(criteriaForEnabledJobs.getPredicate().test(c)).isFalse();
-      assertThat(criteriaForEnabledJobs.getComparator().compare(a, b)).isNegative();
-      assertThat(criteriaForEnabledJobs.getComparator().compare(c, b)).isPositive();
-      assertThat(criteriaForEnabledJobs.getComparator().compare(a, c)).isNegative();
+    Filter disabledFilter = new Filter("deployments.status", "disabled", Sort.Direction.ASC);
+    Criteria<V2DataJob> criteriaForDisabledJobs =
+        strategyByDeploymentStatus.computeFilterCriteria(baseCriteria, disabledFilter);
 
-      Filter disabledFilter = new Filter("deployments.status", "disabled", Sort.Direction.ASC);
-      Criteria<V2DataJob> criteriaForDisabledJobs = strategyByDeploymentStatus.computeFilterCriteria(baseCriteria, disabledFilter);
+    assertThat(criteriaForDisabledJobs.getPredicate().test(a)).isFalse();
+    assertThat(criteriaForDisabledJobs.getPredicate().test(b)).isTrue();
+    assertThat(criteriaForDisabledJobs.getPredicate().test(c)).isFalse();
 
-      assertThat(criteriaForDisabledJobs.getPredicate().test(a)).isFalse();
-      assertThat(criteriaForDisabledJobs.getPredicate().test(b)).isTrue();
-      assertThat(criteriaForDisabledJobs.getPredicate().test(c)).isFalse();
+    Filter notDeployedFilter = new Filter("deployments.status", "not_deployed", Sort.Direction.ASC);
+    Criteria<V2DataJob> criteriaForNotDeployedJobs =
+        strategyByDeploymentStatus.computeFilterCriteria(baseCriteria, notDeployedFilter);
 
-      Filter notDeployedFilter = new Filter("deployments.status", "not_deployed", Sort.Direction.ASC);
-      Criteria<V2DataJob> criteriaForNotDeployedJobs = strategyByDeploymentStatus.computeFilterCriteria(baseCriteria, notDeployedFilter);
+    assertThat(criteriaForNotDeployedJobs.getPredicate().test(a)).isFalse();
+    assertThat(criteriaForNotDeployedJobs.getPredicate().test(b)).isFalse();
+    assertThat(criteriaForNotDeployedJobs.getPredicate().test(c)).isTrue();
+  }
 
-      assertThat(criteriaForNotDeployedJobs.getPredicate().test(a)).isFalse();
-      assertThat(criteriaForNotDeployedJobs.getPredicate().test(b)).isFalse();
-      assertThat(criteriaForNotDeployedJobs.getPredicate().test(c)).isTrue();
-   }
+  @Test
+  void
+      testJobDeploymentStatusStrategy_whenComputingValidSearchProvided_shouldReturnValidPredicate() {
+    Predicate<V2DataJob> predicate = strategyByDeploymentStatus.computeSearchCriteria("enabled");
 
-   @Test
-   void testJobDeploymentStatusStrategy_whenComputingValidSearchProvided_shouldReturnValidPredicate() {
-      Predicate<V2DataJob> predicate = strategyByDeploymentStatus.computeSearchCriteria("enabled");
+    V2DataJob a = createDummyJob(JobFieldStrategyByDeploymentStatus.DeploymentStatus.ENABLED);
+    V2DataJob b = createDummyJob(JobFieldStrategyByDeploymentStatus.DeploymentStatus.DISABLED);
+    V2DataJob c = createDummyJob(JobFieldStrategyByDeploymentStatus.DeploymentStatus.NOT_DEPLOYED);
 
-      V2DataJob a = createDummyJob(JobFieldStrategyByDeploymentStatus.DeploymentStatus.ENABLED);
-      V2DataJob b = createDummyJob(JobFieldStrategyByDeploymentStatus.DeploymentStatus.DISABLED);
-      V2DataJob c = createDummyJob(JobFieldStrategyByDeploymentStatus.DeploymentStatus.NOT_DEPLOYED);
+    assertThat(predicate.test(a)).isTrue();
+    assertThat(predicate.test(b)).isFalse();
+    assertThat(predicate.test(c)).isFalse();
 
-      assertThat(predicate.test(a)).isTrue();
-      assertThat(predicate.test(b)).isFalse();
-      assertThat(predicate.test(c)).isFalse();
+    Predicate<V2DataJob> predicateIgnoredCase =
+        strategyByDeploymentStatus.computeSearchCriteria("eNaBlEd");
+    assertThat(predicateIgnoredCase.test(a)).isTrue();
+  }
 
-      Predicate<V2DataJob> predicateIgnoredCase = strategyByDeploymentStatus.computeSearchCriteria("eNaBlEd");
-      assertThat(predicateIgnoredCase.test(a)).isTrue();
-   }
+  @Test
+  void
+      testJobDeploymentStatusStrategy_whenComputingInvalidSearchProvided_shouldReturnValidPredicate() {
+    Predicate<V2DataJob> predicate = strategyByDeploymentStatus.computeSearchCriteria("blah");
 
-   @Test
-   void testJobDeploymentStatusStrategy_whenComputingInvalidSearchProvided_shouldReturnValidPredicate() {
-      Predicate<V2DataJob> predicate = strategyByDeploymentStatus.computeSearchCriteria("blah");
+    V2DataJob a = new V2DataJob();
 
-      V2DataJob a = new V2DataJob();
+    assertThat(predicate.test(a)).isFalse();
+  }
 
-      assertThat(predicate.test(a)).isFalse();
-   }
+  @Test
+  void testJobDeploymentStatusStrategy_whenUsingInvalidPatternValue_shouldThrowException() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          JobFieldStrategyByDeploymentStatus.DeploymentStatus.fromValue("not-existing-value-123");
+        });
+  }
 
-   @Test
-   void testJobDeploymentStatusStrategy_whenUsingInvalidPatternValue_shouldThrowException() {
-      Assertions.assertThrows(IllegalArgumentException.class, () -> {
-         JobFieldStrategyByDeploymentStatus.DeploymentStatus.fromValue("not-existing-value-123");
-      });
-   }
-
-   private V2DataJob createDummyJob(JobFieldStrategyByDeploymentStatus.DeploymentStatus status) {
-      V2DataJob job = new V2DataJob();
-      if (status.equals(JobFieldStrategyByDeploymentStatus.DeploymentStatus.NOT_DEPLOYED)) {
-         return job;
-      }
-      V2DataJobDeployment deployment = new V2DataJobDeployment();
-      deployment.setEnabled(JobFieldStrategyByDeploymentStatus.DeploymentStatus.ENABLED.equals(status));
-      job.setDeployments(Collections.singletonList(deployment));
+  private V2DataJob createDummyJob(JobFieldStrategyByDeploymentStatus.DeploymentStatus status) {
+    V2DataJob job = new V2DataJob();
+    if (status.equals(JobFieldStrategyByDeploymentStatus.DeploymentStatus.NOT_DEPLOYED)) {
       return job;
-   }
+    }
+    V2DataJobDeployment deployment = new V2DataJobDeployment();
+    deployment.setEnabled(
+        JobFieldStrategyByDeploymentStatus.DeploymentStatus.ENABLED.equals(status));
+    job.setDeployments(Collections.singletonList(deployment));
+    return job;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByDescriptionTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByDescriptionTest.java
@@ -21,101 +21,106 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class JobFieldStrategyByDescriptionTest {
 
-   private final JobFieldStrategyByDescription strategyByDescription = new JobFieldStrategyByDescription();
+  private final JobFieldStrategyByDescription strategyByDescription =
+      new JobFieldStrategyByDescription();
 
-   @Test
-   void testJobDescriptionStrategy_whenGettingStrategyName_shouldBeSpecific() {
-      assertThat(strategyByDescription.getStrategyName()).isEqualTo(JobFieldStrategyBy.DESCRIPTION);
-   }
+  @Test
+  void testJobDescriptionStrategy_whenGettingStrategyName_shouldBeSpecific() {
+    assertThat(strategyByDescription.getStrategyName()).isEqualTo(JobFieldStrategyBy.DESCRIPTION);
+  }
 
-   @Test
-   void testJobDescriptionStrategy_whenAlteringFieldData_shouldNotModifyState() {
-      V2DataJob dataJob = createDummyJob("B");
+  @Test
+  void testJobDescriptionStrategy_whenAlteringFieldData_shouldNotModifyState() {
+    V2DataJob dataJob = createDummyJob("B");
 
-      strategyByDescription.alterFieldData(dataJob);
+    strategyByDescription.alterFieldData(dataJob);
 
-      assertThat(dataJob.getConfig().getDescription()).isEqualTo("B");
-   }
+    assertThat(dataJob.getConfig().getDescription()).isEqualTo("B");
+  }
 
-   @Test
-   void testJobDescriptionStrategy_whenComputingValidCriteriaWithoutFilter_shouldReturnValidCriteria() {
-      Criteria<V2DataJob> baseCriteria = new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
-      Filter baseFilter = new Filter("random", null, Sort.Direction.DESC);
-      V2DataJob a = createDummyJob("A");
-      V2DataJob b = createDummyJob("B");
+  @Test
+  void
+      testJobDescriptionStrategy_whenComputingValidCriteriaWithoutFilter_shouldReturnValidCriteria() {
+    Criteria<V2DataJob> baseCriteria =
+        new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
+    Filter baseFilter = new Filter("random", null, Sort.Direction.DESC);
+    V2DataJob a = createDummyJob("A");
+    V2DataJob b = createDummyJob("B");
 
-      Criteria<V2DataJob> v2DataJobCriteria = strategyByDescription.computeFilterCriteria(baseCriteria, baseFilter);
+    Criteria<V2DataJob> v2DataJobCriteria =
+        strategyByDescription.computeFilterCriteria(baseCriteria, baseFilter);
 
-      assertThat(v2DataJobCriteria.getPredicate().test(a)).isTrue();
-      assertThat(v2DataJobCriteria.getComparator().compare(a, b)).isPositive();
-   }
+    assertThat(v2DataJobCriteria.getPredicate().test(a)).isTrue();
+    assertThat(v2DataJobCriteria.getComparator().compare(a, b)).isPositive();
+  }
 
-   @Test
-   void testJobDescriptionStrategy_whenComputingValidCriteriaWithFilter_shouldReturnValidCriteria() {
-      Criteria<V2DataJob> baseCriteria = new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
-      Filter baseFilter = new Filter("description", "A", Sort.Direction.ASC);
-      V2DataJob a = createDummyJob("a");
-      V2DataJob b = createDummyJob("b");
+  @Test
+  void testJobDescriptionStrategy_whenComputingValidCriteriaWithFilter_shouldReturnValidCriteria() {
+    Criteria<V2DataJob> baseCriteria =
+        new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
+    Filter baseFilter = new Filter("description", "A", Sort.Direction.ASC);
+    V2DataJob a = createDummyJob("a");
+    V2DataJob b = createDummyJob("b");
 
-      Criteria<V2DataJob> v2DataJobCriteria = strategyByDescription.computeFilterCriteria(baseCriteria, baseFilter);
+    Criteria<V2DataJob> v2DataJobCriteria =
+        strategyByDescription.computeFilterCriteria(baseCriteria, baseFilter);
 
-      assertThat(v2DataJobCriteria.getPredicate().test(a)).isTrue();
-      assertThat(v2DataJobCriteria.getPredicate().test(b)).isFalse();
-      assertThat(v2DataJobCriteria.getComparator().compare(a, b)).isNegative();
-   }
+    assertThat(v2DataJobCriteria.getPredicate().test(a)).isTrue();
+    assertThat(v2DataJobCriteria.getPredicate().test(b)).isFalse();
+    assertThat(v2DataJobCriteria.getComparator().compare(a, b)).isNegative();
+  }
 
-   @Test
-   void testJobDescriptionStrategy_whenComputingValidSearchProvided_shouldReturnValidPredicate() {
-      Predicate<V2DataJob> predicate = strategyByDescription.computeSearchCriteria("A");
+  @Test
+  void testJobDescriptionStrategy_whenComputingValidSearchProvided_shouldReturnValidPredicate() {
+    Predicate<V2DataJob> predicate = strategyByDescription.computeSearchCriteria("A");
 
-      V2DataJob a = createDummyJob("A");
-      V2DataJob b = createDummyJob("B");
+    V2DataJob a = createDummyJob("A");
+    V2DataJob b = createDummyJob("B");
 
-      assertThat(predicate.test(a)).isTrue();
-      assertThat(predicate.test(b)).isFalse();
-   }
+    assertThat(predicate.test(a)).isTrue();
+    assertThat(predicate.test(b)).isFalse();
+  }
 
-   @Test
-   void testJobDescriptionStrategy_whenComputingInvalidSearchProvided_shouldReturnValidPredicate() {
-      Predicate<V2DataJob> predicate = strategyByDescription.computeSearchCriteria("A");
+  @Test
+  void testJobDescriptionStrategy_whenComputingInvalidSearchProvided_shouldReturnValidPredicate() {
+    Predicate<V2DataJob> predicate = strategyByDescription.computeSearchCriteria("A");
 
-      V2DataJob a = new V2DataJob();
+    V2DataJob a = new V2DataJob();
 
-      assertThat(predicate.test(a)).isFalse();
-   }
+    assertThat(predicate.test(a)).isFalse();
+  }
 
-   @Test
-   public void testJobDescriptionComparator() {
+  @Test
+  public void testJobDescriptionComparator() {
 
-      V2DataJob a = createDummyJob("A");
-      V2DataJob a1 = createDummyJob("A");
-      V2DataJob b = createDummyJob("B");
-      V2DataJob c = createDummyJob(null);
-      V2DataJob c1 = createDummyJob(null);
+    V2DataJob a = createDummyJob("A");
+    V2DataJob a1 = createDummyJob("A");
+    V2DataJob b = createDummyJob("B");
+    V2DataJob c = createDummyJob(null);
+    V2DataJob c1 = createDummyJob(null);
 
-      var baseCriteria = new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
-      var filter = new Filter("description", "A", Sort.Direction.ASC);
+    var baseCriteria =
+        new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
+    var filter = new Filter("description", "A", Sort.Direction.ASC);
 
-      var descriptionCriteria = strategyByDescription.computeFilterCriteria(baseCriteria, filter);
-      var comparator = descriptionCriteria.getComparator();
+    var descriptionCriteria = strategyByDescription.computeFilterCriteria(baseCriteria, filter);
+    var comparator = descriptionCriteria.getComparator();
 
-      Assertions.assertEquals(-1, comparator.compare(a, b));
-      Assertions.assertEquals(-1, comparator.compare(b, c));
-      Assertions.assertEquals(-1, comparator.compare(a, c));
-      Assertions.assertEquals(1, comparator.compare(b, a));
-      Assertions.assertEquals(1, comparator.compare(c, a));
-      Assertions.assertEquals(0, comparator.compare(a1, a));
-      Assertions.assertEquals(0, comparator.compare(c1, c));
+    Assertions.assertEquals(-1, comparator.compare(a, b));
+    Assertions.assertEquals(-1, comparator.compare(b, c));
+    Assertions.assertEquals(-1, comparator.compare(a, c));
+    Assertions.assertEquals(1, comparator.compare(b, a));
+    Assertions.assertEquals(1, comparator.compare(c, a));
+    Assertions.assertEquals(0, comparator.compare(a1, a));
+    Assertions.assertEquals(0, comparator.compare(c1, c));
+  }
 
-   }
+  private V2DataJob createDummyJob(String desc) {
+    V2DataJob job = new V2DataJob();
+    V2DataJobConfig config = new V2DataJobConfig();
+    config.setDescription(desc);
+    job.setConfig(config);
 
-   private V2DataJob createDummyJob(String desc) {
-      V2DataJob job = new V2DataJob();
-      V2DataJobConfig config = new V2DataJobConfig();
-      config.setDescription(desc);
-      job.setConfig(config);
-
-      return job;
-   }
-
+    return job;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByNameTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByNameTest.java
@@ -19,73 +19,81 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class JobFieldStrategyByNameTest {
 
-   private final JobFieldStrategyByName strategyByName = new JobFieldStrategyByName();
+  private final JobFieldStrategyByName strategyByName = new JobFieldStrategyByName();
 
-   @Test
-   void testJobNameStrategy_whenGettingStrategyName_shouldBeSpecific() {
-      assertThat(strategyByName.getStrategyName()).isEqualTo(JobFieldStrategyBy.JOB_NAME);
-   }
+  @Test
+  void testJobNameStrategy_whenGettingStrategyName_shouldBeSpecific() {
+    assertThat(strategyByName.getStrategyName()).isEqualTo(JobFieldStrategyBy.JOB_NAME);
+  }
 
-   @Test
-   void testJobNameStrategy_whenAlteringFieldData_shouldNotModifyState() {
-      V2DataJob dataJob = createDummyJob("B");
+  @Test
+  void testJobNameStrategy_whenAlteringFieldData_shouldNotModifyState() {
+    V2DataJob dataJob = createDummyJob("B");
 
-      strategyByName.alterFieldData(dataJob);
+    strategyByName.alterFieldData(dataJob);
 
-      assertThat(dataJob.getJobName()).isEqualTo("B");
-   }
+    assertThat(dataJob.getJobName()).isEqualTo("B");
+  }
 
-   @Test
-   void testJobNameStrategy_whenComputingValidCriteriaWithoutFilter_shouldReturnValidCriteria() {
-      Criteria<V2DataJob> baseCriteria = new Criteria<>(Objects::nonNull, Comparator.comparing(dataJob -> dataJob.getConfig().getDescription()));
-      Filter baseFilter = new Filter("random", null, Sort.Direction.DESC);
-      V2DataJob a = createDummyJob("A");
-      V2DataJob b = createDummyJob("B");
+  @Test
+  void testJobNameStrategy_whenComputingValidCriteriaWithoutFilter_shouldReturnValidCriteria() {
+    Criteria<V2DataJob> baseCriteria =
+        new Criteria<>(
+            Objects::nonNull,
+            Comparator.comparing(dataJob -> dataJob.getConfig().getDescription()));
+    Filter baseFilter = new Filter("random", null, Sort.Direction.DESC);
+    V2DataJob a = createDummyJob("A");
+    V2DataJob b = createDummyJob("B");
 
-      Criteria<V2DataJob> v2DataJobCriteria = strategyByName.computeFilterCriteria(baseCriteria, baseFilter);
+    Criteria<V2DataJob> v2DataJobCriteria =
+        strategyByName.computeFilterCriteria(baseCriteria, baseFilter);
 
-      assertThat(v2DataJobCriteria.getPredicate().test(a)).isTrue();
-      assertThat(v2DataJobCriteria.getComparator().compare(a, b)).isPositive();
-   }
+    assertThat(v2DataJobCriteria.getPredicate().test(a)).isTrue();
+    assertThat(v2DataJobCriteria.getComparator().compare(a, b)).isPositive();
+  }
 
-   @Test
-   void testJobNameStrategy_whenComputingValidCriteriaWithFilter_shouldReturnValidCriteria() {
-      Criteria<V2DataJob> baseCriteria = new Criteria<>(Objects::nonNull, Comparator.comparing(dataJob -> dataJob.getConfig().getDescription()));
-      Filter baseFilter = new Filter("jobName", "A", Sort.Direction.ASC);
-      V2DataJob a = createDummyJob("a");
-      V2DataJob b = createDummyJob("b");
+  @Test
+  void testJobNameStrategy_whenComputingValidCriteriaWithFilter_shouldReturnValidCriteria() {
+    Criteria<V2DataJob> baseCriteria =
+        new Criteria<>(
+            Objects::nonNull,
+            Comparator.comparing(dataJob -> dataJob.getConfig().getDescription()));
+    Filter baseFilter = new Filter("jobName", "A", Sort.Direction.ASC);
+    V2DataJob a = createDummyJob("a");
+    V2DataJob b = createDummyJob("b");
 
-      Criteria<V2DataJob> v2DataJobCriteria = strategyByName.computeFilterCriteria(baseCriteria, baseFilter);
+    Criteria<V2DataJob> v2DataJobCriteria =
+        strategyByName.computeFilterCriteria(baseCriteria, baseFilter);
 
-      assertThat(v2DataJobCriteria.getPredicate().test(a)).isTrue();
-      assertThat(v2DataJobCriteria.getPredicate().test(b)).isFalse();
-      assertThat(v2DataJobCriteria.getComparator().compare(a, b)).isNegative();
-   }
+    assertThat(v2DataJobCriteria.getPredicate().test(a)).isTrue();
+    assertThat(v2DataJobCriteria.getPredicate().test(b)).isFalse();
+    assertThat(v2DataJobCriteria.getComparator().compare(a, b)).isNegative();
+  }
 
-   @Test
-   void testJobNameStrategy_whenComputingValidSearchProvided_shouldReturnValidPredicate() {
-      Predicate<V2DataJob> predicate = strategyByName.computeSearchCriteria("A");
+  @Test
+  void testJobNameStrategy_whenComputingValidSearchProvided_shouldReturnValidPredicate() {
+    Predicate<V2DataJob> predicate = strategyByName.computeSearchCriteria("A");
 
-      V2DataJob a = createDummyJob("A");
-      V2DataJob b = createDummyJob("B");
+    V2DataJob a = createDummyJob("A");
+    V2DataJob b = createDummyJob("B");
 
-      assertThat(predicate.test(a)).isTrue();
-      assertThat(predicate.test(b)).isFalse();
-   }
+    assertThat(predicate.test(a)).isTrue();
+    assertThat(predicate.test(b)).isFalse();
+  }
 
-   @Test
-   void testJobNameStrategy_whenComputingInvalidSearchProvided_shouldReturnValidPredicate() {
-      Predicate<V2DataJob> predicate = strategyByName.computeSearchCriteria("A");
+  @Test
+  void testJobNameStrategy_whenComputingInvalidSearchProvided_shouldReturnValidPredicate() {
+    Predicate<V2DataJob> predicate = strategyByName.computeSearchCriteria("A");
 
-      V2DataJob a = new V2DataJob();
+    V2DataJob a = new V2DataJob();
 
-      assertThat(predicate.test(a)).isFalse();
-   }
+    assertThat(predicate.test(a)).isFalse();
+  }
 
-   private V2DataJob createDummyJob(String jobName) {
-      V2DataJob job = new V2DataJob();
-      job.setJobName(jobName);
+  private V2DataJob createDummyJob(String jobName) {
+    V2DataJob job = new V2DataJob();
+    job.setJobName(jobName);
 
-      return job;
-   }
+    return job;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByNextRunTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByNextRunTest.java
@@ -27,158 +27,166 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class JobFieldStrategyByNextRunTest {
 
-   private final JobFieldStrategyByNextRun strategyByNextRun = new JobFieldStrategyByNextRun();
+  private final JobFieldStrategyByNextRun strategyByNextRun = new JobFieldStrategyByNextRun();
 
-   @Test
-   void testJobNextRunStrategy_whenGettingStrategyName_shouldBeSpecific() {
-      assertThat(strategyByNextRun.getStrategyName()).isEqualTo(JobFieldStrategyBy.NEXT_RUN_EPOCH_SECS);
-   }
+  @Test
+  void testJobNextRunStrategy_whenGettingStrategyName_shouldBeSpecific() {
+    assertThat(strategyByNextRun.getStrategyName())
+        .isEqualTo(JobFieldStrategyBy.NEXT_RUN_EPOCH_SECS);
+  }
 
-   @Test
-   void testJobNextRunStrategy_whenAlteringFieldData_shouldModifyState() {
-      String scheduleCron = "12 5 2 3 *";
-      var executionTime = ExecutionTime.forCron(
-            new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX)).parse(scheduleCron));
-      Optional<ZonedDateTime> utc = executionTime.nextExecution(ZonedDateTime.now(ZoneId.of("UTC")));
-      int baseTime = Math.toIntExact(utc.map(ChronoZonedDateTime::toEpochSecond).get());
-      V2DataJob dataJob = new V2DataJob();
-      V2DataJobConfig dataJobConfig = new V2DataJobConfig();
-      V2DataJobSchedule dataJobSchedule = new V2DataJobSchedule();
-      dataJobConfig.setSchedule(dataJobSchedule);
-      dataJobSchedule.setScheduleCron(scheduleCron);
-      dataJob.setConfig(dataJobConfig);
+  @Test
+  void testJobNextRunStrategy_whenAlteringFieldData_shouldModifyState() {
+    String scheduleCron = "12 5 2 3 *";
+    var executionTime =
+        ExecutionTime.forCron(
+            new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX))
+                .parse(scheduleCron));
+    Optional<ZonedDateTime> utc = executionTime.nextExecution(ZonedDateTime.now(ZoneId.of("UTC")));
+    int baseTime = Math.toIntExact(utc.map(ChronoZonedDateTime::toEpochSecond).get());
+    V2DataJob dataJob = new V2DataJob();
+    V2DataJobConfig dataJobConfig = new V2DataJobConfig();
+    V2DataJobSchedule dataJobSchedule = new V2DataJobSchedule();
+    dataJobConfig.setSchedule(dataJobSchedule);
+    dataJobSchedule.setScheduleCron(scheduleCron);
+    dataJob.setConfig(dataJobConfig);
 
-      assertThat(dataJob.getConfig().getSchedule().getNextRunEpochSeconds()).isZero();
-      strategyByNextRun.alterFieldData(dataJob);
+    assertThat(dataJob.getConfig().getSchedule().getNextRunEpochSeconds()).isZero();
+    strategyByNextRun.alterFieldData(dataJob);
 
-      int nextRunEpochSeconds = dataJob.getConfig().getSchedule().getNextRunEpochSeconds();
-      assertThat(nextRunEpochSeconds).isNotZero().isEqualTo(baseTime);
-   }
+    int nextRunEpochSeconds = dataJob.getConfig().getSchedule().getNextRunEpochSeconds();
+    assertThat(nextRunEpochSeconds).isNotZero().isEqualTo(baseTime);
+  }
 
-   @Test
-   void testJobNextRunStrategy_whenAlteringFieldDataWithNullConfig_shouldNotModifyState() {
-      V2DataJob dataJob = createDummyJob("12 5 2 3 *");
-      dataJob.setConfig(null);
+  @Test
+  void testJobNextRunStrategy_whenAlteringFieldDataWithNullConfig_shouldNotModifyState() {
+    V2DataJob dataJob = createDummyJob("12 5 2 3 *");
+    dataJob.setConfig(null);
 
-      strategyByNextRun.alterFieldData(dataJob);
+    strategyByNextRun.alterFieldData(dataJob);
 
-      assertThat(dataJob.getConfig()).isNull();
-   }
+    assertThat(dataJob.getConfig()).isNull();
+  }
 
-   @Test
-   void testJobNextRunStrategy_whenAlteringFieldDataWithNullSchedule_shouldNotModifyState() {
-      V2DataJob dataJob = createDummyJob(null);
-      dataJob.setConfig(new V2DataJobConfig());
+  @Test
+  void testJobNextRunStrategy_whenAlteringFieldDataWithNullSchedule_shouldNotModifyState() {
+    V2DataJob dataJob = createDummyJob(null);
+    dataJob.setConfig(new V2DataJobConfig());
 
-      strategyByNextRun.alterFieldData(dataJob);
+    strategyByNextRun.alterFieldData(dataJob);
 
-      assertThat(dataJob.getConfig().getSchedule()).isNull();
-   }
+    assertThat(dataJob.getConfig().getSchedule()).isNull();
+  }
 
-   @Test
-   void testJobNextRunStrategy_whenAlteringFieldDataWithEmptySchedule_shouldReturnInvalidSchedule() {
-      V2DataJob dataJob = createDummyJob(null);
-      V2DataJobSchedule dataJobSchedule = new V2DataJobSchedule();
-      dataJobSchedule.setScheduleCron(" ");
-      V2DataJobConfig dataJobConfig = new V2DataJobConfig();
-      dataJobConfig.setSchedule(dataJobSchedule);
-      dataJob.setConfig(dataJobConfig);
+  @Test
+  void testJobNextRunStrategy_whenAlteringFieldDataWithEmptySchedule_shouldReturnInvalidSchedule() {
+    V2DataJob dataJob = createDummyJob(null);
+    V2DataJobSchedule dataJobSchedule = new V2DataJobSchedule();
+    dataJobSchedule.setScheduleCron(" ");
+    V2DataJobConfig dataJobConfig = new V2DataJobConfig();
+    dataJobConfig.setSchedule(dataJobSchedule);
+    dataJob.setConfig(dataJobConfig);
 
-      strategyByNextRun.alterFieldData(dataJob);
+    strategyByNextRun.alterFieldData(dataJob);
 
-      assertThat(dataJob.getConfig().getSchedule().getNextRunEpochSeconds()).isEqualTo(-1);
-   }
+    assertThat(dataJob.getConfig().getSchedule().getNextRunEpochSeconds()).isEqualTo(-1);
+  }
 
-   @Test
-   void testJobNextRunStrategy_whenAlteringFieldDataWithInvalidSchedule_shouldReturnInvalidSchedule() {
-      V2DataJob dataJob = createDummyJob(null);
-      V2DataJobSchedule dataJobSchedule = new V2DataJobSchedule();
-      dataJobSchedule.setScheduleCron("* * ");
-      V2DataJobConfig dataJobConfig = new V2DataJobConfig();
-      dataJobConfig.setSchedule(dataJobSchedule);
-      dataJob.setConfig(dataJobConfig);
+  @Test
+  void
+      testJobNextRunStrategy_whenAlteringFieldDataWithInvalidSchedule_shouldReturnInvalidSchedule() {
+    V2DataJob dataJob = createDummyJob(null);
+    V2DataJobSchedule dataJobSchedule = new V2DataJobSchedule();
+    dataJobSchedule.setScheduleCron("* * ");
+    V2DataJobConfig dataJobConfig = new V2DataJobConfig();
+    dataJobConfig.setSchedule(dataJobSchedule);
+    dataJob.setConfig(dataJobConfig);
 
-      strategyByNextRun.alterFieldData(dataJob);
+    strategyByNextRun.alterFieldData(dataJob);
 
-      assertThat(dataJob.getConfig().getSchedule().getNextRunEpochSeconds()).isEqualTo(-1);
-   }
+    assertThat(dataJob.getConfig().getSchedule().getNextRunEpochSeconds()).isEqualTo(-1);
+  }
 
-   @Test
-   void testJobNextRunStrategy_whenComputingValidCriteriaWithoutFilter_shouldReturnValidCriteria() {
-      Criteria<V2DataJob> baseCriteria = new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
-      Filter baseFilter = new Filter("random", null, Sort.Direction.DESC);
-      V2DataJob a = createDummyJob("5 4 * * *");
-      V2DataJob b = createDummyJob("5 6 * * *"); // later than previous
+  @Test
+  void testJobNextRunStrategy_whenComputingValidCriteriaWithoutFilter_shouldReturnValidCriteria() {
+    Criteria<V2DataJob> baseCriteria =
+        new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
+    Filter baseFilter = new Filter("random", null, Sort.Direction.DESC);
+    V2DataJob a = createDummyJob("5 4 * * *");
+    V2DataJob b = createDummyJob("5 6 * * *"); // later than previous
 
-      Criteria<V2DataJob> v2DataJobCriteria = strategyByNextRun.computeFilterCriteria(baseCriteria, baseFilter);
+    Criteria<V2DataJob> v2DataJobCriteria =
+        strategyByNextRun.computeFilterCriteria(baseCriteria, baseFilter);
 
-      assertThat(v2DataJobCriteria.getPredicate().test(a)).isTrue();
-      assertThat(v2DataJobCriteria.getComparator().compare(a, b)).isPositive();
-   }
+    assertThat(v2DataJobCriteria.getPredicate().test(a)).isTrue();
+    assertThat(v2DataJobCriteria.getComparator().compare(a, b)).isPositive();
+  }
 
-   /**
-    * This test should create two data jobs executed:
-    * a - “At 04:05 on day-of-month 1 and on Monday in January.”
-    * b 0 “At 04:05 every day”
-    *
-    * by this info we create a two dates to make a range:
-    * Next week and February 1st next year. This will makes a range which should include data job "a", but excludes "b"
-    * so that test does not fail each year on specific time
-    */
-   @Test
-   void testJobNextRunStrategy_whenComputingValidCriteriaWithFilter_shouldReturnValidCriteria() {
-      Criteria<V2DataJob> baseCriteria = new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
-      Filter baseFilter = new Filter("config.schedule.nextRunEpochSeconds",
-            String.format("%d-%d",getNextWeek(), getSecondMonthOfNextYear()), Sort.Direction.ASC);
-      V2DataJob a = createDummyJob("5 4 1 1 1");
-      V2DataJob b = createDummyJob("5 6 * * *"); // later than previous
+  /**
+   * This test should create two data jobs executed: a - “At 04:05 on day-of-month 1 and on Monday
+   * in January.” b 0 “At 04:05 every day”
+   *
+   * <p>by this info we create a two dates to make a range: Next week and February 1st next year.
+   * This will makes a range which should include data job "a", but excludes "b" so that test does
+   * not fail each year on specific time
+   */
+  @Test
+  void testJobNextRunStrategy_whenComputingValidCriteriaWithFilter_shouldReturnValidCriteria() {
+    Criteria<V2DataJob> baseCriteria =
+        new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
+    Filter baseFilter =
+        new Filter(
+            "config.schedule.nextRunEpochSeconds",
+            String.format("%d-%d", getNextWeek(), getSecondMonthOfNextYear()),
+            Sort.Direction.ASC);
+    V2DataJob a = createDummyJob("5 4 1 1 1");
+    V2DataJob b = createDummyJob("5 6 * * *"); // later than previous
 
-      Criteria<V2DataJob> v2DataJobCriteria = strategyByNextRun.computeFilterCriteria(baseCriteria, baseFilter);
+    Criteria<V2DataJob> v2DataJobCriteria =
+        strategyByNextRun.computeFilterCriteria(baseCriteria, baseFilter);
 
-      //assertThat(v2DataJobCriteria.getPredicate().test(a)).isTrue(); // TODO
-      assertThat(v2DataJobCriteria.getPredicate().test(b)).isFalse();
-      assertThat(v2DataJobCriteria.getComparator().compare(a, b)).isPositive();
-   }
+    // assertThat(v2DataJobCriteria.getPredicate().test(a)).isTrue(); // TODO
+    assertThat(v2DataJobCriteria.getPredicate().test(b)).isFalse();
+    assertThat(v2DataJobCriteria.getComparator().compare(a, b)).isPositive();
+  }
 
-   @Test
-   void testJobNextRunStrategy_whenComputingInvalidSearchProvided_shouldReturnValidPredicate() {
-      Predicate<V2DataJob> predicate = strategyByNextRun.computeSearchCriteria("A");
+  @Test
+  void testJobNextRunStrategy_whenComputingInvalidSearchProvided_shouldReturnValidPredicate() {
+    Predicate<V2DataJob> predicate = strategyByNextRun.computeSearchCriteria("A");
 
-      V2DataJob a = createDummyJob("5 6 * * *");
+    V2DataJob a = createDummyJob("5 6 * * *");
 
+    assertThat(predicate.test(a)).isFalse();
+  }
 
-      assertThat(predicate.test(a)).isFalse();
-   }
+  private V2DataJob createDummyJob(String schedule) {
+    V2DataJob job = new V2DataJob();
+    V2DataJobConfig config = new V2DataJobConfig();
+    V2DataJobSchedule dataJobSchedule = new V2DataJobSchedule();
 
-   private V2DataJob createDummyJob(String schedule) {
-      V2DataJob job = new V2DataJob();
-      V2DataJobConfig config = new V2DataJobConfig();
-      V2DataJobSchedule dataJobSchedule = new V2DataJobSchedule();
+    dataJobSchedule.setScheduleCron(schedule);
+    config.setSchedule(dataJobSchedule);
+    job.setConfig(config);
 
-      dataJobSchedule.setScheduleCron(schedule);
-      config.setSchedule(dataJobSchedule);
-      job.setConfig(config);
+    strategyByNextRun.alterFieldData(job);
+    return job;
+  }
 
-      strategyByNextRun.alterFieldData(job);
-      return job;
-   }
+  private long getSecondMonthOfNextYear() {
+    final Calendar calendar = Calendar.getInstance();
+    calendar.setTime(new Date());
+    calendar.set(Calendar.DAY_OF_MONTH, 1);
+    calendar.set(Calendar.MONTH, 1);
+    calendar.add(Calendar.YEAR, 1);
 
-   private long getSecondMonthOfNextYear() {
-      final Calendar calendar = Calendar.getInstance();
-      calendar.setTime(new Date());
-      calendar.set(Calendar.DAY_OF_MONTH, 1);
-      calendar.set(Calendar.MONTH, 1);
-      calendar.add(Calendar.YEAR, 1);
+    return calendar.getTimeInMillis() / 1000;
+  }
 
-      return calendar.getTimeInMillis() / 1000;
-   }
+  private long getNextWeek() {
+    final Calendar calendar = Calendar.getInstance();
+    calendar.setTime(new Date());
+    calendar.add(Calendar.WEEK_OF_YEAR, 1);
 
-   private long getNextWeek() {
-      final Calendar calendar = Calendar.getInstance();
-      calendar.setTime(new Date());
-      calendar.add(Calendar.WEEK_OF_YEAR, 1);
-
-      return calendar.getTimeInMillis() / 1000;
-   }
-
+    return calendar.getTimeInMillis() / 1000;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByScheduleCronTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByScheduleCronTest.java
@@ -19,53 +19,58 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class JobFieldStrategyByScheduleCronTest {
 
-   private final JobFieldStrategyByScheduleCron strategyBySchedule = new JobFieldStrategyByScheduleCron();
+  private final JobFieldStrategyByScheduleCron strategyBySchedule =
+      new JobFieldStrategyByScheduleCron();
 
-   @Test
-   void testJobScheduleStrategy_whenGettingStrategyName_shouldBeSpecific() {
-      assertThat(strategyBySchedule.getStrategyName()).isEqualTo(JobFieldStrategyBy.SCHEDULE_CRON);
-   }
+  @Test
+  void testJobScheduleStrategy_whenGettingStrategyName_shouldBeSpecific() {
+    assertThat(strategyBySchedule.getStrategyName()).isEqualTo(JobFieldStrategyBy.SCHEDULE_CRON);
+  }
 
-   @Test
-   void testJobScheduleStrategy_whenAlteringFieldData_shouldNotModifyState() {
-      String cron = "5 0 * 8 *";
-      V2DataJob dataJob = createDummyJob(cron);
+  @Test
+  void testJobScheduleStrategy_whenAlteringFieldData_shouldNotModifyState() {
+    String cron = "5 0 * 8 *";
+    V2DataJob dataJob = createDummyJob(cron);
 
-      strategyBySchedule.alterFieldData(dataJob);
+    strategyBySchedule.alterFieldData(dataJob);
 
-      assertThat(dataJob.getConfig().getSchedule().getScheduleCron()).isEqualTo(cron);
-   }
+    assertThat(dataJob.getConfig().getSchedule().getScheduleCron()).isEqualTo(cron);
+  }
 
-   @Test
-   void testJobScheduleStrategy_whenComputingValidCriteriaWithoutFilter_shouldReturnTheSameCriteria() {
-      Criteria<V2DataJob> baseCriteria = new Criteria<>(Objects::nonNull, Comparator.comparing(dataJob -> dataJob.getConfig().getDescription()));
+  @Test
+  void
+      testJobScheduleStrategy_whenComputingValidCriteriaWithoutFilter_shouldReturnTheSameCriteria() {
+    Criteria<V2DataJob> baseCriteria =
+        new Criteria<>(
+            Objects::nonNull,
+            Comparator.comparing(dataJob -> dataJob.getConfig().getDescription()));
 
-      Criteria<V2DataJob> v2DataJobCriteria = strategyBySchedule.computeFilterCriteria(baseCriteria, null);
+    Criteria<V2DataJob> v2DataJobCriteria =
+        strategyBySchedule.computeFilterCriteria(baseCriteria, null);
 
-      assertThat(v2DataJobCriteria.getPredicate()).isEqualTo(baseCriteria.getPredicate());
-      assertThat(v2DataJobCriteria.getComparator()).isEqualTo(baseCriteria.getComparator());
-   }
+    assertThat(v2DataJobCriteria.getPredicate()).isEqualTo(baseCriteria.getPredicate());
+    assertThat(v2DataJobCriteria.getComparator()).isEqualTo(baseCriteria.getComparator());
+  }
 
+  @Test
+  void testJobScheduleStrategy_whenComputingValidSearchProvided_shouldReturnValidPredicate() {
+    Predicate<V2DataJob> predicate = strategyBySchedule.computeSearchCriteria("5 0 * 8 *");
 
-   @Test
-   void testJobScheduleStrategy_whenComputingValidSearchProvided_shouldReturnValidPredicate() {
-      Predicate<V2DataJob> predicate = strategyBySchedule.computeSearchCriteria("5 0 * 8 *");
+    V2DataJob a = createDummyJob("5 0 * 8 *");
+    V2DataJob b = createDummyJob("5 0 * 8 1");
 
-      V2DataJob a = createDummyJob("5 0 * 8 *");
-      V2DataJob b = createDummyJob("5 0 * 8 1");
+    assertThat(predicate.test(a)).isTrue();
+    assertThat(predicate.test(b)).isFalse();
+  }
 
-      assertThat(predicate.test(a)).isTrue();
-      assertThat(predicate.test(b)).isFalse();
-   }
+  private V2DataJob createDummyJob(String schedule) {
+    V2DataJob job = new V2DataJob();
+    V2DataJobConfig config = new V2DataJobConfig();
+    V2DataJobSchedule dataJobSchedule = new V2DataJobSchedule();
 
-   private V2DataJob createDummyJob(String schedule) {
-      V2DataJob job = new V2DataJob();
-      V2DataJobConfig config = new V2DataJobConfig();
-      V2DataJobSchedule dataJobSchedule = new V2DataJobSchedule();
-
-      dataJobSchedule.setScheduleCron(schedule);
-      config.setSchedule(dataJobSchedule);
-      job.setConfig(config);
-      return job;
-   }
+    dataJobSchedule.setScheduleCron(schedule);
+    config.setSchedule(dataJobSchedule);
+    job.setConfig(config);
+    return job;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyBySourceUrlTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyBySourceUrlTest.java
@@ -18,50 +18,58 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class JobFieldStrategyBySourceUrlTest {
 
-   private static final String GIT_REPO_URL_RAW = "gitlab.com/taurus/jobs.git";
-   private static final String GIT_REPO_URL_FORMATTED = "https://gitlab.com/taurus/jobs";
-   private static final String GIT_REPO_BRANCH = "main";
-   private final JobFieldStrategyBySourceUrl strategyBySourceUrl = new JobFieldStrategyBySourceUrl(GIT_REPO_URL_RAW, GIT_REPO_BRANCH, true);
+  private static final String GIT_REPO_URL_RAW = "gitlab.com/taurus/jobs.git";
+  private static final String GIT_REPO_URL_FORMATTED = "https://gitlab.com/taurus/jobs";
+  private static final String GIT_REPO_BRANCH = "main";
+  private final JobFieldStrategyBySourceUrl strategyBySourceUrl =
+      new JobFieldStrategyBySourceUrl(GIT_REPO_URL_RAW, GIT_REPO_BRANCH, true);
 
-   @Test
-   void testJobSourceUrlStrategy_whenGettingStrategyName_shouldBeSpecific() {
-      assertThat(strategyBySourceUrl.getStrategyName()).isEqualTo(JobFieldStrategyBy.SOURCE_URL);
-   }
+  @Test
+  void testJobSourceUrlStrategy_whenGettingStrategyName_shouldBeSpecific() {
+    assertThat(strategyBySourceUrl.getStrategyName()).isEqualTo(JobFieldStrategyBy.SOURCE_URL);
+  }
 
-   @Test
-   void testJobSourceUrlStrategy_whenAlteringFieldData_shouldModifyState() {
-      String jobName = "sample-job";
-      V2DataJob dataJob = createDummyJob(jobName);
+  @Test
+  void testJobSourceUrlStrategy_whenAlteringFieldData_shouldModifyState() {
+    String jobName = "sample-job";
+    V2DataJob dataJob = createDummyJob(jobName);
 
-      strategyBySourceUrl.alterFieldData(dataJob);
+    strategyBySourceUrl.alterFieldData(dataJob);
 
-      assertThat(dataJob.getConfig().getSourceUrl()).isEqualTo(String.format("%s/-/tree/%s/%s", GIT_REPO_URL_FORMATTED, GIT_REPO_BRANCH, jobName));
-   }
+    assertThat(dataJob.getConfig().getSourceUrl())
+        .isEqualTo(
+            String.format("%s/-/tree/%s/%s", GIT_REPO_URL_FORMATTED, GIT_REPO_BRANCH, jobName));
+  }
 
-   @Test
-   void testJobSourceUrlStrategy_whenComputingValidCriteriaWithoutFilter_shouldReturnTheSameCriteria() {
-      Criteria<V2DataJob> baseCriteria = new Criteria<>(Objects::nonNull, Comparator.comparing(dataJob -> dataJob.getConfig().getDescription()));
+  @Test
+  void
+      testJobSourceUrlStrategy_whenComputingValidCriteriaWithoutFilter_shouldReturnTheSameCriteria() {
+    Criteria<V2DataJob> baseCriteria =
+        new Criteria<>(
+            Objects::nonNull,
+            Comparator.comparing(dataJob -> dataJob.getConfig().getDescription()));
 
-      Criteria<V2DataJob> v2DataJobCriteria = strategyBySourceUrl.computeFilterCriteria(baseCriteria, null);
+    Criteria<V2DataJob> v2DataJobCriteria =
+        strategyBySourceUrl.computeFilterCriteria(baseCriteria, null);
 
-      assertThat(v2DataJobCriteria.getPredicate()).isEqualTo(baseCriteria.getPredicate());
-      assertThat(v2DataJobCriteria.getComparator()).isEqualTo(baseCriteria.getComparator());
-   }
+    assertThat(v2DataJobCriteria.getPredicate()).isEqualTo(baseCriteria.getPredicate());
+    assertThat(v2DataJobCriteria.getComparator()).isEqualTo(baseCriteria.getComparator());
+  }
 
-   @Test
-   void testJobSourceUrlStrategy_whenComputingValidSearchProvided_shouldReturnValidPredicate() {
-      Predicate<V2DataJob> predicate = strategyBySourceUrl.computeSearchCriteria("sample-job");
+  @Test
+  void testJobSourceUrlStrategy_whenComputingValidSearchProvided_shouldReturnValidPredicate() {
+    Predicate<V2DataJob> predicate = strategyBySourceUrl.computeSearchCriteria("sample-job");
 
-      V2DataJob a = createDummyJob("sample-job");
+    V2DataJob a = createDummyJob("sample-job");
 
-      assertThat(predicate.test(a)).isFalse(); // always false cause its empty
-   }
+    assertThat(predicate.test(a)).isFalse(); // always false cause its empty
+  }
 
-   private V2DataJob createDummyJob(String jobName) {
-      V2DataJob job = new V2DataJob();
-      job.setJobName(jobName);
-      V2DataJobConfig config = new V2DataJobConfig();
-      job.setConfig(config);
-      return job;
-   }
+  private V2DataJob createDummyJob(String jobName) {
+    V2DataJob job = new V2DataJob();
+    job.setJobName(jobName);
+    V2DataJobConfig config = new V2DataJobConfig();
+    job.setConfig(config);
+    return job;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByTeamTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByTeamTest.java
@@ -21,100 +21,104 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class JobFieldStrategyByTeamTest {
 
-   private final JobFieldStrategyByTeam strategyByTeam = new JobFieldStrategyByTeam();
+  private final JobFieldStrategyByTeam strategyByTeam = new JobFieldStrategyByTeam();
 
-   @Test
-   void testJobTeamStrategy_whenGettingStrategyName_shouldBeSpecific() {
-      assertThat(strategyByTeam.getStrategyName()).isEqualTo(JobFieldStrategyBy.TEAM);
-   }
+  @Test
+  void testJobTeamStrategy_whenGettingStrategyName_shouldBeSpecific() {
+    assertThat(strategyByTeam.getStrategyName()).isEqualTo(JobFieldStrategyBy.TEAM);
+  }
 
-   @Test
-   void testJobTeamStrategy_whenAlteringFieldData_shouldNotModifyState() {
-      V2DataJob dataJob = createDummyJob("starshot");
+  @Test
+  void testJobTeamStrategy_whenAlteringFieldData_shouldNotModifyState() {
+    V2DataJob dataJob = createDummyJob("starshot");
 
-      strategyByTeam.alterFieldData(dataJob);
+    strategyByTeam.alterFieldData(dataJob);
 
-      assertThat(dataJob.getConfig().getTeam()).isEqualTo("starshot");
-   }
+    assertThat(dataJob.getConfig().getTeam()).isEqualTo("starshot");
+  }
 
-   @Test
-   void testJobTeamStrategy_whenComputingValidCriteriaWithoutFilter_shouldReturnValidCriteria() {
-      Criteria<V2DataJob> baseCriteria = new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
-      Filter baseFilter = new Filter("random", null, Sort.Direction.DESC);
-      V2DataJob a = createDummyJob("starshot");
-      V2DataJob b = createDummyJob("taurus");
+  @Test
+  void testJobTeamStrategy_whenComputingValidCriteriaWithoutFilter_shouldReturnValidCriteria() {
+    Criteria<V2DataJob> baseCriteria =
+        new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
+    Filter baseFilter = new Filter("random", null, Sort.Direction.DESC);
+    V2DataJob a = createDummyJob("starshot");
+    V2DataJob b = createDummyJob("taurus");
 
-      Criteria<V2DataJob> v2DataJobCriteria = strategyByTeam.computeFilterCriteria(baseCriteria, baseFilter);
+    Criteria<V2DataJob> v2DataJobCriteria =
+        strategyByTeam.computeFilterCriteria(baseCriteria, baseFilter);
 
-      assertThat(v2DataJobCriteria.getPredicate().test(a)).isTrue();
-      assertThat(v2DataJobCriteria.getComparator().compare(a, b)).isPositive();
-   }
+    assertThat(v2DataJobCriteria.getPredicate().test(a)).isTrue();
+    assertThat(v2DataJobCriteria.getComparator().compare(a, b)).isPositive();
+  }
 
-   @Test
-   void testJobTeamStrategy_whenComputingValidCriteriaWithFilter_shouldReturnValidCriteria() {
-      Criteria<V2DataJob> baseCriteria = new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
-      Filter baseFilter = new Filter("config.team", "starshot", Sort.Direction.ASC);
-      V2DataJob a = createDummyJob("starshot");
-      V2DataJob b = createDummyJob("taurus");
+  @Test
+  void testJobTeamStrategy_whenComputingValidCriteriaWithFilter_shouldReturnValidCriteria() {
+    Criteria<V2DataJob> baseCriteria =
+        new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
+    Filter baseFilter = new Filter("config.team", "starshot", Sort.Direction.ASC);
+    V2DataJob a = createDummyJob("starshot");
+    V2DataJob b = createDummyJob("taurus");
 
-      Criteria<V2DataJob> v2DataJobCriteria = strategyByTeam.computeFilterCriteria(baseCriteria, baseFilter);
+    Criteria<V2DataJob> v2DataJobCriteria =
+        strategyByTeam.computeFilterCriteria(baseCriteria, baseFilter);
 
-      assertThat(v2DataJobCriteria.getPredicate().test(a)).isTrue();
-      assertThat(v2DataJobCriteria.getPredicate().test(b)).isFalse();
-      assertThat(v2DataJobCriteria.getComparator().compare(a, b)).isNegative();
-   }
+    assertThat(v2DataJobCriteria.getPredicate().test(a)).isTrue();
+    assertThat(v2DataJobCriteria.getPredicate().test(b)).isFalse();
+    assertThat(v2DataJobCriteria.getComparator().compare(a, b)).isNegative();
+  }
 
-   @Test
-   void testJobTeamStrategy_whenComputingValidSearchProvided_shouldReturnValidPredicate() {
-      Predicate<V2DataJob> predicate = strategyByTeam.computeSearchCriteria("starshot");
+  @Test
+  void testJobTeamStrategy_whenComputingValidSearchProvided_shouldReturnValidPredicate() {
+    Predicate<V2DataJob> predicate = strategyByTeam.computeSearchCriteria("starshot");
 
-      V2DataJob a = createDummyJob("Starshot");
-      V2DataJob b = createDummyJob("star-shot");
+    V2DataJob a = createDummyJob("Starshot");
+    V2DataJob b = createDummyJob("star-shot");
 
-      assertThat(predicate.test(a)).isTrue();
-      assertThat(predicate.test(b)).isFalse();
-   }
+    assertThat(predicate.test(a)).isTrue();
+    assertThat(predicate.test(b)).isFalse();
+  }
 
-   @Test
-   void testJobTeamStrategy_whenComputingInvalidSearchProvided_shouldReturnValidPredicate() {
-      Predicate<V2DataJob> predicate = strategyByTeam.computeSearchCriteria("starshot");
+  @Test
+  void testJobTeamStrategy_whenComputingInvalidSearchProvided_shouldReturnValidPredicate() {
+    Predicate<V2DataJob> predicate = strategyByTeam.computeSearchCriteria("starshot");
 
-      V2DataJob a = new V2DataJob();
+    V2DataJob a = new V2DataJob();
 
-      assertThat(predicate.test(a)).isFalse();
-   }
+    assertThat(predicate.test(a)).isFalse();
+  }
 
-   @Test
-   public void testJobTeamComparator() {
-      var strategyByTeam = new JobFieldStrategyByTeam();
-      V2DataJob a = createDummyJob("A");
-      V2DataJob a1 = createDummyJob("A");
-      V2DataJob b = createDummyJob("B");
-      V2DataJob c = createDummyJob(null);
-      V2DataJob c1 = createDummyJob(null);
+  @Test
+  public void testJobTeamComparator() {
+    var strategyByTeam = new JobFieldStrategyByTeam();
+    V2DataJob a = createDummyJob("A");
+    V2DataJob a1 = createDummyJob("A");
+    V2DataJob b = createDummyJob("B");
+    V2DataJob c = createDummyJob(null);
+    V2DataJob c1 = createDummyJob(null);
 
-      var baseCriteria = new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
-      var filter = new Filter("team", "A", Sort.Direction.ASC);
+    var baseCriteria =
+        new Criteria<>(Objects::nonNull, Comparator.comparing(V2DataJob::getJobName));
+    var filter = new Filter("team", "A", Sort.Direction.ASC);
 
-      var descriptionCriteria = strategyByTeam.computeFilterCriteria(baseCriteria, filter);
-      var comparator = descriptionCriteria.getComparator();
+    var descriptionCriteria = strategyByTeam.computeFilterCriteria(baseCriteria, filter);
+    var comparator = descriptionCriteria.getComparator();
 
-      Assertions.assertEquals(-1, comparator.compare(a, b));
-      Assertions.assertEquals(-1, comparator.compare(b, c));
-      Assertions.assertEquals(-1, comparator.compare(a, c));
-      Assertions.assertEquals(1, comparator.compare(b, a));
-      Assertions.assertEquals(1, comparator.compare(c, a));
-      Assertions.assertEquals(0, comparator.compare(a1, a));
-      Assertions.assertEquals(0, comparator.compare(c1, c));
+    Assertions.assertEquals(-1, comparator.compare(a, b));
+    Assertions.assertEquals(-1, comparator.compare(b, c));
+    Assertions.assertEquals(-1, comparator.compare(a, c));
+    Assertions.assertEquals(1, comparator.compare(b, a));
+    Assertions.assertEquals(1, comparator.compare(c, a));
+    Assertions.assertEquals(0, comparator.compare(a1, a));
+    Assertions.assertEquals(0, comparator.compare(c1, c));
+  }
 
-   }
+  private V2DataJob createDummyJob(String team) {
+    V2DataJob job = new V2DataJob();
+    V2DataJobConfig dataJobConfig = new V2DataJobConfig();
+    dataJobConfig.setTeam(team);
+    job.setConfig(dataJobConfig);
 
-   private V2DataJob createDummyJob(String team) {
-      V2DataJob job = new V2DataJob();
-      V2DataJobConfig dataJobConfig = new V2DataJobConfig();
-      dataJobConfig.setTeam(team);
-      job.setConfig(dataJobConfig);
-
-      return job;
-   }
+    return job;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/model/K8SAnnotationsLabelsTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/model/K8SAnnotationsLabelsTest.java
@@ -8,53 +8,52 @@ package com.vmware.taurus.service.model;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-
 /**
- * The purpose of this test class is to ensure that every change to
- * the already defined Labels or Annotations is intentional. This is
- * because we will be persisting data based on those labels/annotations.
+ * The purpose of this test class is to ensure that every change to the already defined Labels or
+ * Annotations is intentional. This is because we will be persisting data based on those
+ * labels/annotations.
  */
 public class K8SAnnotationsLabelsTest {
 
-    @Test
-    public void testAnnotations() {
-        var msg = "JobAnnotation enum changed, make sure this change is intentional and update tests.";
+  @Test
+  public void testAnnotations() {
+    var msg = "JobAnnotation enum changed, make sure this change is intentional and update tests.";
 
-        var schedule = JobAnnotation.SCHEDULE.getValue();
-        var startedBy = JobAnnotation.STARTED_BY.getValue();
-        var deployedDate = JobAnnotation.DEPLOYED_DATE.getValue();
-        var deployedBy = JobAnnotation.DEPLOYED_BY.getValue();
-        var executionType = JobAnnotation.EXECUTION_TYPE.getValue();
-        var opId = JobAnnotation.OP_ID.getValue();
-        var unscheduled = JobAnnotation.UNSCHEDULED.getValue();
+    var schedule = JobAnnotation.SCHEDULE.getValue();
+    var startedBy = JobAnnotation.STARTED_BY.getValue();
+    var deployedDate = JobAnnotation.DEPLOYED_DATE.getValue();
+    var deployedBy = JobAnnotation.DEPLOYED_BY.getValue();
+    var executionType = JobAnnotation.EXECUTION_TYPE.getValue();
+    var opId = JobAnnotation.OP_ID.getValue();
+    var unscheduled = JobAnnotation.UNSCHEDULED.getValue();
 
-        Assertions.assertEquals("com.vmware.taurus/schedule", schedule, msg);
-        Assertions.assertEquals("com.vmware.taurus/started-by", startedBy, msg);
-        Assertions.assertEquals("com.vmware.taurus/deployed-date", deployedDate, msg);
-        Assertions.assertEquals("com.vmware.taurus/deployed-by", deployedBy, msg);
-        Assertions.assertEquals("com.vmware.taurus/execution-type", executionType, msg);
-        Assertions.assertEquals("com.vmware.taurus/op-id", opId, msg);
-        Assertions.assertEquals("com.vmware.taurus/unscheduled", unscheduled, msg);
+    Assertions.assertEquals("com.vmware.taurus/schedule", schedule, msg);
+    Assertions.assertEquals("com.vmware.taurus/started-by", startedBy, msg);
+    Assertions.assertEquals("com.vmware.taurus/deployed-date", deployedDate, msg);
+    Assertions.assertEquals("com.vmware.taurus/deployed-by", deployedBy, msg);
+    Assertions.assertEquals("com.vmware.taurus/execution-type", executionType, msg);
+    Assertions.assertEquals("com.vmware.taurus/op-id", opId, msg);
+    Assertions.assertEquals("com.vmware.taurus/unscheduled", unscheduled, msg);
 
-        Assertions.assertEquals(7, JobAnnotation.values().length, msg);
-    }
+    Assertions.assertEquals(7, JobAnnotation.values().length, msg);
+  }
 
-    @Test
-    public void testLabels() {
-        var msg = "JobLabel enum changed, make sure this change is intentional and update tests.";
+  @Test
+  public void testLabels() {
+    var msg = "JobLabel enum changed, make sure this change is intentional and update tests.";
 
-        var jobName = JobLabel.NAME.getValue();
-        var version = JobLabel.VERSION.getValue();
-        var type = JobLabel.TYPE.getValue();
-        var executionId = JobLabel.EXECUTION_ID.getValue();
-        var startedByUsed = JobLabel.STARTED_BY_USER.getValue();
+    var jobName = JobLabel.NAME.getValue();
+    var version = JobLabel.VERSION.getValue();
+    var type = JobLabel.TYPE.getValue();
+    var executionId = JobLabel.EXECUTION_ID.getValue();
+    var startedByUsed = JobLabel.STARTED_BY_USER.getValue();
 
-        Assertions.assertEquals("com.vmware.taurus/name", jobName, msg);
-        Assertions.assertEquals("com.vmware.taurus/version", version, msg);
-        Assertions.assertEquals("com.vmware.taurus/type", type, msg);
-        Assertions.assertEquals("com.vmware.taurus/data-job-execution-id", executionId, msg);
-        Assertions.assertEquals("com.vmware.taurus/start-by-user", startedByUsed, msg);
+    Assertions.assertEquals("com.vmware.taurus/name", jobName, msg);
+    Assertions.assertEquals("com.vmware.taurus/version", version, msg);
+    Assertions.assertEquals("com.vmware.taurus/type", type, msg);
+    Assertions.assertEquals("com.vmware.taurus/data-job-execution-id", executionId, msg);
+    Assertions.assertEquals("com.vmware.taurus/start-by-user", startedByUsed, msg);
 
-        Assertions.assertEquals(5, JobLabel.values().length, msg);
-    }
+    Assertions.assertEquals(5, JobLabel.values().length, msg);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/model/converter/ExecutionStatusConverterTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/model/converter/ExecutionStatusConverterTest.java
@@ -11,45 +11,45 @@ import org.junit.jupiter.api.Test;
 import com.vmware.taurus.service.model.ExecutionStatus;
 
 public class ExecutionStatusConverterTest {
-   private ExecutionStatusConverter converter = new ExecutionStatusConverter();
+  private ExecutionStatusConverter converter = new ExecutionStatusConverter();
 
-   @Test
-   public void testConvertToDatabaseColumn_nullExecutionStatus_shouldReturnNullValue() {
-      Assertions.assertNull(converter.convertToDatabaseColumn(null));
-   }
+  @Test
+  public void testConvertToDatabaseColumn_nullExecutionStatus_shouldReturnNullValue() {
+    Assertions.assertNull(converter.convertToDatabaseColumn(null));
+  }
 
-   @Test
-   public void testConvertToDatabaseColumn_executionStatusSuccess_shouldReturnSuccess() {
-      ExecutionStatus expectedExecutionStatus = ExecutionStatus.SUCCEEDED;
-      Integer actualDbValue = converter.convertToDatabaseColumn(expectedExecutionStatus);
+  @Test
+  public void testConvertToDatabaseColumn_executionStatusSuccess_shouldReturnSuccess() {
+    ExecutionStatus expectedExecutionStatus = ExecutionStatus.SUCCEEDED;
+    Integer actualDbValue = converter.convertToDatabaseColumn(expectedExecutionStatus);
 
-      Assertions.assertEquals(expectedExecutionStatus.getDbValue(), actualDbValue);
-   }
+    Assertions.assertEquals(expectedExecutionStatus.getDbValue(), actualDbValue);
+  }
 
-   @Test
-   public void testConvertToEntityAttribute_nullDbValue_shouldReturnNullValue() {
-      Assertions.assertNull(converter.convertToEntityAttribute(null));
-   }
+  @Test
+  public void testConvertToEntityAttribute_nullDbValue_shouldReturnNullValue() {
+    Assertions.assertNull(converter.convertToEntityAttribute(null));
+  }
 
-   @Test
-   public void testConvertToEntityAttribute_notExistingDbValue_shouldReturnNullValue() {
-      Assertions.assertNull(converter.convertToEntityAttribute(-1));
-   }
+  @Test
+  public void testConvertToEntityAttribute_notExistingDbValue_shouldReturnNullValue() {
+    Assertions.assertNull(converter.convertToEntityAttribute(-1));
+  }
 
-   @Test
-   public void testConvertToEntityAttribute_dbValueTwo_shouldReturnExecutionStatusSuccess() {
-      ExecutionStatus expectedExecutionStatus = ExecutionStatus.SUCCEEDED;
-      ExecutionStatus actualExecutionStatus =
-            converter.convertToEntityAttribute(expectedExecutionStatus.getDbValue());
+  @Test
+  public void testConvertToEntityAttribute_dbValueTwo_shouldReturnExecutionStatusSuccess() {
+    ExecutionStatus expectedExecutionStatus = ExecutionStatus.SUCCEEDED;
+    ExecutionStatus actualExecutionStatus =
+        converter.convertToEntityAttribute(expectedExecutionStatus.getDbValue());
 
-      Assertions.assertEquals(expectedExecutionStatus, actualExecutionStatus);
-   }
+    Assertions.assertEquals(expectedExecutionStatus, actualExecutionStatus);
+  }
 
-   @Test
-   public void testConvertToEntityAttribute_dbValueThree_shouldReturnExecutionStatusPlatformError() {
-      ExecutionStatus expectedExecutionStatus = ExecutionStatus.PLATFORM_ERROR;
-      ExecutionStatus actualExecutionStatus = converter.convertToEntityAttribute(3);
+  @Test
+  public void testConvertToEntityAttribute_dbValueThree_shouldReturnExecutionStatusPlatformError() {
+    ExecutionStatus expectedExecutionStatus = ExecutionStatus.PLATFORM_ERROR;
+    ExecutionStatus actualExecutionStatus = converter.convertToEntityAttribute(3);
 
-      Assertions.assertEquals(expectedExecutionStatus, actualExecutionStatus);
-   }
+    Assertions.assertEquals(expectedExecutionStatus, actualExecutionStatus);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/model/converter/ExecutionTerminationStatusConverterTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/model/converter/ExecutionTerminationStatusConverterTest.java
@@ -9,40 +9,41 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.vmware.taurus.service.model.ExecutionStatus;
-import com.vmware.taurus.service.model.converter.ExecutionTerminationStatusConverter;
 
 public class ExecutionTerminationStatusConverterTest {
-   private ExecutionTerminationStatusConverter converter = new ExecutionTerminationStatusConverter();
+  private ExecutionTerminationStatusConverter converter = new ExecutionTerminationStatusConverter();
 
-   @Test
-   public void testConvertToDatabaseColumn_nullTerminationStatus_shouldReturnNullValue() {
-      Assertions.assertNull(converter.convertToDatabaseColumn(null));
-   }
+  @Test
+  public void testConvertToDatabaseColumn_nullTerminationStatus_shouldReturnNullValue() {
+    Assertions.assertNull(converter.convertToDatabaseColumn(null));
+  }
 
-   @Test
-   public void testConvertToDatabaseColumn_terminationStatusSuccess_shouldReturnSuccess() {
-      ExecutionStatus expectedTerminationStatus = ExecutionStatus.SUCCEEDED;
-      String actualDbValue = converter.convertToDatabaseColumn(expectedTerminationStatus);
+  @Test
+  public void testConvertToDatabaseColumn_terminationStatusSuccess_shouldReturnSuccess() {
+    ExecutionStatus expectedTerminationStatus = ExecutionStatus.SUCCEEDED;
+    String actualDbValue = converter.convertToDatabaseColumn(expectedTerminationStatus);
 
-      Assertions.assertEquals(String.valueOf(expectedTerminationStatus.getAlertValue()), actualDbValue);
-   }
+    Assertions.assertEquals(
+        String.valueOf(expectedTerminationStatus.getAlertValue()), actualDbValue);
+  }
 
-   @Test
-   public void testConvertToEntityAttribute_nullDbValue_shouldReturnNullValue() {
-      Assertions.assertNull(converter.convertToEntityAttribute(null));
-   }
+  @Test
+  public void testConvertToEntityAttribute_nullDbValue_shouldReturnNullValue() {
+    Assertions.assertNull(converter.convertToEntityAttribute(null));
+  }
 
-   @Test
-   public void testConvertToEntityAttribute_dbValueText_shouldReturnNullValue() {
-      Assertions.assertNull(converter.convertToEntityAttribute("test_db_value"));
-   }
+  @Test
+  public void testConvertToEntityAttribute_dbValueText_shouldReturnNullValue() {
+    Assertions.assertNull(converter.convertToEntityAttribute("test_db_value"));
+  }
 
-   @Test
-   public void testConvertToEntityAttribute_dbValueSuccess_shouldReturnTerminationStatusSuccess() {
-      ExecutionStatus expectedTerminationStatus = ExecutionStatus.SUCCEEDED;
-      ExecutionStatus actualTerminationStatus =
-            converter.convertToEntityAttribute(String.valueOf(expectedTerminationStatus.getAlertValue()));
+  @Test
+  public void testConvertToEntityAttribute_dbValueSuccess_shouldReturnTerminationStatusSuccess() {
+    ExecutionStatus expectedTerminationStatus = ExecutionStatus.SUCCEEDED;
+    ExecutionStatus actualTerminationStatus =
+        converter.convertToEntityAttribute(
+            String.valueOf(expectedTerminationStatus.getAlertValue()));
 
-      Assertions.assertEquals(expectedTerminationStatus, actualTerminationStatus);
-   }
+    Assertions.assertEquals(expectedTerminationStatus, actualTerminationStatus);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DataJobExecutionCleanupMonitorTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DataJobExecutionCleanupMonitorTest.java
@@ -15,73 +15,85 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = ControlplaneApplication.class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = ControlplaneApplication.class)
 public class DataJobExecutionCleanupMonitorTest {
 
-    @Autowired
-    private MeterRegistry meterRegistry;
+  @Autowired private MeterRegistry meterRegistry;
 
-    @Autowired
-    private DataJobExecutionCleanupMonitor dataJobExecutionCleanupMonitor;
+  @Autowired private DataJobExecutionCleanupMonitor dataJobExecutionCleanupMonitor;
 
-    @Test
-    public void testInvocationsCounter() {
-        var counter = meterRegistry.counter(DataJobExecutionCleanupMonitor.CLEANUP_JOB_INVOCATIONS_COUNTER_NAME);
-        Assertions.assertEquals(0.0, counter.count(), 0.001);
-        Assertions.assertEquals("Counts the number of times the cleanup task is called.", counter.getId().getDescription());
+  @Test
+  public void testInvocationsCounter() {
+    var counter =
+        meterRegistry.counter(DataJobExecutionCleanupMonitor.CLEANUP_JOB_INVOCATIONS_COUNTER_NAME);
+    Assertions.assertEquals(0.0, counter.count(), 0.001);
+    Assertions.assertEquals(
+        "Counts the number of times the cleanup task is called.", counter.getId().getDescription());
 
-        dataJobExecutionCleanupMonitor.countInvocation();
+    dataJobExecutionCleanupMonitor.countInvocation();
 
-        counter = meterRegistry.counter(DataJobExecutionCleanupMonitor.CLEANUP_JOB_INVOCATIONS_COUNTER_NAME);
-        Assertions.assertEquals(1.0, counter.count(), 0.001);
+    counter =
+        meterRegistry.counter(DataJobExecutionCleanupMonitor.CLEANUP_JOB_INVOCATIONS_COUNTER_NAME);
+    Assertions.assertEquals(1.0, counter.count(), 0.001);
 
-        dataJobExecutionCleanupMonitor.countInvocation();
-        dataJobExecutionCleanupMonitor.countInvocation();
-        dataJobExecutionCleanupMonitor.countInvocation();
-        dataJobExecutionCleanupMonitor.countInvocation();
+    dataJobExecutionCleanupMonitor.countInvocation();
+    dataJobExecutionCleanupMonitor.countInvocation();
+    dataJobExecutionCleanupMonitor.countInvocation();
+    dataJobExecutionCleanupMonitor.countInvocation();
 
-        counter = meterRegistry.counter(DataJobExecutionCleanupMonitor.CLEANUP_JOB_INVOCATIONS_COUNTER_NAME);
-        Assertions.assertEquals(5.0, counter.count(), 0.001);
-    }
+    counter =
+        meterRegistry.counter(DataJobExecutionCleanupMonitor.CLEANUP_JOB_INVOCATIONS_COUNTER_NAME);
+    Assertions.assertEquals(5.0, counter.count(), 0.001);
+  }
 
-    @Test
-    public void testFailedDeletionsCounter() {
-        var counter = meterRegistry.counter(DataJobExecutionCleanupMonitor.FAILED_DELETIONS_COUNTER_NAME);
-        Assertions.assertEquals(0.0, counter.count(), 0.001);
-        Assertions.assertEquals("Counts the total times the data job execution cleanup task was unsuccessful for a data job.", counter.getId().getDescription());
+  @Test
+  public void testFailedDeletionsCounter() {
+    var counter =
+        meterRegistry.counter(DataJobExecutionCleanupMonitor.FAILED_DELETIONS_COUNTER_NAME);
+    Assertions.assertEquals(0.0, counter.count(), 0.001);
+    Assertions.assertEquals(
+        "Counts the total times the data job execution cleanup task was unsuccessful for a data"
+            + " job.",
+        counter.getId().getDescription());
 
-        dataJobExecutionCleanupMonitor.countFailedDeletion();
+    dataJobExecutionCleanupMonitor.countFailedDeletion();
 
-        counter = meterRegistry.counter(DataJobExecutionCleanupMonitor.FAILED_DELETIONS_COUNTER_NAME);
-        Assertions.assertEquals(1.0, counter.count(), 0.001);
+    counter = meterRegistry.counter(DataJobExecutionCleanupMonitor.FAILED_DELETIONS_COUNTER_NAME);
+    Assertions.assertEquals(1.0, counter.count(), 0.001);
 
-        dataJobExecutionCleanupMonitor.countFailedDeletion();
-        dataJobExecutionCleanupMonitor.countFailedDeletion();
-        dataJobExecutionCleanupMonitor.countFailedDeletion();
-        dataJobExecutionCleanupMonitor.countFailedDeletion();
+    dataJobExecutionCleanupMonitor.countFailedDeletion();
+    dataJobExecutionCleanupMonitor.countFailedDeletion();
+    dataJobExecutionCleanupMonitor.countFailedDeletion();
+    dataJobExecutionCleanupMonitor.countFailedDeletion();
 
-        counter = meterRegistry.counter(DataJobExecutionCleanupMonitor.FAILED_DELETIONS_COUNTER_NAME);
-        Assertions.assertEquals(5.0, counter.count(), 0.001);
-    }
+    counter = meterRegistry.counter(DataJobExecutionCleanupMonitor.FAILED_DELETIONS_COUNTER_NAME);
+    Assertions.assertEquals(5.0, counter.count(), 0.001);
+  }
 
-    @Test
-    public void testSuccessfulDeletionsCounter() {
-        var counter = meterRegistry.counter(DataJobExecutionCleanupMonitor.SUCCESSFUL_DELETIONS_COUNTER_NAME);
-        Assertions.assertEquals(0.0, counter.count(), 0.001);
-        Assertions.assertEquals("Counts the total times the data job execution cleanup task was successful for a data job.", counter.getId().getDescription());
+  @Test
+  public void testSuccessfulDeletionsCounter() {
+    var counter =
+        meterRegistry.counter(DataJobExecutionCleanupMonitor.SUCCESSFUL_DELETIONS_COUNTER_NAME);
+    Assertions.assertEquals(0.0, counter.count(), 0.001);
+    Assertions.assertEquals(
+        "Counts the total times the data job execution cleanup task was successful for a data job.",
+        counter.getId().getDescription());
 
-        dataJobExecutionCleanupMonitor.countSuccessfulDeletion();
+    dataJobExecutionCleanupMonitor.countSuccessfulDeletion();
 
-        counter = meterRegistry.counter(DataJobExecutionCleanupMonitor.SUCCESSFUL_DELETIONS_COUNTER_NAME);
-        Assertions.assertEquals(1.0, counter.count(), 0.001);
+    counter =
+        meterRegistry.counter(DataJobExecutionCleanupMonitor.SUCCESSFUL_DELETIONS_COUNTER_NAME);
+    Assertions.assertEquals(1.0, counter.count(), 0.001);
 
-        dataJobExecutionCleanupMonitor.countSuccessfulDeletion();
-        dataJobExecutionCleanupMonitor.countSuccessfulDeletion();
-        dataJobExecutionCleanupMonitor.countSuccessfulDeletion();
-        dataJobExecutionCleanupMonitor.countSuccessfulDeletion();
+    dataJobExecutionCleanupMonitor.countSuccessfulDeletion();
+    dataJobExecutionCleanupMonitor.countSuccessfulDeletion();
+    dataJobExecutionCleanupMonitor.countSuccessfulDeletion();
+    dataJobExecutionCleanupMonitor.countSuccessfulDeletion();
 
-        counter = meterRegistry.counter(DataJobExecutionCleanupMonitor.SUCCESSFUL_DELETIONS_COUNTER_NAME);
-        Assertions.assertEquals(5.0, counter.count(), 0.001);
-    }
-
+    counter =
+        meterRegistry.counter(DataJobExecutionCleanupMonitor.SUCCESSFUL_DELETIONS_COUNTER_NAME);
+    Assertions.assertEquals(5.0, counter.count(), 0.001);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DataJobMetricsTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DataJobMetricsTest.java
@@ -24,227 +24,253 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 
-
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = ControlplaneApplication.class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = ControlplaneApplication.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class DataJobMetricsTest {
 
-   @Autowired
-   private MeterRegistry meterRegistry;
+  @Autowired private MeterRegistry meterRegistry;
 
-   @Autowired
-   private JobsRepository jobsRepository;
+  @Autowired private JobsRepository jobsRepository;
 
-   @Autowired
-   private DataJobMetrics dataJobMetrics;
+  @Autowired private DataJobMetrics dataJobMetrics;
 
-   @Test
-   @Order(1)
-   public void testUpdateInfoGauges() {
-      JobConfig config = new JobConfig();
-      var dataJob = new DataJob("data-job", config);
+  @Test
+  @Order(1)
+  public void testUpdateInfoGauges() {
+    JobConfig config = new JobConfig();
+    var dataJob = new DataJob("data-job", config);
 
-      dataJobMetrics.updateInfoGauges(jobsRepository.save(dataJob));
+    dataJobMetrics.updateInfoGauges(jobsRepository.save(dataJob));
 
-      var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
-      Assertions.assertEquals(1, gauges.size());
-      Assertions.assertEquals(1, gauges.stream().findFirst().get().value());
+    var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
+    Assertions.assertEquals(1, gauges.stream().findFirst().get().value());
 
-      gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
-      Assertions.assertEquals(1, gauges.size());
-      Assertions.assertEquals(DataJobMetrics.DEFAULT_NOTIFICATION_DELAY_PERIOD_MINUTES, gauges.stream().findFirst().get().value());
-   }
+    gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
+    Assertions.assertEquals(
+        DataJobMetrics.DEFAULT_NOTIFICATION_DELAY_PERIOD_MINUTES,
+        gauges.stream().findFirst().get().value());
+  }
 
-   @Test
-   @Order(2)
-   public void testUpdateInfoGauges_whenCalledTwice_shouldNotCreateMultipleGauges() {
-      JobConfig config = new JobConfig();
-      var dataJob = new DataJob("data-job", config);
+  @Test
+  @Order(2)
+  public void testUpdateInfoGauges_whenCalledTwice_shouldNotCreateMultipleGauges() {
+    JobConfig config = new JobConfig();
+    var dataJob = new DataJob("data-job", config);
 
-      dataJobMetrics.updateInfoGauges(dataJob);
+    dataJobMetrics.updateInfoGauges(dataJob);
 
-      var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
-      Assertions.assertEquals(1, gauges.size());
+    var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
 
-      gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
-      Assertions.assertEquals(1, gauges.size());
-   }
+    gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
+  }
 
-   @Test
-   @Order(3)
-   public void testUpdateInfoGauges_withoutConfiguration_shouldDoNothing() {
-      var dataJob = new DataJob("data-job-no-config", null);
+  @Test
+  @Order(3)
+  public void testUpdateInfoGauges_withoutConfiguration_shouldDoNothing() {
+    var dataJob = new DataJob("data-job-no-config", null);
 
-      dataJobMetrics.updateInfoGauges(dataJob);
+    dataJobMetrics.updateInfoGauges(dataJob);
 
-      var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
-      Assertions.assertEquals(1, gauges.size());
+    var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
 
-      gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
-      Assertions.assertEquals(1, gauges.size());
-   }
+    gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
+  }
 
-   @Test
-   @Order(4)
-   public void testUpdateInfoGauges_withDifferentConfig_shouldUpdateTheGauge() {
-      JobConfig config = new JobConfig();
-      config.setEnableExecutionNotifications(true);
-      config.setNotifiedOnJobSuccess(List.of("success@vmware.com"));
-      var dataJob = new DataJob("data-job", config);
+  @Test
+  @Order(4)
+  public void testUpdateInfoGauges_withDifferentConfig_shouldUpdateTheGauge() {
+    JobConfig config = new JobConfig();
+    config.setEnableExecutionNotifications(true);
+    config.setNotifiedOnJobSuccess(List.of("success@vmware.com"));
+    var dataJob = new DataJob("data-job", config);
 
-      dataJobMetrics.updateInfoGauges(dataJob);
+    dataJobMetrics.updateInfoGauges(dataJob);
 
-      var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
-      Assertions.assertEquals(1, gauges.size());
+    var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
 
-      var gauge = gauges.stream().findFirst().get();
-      Assertions.assertTrue(gauge.getId().getTags().contains(Tag.of(DataJobMetrics.TAG_EMAIL_NOTIFIED_ON_SUCCESS, "success@vmware.com")));
+    var gauge = gauges.stream().findFirst().get();
+    Assertions.assertTrue(
+        gauge
+            .getId()
+            .getTags()
+            .contains(Tag.of(DataJobMetrics.TAG_EMAIL_NOTIFIED_ON_SUCCESS, "success@vmware.com")));
 
-      gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
-      Assertions.assertEquals(1, gauges.size());
-   }
+    gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
+  }
 
-   @Test
-   @Order(5)
-   public void testUpdateInfoGauges_withNullJob_shouldThrowException() {
-      Assertions.assertThrows(NullPointerException.class, () -> dataJobMetrics.updateInfoGauges(null));
-   }
+  @Test
+  @Order(5)
+  public void testUpdateInfoGauges_withNullJob_shouldThrowException() {
+    Assertions.assertThrows(
+        NullPointerException.class, () -> dataJobMetrics.updateInfoGauges(null));
+  }
 
-   @Test
-   @Order(6)
-   public void testUpdateInfoGauges_withNewTeam_shouldUpdateTheGauge() {
-      var config = new JobConfig();
-      config.setTeam("my-team");
-      var dataJob = new DataJob("data-job", config);
+  @Test
+  @Order(6)
+  public void testUpdateInfoGauges_withNewTeam_shouldUpdateTheGauge() {
+    var config = new JobConfig();
+    config.setTeam("my-team");
+    var dataJob = new DataJob("data-job", config);
 
-      dataJobMetrics.updateInfoGauges(dataJob);
+    dataJobMetrics.updateInfoGauges(dataJob);
 
-      var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
-      Assertions.assertEquals(1, gauges.size());
+    var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
 
-      var gauge = gauges.stream().findFirst().get();
-      Assertions.assertTrue(gauge.getId().getTags().contains(Tag.of(DataJobMetrics.TAG_TEAM, "my-team")));
-   }
+    var gauge = gauges.stream().findFirst().get();
+    Assertions.assertTrue(
+        gauge.getId().getTags().contains(Tag.of(DataJobMetrics.TAG_TEAM, "my-team")));
+  }
 
-   @Test
-   @Order(7)
-   void testUpdateInfoGauges_withDisabledExecutionNotifications_shouldExposeEmptyEmails() {
-      var config = new JobConfig();
-      config.setEnableExecutionNotifications(false);
-      config.setNotifiedOnJobSuccess(List.of("someone@vmware.com"));
-      var dataJob = new DataJob("data-job", config);
+  @Test
+  @Order(7)
+  void testUpdateInfoGauges_withDisabledExecutionNotifications_shouldExposeEmptyEmails() {
+    var config = new JobConfig();
+    config.setEnableExecutionNotifications(false);
+    config.setNotifiedOnJobSuccess(List.of("someone@vmware.com"));
+    var dataJob = new DataJob("data-job", config);
 
-      dataJobMetrics.updateInfoGauges(dataJob);
+    dataJobMetrics.updateInfoGauges(dataJob);
 
-      var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
-      Assertions.assertEquals(1, gauges.size());
+    var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
 
-      var gauge = gauges.stream().findFirst().get();
-      Assertions.assertTrue(gauge.getId().getTags().contains(Tag.of(DataJobMetrics.TAG_EMAIL_NOTIFIED_ON_SUCCESS, "")));
-   }
+    var gauge = gauges.stream().findFirst().get();
+    Assertions.assertTrue(
+        gauge.getId().getTags().contains(Tag.of(DataJobMetrics.TAG_EMAIL_NOTIFIED_ON_SUCCESS, "")));
+  }
 
-   @Test
-   @Order(8)
-   void testUpdateInfoGauges_withNullExecutionNotifications_shouldExposeEmails() {
-      var config = new JobConfig();
-      config.setEnableExecutionNotifications(null);
-      config.setNotifiedOnJobSuccess(List.of("someone@vmware.com"));
-      var dataJob = new DataJob("data-job", config);
+  @Test
+  @Order(8)
+  void testUpdateInfoGauges_withNullExecutionNotifications_shouldExposeEmails() {
+    var config = new JobConfig();
+    config.setEnableExecutionNotifications(null);
+    config.setNotifiedOnJobSuccess(List.of("someone@vmware.com"));
+    var dataJob = new DataJob("data-job", config);
 
-      dataJobMetrics.updateInfoGauges(dataJob);
+    dataJobMetrics.updateInfoGauges(dataJob);
 
-      var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
-      Assertions.assertEquals(1, gauges.size());
+    var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
 
-      var gauge = gauges.stream().findFirst().get();
-      Assertions.assertTrue(gauge.getId().getTags().contains(Tag.of(DataJobMetrics.TAG_EMAIL_NOTIFIED_ON_SUCCESS, "someone@vmware.com")));
-   }
+    var gauge = gauges.stream().findFirst().get();
+    Assertions.assertTrue(
+        gauge
+            .getId()
+            .getTags()
+            .contains(Tag.of(DataJobMetrics.TAG_EMAIL_NOTIFIED_ON_SUCCESS, "someone@vmware.com")));
+  }
 
-   @Test
-   @Order(9)
-   void testUpdateInfoGauges_shouldUpdateNotificationDelay() {
-      var config = new JobConfig();
-      config.setNotificationDelayPeriodMinutes(60);
-      var dataJob = new DataJob("data-job", config);
+  @Test
+  @Order(9)
+  void testUpdateInfoGauges_shouldUpdateNotificationDelay() {
+    var config = new JobConfig();
+    config.setNotificationDelayPeriodMinutes(60);
+    var dataJob = new DataJob("data-job", config);
 
-      dataJobMetrics.updateInfoGauges(jobsRepository.save(dataJob));
+    dataJobMetrics.updateInfoGauges(jobsRepository.save(dataJob));
 
-      var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
+    var gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
 
-      Assertions.assertEquals(1, gauges.size());
+    Assertions.assertEquals(1, gauges.size());
 
-      var gauge = gauges.stream().findFirst().get();
-      Assertions.assertEquals(60, gauge.value());
+    var gauge = gauges.stream().findFirst().get();
+    Assertions.assertEquals(60, gauge.value());
 
-      var expectedJob = jobsRepository.findById("data-job");
-      Assertions.assertTrue(expectedJob.isPresent());
-      Assertions.assertEquals(60, expectedJob.get().getJobConfig().getNotificationDelayPeriodMinutes());
-   }
+    var expectedJob = jobsRepository.findById("data-job");
+    Assertions.assertTrue(expectedJob.isPresent());
+    Assertions.assertEquals(
+        60, expectedJob.get().getJobConfig().getNotificationDelayPeriodMinutes());
+  }
 
-   @Test
-   @Order(10)
-   void testUpdateTerminationStatusGauge() {
-      var config = new JobConfig();
-      var dataJob = new DataJob("data-job", config);
-      dataJob.setLatestJobTerminationStatus(ExecutionStatus.SUCCEEDED);
-      dataJob.setLatestJobExecutionId("execution-id");
+  @Test
+  @Order(10)
+  void testUpdateTerminationStatusGauge() {
+    var config = new JobConfig();
+    var dataJob = new DataJob("data-job", config);
+    dataJob.setLatestJobTerminationStatus(ExecutionStatus.SUCCEEDED);
+    dataJob.setLatestJobExecutionId("execution-id");
 
-      dataJobMetrics.updateTerminationStatusGauge(jobsRepository.save(dataJob));
+    dataJobMetrics.updateTerminationStatusGauge(jobsRepository.save(dataJob));
 
-      var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-      Assertions.assertEquals(1, gauges.size());
+    var gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
 
-      var gauge = gauges.stream().findFirst().get();
-      Assertions.assertEquals(ExecutionStatus.SUCCEEDED.getAlertValue().doubleValue(), gauge.value());
-   }
+    var gauge = gauges.stream().findFirst().get();
+    Assertions.assertEquals(ExecutionStatus.SUCCEEDED.getAlertValue().doubleValue(), gauge.value());
+  }
 
+  @Test
+  @Order(11)
+  void testUpdateTerminationStatusGauge_withNewExecution_shouldUpdateTheGauge() {
+    var config = new JobConfig();
+    var dataJob = new DataJob("data-job", config);
+    dataJob.setLatestJobTerminationStatus(ExecutionStatus.SUCCEEDED);
+    dataJob.setLatestJobExecutionId("execution-id-new");
 
-   @Test
-   @Order(11)
-   void testUpdateTerminationStatusGauge_withNewExecution_shouldUpdateTheGauge() {
-      var config = new JobConfig();
-      var dataJob = new DataJob("data-job", config);
-      dataJob.setLatestJobTerminationStatus(ExecutionStatus.SUCCEEDED);
-      dataJob.setLatestJobExecutionId("execution-id-new");
+    dataJobMetrics.updateTerminationStatusGauge(jobsRepository.save(dataJob));
 
-      dataJobMetrics.updateTerminationStatusGauge(jobsRepository.save(dataJob));
+    var gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
 
-      var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-      Assertions.assertEquals(1, gauges.size());
+    var gauge = gauges.stream().findFirst().get();
+    Assertions.assertEquals(ExecutionStatus.SUCCEEDED.getAlertValue().doubleValue(), gauge.value());
+    Assertions.assertTrue(
+        gauge
+            .getId()
+            .getTags()
+            .contains(Tag.of(DataJobMetrics.TAG_EXECUTION_ID, "execution-id-new")));
+  }
 
-      var gauge = gauges.stream().findFirst().get();
-      Assertions.assertEquals(ExecutionStatus.SUCCEEDED.getAlertValue().doubleValue(), gauge.value());
-      Assertions.assertTrue(gauge.getId().getTags().contains(Tag.of(DataJobMetrics.TAG_EXECUTION_ID, "execution-id-new")));
-   }
+  @Test
+  @Order(12)
+  void testClearGauges_shouldClearAllGauges() {
+    dataJobMetrics.clearGauges("data-job");
 
-   @Test
-   @Order(12)
-   void testClearGauges_shouldClearAllGauges() {
-       dataJobMetrics.clearGauges("data-job");
+    var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
+    Assertions.assertEquals(0, gauges.size());
+    gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
+    Assertions.assertEquals(0, gauges.size());
+    gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+    Assertions.assertEquals(0, gauges.size());
+  }
 
-       var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
-       Assertions.assertEquals(0, gauges.size());
-       gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
-       Assertions.assertEquals(0, gauges.size());
-       gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-       Assertions.assertEquals(0, gauges.size());
-   }
+  @Test
+  @Order(13)
+  void testIncrementWatchTaskInvocations() {
+    dataJobMetrics.incrementWatchTaskInvocations();
 
-   @Test
-   @Order(13)
-   void testIncrementWatchTaskInvocations() {
-      dataJobMetrics.incrementWatchTaskInvocations();
+    var counter =
+        meterRegistry.counter(DataJobMetrics.TAURUS_DATAJOB_WATCH_TASK_INVOCATIONS_COUNTER_NAME);
+    Assertions.assertEquals(1.0, counter.count(), 0.001);
 
-      var counter = meterRegistry.counter(DataJobMetrics.TAURUS_DATAJOB_WATCH_TASK_INVOCATIONS_COUNTER_NAME);
-      Assertions.assertEquals(1.0, counter.count(), 0.001);
+    dataJobMetrics.incrementWatchTaskInvocations();
+    dataJobMetrics.incrementWatchTaskInvocations();
+    dataJobMetrics.incrementWatchTaskInvocations();
+    dataJobMetrics.incrementWatchTaskInvocations();
 
-      dataJobMetrics.incrementWatchTaskInvocations();
-      dataJobMetrics.incrementWatchTaskInvocations();
-      dataJobMetrics.incrementWatchTaskInvocations();
-      dataJobMetrics.incrementWatchTaskInvocations();
-
-      counter = meterRegistry.counter(DataJobMetrics.TAURUS_DATAJOB_WATCH_TASK_INVOCATIONS_COUNTER_NAME);
-      Assertions.assertEquals(5.0, counter.count(), 0.001);
-   }
+    counter =
+        meterRegistry.counter(DataJobMetrics.TAURUS_DATAJOB_WATCH_TASK_INVOCATIONS_COUNTER_NAME);
+    Assertions.assertEquals(5.0, counter.count(), 0.001);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DataJobMonitorSyncTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DataJobMonitorSyncTest.java
@@ -19,29 +19,25 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.ArrayList;
 import java.util.List;
 
-
 @ExtendWith(MockitoExtension.class)
 public class DataJobMonitorSyncTest {
 
-    @Mock
-    private JobsRepository jobsRepository;
+  @Mock private JobsRepository jobsRepository;
 
-    @Mock
-    private DataJobMonitor dataJobMonitor;
+  @Mock private DataJobMonitor dataJobMonitor;
 
-    @InjectMocks
-    private DataJobMonitorSync dataJobMonitorSync;
+  @InjectMocks private DataJobMonitorSync dataJobMonitorSync;
 
-    @Test
-    public void testUpdateDataJobStatus() {
-        List<DataJob> mockJobs = new ArrayList<>();
-        Mockito.when(jobsRepository.findAll()).thenReturn(mockJobs);
+  @Test
+  public void testUpdateDataJobStatus() {
+    List<DataJob> mockJobs = new ArrayList<>();
+    Mockito.when(jobsRepository.findAll()).thenReturn(mockJobs);
 
-        dataJobMonitorSync.updateDataJobStatus();
+    dataJobMonitorSync.updateDataJobStatus();
 
-        var dataJobsCaptor = ArgumentCaptor.forClass(Iterable.class);
-        Mockito.verify(dataJobMonitor, Mockito.times(1)).updateDataJobsGauges(dataJobsCaptor.capture());
+    var dataJobsCaptor = ArgumentCaptor.forClass(Iterable.class);
+    Mockito.verify(dataJobMonitor, Mockito.times(1)).updateDataJobsGauges(dataJobsCaptor.capture());
 
-        Assertions.assertEquals(dataJobsCaptor.getValue(), mockJobs);
-    }
+    Assertions.assertEquals(dataJobsCaptor.getValue(), mockJobs);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DataJobMonitorTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DataJobMonitorTest.java
@@ -39,665 +39,895 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 
-
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = ControlplaneApplication.class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = ControlplaneApplication.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class DataJobMonitorTest {
 
-    @Autowired
-    private MeterRegistry meterRegistry;
+  @Autowired private MeterRegistry meterRegistry;
 
-    @Autowired
-    private JobsRepository jobsRepository;
+  @Autowired private JobsRepository jobsRepository;
 
-    @Autowired
-    private JobExecutionRepository jobExecutionRepository;
+  @Autowired private JobExecutionRepository jobExecutionRepository;
 
-    @MockBean
-    private DataJobsKubernetesService dataJobsKubernetesService;
+  @MockBean private DataJobsKubernetesService dataJobsKubernetesService;
 
-    @Autowired
-    private DataJobMonitor dataJobMonitor;
+  @Autowired private DataJobMonitor dataJobMonitor;
 
-    @Test
-    @Order(1)
-    public void testUpdateDataJobTerminationStatusSuccess() {
-        var dataJob = new DataJob("data-job", new JobConfig(),
-                DeploymentStatus.NONE, ExecutionStatus.SUCCEEDED, randomId("data-job-"));
+  @Test
+  @Order(1)
+  public void testUpdateDataJobTerminationStatusSuccess() {
+    var dataJob =
+        new DataJob(
+            "data-job",
+            new JobConfig(),
+            DeploymentStatus.NONE,
+            ExecutionStatus.SUCCEEDED,
+            randomId("data-job-"));
 
-        dataJobMonitor.updateDataJobTerminationStatusGauge(jobsRepository.save(dataJob));
+    dataJobMonitor.updateDataJobTerminationStatusGauge(jobsRepository.save(dataJob));
 
-        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-        Assertions.assertEquals(1, gauges.size());
-        Assertions.assertEquals(ExecutionStatus.SUCCEEDED.getAlertValue().doubleValue(), gauges.stream().findFirst().get().value());
+    var gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
+    Assertions.assertEquals(
+        ExecutionStatus.SUCCEEDED.getAlertValue().doubleValue(),
+        gauges.stream().findFirst().get().value());
 
-        var expectedJob = jobsRepository.findById(dataJob.getName());
-        Assertions.assertTrue(expectedJob.isPresent());
-        Assertions.assertEquals(ExecutionStatus.SUCCEEDED, expectedJob.get().getLatestJobTerminationStatus());
-    }
+    var expectedJob = jobsRepository.findById(dataJob.getName());
+    Assertions.assertTrue(expectedJob.isPresent());
+    Assertions.assertEquals(
+        ExecutionStatus.SUCCEEDED, expectedJob.get().getLatestJobTerminationStatus());
+  }
 
-    @Test
-    @Order(2)
-    public void testUpdateDataJobTerminationStatusPlatformError() {
-        var dataJob = new DataJob("data-job", new JobConfig(),
-                DeploymentStatus.NONE, ExecutionStatus.PLATFORM_ERROR, randomId("data-job-"));
+  @Test
+  @Order(2)
+  public void testUpdateDataJobTerminationStatusPlatformError() {
+    var dataJob =
+        new DataJob(
+            "data-job",
+            new JobConfig(),
+            DeploymentStatus.NONE,
+            ExecutionStatus.PLATFORM_ERROR,
+            randomId("data-job-"));
 
-        dataJobMonitor.updateDataJobTerminationStatusGauge(jobsRepository.save(dataJob));
+    dataJobMonitor.updateDataJobTerminationStatusGauge(jobsRepository.save(dataJob));
 
-        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-        Assertions.assertEquals(1, gauges.size());
-        Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR.getAlertValue().doubleValue(), gauges.stream().findFirst().get().value());
+    var gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
+    Assertions.assertEquals(
+        ExecutionStatus.PLATFORM_ERROR.getAlertValue().doubleValue(),
+        gauges.stream().findFirst().get().value());
 
-        var expectedJob = jobsRepository.findById(dataJob.getName());
-        Assertions.assertTrue(expectedJob.isPresent());
-        Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, expectedJob.get().getLatestJobTerminationStatus());
-    }
+    var expectedJob = jobsRepository.findById(dataJob.getName());
+    Assertions.assertTrue(expectedJob.isPresent());
+    Assertions.assertEquals(
+        ExecutionStatus.PLATFORM_ERROR, expectedJob.get().getLatestJobTerminationStatus());
+  }
 
-    @Test
-    @Order(3)
-    public void testUpdateDataJobTerminationStatusSkipped() {
-        var dataJob = new DataJob("data-job", new JobConfig(),
-                DeploymentStatus.NONE, ExecutionStatus.SKIPPED, randomId("data-job-"));
+  @Test
+  @Order(3)
+  public void testUpdateDataJobTerminationStatusSkipped() {
+    var dataJob =
+        new DataJob(
+            "data-job",
+            new JobConfig(),
+            DeploymentStatus.NONE,
+            ExecutionStatus.SKIPPED,
+            randomId("data-job-"));
 
-        dataJobMonitor.updateDataJobTerminationStatusGauge(jobsRepository.save(dataJob));
+    dataJobMonitor.updateDataJobTerminationStatusGauge(jobsRepository.save(dataJob));
 
-        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-        Assertions.assertEquals(1, gauges.size());
-        Assertions.assertEquals(ExecutionStatus.SKIPPED.getAlertValue().doubleValue(), gauges.stream().findFirst().get().value());
+    var gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
+    Assertions.assertEquals(
+        ExecutionStatus.SKIPPED.getAlertValue().doubleValue(),
+        gauges.stream().findFirst().get().value());
 
-        var expectedJob = jobsRepository.findById(dataJob.getName());
-        Assertions.assertTrue(expectedJob.isPresent());
-        Assertions.assertEquals(ExecutionStatus.SKIPPED, expectedJob.get().getLatestJobTerminationStatus());
-    }
+    var expectedJob = jobsRepository.findById(dataJob.getName());
+    Assertions.assertTrue(expectedJob.isPresent());
+    Assertions.assertEquals(
+        ExecutionStatus.SKIPPED, expectedJob.get().getLatestJobTerminationStatus());
+  }
 
-    @Test
-    @Order(4)
-    public void testUpdateDataJobTerminationStatusStatusUserError() {
-        var dataJob = new DataJob("data-job", new JobConfig(),
-                DeploymentStatus.NONE, ExecutionStatus.USER_ERROR, randomId("data-job-"));
+  @Test
+  @Order(4)
+  public void testUpdateDataJobTerminationStatusStatusUserError() {
+    var dataJob =
+        new DataJob(
+            "data-job",
+            new JobConfig(),
+            DeploymentStatus.NONE,
+            ExecutionStatus.USER_ERROR,
+            randomId("data-job-"));
 
-        dataJobMonitor.updateDataJobTerminationStatusGauge(jobsRepository.save(dataJob));
+    dataJobMonitor.updateDataJobTerminationStatusGauge(jobsRepository.save(dataJob));
 
-        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-        Assertions.assertEquals(1, gauges.size());
-        Assertions.assertEquals(ExecutionStatus.USER_ERROR.getAlertValue().doubleValue(), gauges.stream().findFirst().get().value());
+    var gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
+    Assertions.assertEquals(
+        ExecutionStatus.USER_ERROR.getAlertValue().doubleValue(),
+        gauges.stream().findFirst().get().value());
 
-        var expectedJob = jobsRepository.findById(dataJob.getName());
-        Assertions.assertTrue(expectedJob.isPresent());
-        Assertions.assertEquals(ExecutionStatus.USER_ERROR, expectedJob.get().getLatestJobTerminationStatus());
-    }
+    var expectedJob = jobsRepository.findById(dataJob.getName());
+    Assertions.assertTrue(expectedJob.isPresent());
+    Assertions.assertEquals(
+        ExecutionStatus.USER_ERROR, expectedJob.get().getLatestJobTerminationStatus());
+  }
 
-    @Test
-    @Order(5)
-    public void testUpdateDataJobsGaugesWithoutJobs() {
-        dataJobMonitor.updateDataJobsGauges(Collections.emptyList());
+  @Test
+  @Order(5)
+  public void testUpdateDataJobsGaugesWithoutJobs() {
+    dataJobMonitor.updateDataJobsGauges(Collections.emptyList());
 
-        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-        Assertions.assertEquals(1, gauges.size());
-    }
+    var gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
+  }
 
-    @Test
-    @Order(6)
-    public void testWatchJobs() throws IOException, ApiException {
-        var jobStatuses = List.of(
-              buildJobExecutionStatus(randomId("datajob-"), randomId("job-"), ExecutionStatus.SUCCEEDED.getPodStatus()),
-              buildJobExecutionStatus(randomId("datajob-"), randomId("job-"), ExecutionStatus.USER_ERROR.getPodStatus(), false),
-              buildJobExecutionStatus(randomId("datajob-"), randomId("job-"), ExecutionStatus.PLATFORM_ERROR.getPodStatus(), false),
-              buildJobExecutionStatus(randomId("datajob-"), randomId("job-"), ExecutionStatus.SKIPPED.getPodStatus())
-        );
-        doAnswer(inv -> {
-            jobStatuses.forEach(inv.getArgument(1));
-            return null;
-        }).when(dataJobsKubernetesService).watchJobs(anyMap(), any(), any(), anyLong());
-        jobStatuses.forEach(s -> jobsRepository.save(new DataJob(s.getJobName(), new JobConfig())));
+  @Test
+  @Order(6)
+  public void testWatchJobs() throws IOException, ApiException {
+    var jobStatuses =
+        List.of(
+            buildJobExecutionStatus(
+                randomId("datajob-"), randomId("job-"), ExecutionStatus.SUCCEEDED.getPodStatus()),
+            buildJobExecutionStatus(
+                randomId("datajob-"),
+                randomId("job-"),
+                ExecutionStatus.USER_ERROR.getPodStatus(),
+                false),
+            buildJobExecutionStatus(
+                randomId("datajob-"),
+                randomId("job-"),
+                ExecutionStatus.PLATFORM_ERROR.getPodStatus(),
+                false),
+            buildJobExecutionStatus(
+                randomId("datajob-"), randomId("job-"), ExecutionStatus.SKIPPED.getPodStatus()));
+    doAnswer(
+            inv -> {
+              jobStatuses.forEach(inv.getArgument(1));
+              return null;
+            })
+        .when(dataJobsKubernetesService)
+        .watchJobs(anyMap(), any(), any(), anyLong());
+    jobStatuses.forEach(s -> jobsRepository.save(new DataJob(s.getJobName(), new JobConfig())));
 
-        dataJobMonitor.watchJobs();
+    dataJobMonitor.watchJobs();
 
-        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-        // We had 1 gauge from previous tests and added 4 more; but data jobs with last termination status SKIPPED
-        // have no metrics exposed; so effectively the expected number of gauges is 4
-        Assertions.assertEquals(4, gauges.size());
-        jobStatuses.forEach(s -> {
-            var expectedJob = jobsRepository.findById(s.getJobName());
-            Assertions.assertTrue(expectedJob.isPresent());
-            ExecutionStatus expectedStatus = getTerminationStatus(s);
-            if (expectedStatus != ExecutionStatus.SKIPPED) {
-                Assertions.assertEquals(expectedStatus, expectedJob.get().getLatestJobTerminationStatus());
-            }
+    var gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+    // We had 1 gauge from previous tests and added 4 more; but data jobs with last termination
+    // status SKIPPED
+    // have no metrics exposed; so effectively the expected number of gauges is 4
+    Assertions.assertEquals(4, gauges.size());
+    jobStatuses.forEach(
+        s -> {
+          var expectedJob = jobsRepository.findById(s.getJobName());
+          Assertions.assertTrue(expectedJob.isPresent());
+          ExecutionStatus expectedStatus = getTerminationStatus(s);
+          if (expectedStatus != ExecutionStatus.SKIPPED) {
+            Assertions.assertEquals(
+                expectedStatus, expectedJob.get().getLatestJobTerminationStatus());
+          }
         });
-    }
+  }
 
-    // NOTE: The below two test cases may throw assertion errors if the data_job table in the
-    // database used is not empty. In such case, delete all entries in the data_jobs table, and
-    // re-run the tests.
-    @Test
-    @Order(7)
-    public void testWatchJobsWithEmptyJobName() throws IOException, ApiException {
-        var jobStatuses = List.of(
-              buildJobExecutionStatus(randomId("datajob-"), "", "")
-        );
-        doAnswer(inv -> {
-            jobStatuses.forEach(inv.getArgument(1));
-            return null;
-        }).when(dataJobsKubernetesService).watchJobs(anyMap(), any(), any(), anyLong());
+  // NOTE: The below two test cases may throw assertion errors if the data_job table in the
+  // database used is not empty. In such case, delete all entries in the data_jobs table, and
+  // re-run the tests.
+  @Test
+  @Order(7)
+  public void testWatchJobsWithEmptyJobName() throws IOException, ApiException {
+    var jobStatuses = List.of(buildJobExecutionStatus(randomId("datajob-"), "", ""));
+    doAnswer(
+            inv -> {
+              jobStatuses.forEach(inv.getArgument(1));
+              return null;
+            })
+        .when(dataJobsKubernetesService)
+        .watchJobs(anyMap(), any(), any(), anyLong());
 
-        dataJobMonitor.watchJobs();
+    dataJobMonitor.watchJobs();
 
-        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-        Assertions.assertEquals(4, gauges.size());
-        Assertions.assertEquals(5, jobsRepository.count());
-    }
+    var gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+    Assertions.assertEquals(4, gauges.size());
+    Assertions.assertEquals(5, jobsRepository.count());
+  }
 
-    @Test
-    @Order(8)
-    public void testWatchJobsWithMissingJob() throws IOException, ApiException {
-        var jobStatuses = List.of(
-              buildJobExecutionStatus(randomId("datajob-"), "missing-id", "")
-        );
-        doAnswer(inv -> {
-            jobStatuses.forEach(inv.getArgument(1));
-            return null;
-        }).when(dataJobsKubernetesService).watchJobs(anyMap(), any(), any(), anyLong());
+  @Test
+  @Order(8)
+  public void testWatchJobsWithMissingJob() throws IOException, ApiException {
+    var jobStatuses = List.of(buildJobExecutionStatus(randomId("datajob-"), "missing-id", ""));
+    doAnswer(
+            inv -> {
+              jobStatuses.forEach(inv.getArgument(1));
+              return null;
+            })
+        .when(dataJobsKubernetesService)
+        .watchJobs(anyMap(), any(), any(), anyLong());
 
-        dataJobMonitor.watchJobs();
+    dataJobMonitor.watchJobs();
 
-        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-        Assertions.assertEquals(4, gauges.size());
-        Assertions.assertEquals(5, jobsRepository.count());
-    }
+    var gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+    Assertions.assertEquals(4, gauges.size());
+    Assertions.assertEquals(5, jobsRepository.count());
+  }
 
-    @Test
-    @Order(9)
-    public void testWatchJobsWithTheSameStatus() throws IOException, ApiException {
-        var jobStatuses = List.of(
-              buildJobExecutionStatus(randomId("datajob-"), randomId("job-"), ExecutionStatus.SUCCEEDED.getPodStatus())
-        );
-        doAnswer(inv -> {
-            jobStatuses.forEach(inv.getArgument(1));
-            return null;
-        }).when(dataJobsKubernetesService).watchJobs(anyMap(), any(), any(), anyLong());
-        jobStatuses.forEach(s -> jobsRepository.save(
-                new DataJob(s.getJobName(), new JobConfig(), DeploymentStatus.NONE, getTerminationStatus(s), s.getExecutionId())));
+  @Test
+  @Order(9)
+  public void testWatchJobsWithTheSameStatus() throws IOException, ApiException {
+    var jobStatuses =
+        List.of(
+            buildJobExecutionStatus(
+                randomId("datajob-"), randomId("job-"), ExecutionStatus.SUCCEEDED.getPodStatus()));
+    doAnswer(
+            inv -> {
+              jobStatuses.forEach(inv.getArgument(1));
+              return null;
+            })
+        .when(dataJobsKubernetesService)
+        .watchJobs(anyMap(), any(), any(), anyLong());
+    jobStatuses.forEach(
+        s ->
+            jobsRepository.save(
+                new DataJob(
+                    s.getJobName(),
+                    new JobConfig(),
+                    DeploymentStatus.NONE,
+                    getTerminationStatus(s),
+                    s.getExecutionId())));
 
-        dataJobMonitor.watchJobs();
+    dataJobMonitor.watchJobs();
 
-        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-        Assertions.assertEquals(4, gauges.size());
-        jobStatuses.forEach(s -> {
-            var expectedJob = jobsRepository.findById(s.getJobName());
-            Assertions.assertTrue(expectedJob.isPresent());
-            Assertions.assertEquals(getTerminationStatus(s), expectedJob.get().getLatestJobTerminationStatus());
+    var gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+    Assertions.assertEquals(4, gauges.size());
+    jobStatuses.forEach(
+        s -> {
+          var expectedJob = jobsRepository.findById(s.getJobName());
+          Assertions.assertTrue(expectedJob.isPresent());
+          Assertions.assertEquals(
+              getTerminationStatus(s), expectedJob.get().getLatestJobTerminationStatus());
         });
-    }
+  }
 
-    @Test
-    @Order(10)
-    void testWatchJobsWithoutTerminationMessage() throws IOException, ApiException {
-        var jobStatuses = List.of(
-              buildJobExecutionStatus(randomId("datajob-"), randomId("job-"), null)
-        );
-        doAnswer(inv -> {
-            jobStatuses.forEach(inv.getArgument(1));
-            return null;
-        }).when(dataJobsKubernetesService).watchJobs(anyMap(), any(), any(), anyLong());
-        jobStatuses.forEach(s -> jobsRepository.save(
-                new DataJob(s.getJobName(), new JobConfig(), DeploymentStatus.NONE, getTerminationStatus(s), null)));
+  @Test
+  @Order(10)
+  void testWatchJobsWithoutTerminationMessage() throws IOException, ApiException {
+    var jobStatuses =
+        List.of(buildJobExecutionStatus(randomId("datajob-"), randomId("job-"), null));
+    doAnswer(
+            inv -> {
+              jobStatuses.forEach(inv.getArgument(1));
+              return null;
+            })
+        .when(dataJobsKubernetesService)
+        .watchJobs(anyMap(), any(), any(), anyLong());
+    jobStatuses.forEach(
+        s ->
+            jobsRepository.save(
+                new DataJob(
+                    s.getJobName(),
+                    new JobConfig(),
+                    DeploymentStatus.NONE,
+                    getTerminationStatus(s),
+                    null)));
 
-        dataJobMonitor.watchJobs();
+    dataJobMonitor.watchJobs();
 
-        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-        Assertions.assertEquals(5, gauges.size());
-        jobStatuses.forEach(s -> {
-            var expectedJob = jobsRepository.findById(s.getJobName());
-            Assertions.assertTrue(expectedJob.isPresent());
-            Assertions.assertEquals(ExecutionStatus.SUCCEEDED, expectedJob.get().getLatestJobTerminationStatus());
+    var gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+    Assertions.assertEquals(5, gauges.size());
+    jobStatuses.forEach(
+        s -> {
+          var expectedJob = jobsRepository.findById(s.getJobName());
+          Assertions.assertTrue(expectedJob.isPresent());
+          Assertions.assertEquals(
+              ExecutionStatus.SUCCEEDED, expectedJob.get().getLatestJobTerminationStatus());
         });
-    }
-
-    @Test
-    @Order(11)
-    public void testUpdateDataJobTerminationStatusWithoutExecutionId() {
-        var dataJob = new DataJob("data-job", new JobConfig(), DeploymentStatus.NONE);
-
-        dataJobMonitor.updateDataJobTerminationStatusGauge(jobsRepository.save(dataJob));
-
-        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-        Assertions.assertEquals(5, gauges.size());
-    }
-
-    @Test
-    @Order(12)
-    public void testWatchJobsWhenExceptionIsThrown() throws IOException, ApiException {
-        doThrow(new ApiException()).when(dataJobsKubernetesService).watchJobs(anyMap(), any(), any(), anyLong());
-
-        Assertions.assertDoesNotThrow(() -> dataJobMonitor.watchJobs());
-    }
-
-    @Test
-    @Order(13)
-    public void testRecordJobExecutionStatus_nullDataJobName_shouldNotRecordExecution() {
-        JobExecution jobExecution = buildJobExecutionStatus(null, randomId("job-"), ExecutionStatus.SUCCEEDED.getPodStatus());
-        dataJobMonitor.recordJobExecutionStatus(jobExecution);
-        Optional<DataJobExecution> actualJobExecution = jobExecutionRepository.findById(jobExecution.getExecutionId());
-
-        Assertions.assertTrue(actualJobExecution.isEmpty());
-    }
-
-    @Test
-    @Order(14)
-    public void testRecordJobExecutionStatus_emptyDataJobName_shouldNotRecordExecution() {
-        JobExecution jobExecution = buildJobExecutionStatus("", randomId("job-"), ExecutionStatus.SUCCEEDED.getPodStatus());
-        dataJobMonitor.recordJobExecutionStatus(jobExecution);
-        Optional<DataJobExecution> actualJobExecution = jobExecutionRepository.findById(jobExecution.getExecutionId());
-
-        Assertions.assertTrue(actualJobExecution.isEmpty());
-    }
-
-    @Test
-    @Order(15)
-    public void testRecordJobExecutionStatus_existingDataJobAndNonExistingExecution_shouldRecordExecution() {
-        JobExecution expectedJobExecution = buildJobExecutionStatus("data-job", "execution-id", ExecutionStatus.SUCCEEDED.getPodStatus(), true);
-        dataJobMonitor.recordJobExecutionStatus(expectedJobExecution);
-        Optional<DataJobExecution> actualJobExecution = jobExecutionRepository.findById(expectedJobExecution.getExecutionId());
-
-        assertDataJobExecutionValid(expectedJobExecution, actualJobExecution);
-    }
-
-    @Test
-    @Order(16)
-    public void testRecordJobExecutionStatus_existingDataJobAndExistingExecution_shouldUpdateExecution() {
-        DataJobExecution jobExecutionBeforeUpdate = jobExecutionRepository.findById("execution-id").get();
-        JobExecution expectedJobExecution = JobExecution.builder()
-              .jobName(jobExecutionBeforeUpdate.getDataJob().getName())
-              .executionId(jobExecutionBeforeUpdate.getId())
-              .podTerminationMessage(ExecutionStatus.SUCCEEDED.getPodStatus())
-              .executionType("scheduled")
-              .opId("opId")
-              .startTime(jobExecutionBeforeUpdate.getStartTime())
-              .endTime(jobExecutionBeforeUpdate.getEndTime())
-              .jobVersion("jobVersion")
-              .jobSchedule("jobSchedule")
-              .resourcesCpuRequest(1F)
-              .resourcesCpuLimit(2F)
-              .resourcesMemoryRequest(500)
-              .resourcesMemoryLimit(1000)
-              .deployedDate(jobExecutionBeforeUpdate.getLastDeployedDate())
-              .deployedBy("lastDeployedBy")
-              .succeeded(true)
-              .build();
-
-        dataJobMonitor.recordJobExecutionStatus(expectedJobExecution);
-        Optional<DataJobExecution> actualJobExecution = jobExecutionRepository.findById(expectedJobExecution.getExecutionId());
-
-        assertDataJobExecutionValid(expectedJobExecution, actualJobExecution);
-    }
-
-    @Test
-    @Order(17)
-    public void testRecordJobExecutionStatusSkipped_existingDataJobAndNonExistingExecution_shouldRecordExecution() {
-        JobExecution expectedJobExecution = buildJobExecutionStatus("data-job", "different-execution-id", ExecutionStatus.RUNNING.getPodStatus(), null);
-        dataJobMonitor.recordJobExecutionStatus(expectedJobExecution);
-        Optional<DataJobExecution> actualJobExecution = jobExecutionRepository.findById(expectedJobExecution.getExecutionId());
-
-        assertDataJobExecutionValid(expectedJobExecution, actualJobExecution);
-    }
-
-    @Test
-    @Order(18)
-    public void testRecordJobExecutionStatusSkipped_existingDataJobAndExistingExecution_shouldRecordExecution() {
-        var expectedExecutionMessage = "Skipping job execution due to another parallel running execution.";
-        JobExecution expectedJobExecution = buildJobExecutionStatus("data-job", "different-execution-id", ExecutionStatus.SKIPPED.getPodStatus(), true);
-        Optional<DataJobExecution> jobExecutionBeforeUpdate = jobExecutionRepository.findById(expectedJobExecution.getExecutionId());
-        dataJobMonitor.recordJobExecutionStatus(expectedJobExecution);
-        Optional<DataJobExecution> actualJobExecution = jobExecutionRepository.findById(expectedJobExecution.getExecutionId());
-
-        assertDataJobExecutionValid(expectedJobExecution, actualJobExecution, expectedExecutionMessage, jobExecutionBeforeUpdate.get().getStartTime());
-    }
-
-    @Test
-    @Order(19)
-    public void testRecordJobExecutionStatus_nonExistingDataJobAndNonExistingExecution_shouldNotRecordExecution() {
-        JobExecution jobExecution = buildJobExecutionStatus(randomId("data-job-"), randomId("job-"), ExecutionStatus.SUCCEEDED.getPodStatus());
-        dataJobMonitor.recordJobExecutionStatus(jobExecution);
-        Optional<DataJobExecution> actualJobExecution = jobExecutionRepository.findById(jobExecution.getExecutionId());
-
-        Assertions.assertTrue(actualJobExecution.isEmpty());
-    }
-
-    @Test
-    @Order(20)
-    void testUpdateDataJobInfoGauges() {
-        var dataJob = new DataJob("data-job", new JobConfig(),
-                DeploymentStatus.NONE, ExecutionStatus.SUCCEEDED, randomId("data-job-"));
-
-        dataJobMonitor.updateDataJobInfoGauges(jobsRepository.save(dataJob));
-
-        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
-        Assertions.assertEquals(1, gauges.size());
-        gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
-        Assertions.assertEquals(1, gauges.size());
-    }
-
-    @Test
-    @Order(21)
-    void testUpdateDataJobInfoGauges_withNullDataJob_throwsException() {
-        Assertions.assertThrows(NullPointerException.class, () -> dataJobMonitor.updateDataJobInfoGauges(null));
-    }
-
-    @Test
-    @Order(22)
-    void testClearDataJobsGaugesNotIn() {
-        var dataJobs = Arrays.asList(
-                new DataJob("data-job1", new JobConfig(), DeploymentStatus.NONE, ExecutionStatus.SUCCEEDED, randomId("data-job1-")),
-                new DataJob("data-job2", new JobConfig(), DeploymentStatus.NONE, ExecutionStatus.SUCCEEDED, randomId("data-job2-")),
-                new DataJob("data-job3", new JobConfig(), DeploymentStatus.NONE, ExecutionStatus.SUCCEEDED, randomId("data-job3-")));
-
-        // Clean up from previous tests
-        jobsRepository.deleteAll();
-        dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
-
-        // Add some more gauges
-        dataJobMonitor.updateDataJobsGauges(jobsRepository.saveAll(dataJobs));
-
-        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
-        Assertions.assertEquals(3, gauges.size());
-        gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
-        Assertions.assertEquals(3, gauges.size());
-        gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-        Assertions.assertEquals(3, gauges.size());
-
-        // Delete a data job and verify that its gauges are removed as a result
-        jobsRepository.deleteById(dataJobs.get(0).getName());
-        dataJobMonitor.clearDataJobsGaugesNotIn(Arrays.asList(dataJobs.get(1), dataJobs.get(2)));
-
-        gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
-        Assertions.assertEquals(2, gauges.size());
-        gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
-        Assertions.assertEquals(2, gauges.size());
-        gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-        Assertions.assertEquals(2, gauges.size());
-    }
-
-    @Test
-    @Order(23)
-    void testRecordJobExecutionStatus_withStatusSkipped_shouldNotUpdateTerminationStatus() {
-        // Clean up from previous tests
-        jobsRepository.deleteAll();
-        dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
-
-        var dataJob = new DataJob("new-job", new JobConfig(),
-                DeploymentStatus.NONE, null, "old-execution-id");
-        jobsRepository.save(dataJob);
-
-        JobExecution jobExecution = buildJobExecutionStatus("new-job", "new-execution-id", ExecutionStatus.SKIPPED.getPodStatus(), true);
-        dataJobMonitor.recordJobExecutionStatus(jobExecution);
-        Optional<DataJob> actualJob = jobsRepository.findById(dataJob.getName());
-
-        Assertions.assertTrue(actualJob.isPresent());
-        Assertions.assertEquals("old-execution-id", actualJob.get().getLatestJobExecutionId());
-    }
-
-    @Test
-    @Order(24)
-    void testRecordJobExecutionStatus_withDifferentStatus_shouldUpdateTerminationStatus() {
-        // Clean up from previous tests
-        jobsRepository.deleteAll();
-        dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
-
-        var dataJob = new DataJob("new-job", new JobConfig(),
-                DeploymentStatus.NONE, ExecutionStatus.PLATFORM_ERROR, "old-execution-id");
-        jobsRepository.save(dataJob);
-
-        JobExecution jobExecution = buildJobExecutionStatus("new-job", "old-execution-id", ExecutionStatus.SUCCEEDED.getPodStatus());
-
-        dataJobMonitor.recordJobExecutionStatus(jobExecution);
-
-        Optional<DataJob> actualJob = jobsRepository.findById(dataJob.getName());
-        Assertions.assertTrue(actualJob.isPresent());
-        Assertions.assertEquals("old-execution-id", actualJob.get().getLatestJobExecutionId());
-        Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualJob.get().getLatestJobTerminationStatus());
-    }
-
-    @Test
-    @Order(25)
-    void testRecordJobExecutionStatus_withDifferentExecutionId_shouldUpdateTerminationStatus() {
-        // Clean up from previous tests
-        jobsRepository.deleteAll();
-        dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
-
-        var dataJob = new DataJob("new-job", new JobConfig(),
-                DeploymentStatus.NONE, null, "old-execution-id");
-        jobsRepository.save(dataJob);
-
-        JobExecution jobExecution = buildJobExecutionStatus("new-job", "new-execution-id", ExecutionStatus.USER_ERROR.getPodStatus(), true);
-
-        dataJobMonitor.recordJobExecutionStatus(jobExecution);
-
-        Optional<DataJob> actualJob = jobsRepository.findById(dataJob.getName());
-        Assertions.assertTrue(actualJob.isPresent());
-        Assertions.assertEquals("new-execution-id", actualJob.get().getLatestJobExecutionId());
-        Assertions.assertEquals(ExecutionStatus.USER_ERROR, actualJob.get().getLatestJobTerminationStatus());
-    }
-
-    @Test
-    @Order(26)
-    void testRecordJobExecutionStatus_shouldUpdateLastExecution() {
-        // Clean up from previous tests
-        jobsRepository.deleteAll();
-        dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
-
-        var dataJob = new DataJob("new-job", new JobConfig(),
-                DeploymentStatus.NONE, ExecutionStatus.PLATFORM_ERROR, "old-execution-id");
-        dataJob.setLastExecutionStatus(ExecutionStatus.PLATFORM_ERROR);
-        dataJob.setLastExecutionEndTime(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
-        dataJob.setLastExecutionDuration(1000);
-        jobsRepository.save(dataJob);
-
-        JobExecution jobExecution = buildJobExecutionStatus("new-job", "old-execution-id", ExecutionStatus.PLATFORM_ERROR.getPodStatus(), false);
-
-        dataJobMonitor.recordJobExecutionStatus(jobExecution);
-
-        Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
-        Assertions.assertFalse(actualJob.isEmpty());
-        Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualJob.get().getLastExecutionStatus());
-    }
-
-    @Test
-    @Order(27)
-    void testRecordJobExecutionStatus_withNullExecutionId_shouldNotUpdateLastExecution() {
-        JobExecution jobExecution = buildJobExecutionStatus("new-job", null, ExecutionStatus.SUCCEEDED.getPodStatus());
-
-        dataJobMonitor.recordJobExecutionStatus(jobExecution);
-
-        Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
-        Assertions.assertFalse(actualJob.isEmpty());
-        Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualJob.get().getLastExecutionStatus());
-    }
-
-    @Test
-    @Order(28)
-    void testRecordJobExecutionStatus_withEmptyExecutionId_shouldNotUpdateLastExecution() {
-        JobExecution jobExecution = buildJobExecutionStatus("new-job", "", ExecutionStatus.SUCCEEDED.getPodStatus());
-
-        dataJobMonitor.recordJobExecutionStatus(jobExecution);
-
-        Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
-        Assertions.assertFalse(actualJob.isEmpty());
-        Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualJob.get().getLastExecutionStatus());
-    }
-
-
-    @Test
-    @Order(29)
-    void testRecordJobExecutionStatus_withSameExecutionIdAndNewStatus_shouldUpdateLastExecution() {
-        //Status gets updated from PLATFORM_ERROR to Succeeded with the same ID.
-        JobExecution jobExecution = buildJobExecutionStatus("new-job", "old-execution-id", ExecutionStatus.SUCCEEDED.getPodStatus());
-
-        dataJobMonitor.recordJobExecutionStatus(jobExecution);
-
-        Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
-        Assertions.assertFalse(actualJob.isEmpty());
-        Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualJob.get().getLastExecutionStatus());
-    }
-
-    @Test
-    @Order(30)
-    void testRecordJobExecutionStatus_withNewExecutionIdAndNewStatus_shouldUpdateLastExecution() {
-        JobExecution jobExecution = buildJobExecutionStatus("new-job", "new-execution-id", ExecutionStatus.SUCCEEDED.getPodStatus());
-
-        dataJobMonitor.recordJobExecutionStatus(jobExecution);
-
-        Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
-        Assertions.assertFalse(actualJob.isEmpty());
-        Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualJob.get().getLastExecutionStatus());
-        Assertions.assertEquals(jobExecution.getEndTime(), actualJob.get().getLastExecutionEndTime());
-    }
-
-    @Test
-    @Order(31)
-    void testRecordJobExecutionStatus_withSameExecutionIdAndOldStatusIsFinal_shouldNotUpdateTerminationStatus() {
-        JobExecution jobExecution = buildJobExecutionStatus("new-job", "new-execution-id", ExecutionStatus.USER_ERROR.getPodStatus());
-
-        dataJobMonitor.recordJobExecutionStatus(jobExecution);
-
-        Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
-        Assertions.assertFalse(actualJob.isEmpty());
-        // The termination status should not have changed from SUCCESS to USER_ERROR because SUCCESS is a final status
-        Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualJob.get().getLatestJobTerminationStatus());
-    }
-
-    @Test
-    @Order(32)
-    void testRecordJobExecutionStatus_withAnOlderExecution_shouldNotUpdateLastExecution() {
-        JobExecution jobExecution = buildJobExecutionStatus("new-job", "newer-execution-id",
-                ExecutionStatus.USER_ERROR.getPodStatus(), false,
-                OffsetDateTime.now().minus(Duration.ofDays(2)),
-                OffsetDateTime.now().minus(Duration.ofDays(1)));
-
-        dataJobMonitor.recordJobExecutionStatus(jobExecution);
-
-        Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
-        Assertions.assertFalse(actualJob.isEmpty());
-        // The last execution status should not have changed from SUCCEEDED to USER_ERROR because the execution is not recent
-        Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualJob.get().getLastExecutionStatus());
-    }
-
-    @Test
-    @Order(33)
-    void testJobExecutionStatus_fromPlatformToUser_shouldUpdateExecution() {
-        // Clean up from previous tests
-        jobsRepository.deleteAll();
-        dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
-        // Create data job
-        String jobId = "job-id-test";
-        var dataJob = new DataJob(jobId, new JobConfig(),
-              DeploymentStatus.NONE, ExecutionStatus.SUCCEEDED, "old-execution-id");
-        jobsRepository.save(dataJob);
-        // Change status to PLATFORM_ERROR
-        JobExecution jobExecution = buildJobExecutionStatus(jobId, "last-execution-id",
-              ExecutionStatus.PLATFORM_ERROR.getPodStatus(), false,
-              OffsetDateTime.now().minus(Duration.ofDays(2)),
-              OffsetDateTime.now().minus(Duration.ofDays(1)));
-        dataJobMonitor.recordJobExecutionStatus(jobExecution);
-        // Check status is saved OK.
-        Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
-        Assertions.assertFalse(actualJob.isEmpty());
-        Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualJob.get().getLastExecutionStatus());
-        // Check gauge status
-        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-        Assertions.assertEquals(1, gauges.size());
-        Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR.getAlertValue().doubleValue(), gauges.stream().findFirst().get().value());
-        // Change status to USER_ERROR, same execution ID simulating retry. Different ID's change without issues.
-        jobExecution = buildJobExecutionStatus(jobId, "last-execution-id",
-              ExecutionStatus.USER_ERROR.getPodStatus(), false,
-              OffsetDateTime.now().minus(Duration.ofDays(2)),
-              OffsetDateTime.now().minus(Duration.ofDays(1)));
-        dataJobMonitor.recordJobExecutionStatus(jobExecution);
-        // Check status is saved OK.
-        actualJob = jobsRepository.findById(jobExecution.getJobName());
-        Assertions.assertFalse(actualJob.isEmpty());
-        Assertions.assertEquals(ExecutionStatus.USER_ERROR, actualJob.get().getLastExecutionStatus());
-        // Check gauge status is changed OK.
-        gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-        Assertions.assertEquals(1, gauges.size());
-        Assertions.assertEquals(ExecutionStatus.USER_ERROR.getAlertValue().doubleValue(), gauges.stream().findFirst().get().value());
-    }
-
-    private static String randomId(String prefix) {
-        return prefix + UUID.randomUUID();
-    }
-
-    private static ExecutionStatus getTerminationStatus(JobExecution jobExecution) {
-        return JobExecutionResultManager.getResult(jobExecution).getExecutionStatus();
-    }
-
-    private static JobExecution buildJobExecutionStatus(String jobName, String executionId, String terminationMessage) {
-        return buildJobExecutionStatus(jobName, executionId, terminationMessage, true);
-    }
-
-    private static JobExecution buildJobExecutionStatus(
-            String jobName,
-            String executionId,
-            String terminationMessage,
-            Boolean executionSucceeded) {
-        return buildJobExecutionStatus(jobName, executionId, terminationMessage,
-                executionSucceeded, OffsetDateTime.now(), OffsetDateTime.now());
-    }
-
-    private static JobExecution buildJobExecutionStatus(
-          String jobName,
-          String executionId,
-          String terminationMessage,
-          Boolean executionSucceeded,
-          OffsetDateTime startTime,
-          OffsetDateTime endTime) {
-        return JobExecution.builder()
-              .jobName(jobName)
-              .executionId(executionId)
-              .podTerminationMessage(terminationMessage)
-              .executionType("scheduled")
-              .opId("opId")
-              .startTime(startTime)
-              .endTime(endTime)
-              .jobVersion("jobVersion")
-              .jobSchedule("jobSchedule")
-              .resourcesCpuRequest(1F)
-              .resourcesCpuLimit(2F)
-              .resourcesMemoryRequest(500)
-              .resourcesMemoryLimit(1000)
-              .deployedDate(OffsetDateTime.now())
-              .deployedBy("lastDeployedBy")
-              .succeeded(executionSucceeded)
-              .build();
-    }
-
-    private void assertDataJobExecutionValid(JobExecution expectedJobExecution, Optional<DataJobExecution> actualJobExecution) {
-        assertDataJobExecutionValid(expectedJobExecution, actualJobExecution, null, null);
-    }
-
-    private void assertDataJobExecutionValid(JobExecution expectedJobExecution, Optional<DataJobExecution> actualJobExecution, OffsetDateTime startTime) {
-        assertDataJobExecutionValid(expectedJobExecution, actualJobExecution, null, startTime);
-    }
-
-    private void assertDataJobExecutionValid(JobExecution expectedJobExecution, Optional<DataJobExecution> actualJobExecution, String expectedExecutionMessage, OffsetDateTime startTime) {
-        Assertions.assertTrue(actualJobExecution.isPresent());
-
-        DataJobExecution actualDataJobExecution = actualJobExecution.get();
-        Assertions.assertEquals(expectedJobExecution.getExecutionId(), actualDataJobExecution.getId());
-        Assertions.assertEquals(expectedJobExecution.getJobName(), actualDataJobExecution.getDataJob().getName());
-        MatcherAssert.assertThat(expectedJobExecution.getExecutionType(), IsEqualIgnoringCase.equalToIgnoringCase(actualDataJobExecution.getType().name()));
-        Assertions.assertEquals(expectedJobExecution.getJobVersion(), actualDataJobExecution.getJobVersion());
-        Assertions.assertEquals(expectedJobExecution.getJobSchedule(), actualDataJobExecution.getJobSchedule());
-        Assertions.assertEquals(startTime == null ? expectedJobExecution.getStartTime() : startTime, actualDataJobExecution.getStartTime());
-        Assertions.assertEquals(expectedJobExecution.getEndTime(), actualDataJobExecution.getEndTime());
-        Assertions.assertEquals(expectedJobExecution.getOpId(), actualDataJobExecution.getOpId());
-        Assertions.assertEquals(expectedJobExecution.getResourcesCpuRequest(), actualDataJobExecution.getResourcesCpuRequest());
-        Assertions.assertEquals(expectedJobExecution.getResourcesCpuLimit(), actualDataJobExecution.getResourcesCpuLimit());
-        Assertions.assertEquals(expectedJobExecution.getResourcesMemoryRequest(), actualDataJobExecution.getResourcesMemoryRequest());
-        Assertions.assertEquals(expectedJobExecution.getResourcesMemoryLimit(), actualDataJobExecution.getResourcesMemoryLimit());
-        Assertions.assertEquals(expectedExecutionMessage == null ? expectedJobExecution.getPodTerminationMessage() : expectedExecutionMessage, actualDataJobExecution.getMessage());
-        Assertions.assertEquals(expectedJobExecution.getDeployedBy(), actualDataJobExecution.getLastDeployedBy());
-        Assertions.assertEquals(expectedJobExecution.getDeployedDate(), actualDataJobExecution.getLastDeployedDate());
-    }
+  }
+
+  @Test
+  @Order(11)
+  public void testUpdateDataJobTerminationStatusWithoutExecutionId() {
+    var dataJob = new DataJob("data-job", new JobConfig(), DeploymentStatus.NONE);
+
+    dataJobMonitor.updateDataJobTerminationStatusGauge(jobsRepository.save(dataJob));
+
+    var gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+    Assertions.assertEquals(5, gauges.size());
+  }
+
+  @Test
+  @Order(12)
+  public void testWatchJobsWhenExceptionIsThrown() throws IOException, ApiException {
+    doThrow(new ApiException())
+        .when(dataJobsKubernetesService)
+        .watchJobs(anyMap(), any(), any(), anyLong());
+
+    Assertions.assertDoesNotThrow(() -> dataJobMonitor.watchJobs());
+  }
+
+  @Test
+  @Order(13)
+  public void testRecordJobExecutionStatus_nullDataJobName_shouldNotRecordExecution() {
+    JobExecution jobExecution =
+        buildJobExecutionStatus(null, randomId("job-"), ExecutionStatus.SUCCEEDED.getPodStatus());
+    dataJobMonitor.recordJobExecutionStatus(jobExecution);
+    Optional<DataJobExecution> actualJobExecution =
+        jobExecutionRepository.findById(jobExecution.getExecutionId());
+
+    Assertions.assertTrue(actualJobExecution.isEmpty());
+  }
+
+  @Test
+  @Order(14)
+  public void testRecordJobExecutionStatus_emptyDataJobName_shouldNotRecordExecution() {
+    JobExecution jobExecution =
+        buildJobExecutionStatus("", randomId("job-"), ExecutionStatus.SUCCEEDED.getPodStatus());
+    dataJobMonitor.recordJobExecutionStatus(jobExecution);
+    Optional<DataJobExecution> actualJobExecution =
+        jobExecutionRepository.findById(jobExecution.getExecutionId());
+
+    Assertions.assertTrue(actualJobExecution.isEmpty());
+  }
+
+  @Test
+  @Order(15)
+  public void
+      testRecordJobExecutionStatus_existingDataJobAndNonExistingExecution_shouldRecordExecution() {
+    JobExecution expectedJobExecution =
+        buildJobExecutionStatus(
+            "data-job", "execution-id", ExecutionStatus.SUCCEEDED.getPodStatus(), true);
+    dataJobMonitor.recordJobExecutionStatus(expectedJobExecution);
+    Optional<DataJobExecution> actualJobExecution =
+        jobExecutionRepository.findById(expectedJobExecution.getExecutionId());
+
+    assertDataJobExecutionValid(expectedJobExecution, actualJobExecution);
+  }
+
+  @Test
+  @Order(16)
+  public void
+      testRecordJobExecutionStatus_existingDataJobAndExistingExecution_shouldUpdateExecution() {
+    DataJobExecution jobExecutionBeforeUpdate =
+        jobExecutionRepository.findById("execution-id").get();
+    JobExecution expectedJobExecution =
+        JobExecution.builder()
+            .jobName(jobExecutionBeforeUpdate.getDataJob().getName())
+            .executionId(jobExecutionBeforeUpdate.getId())
+            .podTerminationMessage(ExecutionStatus.SUCCEEDED.getPodStatus())
+            .executionType("scheduled")
+            .opId("opId")
+            .startTime(jobExecutionBeforeUpdate.getStartTime())
+            .endTime(jobExecutionBeforeUpdate.getEndTime())
+            .jobVersion("jobVersion")
+            .jobSchedule("jobSchedule")
+            .resourcesCpuRequest(1F)
+            .resourcesCpuLimit(2F)
+            .resourcesMemoryRequest(500)
+            .resourcesMemoryLimit(1000)
+            .deployedDate(jobExecutionBeforeUpdate.getLastDeployedDate())
+            .deployedBy("lastDeployedBy")
+            .succeeded(true)
+            .build();
+
+    dataJobMonitor.recordJobExecutionStatus(expectedJobExecution);
+    Optional<DataJobExecution> actualJobExecution =
+        jobExecutionRepository.findById(expectedJobExecution.getExecutionId());
+
+    assertDataJobExecutionValid(expectedJobExecution, actualJobExecution);
+  }
+
+  @Test
+  @Order(17)
+  public void
+      testRecordJobExecutionStatusSkipped_existingDataJobAndNonExistingExecution_shouldRecordExecution() {
+    JobExecution expectedJobExecution =
+        buildJobExecutionStatus(
+            "data-job", "different-execution-id", ExecutionStatus.RUNNING.getPodStatus(), null);
+    dataJobMonitor.recordJobExecutionStatus(expectedJobExecution);
+    Optional<DataJobExecution> actualJobExecution =
+        jobExecutionRepository.findById(expectedJobExecution.getExecutionId());
+
+    assertDataJobExecutionValid(expectedJobExecution, actualJobExecution);
+  }
+
+  @Test
+  @Order(18)
+  public void
+      testRecordJobExecutionStatusSkipped_existingDataJobAndExistingExecution_shouldRecordExecution() {
+    var expectedExecutionMessage =
+        "Skipping job execution due to another parallel running execution.";
+    JobExecution expectedJobExecution =
+        buildJobExecutionStatus(
+            "data-job", "different-execution-id", ExecutionStatus.SKIPPED.getPodStatus(), true);
+    Optional<DataJobExecution> jobExecutionBeforeUpdate =
+        jobExecutionRepository.findById(expectedJobExecution.getExecutionId());
+    dataJobMonitor.recordJobExecutionStatus(expectedJobExecution);
+    Optional<DataJobExecution> actualJobExecution =
+        jobExecutionRepository.findById(expectedJobExecution.getExecutionId());
+
+    assertDataJobExecutionValid(
+        expectedJobExecution,
+        actualJobExecution,
+        expectedExecutionMessage,
+        jobExecutionBeforeUpdate.get().getStartTime());
+  }
+
+  @Test
+  @Order(19)
+  public void
+      testRecordJobExecutionStatus_nonExistingDataJobAndNonExistingExecution_shouldNotRecordExecution() {
+    JobExecution jobExecution =
+        buildJobExecutionStatus(
+            randomId("data-job-"), randomId("job-"), ExecutionStatus.SUCCEEDED.getPodStatus());
+    dataJobMonitor.recordJobExecutionStatus(jobExecution);
+    Optional<DataJobExecution> actualJobExecution =
+        jobExecutionRepository.findById(jobExecution.getExecutionId());
+
+    Assertions.assertTrue(actualJobExecution.isEmpty());
+  }
+
+  @Test
+  @Order(20)
+  void testUpdateDataJobInfoGauges() {
+    var dataJob =
+        new DataJob(
+            "data-job",
+            new JobConfig(),
+            DeploymentStatus.NONE,
+            ExecutionStatus.SUCCEEDED,
+            randomId("data-job-"));
+
+    dataJobMonitor.updateDataJobInfoGauges(jobsRepository.save(dataJob));
+
+    var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
+    gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
+  }
+
+  @Test
+  @Order(21)
+  void testUpdateDataJobInfoGauges_withNullDataJob_throwsException() {
+    Assertions.assertThrows(
+        NullPointerException.class, () -> dataJobMonitor.updateDataJobInfoGauges(null));
+  }
+
+  @Test
+  @Order(22)
+  void testClearDataJobsGaugesNotIn() {
+    var dataJobs =
+        Arrays.asList(
+            new DataJob(
+                "data-job1",
+                new JobConfig(),
+                DeploymentStatus.NONE,
+                ExecutionStatus.SUCCEEDED,
+                randomId("data-job1-")),
+            new DataJob(
+                "data-job2",
+                new JobConfig(),
+                DeploymentStatus.NONE,
+                ExecutionStatus.SUCCEEDED,
+                randomId("data-job2-")),
+            new DataJob(
+                "data-job3",
+                new JobConfig(),
+                DeploymentStatus.NONE,
+                ExecutionStatus.SUCCEEDED,
+                randomId("data-job3-")));
+
+    // Clean up from previous tests
+    jobsRepository.deleteAll();
+    dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
+
+    // Add some more gauges
+    dataJobMonitor.updateDataJobsGauges(jobsRepository.saveAll(dataJobs));
+
+    var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
+    Assertions.assertEquals(3, gauges.size());
+    gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
+    Assertions.assertEquals(3, gauges.size());
+    gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+    Assertions.assertEquals(3, gauges.size());
+
+    // Delete a data job and verify that its gauges are removed as a result
+    jobsRepository.deleteById(dataJobs.get(0).getName());
+    dataJobMonitor.clearDataJobsGaugesNotIn(Arrays.asList(dataJobs.get(1), dataJobs.get(2)));
+
+    gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
+    Assertions.assertEquals(2, gauges.size());
+    gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
+    Assertions.assertEquals(2, gauges.size());
+    gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+    Assertions.assertEquals(2, gauges.size());
+  }
+
+  @Test
+  @Order(23)
+  void testRecordJobExecutionStatus_withStatusSkipped_shouldNotUpdateTerminationStatus() {
+    // Clean up from previous tests
+    jobsRepository.deleteAll();
+    dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
+
+    var dataJob =
+        new DataJob("new-job", new JobConfig(), DeploymentStatus.NONE, null, "old-execution-id");
+    jobsRepository.save(dataJob);
+
+    JobExecution jobExecution =
+        buildJobExecutionStatus(
+            "new-job", "new-execution-id", ExecutionStatus.SKIPPED.getPodStatus(), true);
+    dataJobMonitor.recordJobExecutionStatus(jobExecution);
+    Optional<DataJob> actualJob = jobsRepository.findById(dataJob.getName());
+
+    Assertions.assertTrue(actualJob.isPresent());
+    Assertions.assertEquals("old-execution-id", actualJob.get().getLatestJobExecutionId());
+  }
+
+  @Test
+  @Order(24)
+  void testRecordJobExecutionStatus_withDifferentStatus_shouldUpdateTerminationStatus() {
+    // Clean up from previous tests
+    jobsRepository.deleteAll();
+    dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
+
+    var dataJob =
+        new DataJob(
+            "new-job",
+            new JobConfig(),
+            DeploymentStatus.NONE,
+            ExecutionStatus.PLATFORM_ERROR,
+            "old-execution-id");
+    jobsRepository.save(dataJob);
+
+    JobExecution jobExecution =
+        buildJobExecutionStatus(
+            "new-job", "old-execution-id", ExecutionStatus.SUCCEEDED.getPodStatus());
+
+    dataJobMonitor.recordJobExecutionStatus(jobExecution);
+
+    Optional<DataJob> actualJob = jobsRepository.findById(dataJob.getName());
+    Assertions.assertTrue(actualJob.isPresent());
+    Assertions.assertEquals("old-execution-id", actualJob.get().getLatestJobExecutionId());
+    Assertions.assertEquals(
+        ExecutionStatus.SUCCEEDED, actualJob.get().getLatestJobTerminationStatus());
+  }
+
+  @Test
+  @Order(25)
+  void testRecordJobExecutionStatus_withDifferentExecutionId_shouldUpdateTerminationStatus() {
+    // Clean up from previous tests
+    jobsRepository.deleteAll();
+    dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
+
+    var dataJob =
+        new DataJob("new-job", new JobConfig(), DeploymentStatus.NONE, null, "old-execution-id");
+    jobsRepository.save(dataJob);
+
+    JobExecution jobExecution =
+        buildJobExecutionStatus(
+            "new-job", "new-execution-id", ExecutionStatus.USER_ERROR.getPodStatus(), true);
+
+    dataJobMonitor.recordJobExecutionStatus(jobExecution);
+
+    Optional<DataJob> actualJob = jobsRepository.findById(dataJob.getName());
+    Assertions.assertTrue(actualJob.isPresent());
+    Assertions.assertEquals("new-execution-id", actualJob.get().getLatestJobExecutionId());
+    Assertions.assertEquals(
+        ExecutionStatus.USER_ERROR, actualJob.get().getLatestJobTerminationStatus());
+  }
+
+  @Test
+  @Order(26)
+  void testRecordJobExecutionStatus_shouldUpdateLastExecution() {
+    // Clean up from previous tests
+    jobsRepository.deleteAll();
+    dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
+
+    var dataJob =
+        new DataJob(
+            "new-job",
+            new JobConfig(),
+            DeploymentStatus.NONE,
+            ExecutionStatus.PLATFORM_ERROR,
+            "old-execution-id");
+    dataJob.setLastExecutionStatus(ExecutionStatus.PLATFORM_ERROR);
+    dataJob.setLastExecutionEndTime(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
+    dataJob.setLastExecutionDuration(1000);
+    jobsRepository.save(dataJob);
+
+    JobExecution jobExecution =
+        buildJobExecutionStatus(
+            "new-job", "old-execution-id", ExecutionStatus.PLATFORM_ERROR.getPodStatus(), false);
+
+    dataJobMonitor.recordJobExecutionStatus(jobExecution);
+
+    Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
+    Assertions.assertFalse(actualJob.isEmpty());
+    Assertions.assertEquals(
+        ExecutionStatus.PLATFORM_ERROR, actualJob.get().getLastExecutionStatus());
+  }
+
+  @Test
+  @Order(27)
+  void testRecordJobExecutionStatus_withNullExecutionId_shouldNotUpdateLastExecution() {
+    JobExecution jobExecution =
+        buildJobExecutionStatus("new-job", null, ExecutionStatus.SUCCEEDED.getPodStatus());
+
+    dataJobMonitor.recordJobExecutionStatus(jobExecution);
+
+    Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
+    Assertions.assertFalse(actualJob.isEmpty());
+    Assertions.assertEquals(
+        ExecutionStatus.PLATFORM_ERROR, actualJob.get().getLastExecutionStatus());
+  }
+
+  @Test
+  @Order(28)
+  void testRecordJobExecutionStatus_withEmptyExecutionId_shouldNotUpdateLastExecution() {
+    JobExecution jobExecution =
+        buildJobExecutionStatus("new-job", "", ExecutionStatus.SUCCEEDED.getPodStatus());
+
+    dataJobMonitor.recordJobExecutionStatus(jobExecution);
+
+    Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
+    Assertions.assertFalse(actualJob.isEmpty());
+    Assertions.assertEquals(
+        ExecutionStatus.PLATFORM_ERROR, actualJob.get().getLastExecutionStatus());
+  }
+
+  @Test
+  @Order(29)
+  void testRecordJobExecutionStatus_withSameExecutionIdAndNewStatus_shouldUpdateLastExecution() {
+    // Status gets updated from PLATFORM_ERROR to Succeeded with the same ID.
+    JobExecution jobExecution =
+        buildJobExecutionStatus(
+            "new-job", "old-execution-id", ExecutionStatus.SUCCEEDED.getPodStatus());
+
+    dataJobMonitor.recordJobExecutionStatus(jobExecution);
+
+    Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
+    Assertions.assertFalse(actualJob.isEmpty());
+    Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualJob.get().getLastExecutionStatus());
+  }
+
+  @Test
+  @Order(30)
+  void testRecordJobExecutionStatus_withNewExecutionIdAndNewStatus_shouldUpdateLastExecution() {
+    JobExecution jobExecution =
+        buildJobExecutionStatus(
+            "new-job", "new-execution-id", ExecutionStatus.SUCCEEDED.getPodStatus());
+
+    dataJobMonitor.recordJobExecutionStatus(jobExecution);
+
+    Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
+    Assertions.assertFalse(actualJob.isEmpty());
+    Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualJob.get().getLastExecutionStatus());
+    Assertions.assertEquals(jobExecution.getEndTime(), actualJob.get().getLastExecutionEndTime());
+  }
+
+  @Test
+  @Order(31)
+  void
+      testRecordJobExecutionStatus_withSameExecutionIdAndOldStatusIsFinal_shouldNotUpdateTerminationStatus() {
+    JobExecution jobExecution =
+        buildJobExecutionStatus(
+            "new-job", "new-execution-id", ExecutionStatus.USER_ERROR.getPodStatus());
+
+    dataJobMonitor.recordJobExecutionStatus(jobExecution);
+
+    Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
+    Assertions.assertFalse(actualJob.isEmpty());
+    // The termination status should not have changed from SUCCESS to USER_ERROR because SUCCESS is
+    // a final status
+    Assertions.assertEquals(
+        ExecutionStatus.SUCCEEDED, actualJob.get().getLatestJobTerminationStatus());
+  }
+
+  @Test
+  @Order(32)
+  void testRecordJobExecutionStatus_withAnOlderExecution_shouldNotUpdateLastExecution() {
+    JobExecution jobExecution =
+        buildJobExecutionStatus(
+            "new-job",
+            "newer-execution-id",
+            ExecutionStatus.USER_ERROR.getPodStatus(),
+            false,
+            OffsetDateTime.now().minus(Duration.ofDays(2)),
+            OffsetDateTime.now().minus(Duration.ofDays(1)));
+
+    dataJobMonitor.recordJobExecutionStatus(jobExecution);
+
+    Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
+    Assertions.assertFalse(actualJob.isEmpty());
+    // The last execution status should not have changed from SUCCEEDED to USER_ERROR because the
+    // execution is not recent
+    Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualJob.get().getLastExecutionStatus());
+  }
+
+  @Test
+  @Order(33)
+  void testJobExecutionStatus_fromPlatformToUser_shouldUpdateExecution() {
+    // Clean up from previous tests
+    jobsRepository.deleteAll();
+    dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
+    // Create data job
+    String jobId = "job-id-test";
+    var dataJob =
+        new DataJob(
+            jobId,
+            new JobConfig(),
+            DeploymentStatus.NONE,
+            ExecutionStatus.SUCCEEDED,
+            "old-execution-id");
+    jobsRepository.save(dataJob);
+    // Change status to PLATFORM_ERROR
+    JobExecution jobExecution =
+        buildJobExecutionStatus(
+            jobId,
+            "last-execution-id",
+            ExecutionStatus.PLATFORM_ERROR.getPodStatus(),
+            false,
+            OffsetDateTime.now().minus(Duration.ofDays(2)),
+            OffsetDateTime.now().minus(Duration.ofDays(1)));
+    dataJobMonitor.recordJobExecutionStatus(jobExecution);
+    // Check status is saved OK.
+    Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
+    Assertions.assertFalse(actualJob.isEmpty());
+    Assertions.assertEquals(
+        ExecutionStatus.PLATFORM_ERROR, actualJob.get().getLastExecutionStatus());
+    // Check gauge status
+    var gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
+    Assertions.assertEquals(
+        ExecutionStatus.PLATFORM_ERROR.getAlertValue().doubleValue(),
+        gauges.stream().findFirst().get().value());
+    // Change status to USER_ERROR, same execution ID simulating retry. Different ID's change
+    // without issues.
+    jobExecution =
+        buildJobExecutionStatus(
+            jobId,
+            "last-execution-id",
+            ExecutionStatus.USER_ERROR.getPodStatus(),
+            false,
+            OffsetDateTime.now().minus(Duration.ofDays(2)),
+            OffsetDateTime.now().minus(Duration.ofDays(1)));
+    dataJobMonitor.recordJobExecutionStatus(jobExecution);
+    // Check status is saved OK.
+    actualJob = jobsRepository.findById(jobExecution.getJobName());
+    Assertions.assertFalse(actualJob.isEmpty());
+    Assertions.assertEquals(ExecutionStatus.USER_ERROR, actualJob.get().getLastExecutionStatus());
+    // Check gauge status is changed OK.
+    gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
+    Assertions.assertEquals(
+        ExecutionStatus.USER_ERROR.getAlertValue().doubleValue(),
+        gauges.stream().findFirst().get().value());
+  }
+
+  private static String randomId(String prefix) {
+    return prefix + UUID.randomUUID();
+  }
+
+  private static ExecutionStatus getTerminationStatus(JobExecution jobExecution) {
+    return JobExecutionResultManager.getResult(jobExecution).getExecutionStatus();
+  }
+
+  private static JobExecution buildJobExecutionStatus(
+      String jobName, String executionId, String terminationMessage) {
+    return buildJobExecutionStatus(jobName, executionId, terminationMessage, true);
+  }
+
+  private static JobExecution buildJobExecutionStatus(
+      String jobName, String executionId, String terminationMessage, Boolean executionSucceeded) {
+    return buildJobExecutionStatus(
+        jobName,
+        executionId,
+        terminationMessage,
+        executionSucceeded,
+        OffsetDateTime.now(),
+        OffsetDateTime.now());
+  }
+
+  private static JobExecution buildJobExecutionStatus(
+      String jobName,
+      String executionId,
+      String terminationMessage,
+      Boolean executionSucceeded,
+      OffsetDateTime startTime,
+      OffsetDateTime endTime) {
+    return JobExecution.builder()
+        .jobName(jobName)
+        .executionId(executionId)
+        .podTerminationMessage(terminationMessage)
+        .executionType("scheduled")
+        .opId("opId")
+        .startTime(startTime)
+        .endTime(endTime)
+        .jobVersion("jobVersion")
+        .jobSchedule("jobSchedule")
+        .resourcesCpuRequest(1F)
+        .resourcesCpuLimit(2F)
+        .resourcesMemoryRequest(500)
+        .resourcesMemoryLimit(1000)
+        .deployedDate(OffsetDateTime.now())
+        .deployedBy("lastDeployedBy")
+        .succeeded(executionSucceeded)
+        .build();
+  }
+
+  private void assertDataJobExecutionValid(
+      JobExecution expectedJobExecution, Optional<DataJobExecution> actualJobExecution) {
+    assertDataJobExecutionValid(expectedJobExecution, actualJobExecution, null, null);
+  }
+
+  private void assertDataJobExecutionValid(
+      JobExecution expectedJobExecution,
+      Optional<DataJobExecution> actualJobExecution,
+      OffsetDateTime startTime) {
+    assertDataJobExecutionValid(expectedJobExecution, actualJobExecution, null, startTime);
+  }
+
+  private void assertDataJobExecutionValid(
+      JobExecution expectedJobExecution,
+      Optional<DataJobExecution> actualJobExecution,
+      String expectedExecutionMessage,
+      OffsetDateTime startTime) {
+    Assertions.assertTrue(actualJobExecution.isPresent());
+
+    DataJobExecution actualDataJobExecution = actualJobExecution.get();
+    Assertions.assertEquals(expectedJobExecution.getExecutionId(), actualDataJobExecution.getId());
+    Assertions.assertEquals(
+        expectedJobExecution.getJobName(), actualDataJobExecution.getDataJob().getName());
+    MatcherAssert.assertThat(
+        expectedJobExecution.getExecutionType(),
+        IsEqualIgnoringCase.equalToIgnoringCase(actualDataJobExecution.getType().name()));
+    Assertions.assertEquals(
+        expectedJobExecution.getJobVersion(), actualDataJobExecution.getJobVersion());
+    Assertions.assertEquals(
+        expectedJobExecution.getJobSchedule(), actualDataJobExecution.getJobSchedule());
+    Assertions.assertEquals(
+        startTime == null ? expectedJobExecution.getStartTime() : startTime,
+        actualDataJobExecution.getStartTime());
+    Assertions.assertEquals(expectedJobExecution.getEndTime(), actualDataJobExecution.getEndTime());
+    Assertions.assertEquals(expectedJobExecution.getOpId(), actualDataJobExecution.getOpId());
+    Assertions.assertEquals(
+        expectedJobExecution.getResourcesCpuRequest(),
+        actualDataJobExecution.getResourcesCpuRequest());
+    Assertions.assertEquals(
+        expectedJobExecution.getResourcesCpuLimit(), actualDataJobExecution.getResourcesCpuLimit());
+    Assertions.assertEquals(
+        expectedJobExecution.getResourcesMemoryRequest(),
+        actualDataJobExecution.getResourcesMemoryRequest());
+    Assertions.assertEquals(
+        expectedJobExecution.getResourcesMemoryLimit(),
+        actualDataJobExecution.getResourcesMemoryLimit());
+    Assertions.assertEquals(
+        expectedExecutionMessage == null
+            ? expectedJobExecution.getPodTerminationMessage()
+            : expectedExecutionMessage,
+        actualDataJobExecution.getMessage());
+    Assertions.assertEquals(
+        expectedJobExecution.getDeployedBy(), actualDataJobExecution.getLastDeployedBy());
+    Assertions.assertEquals(
+        expectedJobExecution.getDeployedDate(), actualDataJobExecution.getLastDeployedDate());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DeploymentMonitorIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DeploymentMonitorIT.java
@@ -17,103 +17,104 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = ControlplaneApplication.class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = ControlplaneApplication.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class DeploymentMonitorIT {
 
-   @Autowired
-   private MeterRegistry meterRegistry;
+  @Autowired private MeterRegistry meterRegistry;
 
-   @Autowired
-   private JobsRepository jobsRepository;
+  @Autowired private JobsRepository jobsRepository;
 
-   @Autowired
-   private DeploymentMonitor deploymentMonitor;
+  @Autowired private DeploymentMonitor deploymentMonitor;
 
-   @Test
-   @Order(1)
-   public void testRecordDeploymentStatusExistingJob() {
-      JobConfig config = new JobConfig();
-      config.setSchedule("schedule");
-      var entity = new DataJob("data-job", config, DeploymentStatus.NONE);
-      jobsRepository.save(entity);
+  @Test
+  @Order(1)
+  public void testRecordDeploymentStatusExistingJob() {
+    JobConfig config = new JobConfig();
+    config.setSchedule("schedule");
+    var entity = new DataJob("data-job", config, DeploymentStatus.NONE);
+    jobsRepository.save(entity);
 
-      deploymentMonitor.recordDeploymentStatus("data-job", DeploymentStatus.SUCCESS);
+    deploymentMonitor.recordDeploymentStatus("data-job", DeploymentStatus.SUCCESS);
 
-      var gauges = meterRegistry.find(DeploymentMonitor.GAUGE_METRIC_NAME).gauges();
-      var summaries = meterRegistry.find(DeploymentMonitor.SUMMARY_METRIC_NAME).summaries();
+    var gauges = meterRegistry.find(DeploymentMonitor.GAUGE_METRIC_NAME).gauges();
+    var summaries = meterRegistry.find(DeploymentMonitor.SUMMARY_METRIC_NAME).summaries();
 
-      Assertions.assertEquals(1, gauges.size());
-      Assertions.assertEquals(1, summaries.size());
+    Assertions.assertEquals(1, gauges.size());
+    Assertions.assertEquals(1, summaries.size());
 
-      DataJob expectedJob = jobsRepository.findById("data-job").get();
+    DataJob expectedJob = jobsRepository.findById("data-job").get();
 
-      Assertions.assertEquals(expectedJob.getLatestJobDeploymentStatus(), DeploymentStatus.SUCCESS);
-   }
+    Assertions.assertEquals(expectedJob.getLatestJobDeploymentStatus(), DeploymentStatus.SUCCESS);
+  }
 
-   @Test
-   @Order(2)
-   public void testUpdateDeploymentStatusExistingJob() {
+  @Test
+  @Order(2)
+  public void testUpdateDeploymentStatusExistingJob() {
 
-      deploymentMonitor.recordDeploymentStatus("data-job", DeploymentStatus.PLATFORM_ERROR);
+    deploymentMonitor.recordDeploymentStatus("data-job", DeploymentStatus.PLATFORM_ERROR);
 
-      var gauges = meterRegistry.find(DeploymentMonitor.GAUGE_METRIC_NAME).gauges();
-      var summaries = meterRegistry.find(DeploymentMonitor.SUMMARY_METRIC_NAME).summaries();
+    var gauges = meterRegistry.find(DeploymentMonitor.GAUGE_METRIC_NAME).gauges();
+    var summaries = meterRegistry.find(DeploymentMonitor.SUMMARY_METRIC_NAME).summaries();
 
-      Assertions.assertEquals(1, gauges.size());
-      Assertions.assertEquals(2, summaries.size());
+    Assertions.assertEquals(1, gauges.size());
+    Assertions.assertEquals(2, summaries.size());
 
-      DataJob expectedJob = jobsRepository.findById("data-job").get();
+    DataJob expectedJob = jobsRepository.findById("data-job").get();
 
-      Assertions.assertEquals(expectedJob.getLatestJobDeploymentStatus(), DeploymentStatus.PLATFORM_ERROR);
-   }
+    Assertions.assertEquals(
+        expectedJob.getLatestJobDeploymentStatus(), DeploymentStatus.PLATFORM_ERROR);
+  }
 
-   @Test
-   @Order(3)
-   public void testJobNameNull() {
+  @Test
+  @Order(3)
+  public void testJobNameNull() {
 
-      deploymentMonitor.recordDeploymentStatus(null, DeploymentStatus.PLATFORM_ERROR);
+    deploymentMonitor.recordDeploymentStatus(null, DeploymentStatus.PLATFORM_ERROR);
 
-      var gauges = meterRegistry.find(DeploymentMonitor.GAUGE_METRIC_NAME).gauges();
-      var summaries = meterRegistry.find(DeploymentMonitor.SUMMARY_METRIC_NAME).summaries();
+    var gauges = meterRegistry.find(DeploymentMonitor.GAUGE_METRIC_NAME).gauges();
+    var summaries = meterRegistry.find(DeploymentMonitor.SUMMARY_METRIC_NAME).summaries();
 
-      Assertions.assertEquals(1, gauges.size());
-      Assertions.assertEquals(2, summaries.size());
+    Assertions.assertEquals(1, gauges.size());
+    Assertions.assertEquals(2, summaries.size());
 
-      DataJob expectedJob = jobsRepository.findById("data-job").get();
+    DataJob expectedJob = jobsRepository.findById("data-job").get();
 
-      Assertions.assertEquals(DeploymentStatus.PLATFORM_ERROR, expectedJob.getLatestJobDeploymentStatus());
-   }
+    Assertions.assertEquals(
+        DeploymentStatus.PLATFORM_ERROR, expectedJob.getLatestJobDeploymentStatus());
+  }
 
-   @Test
-   @Order(4)
-   public void testJobNameEmpty() {
+  @Test
+  @Order(4)
+  public void testJobNameEmpty() {
 
-      deploymentMonitor.recordDeploymentStatus("", DeploymentStatus.PLATFORM_ERROR);
+    deploymentMonitor.recordDeploymentStatus("", DeploymentStatus.PLATFORM_ERROR);
 
-      var gauges = meterRegistry.find(DeploymentMonitor.GAUGE_METRIC_NAME).gauges();
-      var summaries = meterRegistry.find(DeploymentMonitor.SUMMARY_METRIC_NAME).summaries();
+    var gauges = meterRegistry.find(DeploymentMonitor.GAUGE_METRIC_NAME).gauges();
+    var summaries = meterRegistry.find(DeploymentMonitor.SUMMARY_METRIC_NAME).summaries();
 
-      Assertions.assertEquals(1, gauges.size());
-      Assertions.assertEquals(2, summaries.size());
+    Assertions.assertEquals(1, gauges.size());
+    Assertions.assertEquals(2, summaries.size());
 
-      DataJob expectedJob = jobsRepository.findById("data-job").get();
+    DataJob expectedJob = jobsRepository.findById("data-job").get();
 
-      Assertions.assertEquals(DeploymentStatus.PLATFORM_ERROR, expectedJob.getLatestJobDeploymentStatus());
-   }
+    Assertions.assertEquals(
+        DeploymentStatus.PLATFORM_ERROR, expectedJob.getLatestJobDeploymentStatus());
+  }
 
-   @Test
-   @Order(5)
-   public void testNonExistingJob() {
+  @Test
+  @Order(5)
+  public void testNonExistingJob() {
 
-      deploymentMonitor.recordDeploymentStatus("data-job-missing", DeploymentStatus.PLATFORM_ERROR);
+    deploymentMonitor.recordDeploymentStatus("data-job-missing", DeploymentStatus.PLATFORM_ERROR);
 
-      var gauges = meterRegistry.find(DeploymentMonitor.GAUGE_METRIC_NAME).gauges();
-      var summaries = meterRegistry.find(DeploymentMonitor.SUMMARY_METRIC_NAME).summaries();
+    var gauges = meterRegistry.find(DeploymentMonitor.GAUGE_METRIC_NAME).gauges();
+    var summaries = meterRegistry.find(DeploymentMonitor.SUMMARY_METRIC_NAME).summaries();
 
-      Assertions.assertEquals(1, gauges.size());
-      Assertions.assertEquals(2, summaries.size());
-   }
+    Assertions.assertEquals(1, gauges.size());
+    Assertions.assertEquals(2, summaries.size());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DeploymentMonitorSyncTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DeploymentMonitorSyncTest.java
@@ -22,74 +22,72 @@ import java.util.List;
 @ExtendWith(MockitoExtension.class)
 public class DeploymentMonitorSyncTest {
 
-   @Mock
-   private JobsRepository jobsRepository;
+  @Mock private JobsRepository jobsRepository;
 
-   @Mock
-   private DeploymentMonitor deploymentMonitor;
+  @Mock private DeploymentMonitor deploymentMonitor;
 
-   @InjectMocks
-   private DeploymentMonitorSync deploymentMonitorSync;
+  @InjectMocks private DeploymentMonitorSync deploymentMonitorSync;
 
-   @Test
-   public void testEmptyRepository() throws InterruptedException {
-      Iterable<DataJob> mockJobs = new ArrayList<DataJob>();
-      Mockito.when(jobsRepository.findAll()).thenReturn(mockJobs);
+  @Test
+  public void testEmptyRepository() throws InterruptedException {
+    Iterable<DataJob> mockJobs = new ArrayList<DataJob>();
+    Mockito.when(jobsRepository.findAll()).thenReturn(mockJobs);
 
-      deploymentMonitorSync.updateJobDeploymentStatuses();
+    deploymentMonitorSync.updateJobDeploymentStatuses();
 
-      Mockito.verify(deploymentMonitor, Mockito.times(0)).updateDataJobStatus(Mockito.any(), Mockito.any());
-   }
+    Mockito.verify(deploymentMonitor, Mockito.times(0))
+        .updateDataJobStatus(Mockito.any(), Mockito.any());
+  }
 
-   @Test
-   public void testOneJobInRepository() throws InterruptedException {
-      List<DataJob> mockJobs = new ArrayList<DataJob>();
-      mockJobs.add(new DataJob("test-job", new JobConfig(), DeploymentStatus.SUCCESS));
-      Mockito.when(jobsRepository.findAll()).thenReturn(mockJobs);
+  @Test
+  public void testOneJobInRepository() throws InterruptedException {
+    List<DataJob> mockJobs = new ArrayList<DataJob>();
+    mockJobs.add(new DataJob("test-job", new JobConfig(), DeploymentStatus.SUCCESS));
+    Mockito.when(jobsRepository.findAll()).thenReturn(mockJobs);
 
-      deploymentMonitorSync.updateJobDeploymentStatuses();
+    deploymentMonitorSync.updateJobDeploymentStatuses();
 
-      Mockito.verify(deploymentMonitor, Mockito.times(1))
-              .updateDataJobStatus("test-job", DeploymentStatus.SUCCESS);
-   }
+    Mockito.verify(deploymentMonitor, Mockito.times(1))
+        .updateDataJobStatus("test-job", DeploymentStatus.SUCCESS);
+  }
 
-   @Test
-   public void testTwoJobsInRepository() throws InterruptedException {
-      List<DataJob> mockJobs = new ArrayList<DataJob>();
-      mockJobs.add(new DataJob("test-job", new JobConfig()));
-      mockJobs.add(new DataJob("test-job-2", new JobConfig(), DeploymentStatus.PLATFORM_ERROR));
-      Mockito.when(jobsRepository.findAll()).thenReturn(mockJobs);
+  @Test
+  public void testTwoJobsInRepository() throws InterruptedException {
+    List<DataJob> mockJobs = new ArrayList<DataJob>();
+    mockJobs.add(new DataJob("test-job", new JobConfig()));
+    mockJobs.add(new DataJob("test-job-2", new JobConfig(), DeploymentStatus.PLATFORM_ERROR));
+    Mockito.when(jobsRepository.findAll()).thenReturn(mockJobs);
 
-      deploymentMonitorSync.updateJobDeploymentStatuses();
+    deploymentMonitorSync.updateJobDeploymentStatuses();
 
-      Mockito.verify(deploymentMonitor, Mockito.times(0))
-              .updateDataJobStatus("test-job", DeploymentStatus.NONE);
+    Mockito.verify(deploymentMonitor, Mockito.times(0))
+        .updateDataJobStatus("test-job", DeploymentStatus.NONE);
 
-      Mockito.verify(deploymentMonitor, Mockito.times(1))
-              .updateDataJobStatus("test-job-2", DeploymentStatus.PLATFORM_ERROR);
-   }
+    Mockito.verify(deploymentMonitor, Mockito.times(1))
+        .updateDataJobStatus("test-job-2", DeploymentStatus.PLATFORM_ERROR);
+  }
 
-   @Test
-   public void testJobWithNoneStatusSkipped() throws InterruptedException {
-      List<DataJob> mockJobs = new ArrayList<DataJob>();
-      mockJobs.add(new DataJob("test-job", new JobConfig()));
-      Mockito.when(jobsRepository.findAll()).thenReturn(mockJobs);
+  @Test
+  public void testJobWithNoneStatusSkipped() throws InterruptedException {
+    List<DataJob> mockJobs = new ArrayList<DataJob>();
+    mockJobs.add(new DataJob("test-job", new JobConfig()));
+    Mockito.when(jobsRepository.findAll()).thenReturn(mockJobs);
 
-      deploymentMonitorSync.updateJobDeploymentStatuses();
+    deploymentMonitorSync.updateJobDeploymentStatuses();
 
-      Mockito.verify(deploymentMonitor, Mockito.times(0))
-              .updateDataJobStatus(Mockito.any(), Mockito.any());
-   }
+    Mockito.verify(deploymentMonitor, Mockito.times(0))
+        .updateDataJobStatus(Mockito.any(), Mockito.any());
+  }
 
-   @Test
-   public void testJobWithNullStatusHandled() throws InterruptedException {
-      List<DataJob> mockJobs = new ArrayList<DataJob>();
-      mockJobs.add(new DataJob("test-job", new JobConfig(), null));
-      Mockito.when(jobsRepository.findAll()).thenReturn(mockJobs);
+  @Test
+  public void testJobWithNullStatusHandled() throws InterruptedException {
+    List<DataJob> mockJobs = new ArrayList<DataJob>();
+    mockJobs.add(new DataJob("test-job", new JobConfig(), null));
+    Mockito.when(jobsRepository.findAll()).thenReturn(mockJobs);
 
-      deploymentMonitorSync.updateJobDeploymentStatuses();
+    deploymentMonitorSync.updateJobDeploymentStatuses();
 
-      Mockito.verify(deploymentMonitor, Mockito.times(0))
-              .updateDataJobStatus(Mockito.any(), Mockito.any());
-   }
+    Mockito.verify(deploymentMonitor, Mockito.times(0))
+        .updateDataJobStatus(Mockito.any(), Mockito.any());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/notification/DataJobNotificationTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/notification/DataJobNotificationTest.java
@@ -20,80 +20,87 @@ import java.util.*;
 
 public class DataJobNotificationTest {
 
-    private SimpleSmtpServer smptServer;
-    private EmailNotification.SmtpProperties smtpProperties;
-    private JobConfig jobConfig;
-    private DataJobNotification dataJobNotification;
-    private String receiverMail;
+  private SimpleSmtpServer smptServer;
+  private EmailNotification.SmtpProperties smtpProperties;
+  private JobConfig jobConfig;
+  private DataJobNotification dataJobNotification;
+  private String receiverMail;
 
-    @BeforeEach
-    public void setup() throws IOException {
-        this.smptServer = SimpleSmtpServer.start(SimpleSmtpServer.AUTO_SMTP_PORT);
-        this.smtpProperties = Mockito.mock(EmailNotification.SmtpProperties.class);
-        Mockito.when(smtpProperties.smtpWithPrefix()).thenReturn(getMailProperties(this.smptServer.getPort()));
+  @BeforeEach
+  public void setup() throws IOException {
+    this.smptServer = SimpleSmtpServer.start(SimpleSmtpServer.AUTO_SMTP_PORT);
+    this.smtpProperties = Mockito.mock(EmailNotification.SmtpProperties.class);
+    Mockito.when(smtpProperties.smtpWithPrefix())
+        .thenReturn(getMailProperties(this.smptServer.getPort()));
 
-        this.dataJobNotification = new DataJobNotification(new EmailNotification(this.smtpProperties),
-                "Example Name","your_username@vmware.com", Collections.singletonList("cc@dummy.com"));
-        this.receiverMail = "dummy@dummy.dummy";
-        this.jobConfig = getJobConfig();
-    }
+    this.dataJobNotification =
+        new DataJobNotification(
+            new EmailNotification(this.smtpProperties),
+            "Example Name",
+            "your_username@vmware.com",
+            Collections.singletonList("cc@dummy.com"));
+    this.receiverMail = "dummy@dummy.dummy";
+    this.jobConfig = getJobConfig();
+  }
 
-    @AfterEach
-    public void clean() {
-        this.smptServer.close();
-    }
+  @AfterEach
+  public void clean() {
+    this.smptServer.close();
+  }
 
-    @Test
-    public void jobNotificationsMultiple() throws IOException {
-        dataJobNotification.notifyJobDeployError(jobConfig, "bad", "very bad");
-        dataJobNotification.notifyJobDeploySuccess(jobConfig);
-        dataJobNotification.notifyJobDeployError(jobConfig, "Some error", "Some error body");
+  @Test
+  public void jobNotificationsMultiple() throws IOException {
+    dataJobNotification.notifyJobDeployError(jobConfig, "bad", "very bad");
+    dataJobNotification.notifyJobDeploySuccess(jobConfig);
+    dataJobNotification.notifyJobDeployError(jobConfig, "Some error", "Some error body");
 
-        List<SmtpMessage> emails = this.smptServer.getReceivedEmails();
-        Assertions.assertEquals(3, emails.size());
-        Assertions.assertEquals("[deploy][data job failure] example_unittest_job", emails.get(0).getHeaderValue("Subject"));
-        Assertions.assertEquals("[deploy][data job success] example_unittest_job", emails.get(1).getHeaderValue("Subject"));
-    }
+    List<SmtpMessage> emails = this.smptServer.getReceivedEmails();
+    Assertions.assertEquals(3, emails.size());
+    Assertions.assertEquals(
+        "[deploy][data job failure] example_unittest_job", emails.get(0).getHeaderValue("Subject"));
+    Assertions.assertEquals(
+        "[deploy][data job success] example_unittest_job", emails.get(1).getHeaderValue("Subject"));
+  }
 
-    @Test
-    public void jobNotificationsJobDeployError() throws IOException {
-        dataJobNotification.notifyJobDeployError(jobConfig, "Some error", "Some error body");
+  @Test
+  public void jobNotificationsJobDeployError() throws IOException {
+    dataJobNotification.notifyJobDeployError(jobConfig, "Some error", "Some error body");
 
-        List<SmtpMessage> emails = this.smptServer.getReceivedEmails();
-        Assertions.assertEquals(1, emails.size());
-        var email = emails.get(0);
-        Assertions.assertEquals("[deploy][data job failure] example_unittest_job", email.getHeaderValue("Subject"));
-        Assertions.assertEquals("cc@dummy.com, dummy@dummy.dummy", email.getHeaderValue("To"));
-    }
+    List<SmtpMessage> emails = this.smptServer.getReceivedEmails();
+    Assertions.assertEquals(1, emails.size());
+    var email = emails.get(0);
+    Assertions.assertEquals(
+        "[deploy][data job failure] example_unittest_job", email.getHeaderValue("Subject"));
+    Assertions.assertEquals("cc@dummy.com, dummy@dummy.dummy", email.getHeaderValue("To"));
+  }
 
-    @Test
-    public void jobNotificationsJobDeploySuccess() throws IOException {
-        dataJobNotification.notifyJobDeploySuccess(jobConfig);
+  @Test
+  public void jobNotificationsJobDeploySuccess() throws IOException {
+    dataJobNotification.notifyJobDeploySuccess(jobConfig);
 
-        List<SmtpMessage> emails = this.smptServer.getReceivedEmails();
-        Assertions.assertEquals(1, emails.size());
-        var email = emails.get(0);
-        Assertions.assertEquals("[deploy][data job success] example_unittest_job", email.getHeaderValue("Subject"));
-        Assertions.assertEquals("cc@dummy.com, dummy@dummy.dummy", email.getHeaderValue("To"));
-    }
+    List<SmtpMessage> emails = this.smptServer.getReceivedEmails();
+    Assertions.assertEquals(1, emails.size());
+    var email = emails.get(0);
+    Assertions.assertEquals(
+        "[deploy][data job success] example_unittest_job", email.getHeaderValue("Subject"));
+    Assertions.assertEquals("cc@dummy.com, dummy@dummy.dummy", email.getHeaderValue("To"));
+  }
 
+  @NotNull
+  private JobConfig getJobConfig() {
+    JobConfig jobConfig = new JobConfig();
+    List<String> receivers = new ArrayList<>();
+    receivers.add(receiverMail);
+    jobConfig.setNotifiedOnJobDeploy(receivers);
+    jobConfig.setJobName("example_unittest_job");
+    return jobConfig;
+  }
 
-
-    @NotNull
-    private JobConfig getJobConfig() {
-        JobConfig jobConfig = new JobConfig();
-        List<String> receivers = new ArrayList<>();
-        receivers.add(receiverMail);
-        jobConfig.setNotifiedOnJobDeploy(receivers);
-        jobConfig.setJobName("example_unittest_job");
-        return jobConfig;
-    }
-
-    private Map<String, String> getMailProperties(int port) {
-        Map<String, String> mailProps = new HashMap<>();
-        mailProps.put("mail.smtp.host", "localhost");
-        mailProps.put("mail.smtp.port", "" + port);
-        mailProps.put("mail.smtp.sendpartial", "true");
-        return mailProps;
-    }
+  private Map<String, String> getMailProperties(int port) {
+    Map<String, String> mailProps = new HashMap<>();
+    mailProps.put("mail.smtp.host", "localhost");
+    mailProps.put("mail.smtp.port", "" + port);
+    mailProps.put("mail.smtp.sendpartial", "true");
+    return mailProps;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/notification/EmailNotificationTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/notification/EmailNotificationTest.java
@@ -17,41 +17,41 @@ import com.vmware.taurus.ControlplaneApplication;
 @SpringBootTest(classes = ControlplaneApplication.class)
 public class EmailNotificationTest {
 
-   @Autowired
-   private EmailNotification emailNotification;
+  @Autowired private EmailNotification emailNotification;
 
-   @Test
-   public void testConcatAddresses_nullAddresses_shouldReturnNull() {
-      String result = emailNotification.concatAddresses(null);
-      Assertions.assertNull(result);
-   }
+  @Test
+  public void testConcatAddresses_nullAddresses_shouldReturnNull() {
+    String result = emailNotification.concatAddresses(null);
+    Assertions.assertNull(result);
+  }
 
-   @Test
-   public void testConcatAddresses_validAddresses_shouldReturnNull() {
-      String address1 = "a@a.a";
-      String address2 = "b@b.b";
-      String result = emailNotification.concatAddresses(
-            new Address[]{createAddress(address1), createAddress(address2)});
+  @Test
+  public void testConcatAddresses_validAddresses_shouldReturnNull() {
+    String address1 = "a@a.a";
+    String address2 = "b@b.b";
+    String result =
+        emailNotification.concatAddresses(
+            new Address[] {createAddress(address1), createAddress(address2)});
 
-      Assertions.assertEquals(address1 + " " + address2, result);
-   }
+    Assertions.assertEquals(address1 + " " + address2, result);
+  }
 
-   private static Address createAddress(String address) {
-      return new Address() {
-         @Override
-         public String getType() {
-            return null;
-         }
+  private static Address createAddress(String address) {
+    return new Address() {
+      @Override
+      public String getType() {
+        return null;
+      }
 
-         @Override
-         public String toString() {
-            return address;
-         }
+      @Override
+      public String toString() {
+        return address;
+      }
 
-         @Override
-         public boolean equals(Object address) {
-            return false;
-         }
-      };
-   }
+      @Override
+      public boolean equals(Object address) {
+        return false;
+      }
+    };
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/notification/NotificationContentTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/notification/NotificationContentTest.java
@@ -16,91 +16,108 @@ import java.util.Collections;
 
 public class NotificationContentTest {
 
-    @Test
-    public void test_basic_notification() {
-        JobConfig jobConfig = createValidJobConfigStub();
-        try {
-            NotificationContent notificationContent =
-                    new NotificationContent(jobConfig, "run", "failure", "Example Name" , "sender@vmware.com",
-                            Arrays.asList("foo@bar.com", "bar@foo.com"));
+  @Test
+  public void test_basic_notification() {
+    JobConfig jobConfig = createValidJobConfigStub();
+    try {
+      NotificationContent notificationContent =
+          new NotificationContent(
+              jobConfig,
+              "run",
+              "failure",
+              "Example Name",
+              "sender@vmware.com",
+              Arrays.asList("foo@bar.com", "bar@foo.com"));
 
-            InternetAddress expectedSender = new InternetAddress("sender@vmware.com");
-            InternetAddress[] expectedRecipients = new InternetAddress[]{
-                    new InternetAddress("foo@bar.com"),
-                    new InternetAddress("bar@foo.com"),
-                    new InternetAddress("receiver@vmware.com")};
-            String expectedSubject = "[run][data job failure] test_job";
-            String expectedContent =
-                    "<p>Dear Data Pipelines user,<br/>\n" +
-                            "Last run of your data job <strong>test_job</strong> has status: failure.</p>\n" +
-                            "\n" +
-                            "<p>The sender mailbox is not monitored, please do not reply to this email.</p>\n" +
-                            "<p>Best,<br/>Example Name</p>\n";
+      InternetAddress expectedSender = new InternetAddress("sender@vmware.com");
+      InternetAddress[] expectedRecipients =
+          new InternetAddress[] {
+            new InternetAddress("foo@bar.com"),
+            new InternetAddress("bar@foo.com"),
+            new InternetAddress("receiver@vmware.com")
+          };
+      String expectedSubject = "[run][data job failure] test_job";
+      String expectedContent =
+          "<p>Dear Data Pipelines user,<br/>\n"
+              + "Last run of your data job <strong>test_job</strong> has status: failure.</p>\n"
+              + "\n"
+              + "<p>The sender mailbox is not monitored, please do not reply to this email.</p>\n"
+              + "<p>Best,<br/>Example Name</p>\n";
 
-
-            Assertions.assertEquals(notificationContent.getSender().getAddress(), expectedSender.getAddress());
-            Assertions.assertArrayEquals(notificationContent.getRecipients(), expectedRecipients);
-            Assertions.assertEquals(notificationContent.getSubject(), expectedSubject);
-            Assertions.assertEquals(notificationContent.getContent(), expectedContent);
-        } catch (AddressException e) {
-            Assertions.fail("Unexpected exception" + e.toString());
-        }
+      Assertions.assertEquals(
+          notificationContent.getSender().getAddress(), expectedSender.getAddress());
+      Assertions.assertArrayEquals(notificationContent.getRecipients(), expectedRecipients);
+      Assertions.assertEquals(notificationContent.getSubject(), expectedSubject);
+      Assertions.assertEquals(notificationContent.getContent(), expectedContent);
+    } catch (AddressException e) {
+      Assertions.fail("Unexpected exception" + e.toString());
     }
+  }
 
-    @Test
-    public void test_address_exception() {
-        JobConfig jobConfig = createInvalidJobConfigStub();
-        try {
-            new NotificationContent(jobConfig, "run", "failure", "Example Name", "@vmware.com", Collections.emptyList());
-        } catch (AddressException e) {
-            Assertions.assertEquals("Missing local name", e.getMessage());
-        }
+  @Test
+  public void test_address_exception() {
+    JobConfig jobConfig = createInvalidJobConfigStub();
+    try {
+      new NotificationContent(
+          jobConfig, "run", "failure", "Example Name", "@vmware.com", Collections.emptyList());
+    } catch (AddressException e) {
+      Assertions.assertEquals("Missing local name", e.getMessage());
     }
+  }
 
+  @Test
+  public void test_error_notification() {
+    JobConfig jobConfig = createValidJobConfigStub();
+    try {
+      NotificationContent notificationContent =
+          new NotificationContent(
+              jobConfig,
+              "run",
+              "failure",
+              "RuntimeError",
+              "Some body",
+              "Example Name",
+              "sender@vmware.com",
+              Collections.emptyList());
 
-    @Test
-    public void test_error_notification() {
-        JobConfig jobConfig = createValidJobConfigStub();
-        try {
-            NotificationContent notificationContent =
-                    new NotificationContent(jobConfig, "run", "failure", "RuntimeError", "Some body", "Example Name", "sender@vmware.com", Collections.emptyList());
+      InternetAddress expectedSender = new InternetAddress("sender@vmware.com");
+      InternetAddress[] expectedRecipients =
+          new InternetAddress[] {new InternetAddress("receiver@vmware.com")};
+      String expectedSubject = "[run][data job failure] test_job";
+      String expectedContent =
+          "<p>Dear Data Pipelines user,<br/>\n"
+              + "Last run of your data job <strong>test_job</strong> has status: failure.</p>\n"
+              + "<p>Data job: test_job error.</p>\n"
+              + "<p>Details:</p>\n"
+              + "<p style=\"padding-left: 30px; color:red;\">RuntimeError</p>\n"
+              + "<p>Some body</p>\n"
+              + "<p>For more information please visit&nbsp;\n"
+              + "<a href=\"https://confluence.eng.vmware.com/display/SUPCR/Data+Pipelines+User+Guide#DataPipelinesUserGuide-Monitoring&amp;Troubleshooting\">Data"
+              + " Pipelines User Guide - Monitoring&amp;Troubleshooting</a>.</p>\n"
+              + "<p>The sender mailbox is not monitored, please do not reply to this email.</p>\n"
+              + "<p>Best,<br/>Example Name</p>\n";
 
-            InternetAddress expectedSender = new InternetAddress("sender@vmware.com");
-            InternetAddress[] expectedRecipients = new InternetAddress[]{new InternetAddress("receiver@vmware.com")};
-            String expectedSubject = "[run][data job failure] test_job";
-            String expectedContent =
-                    "<p>Dear Data Pipelines user,<br/>\n" +
-                            "Last run of your data job <strong>test_job</strong> has status: failure.</p>\n" +
-                            "<p>Data job: test_job error.</p>\n" +
-                            "<p>Details:</p>\n" +
-                            "<p style=\"padding-left: 30px; color:red;\">RuntimeError</p>\n" +
-                            "<p>Some body</p>\n" +
-                            "<p>For more information please visit&nbsp;\n" +
-                            "<a href=\"https://confluence.eng.vmware.com/display/SUPCR/Data+Pipelines+User+Guide#DataPipelinesUserGuide-Monitoring&amp;Troubleshooting\">Data Pipelines User Guide - Monitoring&amp;Troubleshooting</a>.</p>\n" +
-                            "<p>The sender mailbox is not monitored, please do not reply to this email.</p>\n" +
-                            "<p>Best,<br/>Example Name</p>\n";
-
-
-            Assertions.assertEquals(notificationContent.getSender().getAddress(), expectedSender.getAddress());
-            Assertions.assertArrayEquals(notificationContent.getRecipients(), expectedRecipients);
-            Assertions.assertEquals(notificationContent.getSubject(), expectedSubject);
-            Assertions.assertEquals(notificationContent.getContent(), expectedContent);
-        } catch (AddressException e) {
-            Assertions.fail("Unexpected exception" + e.toString());
-        }
+      Assertions.assertEquals(
+          notificationContent.getSender().getAddress(), expectedSender.getAddress());
+      Assertions.assertArrayEquals(notificationContent.getRecipients(), expectedRecipients);
+      Assertions.assertEquals(notificationContent.getSubject(), expectedSubject);
+      Assertions.assertEquals(notificationContent.getContent(), expectedContent);
+    } catch (AddressException e) {
+      Assertions.fail("Unexpected exception" + e.toString());
     }
+  }
 
-    private JobConfig createValidJobConfigStub() {
-        JobConfig jobConfig = new JobConfig();
-        jobConfig.setNotifiedOnJobDeploy(Collections.singletonList("receiver@vmware.com"));
-        jobConfig.setJobName("test_job");
-        return jobConfig;
-    }
+  private JobConfig createValidJobConfigStub() {
+    JobConfig jobConfig = new JobConfig();
+    jobConfig.setNotifiedOnJobDeploy(Collections.singletonList("receiver@vmware.com"));
+    jobConfig.setJobName("test_job");
+    return jobConfig;
+  }
 
-    private JobConfig createInvalidJobConfigStub() {
-        JobConfig jobConfig = new JobConfig();
-        jobConfig.setNotifiedOnJobDeploy(Collections.singletonList("@vmware.com"));
-        jobConfig.setJobName("test_job");
-        return jobConfig;
-    }
+  private JobConfig createInvalidJobConfigStub() {
+    JobConfig jobConfig = new JobConfig();
+    jobConfig.setNotifiedOnJobDeploy(Collections.singletonList("@vmware.com"));
+    jobConfig.setJobName("test_job");
+    return jobConfig;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/upload/FileUtilsTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/upload/FileUtilsTest.java
@@ -22,67 +22,72 @@ import java.util.Arrays;
 
 public class FileUtilsTest {
 
-    @Test
-    public void endToEndFileTest() throws IOException, URISyntaxException {
-        Resource zipResource = new ClassPathResource("file_test/test_job.zip");
-        Path tempDirPathFirst = FileUtils.createTempDir("test1_");
-        Path tempDirPathSecond = FileUtils.createTempDir("test2_");
+  @Test
+  public void endToEndFileTest() throws IOException, URISyntaxException {
+    Resource zipResource = new ClassPathResource("file_test/test_job.zip");
+    Path tempDirPathFirst = FileUtils.createTempDir("test1_");
+    Path tempDirPathSecond = FileUtils.createTempDir("test2_");
 
-        File unzippedFile = FileUtils.unzipDataJob(zipResource, tempDirPathFirst.toFile(), "example");
-        Assertions.assertTrue(unzippedFile.exists());
+    File unzippedFile = FileUtils.unzipDataJob(zipResource, tempDirPathFirst.toFile(), "example");
+    Assertions.assertTrue(unzippedFile.exists());
 
-        FileUtils.copy(unzippedFile.toString(), tempDirPathSecond.toString(), "example");
-        File newTestFileLocation = new File(tempDirPathSecond.toFile(), "example");
-        Assertions.assertTrue(newTestFileLocation.exists());
-        Assertions.assertTrue(newTestFileLocation.isDirectory());
-        Assertions.assertTrue(newTestFileLocation.list().length > 0);
+    FileUtils.copy(unzippedFile.toString(), tempDirPathSecond.toString(), "example");
+    File newTestFileLocation = new File(tempDirPathSecond.toFile(), "example");
+    Assertions.assertTrue(newTestFileLocation.exists());
+    Assertions.assertTrue(newTestFileLocation.isDirectory());
+    Assertions.assertTrue(newTestFileLocation.list().length > 0);
 
-        File secondUnzippedFile = FileUtils.unzipDataJob(zipResource, tempDirPathFirst.toFile(), "example");
-        Assertions.assertTrue(secondUnzippedFile.exists());
-        Assertions.assertTrue(secondUnzippedFile.isDirectory());
-        Assertions.assertTrue(secondUnzippedFile.list().length > 0);
+    File secondUnzippedFile =
+        FileUtils.unzipDataJob(zipResource, tempDirPathFirst.toFile(), "example");
+    Assertions.assertTrue(secondUnzippedFile.exists());
+    Assertions.assertTrue(secondUnzippedFile.isDirectory());
+    Assertions.assertTrue(secondUnzippedFile.list().length > 0);
 
-        FileUtils.copy(secondUnzippedFile.toString(), tempDirPathSecond.toString(), "example");
-        Assertions.assertTrue(newTestFileLocation.exists());
+    FileUtils.copy(secondUnzippedFile.toString(), tempDirPathSecond.toString(), "example");
+    Assertions.assertTrue(newTestFileLocation.exists());
 
-        File renamedTestFile = new File(tempDirPathSecond.toFile(), "new_example");
-        Assertions.assertThrows(IOException.class, () ->
-                FileUtils.renameFile(unzippedFile.getAbsolutePath(), renamedTestFile.getAbsolutePath()));
+    File renamedTestFile = new File(tempDirPathSecond.toFile(), "new_example");
+    Assertions.assertThrows(
+        IOException.class,
+        () ->
+            FileUtils.renameFile(
+                unzippedFile.getAbsolutePath(), renamedTestFile.getAbsolutePath()));
 
-        FileUtils.renameFile(newTestFileLocation.getAbsolutePath(), renamedTestFile.getAbsolutePath());
-        Assertions.assertTrue(renamedTestFile.exists());
+    FileUtils.renameFile(newTestFileLocation.getAbsolutePath(), renamedTestFile.getAbsolutePath());
+    Assertions.assertTrue(renamedTestFile.exists());
 
-        FileUtils.removeDir(tempDirPathFirst);
-        Assertions.assertTrue(!tempDirPathFirst.toFile().exists());
+    FileUtils.removeDir(tempDirPathFirst);
+    Assertions.assertTrue(!tempDirPathFirst.toFile().exists());
 
-        FileUtils.removeDir(tempDirPathSecond);
-        Assertions.assertTrue(!tempDirPathSecond.toFile().exists());
-    }
+    FileUtils.removeDir(tempDirPathSecond);
+    Assertions.assertTrue(!tempDirPathSecond.toFile().exists());
+  }
 
-    @Test
-    public void testZipDirectory(@TempDir Path tempDir) throws IOException {
-        Path directory = Paths.get(tempDir.toString(), "test-directory");
-        Path zipFile = Paths.get(tempDir.toString(), "zip-file");
+  @Test
+  public void testZipDirectory(@TempDir Path tempDir) throws IOException {
+    Path directory = Paths.get(tempDir.toString(), "test-directory");
+    Path zipFile = Paths.get(tempDir.toString(), "zip-file");
 
-        Files.createDirectory(directory);
-        Files.writeString(Paths.get(directory.toString(), "config.ini"), "team=xxx");
-        Path subDir = Paths.get(directory.toString(), "subdir");
-        Files.createDirectory(subDir);
-        Files.writeString(Paths.get(subDir.toString(), "x.py"), "import this");
+    Files.createDirectory(directory);
+    Files.writeString(Paths.get(directory.toString(), "config.ini"), "team=xxx");
+    Path subDir = Paths.get(directory.toString(), "subdir");
+    Files.createDirectory(subDir);
+    Files.writeString(Paths.get(subDir.toString(), "x.py"), "import this");
 
-        FileUtils.zipDataJob(directory.toFile(), zipFile.toFile());
+    FileUtils.zipDataJob(directory.toFile(), zipFile.toFile());
 
-        byte[] zipFileBytes = Files.readAllBytes(zipFile);
-        System.out.println(zipFileBytes.length);
-        Assertions.assertTrue(zipFileBytes.length > 0);
-        // check that valid zip is expected - first 4 chars of every zip match those
-        byte[] zipSignature = {0x50, 0x4b, 0x03, 0x04};
-        Assertions.assertArrayEquals(zipSignature, Arrays.copyOfRange(zipFileBytes, 0, 4));
+    byte[] zipFileBytes = Files.readAllBytes(zipFile);
+    System.out.println(zipFileBytes.length);
+    Assertions.assertTrue(zipFileBytes.length > 0);
+    // check that valid zip is expected - first 4 chars of every zip match those
+    byte[] zipSignature = {0x50, 0x4b, 0x03, 0x04};
+    Assertions.assertArrayEquals(zipSignature, Arrays.copyOfRange(zipFileBytes, 0, 4));
 
-        File unzipped = FileUtils.unzipDataJob(new FileSystemResource(zipFile.toFile()), tempDir.toFile(), "name");
-        Assertions.assertTrue(unzipped.isDirectory());
-        Assertions.assertTrue(new File(unzipped, "config.ini").isFile());
-        Assertions.assertTrue(new File(unzipped, "subdir").isDirectory());
-        Assertions.assertTrue(new File(new File(unzipped, "subdir"), "x.py").isFile());
-    }
+    File unzipped =
+        FileUtils.unzipDataJob(new FileSystemResource(zipFile.toFile()), tempDir.toFile(), "name");
+    Assertions.assertTrue(unzipped.isDirectory());
+    Assertions.assertTrue(new File(unzipped, "config.ini").isFile());
+    Assertions.assertTrue(new File(unzipped, "subdir").isDirectory());
+    Assertions.assertTrue(new File(new File(unzipped, "subdir"), "x.py").isFile());
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/upload/GitCredentialsProviderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/upload/GitCredentialsProviderTest.java
@@ -12,22 +12,22 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 public class GitCredentialsProviderTest {
 
-    @Test
-    public void testProperCredentials() {
-        GitCredentialsProvider credentialsProvider = new GitCredentialsProvider();
-        ReflectionTestUtils.setField(credentialsProvider, "gitReadWriteUsername", "example_user");
-        ReflectionTestUtils.setField(credentialsProvider, "gitReadWritePassword", "z7d766asdv6019cz0a");
+  @Test
+  public void testProperCredentials() {
+    GitCredentialsProvider credentialsProvider = new GitCredentialsProvider();
+    ReflectionTestUtils.setField(credentialsProvider, "gitReadWriteUsername", "example_user");
+    ReflectionTestUtils.setField(credentialsProvider, "gitReadWritePassword", "z7d766asdv6019cz0a");
 
-        CredentialsProvider provider = credentialsProvider.getProvider();
-        Assertions.assertNotNull(provider);
-    }
+    CredentialsProvider provider = credentialsProvider.getProvider();
+    Assertions.assertNotNull(provider);
+  }
 
-    @Test
-    public void testEmptyCredentials() {
-        GitCredentialsProvider credentialsProvider = new GitCredentialsProvider();
-        ReflectionTestUtils.setField(credentialsProvider, "gitReadWriteUsername", "");
-        ReflectionTestUtils.setField(credentialsProvider, "gitReadWritePassword", "");
-        CredentialsProvider provider = credentialsProvider.getProvider();
-        Assertions.assertNotNull(provider);
-    }
+  @Test
+  public void testEmptyCredentials() {
+    GitCredentialsProvider credentialsProvider = new GitCredentialsProvider();
+    ReflectionTestUtils.setField(credentialsProvider, "gitReadWriteUsername", "");
+    ReflectionTestUtils.setField(credentialsProvider, "gitReadWritePassword", "");
+    CredentialsProvider provider = credentialsProvider.getProvider();
+    Assertions.assertNotNull(provider);
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/upload/GitWrapperTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/upload/GitWrapperTest.java
@@ -30,227 +30,242 @@ import java.util.stream.StreamSupport;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class GitWrapperTest {
 
-    private CredentialsProvider credentialsProvider;
+  private CredentialsProvider credentialsProvider;
 
-    private GitWrapper gitWrapper;
+  private GitWrapper gitWrapper;
 
-    private File localRepositoryMock;
+  private File localRepositoryMock;
 
-    private Git git;
+  private Git git;
 
-    private File secondLocalRepositoryMock;
+  private File secondLocalRepositoryMock;
 
-    private Git secondGit;
+  private Git secondGit;
 
-    private File thirdLocalRepositoryMock;
+  private File thirdLocalRepositoryMock;
 
-    private Git thirdGit;
+  private Git thirdGit;
 
-    private File remoteRepositoryMock;
+  private File remoteRepositoryMock;
 
-    private Git remoteGit;
+  private Git remoteGit;
 
-    @BeforeEach
-    public void setup() throws Exception {
-        localRepositoryMock = Files.createTempDir();
-        remoteRepositoryMock = Files.createTempDir();
-        secondLocalRepositoryMock = Files.createTempDir();
-        thirdLocalRepositoryMock = Files.createTempDir();
+  @BeforeEach
+  public void setup() throws Exception {
+    localRepositoryMock = Files.createTempDir();
+    remoteRepositoryMock = Files.createTempDir();
+    secondLocalRepositoryMock = Files.createTempDir();
+    thirdLocalRepositoryMock = Files.createTempDir();
 
-        git = Git.init().setDirectory(localRepositoryMock).call();
-        git.commit().setMessage("Initial commit").call();
+    git = Git.init().setDirectory(localRepositoryMock).call();
+    git.commit().setMessage("Initial commit").call();
 
-        secondGit = Git.init().setDirectory(secondLocalRepositoryMock).call();
-        secondGit.commit().setMessage("Initial commit").call();
+    secondGit = Git.init().setDirectory(secondLocalRepositoryMock).call();
+    secondGit.commit().setMessage("Initial commit").call();
 
-        thirdGit = Git.init().setDirectory(thirdLocalRepositoryMock).call();
-        thirdGit.commit().setMessage("Initial commit").call();
+    thirdGit = Git.init().setDirectory(thirdLocalRepositoryMock).call();
+    thirdGit.commit().setMessage("Initial commit").call();
 
-        remoteGit = Git.init().setDirectory(remoteRepositoryMock).call();
+    remoteGit = Git.init().setDirectory(remoteRepositoryMock).call();
 
-        Git.init().setDirectory(remoteRepositoryMock).call();
-        URIish repoURI = new URIish().setPath(remoteRepositoryMock.getPath());
+    Git.init().setDirectory(remoteRepositoryMock).call();
+    URIish repoURI = new URIish().setPath(remoteRepositoryMock.getPath());
 
-        git.remoteAdd().setUri(repoURI).setName("origin").call();
+    git.remoteAdd().setUri(repoURI).setName("origin").call();
 
-        secondGit.remoteAdd().setUri(repoURI).setName("origin").call();
+    secondGit.remoteAdd().setUri(repoURI).setName("origin").call();
 
-        thirdGit.remoteAdd().setUri(repoURI).setName("origin").call();
+    thirdGit.remoteAdd().setUri(repoURI).setName("origin").call();
 
-        gitWrapper = new GitWrapper("", "", "", true);
+    gitWrapper = new GitWrapper("", "", "", true);
 
-        credentialsProvider = new UsernamePasswordCredentialsProvider("example-user", "example-password");
-    }
+    credentialsProvider =
+        new UsernamePasswordCredentialsProvider("example-user", "example-password");
+  }
 
-    @AfterEach
-    public void cleanup() {
-        localRepositoryMock.delete();
-        secondLocalRepositoryMock.delete();
-        thirdLocalRepositoryMock.delete();
-        remoteRepositoryMock.delete();
-    }
+  @AfterEach
+  public void cleanup() {
+    localRepositoryMock.delete();
+    secondLocalRepositoryMock.delete();
+    thirdLocalRepositoryMock.delete();
+    remoteRepositoryMock.delete();
+  }
 
-    @Test
-    public void testAddFileNoException() throws IOException {
-        File file = new File(localRepositoryMock, "example");
-        file.createNewFile();
+  @Test
+  public void testAddFileNoException() throws IOException {
+    File file = new File(localRepositoryMock, "example");
+    file.createNewFile();
 
-        Assertions.assertDoesNotThrow(() -> gitWrapper.gitAdd(git));
-    }
+    Assertions.assertDoesNotThrow(() -> gitWrapper.gitAdd(git));
+  }
 
-    @Test
-    public void testCommitChanges() throws GitAPIException {
-        RevCommit commit = gitWrapper.commitChanges(git, "user", "example-job", "example-reason");
+  @Test
+  public void testCommitChanges() throws GitAPIException {
+    RevCommit commit = gitWrapper.commitChanges(git, "user", "example-job", "example-reason");
 
-        Assertions.assertEquals("user", commit.getAuthorIdent().getName());
-        Assertions.assertEquals("", commit.getAuthorIdent().getEmailAddress());
-        Assertions.assertTrue(commit.getFullMessage().contains("user"));
-        Assertions.assertTrue(commit.getFullMessage().contains("example-job"));
-        Assertions.assertTrue(commit.getFullMessage().contains("example-reason"));
-    }
+    Assertions.assertEquals("user", commit.getAuthorIdent().getName());
+    Assertions.assertEquals("", commit.getAuthorIdent().getEmailAddress());
+    Assertions.assertTrue(commit.getFullMessage().contains("user"));
+    Assertions.assertTrue(commit.getFullMessage().contains("example-job"));
+    Assertions.assertTrue(commit.getFullMessage().contains("example-reason"));
+  }
 
-    @Test
-    public void testFileCommitSha() throws GitAPIException, IOException {
-        new File(localRepositoryMock, "example").createNewFile();
-        gitWrapper.gitAdd(git);
-        gitWrapper.commitChanges(git, "user", "example-job", "example-reason");
+  @Test
+  public void testFileCommitSha() throws GitAPIException, IOException {
+    new File(localRepositoryMock, "example").createNewFile();
+    gitWrapper.gitAdd(git);
+    gitWrapper.commitChanges(git, "user", "example-job", "example-reason");
 
-        String fileLatestCommitSha = gitWrapper.getLatestCommitSHAFile(git, "example");
+    String fileLatestCommitSha = gitWrapper.getLatestCommitSHAFile(git, "example");
 
-        Assertions.assertFalse(StringUtils.isBlank(fileLatestCommitSha));
-    }
+    Assertions.assertFalse(StringUtils.isBlank(fileLatestCommitSha));
+  }
 
-    @Test
-    public void testRepoCommitSha() throws GitAPIException {
-        String repoLatestCommitSha = gitWrapper.getLatestCommitSHARepository(git);
+  @Test
+  public void testRepoCommitSha() throws GitAPIException {
+    String repoLatestCommitSha = gitWrapper.getLatestCommitSHARepository(git);
 
-        Assertions.assertFalse(StringUtils.isBlank(repoLatestCommitSha));
-    }
+    Assertions.assertFalse(StringUtils.isBlank(repoLatestCommitSha));
+  }
 
-    @Test
-    public void testCommitWithNoUsername() throws GitAPIException, IOException {
-        File file = new File(localRepositoryMock, "example-job-1");
-        file.createNewFile();
-        RevCommit commit = gitWrapper.commitChanges(git, null, "example-job-1", "example-reason");
-
-        Assertions.assertTrue(commit.getFullMessage().contains("example-job-1"));
-    }
-
-
-    @Test
-    public void testPushInvalid(@TempDir Path tempDir) throws GitAPIException, IOException, URISyntaxException {
-        URIish repoURI = new URIish("git@foo:bar.git");
-        git.remoteAdd().setUri(repoURI).setName("origin").call();
-
-        new File(tempDir.toFile(), "05_query.py").createNewFile();
-        FileUtils.copyDirectoryToDirectory(tempDir.toFile(), localRepositoryMock);
-
-        gitWrapper.gitAdd(git);
-
-        Assertions.assertThrows(Exception.class,() ->
-                gitWrapper.pushCreateJob(git, "example-job-1", credentialsProvider, "example-user", null, tempDir.toFile()));
-    }
-
-    @Test
-    public void testConcurrentPushes() throws GitAPIException, IOException {
-        String pushedCommitSHA;
-        String latestCommitSHARepo;
-        String latestCommitSHAFile;
-
-        File jobsBaseFolder1 = Files.createTempDir();
-
-        File jobFolder1 = new File(jobsBaseFolder1.getPath(), "example-job-1");
-        jobFolder1.mkdir();
-
-        File file1 = new File(jobFolder1, "05_query.py");
-        file1.createNewFile();
-        FileUtils.writeStringToFile(file1, "1", Charset.defaultCharset());
-
-        FileUtils.copyDirectoryToDirectory(jobFolder1, localRepositoryMock);
-
-        gitWrapper.gitAdd(git);
-
-        pushedCommitSHA = gitWrapper.pushCreateJob(git, "example-job-1", credentialsProvider, "example-user", null, jobFolder1);
-        latestCommitSHARepo = gitWrapper.getLatestCommitSHARepository(git);
-        latestCommitSHAFile = gitWrapper.getLatestCommitSHAFile(git, "example-job-1");
-
-        remoteGit.reset().setMode(ResetCommand.ResetType.HARD).call();
-
-        File remoteFolder1 = new File(remoteRepositoryMock, jobFolder1.getName());
-        File remoteFileContent1 = new File(remoteFolder1, remoteFolder1.list()[0]);
-        Assertions.assertTrue(remoteFolder1.exists());
-        Assertions.assertTrue(remoteFileContent1.exists());
-        Assertions.assertEquals("1", FileUtils.readFileToString(remoteFileContent1, Charset.defaultCharset()));
-        Assertions.assertEquals("1", FileUtils.readFileToString(remoteFileContent1, Charset.defaultCharset()));
-        Assertions.assertEquals(pushedCommitSHA, latestCommitSHARepo);
-        Assertions.assertEquals(pushedCommitSHA, latestCommitSHAFile);
-        var firstPushCommits = StreamSupport.stream(remoteGit.log().call().spliterator(), false)
-                .collect(Collectors.toList());
-        Assertions.assertEquals(2, firstPushCommits.size());
-
-
-        File jobFolder2 = new File(jobsBaseFolder1.getPath(), "example-job-2");
-        jobFolder2.mkdir();
-
-        File file2 = new File(jobFolder2, "05_query.py");
-        file2.createNewFile();
-        FileUtils.writeStringToFile(file2, "2", Charset.defaultCharset());
-
-        FileUtils.copyDirectoryToDirectory(jobFolder2, secondLocalRepositoryMock);
-
-        gitWrapper.gitAdd(secondGit);
-        pushedCommitSHA = gitWrapper.pushCreateJob(secondGit, "example-job-2", credentialsProvider, "example-user", null, jobFolder2);
-        latestCommitSHARepo = gitWrapper.getLatestCommitSHARepository(secondGit);
-        latestCommitSHAFile = gitWrapper.getLatestCommitSHAFile(secondGit, "example-job-2");
-
-        remoteGit.reset().setMode(ResetCommand.ResetType.HARD).setRef("HEAD").call();
-        File remoteFile2 = new File(remoteRepositoryMock, jobFolder2.getName());
-        File remoteFileContent2 = new File(remoteFile2, remoteFile2.list()[0]);
-        Assertions.assertTrue(remoteFile2.exists());
-        Assertions.assertEquals("2", FileUtils.readFileToString(remoteFileContent2, Charset.defaultCharset()));
-        Assertions.assertTrue(remoteFolder1.exists());
-        Assertions.assertEquals("1", FileUtils.readFileToString(remoteFileContent1, Charset.defaultCharset()));
-        Assertions.assertEquals(pushedCommitSHA, latestCommitSHARepo);
-        Assertions.assertEquals(pushedCommitSHA, latestCommitSHAFile);
-        List<RevCommit> secondPushCommits = StreamSupport.stream(remoteGit.log().call().spliterator(), false)
-                .collect(Collectors.toList());
-        Assertions.assertEquals(3, secondPushCommits.size());
-
-
-        File jobsBaseFolder2 = Files.createTempDir();
-
-        File jobFolder3 = new File(jobsBaseFolder2.getPath(), "example-job-1");
-        jobFolder3.mkdir();
-
-        File file3 = new File(jobFolder3, "05_query.py");
-        file3.createNewFile();
-        FileUtils.writeStringToFile(file3, "3", Charset.defaultCharset());
-
-        FileUtils.copyDirectoryToDirectory(jobFolder3, thirdLocalRepositoryMock);
-
-        gitWrapper.gitAdd(thirdGit);
-        pushedCommitSHA = gitWrapper.pushCreateJob(thirdGit, "example-job-1", credentialsProvider, "example-user", null, jobFolder3);
-        latestCommitSHARepo = gitWrapper.getLatestCommitSHARepository(thirdGit);
-        latestCommitSHAFile = gitWrapper.getLatestCommitSHAFile(thirdGit, "example-job-1");
-
-
-        remoteGit.reset().setMode(ResetCommand.ResetType.HARD).call();
-        Assertions.assertTrue(remoteFile2.exists());
-        Assertions.assertEquals("2", FileUtils.readFileToString(remoteFileContent2, Charset.defaultCharset()));
-        Assertions.assertTrue(remoteFolder1.exists());
-        Assertions.assertEquals("3", FileUtils.readFileToString(remoteFileContent1, Charset.defaultCharset()));
-        Assertions.assertEquals(pushedCommitSHA, latestCommitSHARepo);
-        Assertions.assertEquals(pushedCommitSHA, latestCommitSHAFile);
-
-
-        gitWrapper.pushDeleteJob(secondGit, "example-job-2", credentialsProvider, "example-user", null);
-        remoteGit.reset().setMode(ResetCommand.ResetType.HARD).setRef("HEAD").call();
-        File remoteJobFolder2 = new File(remoteRepositoryMock, "example-job-2");
-        Assertions.assertFalse(remoteJobFolder2.exists());
-
-        var remoteCommits = StreamSupport.stream(remoteGit.log().call().spliterator(), false)
-                .collect(Collectors.toList());;
-        Assertions.assertEquals(5, remoteCommits.size());
-    }
-
+  @Test
+  public void testCommitWithNoUsername() throws GitAPIException, IOException {
+    File file = new File(localRepositoryMock, "example-job-1");
+    file.createNewFile();
+    RevCommit commit = gitWrapper.commitChanges(git, null, "example-job-1", "example-reason");
+
+    Assertions.assertTrue(commit.getFullMessage().contains("example-job-1"));
+  }
+
+  @Test
+  public void testPushInvalid(@TempDir Path tempDir)
+      throws GitAPIException, IOException, URISyntaxException {
+    URIish repoURI = new URIish("git@foo:bar.git");
+    git.remoteAdd().setUri(repoURI).setName("origin").call();
+
+    new File(tempDir.toFile(), "05_query.py").createNewFile();
+    FileUtils.copyDirectoryToDirectory(tempDir.toFile(), localRepositoryMock);
+
+    gitWrapper.gitAdd(git);
+
+    Assertions.assertThrows(
+        Exception.class,
+        () ->
+            gitWrapper.pushCreateJob(
+                git, "example-job-1", credentialsProvider, "example-user", null, tempDir.toFile()));
+  }
+
+  @Test
+  public void testConcurrentPushes() throws GitAPIException, IOException {
+    String pushedCommitSHA;
+    String latestCommitSHARepo;
+    String latestCommitSHAFile;
+
+    File jobsBaseFolder1 = Files.createTempDir();
+
+    File jobFolder1 = new File(jobsBaseFolder1.getPath(), "example-job-1");
+    jobFolder1.mkdir();
+
+    File file1 = new File(jobFolder1, "05_query.py");
+    file1.createNewFile();
+    FileUtils.writeStringToFile(file1, "1", Charset.defaultCharset());
+
+    FileUtils.copyDirectoryToDirectory(jobFolder1, localRepositoryMock);
+
+    gitWrapper.gitAdd(git);
+
+    pushedCommitSHA =
+        gitWrapper.pushCreateJob(
+            git, "example-job-1", credentialsProvider, "example-user", null, jobFolder1);
+    latestCommitSHARepo = gitWrapper.getLatestCommitSHARepository(git);
+    latestCommitSHAFile = gitWrapper.getLatestCommitSHAFile(git, "example-job-1");
+
+    remoteGit.reset().setMode(ResetCommand.ResetType.HARD).call();
+
+    File remoteFolder1 = new File(remoteRepositoryMock, jobFolder1.getName());
+    File remoteFileContent1 = new File(remoteFolder1, remoteFolder1.list()[0]);
+    Assertions.assertTrue(remoteFolder1.exists());
+    Assertions.assertTrue(remoteFileContent1.exists());
+    Assertions.assertEquals(
+        "1", FileUtils.readFileToString(remoteFileContent1, Charset.defaultCharset()));
+    Assertions.assertEquals(
+        "1", FileUtils.readFileToString(remoteFileContent1, Charset.defaultCharset()));
+    Assertions.assertEquals(pushedCommitSHA, latestCommitSHARepo);
+    Assertions.assertEquals(pushedCommitSHA, latestCommitSHAFile);
+    var firstPushCommits =
+        StreamSupport.stream(remoteGit.log().call().spliterator(), false)
+            .collect(Collectors.toList());
+    Assertions.assertEquals(2, firstPushCommits.size());
+
+    File jobFolder2 = new File(jobsBaseFolder1.getPath(), "example-job-2");
+    jobFolder2.mkdir();
+
+    File file2 = new File(jobFolder2, "05_query.py");
+    file2.createNewFile();
+    FileUtils.writeStringToFile(file2, "2", Charset.defaultCharset());
+
+    FileUtils.copyDirectoryToDirectory(jobFolder2, secondLocalRepositoryMock);
+
+    gitWrapper.gitAdd(secondGit);
+    pushedCommitSHA =
+        gitWrapper.pushCreateJob(
+            secondGit, "example-job-2", credentialsProvider, "example-user", null, jobFolder2);
+    latestCommitSHARepo = gitWrapper.getLatestCommitSHARepository(secondGit);
+    latestCommitSHAFile = gitWrapper.getLatestCommitSHAFile(secondGit, "example-job-2");
+
+    remoteGit.reset().setMode(ResetCommand.ResetType.HARD).setRef("HEAD").call();
+    File remoteFile2 = new File(remoteRepositoryMock, jobFolder2.getName());
+    File remoteFileContent2 = new File(remoteFile2, remoteFile2.list()[0]);
+    Assertions.assertTrue(remoteFile2.exists());
+    Assertions.assertEquals(
+        "2", FileUtils.readFileToString(remoteFileContent2, Charset.defaultCharset()));
+    Assertions.assertTrue(remoteFolder1.exists());
+    Assertions.assertEquals(
+        "1", FileUtils.readFileToString(remoteFileContent1, Charset.defaultCharset()));
+    Assertions.assertEquals(pushedCommitSHA, latestCommitSHARepo);
+    Assertions.assertEquals(pushedCommitSHA, latestCommitSHAFile);
+    List<RevCommit> secondPushCommits =
+        StreamSupport.stream(remoteGit.log().call().spliterator(), false)
+            .collect(Collectors.toList());
+    Assertions.assertEquals(3, secondPushCommits.size());
+
+    File jobsBaseFolder2 = Files.createTempDir();
+
+    File jobFolder3 = new File(jobsBaseFolder2.getPath(), "example-job-1");
+    jobFolder3.mkdir();
+
+    File file3 = new File(jobFolder3, "05_query.py");
+    file3.createNewFile();
+    FileUtils.writeStringToFile(file3, "3", Charset.defaultCharset());
+
+    FileUtils.copyDirectoryToDirectory(jobFolder3, thirdLocalRepositoryMock);
+
+    gitWrapper.gitAdd(thirdGit);
+    pushedCommitSHA =
+        gitWrapper.pushCreateJob(
+            thirdGit, "example-job-1", credentialsProvider, "example-user", null, jobFolder3);
+    latestCommitSHARepo = gitWrapper.getLatestCommitSHARepository(thirdGit);
+    latestCommitSHAFile = gitWrapper.getLatestCommitSHAFile(thirdGit, "example-job-1");
+
+    remoteGit.reset().setMode(ResetCommand.ResetType.HARD).call();
+    Assertions.assertTrue(remoteFile2.exists());
+    Assertions.assertEquals(
+        "2", FileUtils.readFileToString(remoteFileContent2, Charset.defaultCharset()));
+    Assertions.assertTrue(remoteFolder1.exists());
+    Assertions.assertEquals(
+        "3", FileUtils.readFileToString(remoteFileContent1, Charset.defaultCharset()));
+    Assertions.assertEquals(pushedCommitSHA, latestCommitSHARepo);
+    Assertions.assertEquals(pushedCommitSHA, latestCommitSHAFile);
+
+    gitWrapper.pushDeleteJob(secondGit, "example-job-2", credentialsProvider, "example-user", null);
+    remoteGit.reset().setMode(ResetCommand.ResetType.HARD).setRef("HEAD").call();
+    File remoteJobFolder2 = new File(remoteRepositoryMock, "example-job-2");
+    Assertions.assertFalse(remoteJobFolder2.exists());
+
+    var remoteCommits =
+        StreamSupport.stream(remoteGit.log().call().spliterator(), false)
+            .collect(Collectors.toList());
+    ;
+    Assertions.assertEquals(5, remoteCommits.size());
+  }
 }


### PR DESCRIPTION
We have settled on using Google Java coding style . This is adding
github action to automatically format the code.

I nitially wanted to use pre-commit hook
(https://github.com/macisamuele/language-formatters-pre-commit-hooks)
but it requires to have installed locally java and I could not figuore
out how to make it optional for local runs.


Signed-off-by: Antoni Ivanov <aivanov@vmware.com>