### PR TITLE
vdk-heartbeat: Fix initial job executions with specific vdk version

### DIFF
--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/hearbeat.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/hearbeat.py
@@ -42,7 +42,7 @@ class Heartbeat:
 
             run_test.setup()
 
-            job_controller.enable_deployment_and_update_vdk_version()
+            job_controller.enable_deployment()
             job_controller.show_job_details()
 
             run_test.execute_test()

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
@@ -57,7 +57,6 @@ class JobController:
     def __get_vdk_version_arg(self):
         if self.config.deploy_job_vdk_version:
             return [
-                "--update",
                 "--vdk-version",
                 f"{self.config.deploy_job_vdk_version}",
             ]
@@ -246,7 +245,7 @@ class JobController:
         )
 
     @LogDecorator(log)
-    def enable_deployment_and_update_vdk_version(self):
+    def enable_deployment(self):
         self._execute(
             [
                 "deploy",
@@ -256,7 +255,6 @@ class JobController:
                 "-t",
                 self.config.job_team,
             ]
-            + self.__get_vdk_version_arg()
             + self.__get_rest_api_url_arg()
         )
 
@@ -293,6 +291,7 @@ class JobController:
                     "-r",
                     "Updating heartbeat data job",
                 ]
+                + self.__get_vdk_version_arg()
                 + self.__get_rest_api_url_arg()
             )
 


### PR DESCRIPTION
When vdk-heartbeat is run with a configured vdk version
(VDK_HEARTBEAT_DEPLOY_JOB_VDK_VERSION) sometimes the cron job
manages to start an execution before actually setting the
deployment vdk_version. This happens because vdk_version is
set with a separate update deployment
call (function enable_deployment_and_update_vdk_version)
after the deployment was ready.

Move setting vdk_version in the create deployment command.

Testing Done: locally tested vdk-heartbeat against demo
control service with set VDK_HEARTBEAT_DEPLOY_JOB_VDK_VERSION
and observed that all execution pods used the specified
vdk version image.

Signed-off-by: Yana Zhivkova <yzhivkova@vmware.com>