### PR TITLE
vdk-server: bugfix in running status check

### DIFF
--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/installer.py
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/installer.py
@@ -793,7 +793,9 @@ class Installer:
     @staticmethod
     def __control_service_is_up():
         with server_plugin_utils.requests_retry_session() as s:
-            response: requests.Response = s.get("http://localhost:8092")
+            response: requests.Response = s.get(
+                "http://localhost:8092/data-jobs/swagger-ui.html"
+            )
             if response.status_code < 300:
                 log.debug("Control Service at http://localhost:8092 is UP.")
             else:


### PR DESCRIPTION
The check if the service is up was using bad URL (which was returning
404) so `vdk server -s` is always returning that it is down

Testing Done: installed locally vdk server (`vdk server -i`) and check
its status was correctly returned with `vdk server -s`

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>