### PR TITLE
[helm-chart]: add kerberos auth properties to helm chart

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -206,6 +206,14 @@ spec:
             - name: DATAJOBS_EXECUTIONS_LOGS_URL_END_TIME_OFFSET_SECONDS
               value: "{{ .Values.dataJob.executions.logsUrl.endTimeOffsetSeconds }}"
             {{- end }}
+#            {{- if .Values.security.kerberos.enabled }}
+#            - name: SECURITY_KERBEROS_KERBEROS_PRINCIPAL
+#              value: "{{ .Values.security.kerberos.kerberosPrincipal }}"
+#            - name: SECURITY_KERBEROS_KEYTAB_FILE_LOCATION
+#              value: "{{ .Values.security.kerberos.keytabFileLocation}}"
+#            - name: SECURITY_KERBEROS_KRB5_CONFIG_LOCATION
+#              value: "{{ .Values.security.kerberos.krb5ConfigLocation}}"
+#            {{- end }}
 {{- if .Values.extraVars }}
 {{ toYaml .Values.extraVars | indent 12 }}
 {{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -209,12 +209,12 @@ spec:
             {{- if .Values.security.kerberos.enabled }}
             - name: SECURITY_KERBEROS_ENABLED
               value: "{{ .Values.security.kerberos.enabled }}"
-            - name: SECURITY_KERBEROS_KERBEROS_PRINCIPAL
-              value: "{{ .Values.security.kerberos.kerberosPrincipal }}"
-            - name: SECURITY_KERBEROS_KEYTAB_FILE_LOCATION
-              value: "{{ .Values.security.kerberos.kerberosMountPath}}/{{ .Values.security.kerberos.keytabFileName }}"
+            - name: SECURITY_KERBEROS_SERVICE_PRINCIPAL
+              value: "{{ .Values.security.kerberos.kerberosServicePrincipal }}"
+            - name: SECURITY_KERBEROS_SERVICE_KEYTAB_FILE_LOCATION
+              value: "/etc/security/kerberos/authenticator-keytab-file.keytab"
             - name: SECURITY_KERBEROS_KRB5_CONFIG_LOCATION
-              value: "{{ .Values.security.kerberos.kerberosMountPath}}/{{ .Values.security.kerberos.krb5ConfigFileName }}"
+              value: "/etc/secrets/krb5.conf"
             {{- end }}
 {{- if .Values.extraVars }}
 {{ toYaml .Values.extraVars | indent 12 }}
@@ -233,7 +233,7 @@ spec:
             {{- end }}
             {{- if .Values.security.kerberos.enabled }}
             - name: kubernetes-authenticator-secret
-              mountPath: {{ .Values.security.kerberos.kerberosMountPath }}
+              mountPath: "/etc/security/kerberos"
             {{- end }}
           {{- if .Values.resources }}
           resources: {{ toYaml .Values.resources | nindent 12 }}
@@ -295,10 +295,8 @@ spec:
           secret:
             secretName: kubernetes-authenticator-secret
             items:
-              - key: {{ .Values.security.kerberos.krb5ConfigFileName }}
-                path: {{ .Values.security.kerberos.krb5ConfigFileName }}
-              - key: {{ .Values.security.kerberos.keytabFileName }}
-                path: {{ .Values.security.kerberos.keytabFileName }}
+              - key: authenticator-keytab-file.keytab
+                path: authenticator-keytab-file.keytab
         {{- end }}
         {{- if .Values.datajobTemplate.enabled }}
         - name: datajob-template-volume

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -206,14 +206,16 @@ spec:
             - name: DATAJOBS_EXECUTIONS_LOGS_URL_END_TIME_OFFSET_SECONDS
               value: "{{ .Values.dataJob.executions.logsUrl.endTimeOffsetSeconds }}"
             {{- end }}
-#            {{- if .Values.security.kerberos.enabled }}
-#            - name: SECURITY_KERBEROS_KERBEROS_PRINCIPAL
-#              value: "{{ .Values.security.kerberos.kerberosPrincipal }}"
-#            - name: SECURITY_KERBEROS_KEYTAB_FILE_LOCATION
-#              value: "{{ .Values.security.kerberos.keytabFileLocation}}"
-#            - name: SECURITY_KERBEROS_KRB5_CONFIG_LOCATION
-#              value: "{{ .Values.security.kerberos.krb5ConfigLocation}}"
-#            {{- end }}
+            {{- if .Values.security.kerberos.enabled }}
+            - name: SECURITY_KERBEROS_ENABLED
+              value: "{{ .Values.security.kerberos.enabled }}"
+            - name: SECURITY_KERBEROS_KERBEROS_PRINCIPAL
+              value: "{{ .Values.security.kerberos.kerberosPrincipal }}"
+            - name: SECURITY_KERBEROS_KEYTAB_FILE_LOCATION
+              value: "{{ .Values.security.kerberos.kerberosMountPath}}/{{ .Values.security.kerberos.keytabFileName }}"
+            - name: SECURITY_KERBEROS_KRB5_CONFIG_LOCATION
+              value: "{{ .Values.security.kerberos.kerberosMountPath}}/{{ .Values.security.kerberos.krb5ConfigFileName }}"
+            {{- end }}
 {{- if .Values.extraVars }}
 {{ toYaml .Values.extraVars | indent 12 }}
 {{- end }}
@@ -228,6 +230,10 @@ spec:
             {{- if .Values.datajobTemplate.enabled }}
             - name: datajob-template-volume
               mountPath: "/etc/datajobs"
+            {{- end }}
+            {{- if .Values.security.kerberos.enabled }}
+            - name: kubernetes-authenticator-secret
+              mountPath: {{ .Values.security.kerberos.kerberosMountPath }}
             {{- end }}
           {{- if .Values.resources }}
           resources: {{ toYaml .Values.resources | nindent 12 }}
@@ -284,6 +290,16 @@ spec:
                 path: krb5.conf
               - key: vdk-options.ini
                 path: vdk-options.ini
+        {{- if .Values.security.kerberos.enabled }}
+        - name : kubernetes-authenticator-secret
+          secret:
+            secretName: kubernetes-authenticator-secret
+            items:
+              - key: {{ .Values.security.kerberos.krb5ConfigFileName }}
+                path: {{ .Values.security.kerberos.krb5ConfigFileName }}
+              - key: {{ .Values.security.kerberos.keytabFileName }}
+                path: {{ .Values.security.kerberos.keytabFileName }}
+        {{- end }}
         {{- if .Values.datajobTemplate.enabled }}
         - name: datajob-template-volume
           configMap:

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_kubernetes_authenticator.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_kubernetes_authenticator.yaml
@@ -1,6 +1,6 @@
 ## Create a secret with Kerberos keytab for authentication if kerberos authentication flag is turned on.
-## The keytab and krb5.conf files' contents are set from the values.yaml chart and are intended to be
-## populated by an environment variable.
+## The keytab file contents are set from the values.yaml file and are intended to be populated by an env
+## variable.
 {{- if .Values.security.kerberos.enabled }}
 apiVersion: v1
 kind: Secret
@@ -10,6 +10,5 @@ metadata:
   labels: {{- include "pipelines-control-service.labels" . | nindent 4 }}
 type: Opaque
 data:
-  authenticator-keytab-file.keytab: {{ default "" .Values.security.kerberos.keytabFileContents | b64enc | quote }}
-  krb5.conf: {{ default "" .Values.security.kerberos.krb5ConfigContents | b64enc | quote }}
+  authenticator-keytab-file.keytab: {{ default "" .Values.security.kerberos.kerberosServiceKeytab | b64enc | quote }}
 {{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_kubernetes_authenticator.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_kubernetes_authenticator.yaml
@@ -1,0 +1,15 @@
+## Create a secret with Kerberos keytab for authentication if kerberos authentication flag is turned on.
+## The keytab and krb5.conf files' contents are set from the values.yaml chart and are intended to be
+## populated by an environment variable.
+{{- if .Values.security.kerberos.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubernetes-authenticator-secret
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "pipelines-control-service.labels" . | nindent 4 }}
+type: Opaque
+data:
+  authenticator-keytab-file.keytab: {{ default "" .Values.security.kerberos.keytabFileContents | b64enc | quote }}
+  krb5.conf: {{ default "" .Values.security.kerberos.krb5ConfigContents | b64enc | quote }}
+{{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -320,6 +320,19 @@ security:
 
       ## [ Required if security.enabled = True ]
       jwtIssuerUrl: ""
+#    kerberos:
+#      ## These values contain configuration settings for the kerberos authentication provider in control-service.
+#      enabled: false
+#      ## A string which contains the kerberos principal
+#      ## [ Required if kerberos.enabled = True ]
+#      kerberosPrincipal:
+#      ## Path(URI) to the keytab file location, needed to configure the KerberosAuthProvider in control-service
+#      ## [ Required if kerberos.enabled = True ]
+#      keytabFileLocation:
+#      ## Path(URI) to the krb5 config file location, needed to configure the KerberosAuthProvider in control-service
+#      ## [ Required if kerberos.enabled = True ]
+#      krb5ConfigLocation:
+
 
    ## Feature flag to enable/disable authorization
    authorizationEnabled: false

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -112,7 +112,6 @@ credentials:
    kerberosKadminUser: ""
    kerberosKadminPassword: ""
 
-
 ## The owner name and email address that will be used to send all Versatile Data Kit related email notifications.
 notificationOwnerEmail: "taurus@vmware.com"
 notificationOwnerName: "Versatile Data Kit"
@@ -326,35 +325,24 @@ security:
       ## which get picked up by our spring application (contorl-service)
       ## on startup. More information about kerberos and spring can be found here:
       ## https://docs.spring.io/spring-security-kerberos/docs/current/reference/htmlsingle/index.html
-      ## You only need to set the flag and file contents with correct values and kerberos authentication should work,
+      ## You only need to set the flag and property contents with correct values and kerberos authentication should work,
       ## provided global security is enabled.
-      ## Flag to determine whether kerberos authentication should be enabled/disabled
+      ##
+      ## The krb5.conf file that we use is the one specified in the credentials section and is required for kerberos
+      ## authentication to work. If kerberos authentication is enabled make sure the kerberosKrb5Conf property is set in
+      ## the credentials section as described in the documentation.
+      ##
+      ## Flag to determine whether kerberos authorization should be enabled/disabled
       enabled: false
-      ## This is the path to which the kerberos authentication configuration files will be mounted in the pod.
-      ## [ Required if kerberos.enabled = True ]
-      kerberosMountPath : "/etc/security/kerberos"
-      ## A string which contains the kerberos principal
-      ## [ Required if kerberos.enabled = True ]
       ## For more information on kerberos principal please review the official kerberos documentation:
       ## https://web.mit.edu/kerberos/krb5-1.5/krb5-1.5.4/doc/krb5-user/What-is-a-Kerberos-Principal_003f.html
-      kerberosPrincipal: ""
-      ## This is the filename of the keytab file
-      ## The contents of the variable keytabFileContents will be mounted as a secret to the specified path
-      ## essentially the file name, and it's contents.
+      kerberosServicePrincipal: ""
       ## [ Required if kerberos.enabled = True ]
+      ## Contents of kerberos keytab used for authorization against control-service.
       ## For more information on kerberos keytabs please review the official kerberos documentation:
       ## https://web.mit.edu/kerberos/krb5-devel/doc/basic/keytab_def.html
-      keytabFileName: "authenticator-keytab-file.keytab"
-      keytabFileContents: ""
-      ## Path(URI) to the krb5 config file location, needed to configure the KerberosAuthProvider in control-service
-      ## The contents of the variable will be mounted as a secret to the specified path.
-      ## [ Required if kerberos.enabled = True ]
-      ## For more information on kerberos configuration files please review the official kerberos documentation:
-      ## https://web.mit.edu/kerberos/krb5-1.12/doc/admin/conf_files/krb5_conf.html
-      krb5ConfigFileName: "krb5.conf"
-      krb5ConfigContents: ""
-
-
+      ## You may use e.g. helm --set-file <filename.keytab> to set the contents of the file.
+      kerberosServiceKeytab: ""
 
    ## Feature flag to enable/disable authorization
    authorizationEnabled: false

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -320,18 +320,40 @@ security:
 
       ## [ Required if security.enabled = True ]
       jwtIssuerUrl: ""
-#    kerberos:
-#      ## These values contain configuration settings for the kerberos authentication provider in control-service.
-#      enabled: false
-#      ## A string which contains the kerberos principal
-#      ## [ Required if kerberos.enabled = True ]
-#      kerberosPrincipal:
-#      ## Path(URI) to the keytab file location, needed to configure the KerberosAuthProvider in control-service
-#      ## [ Required if kerberos.enabled = True ]
-#      keytabFileLocation:
-#      ## Path(URI) to the krb5 config file location, needed to configure the KerberosAuthProvider in control-service
-#      ## [ Required if kerberos.enabled = True ]
-#      krb5ConfigLocation:
+   kerberos:
+      ## These values contain configuration settings for the kerberos authentication provider in control-service.
+      ## The values are exposed as environment variables through the helm chart
+      ## which get picked up by our spring application (contorl-service)
+      ## on startup. More information about kerberos and spring can be found here:
+      ## https://docs.spring.io/spring-security-kerberos/docs/current/reference/htmlsingle/index.html
+      ## You only need to set the flag and file contents with correct values and kerberos authentication should work,
+      ## provided global security is enabled.
+      ## Flag to determine whether kerberos authentication should be enabled/disabled
+      enabled: false
+      ## This is the path to which the kerberos authentication configuration files will be mounted in the pod.
+      ## [ Required if kerberos.enabled = True ]
+      kerberosMountPath : "/etc/security/kerberos"
+      ## A string which contains the kerberos principal
+      ## [ Required if kerberos.enabled = True ]
+      ## For more information on kerberos principal please review the official kerberos documentation:
+      ## https://web.mit.edu/kerberos/krb5-1.5/krb5-1.5.4/doc/krb5-user/What-is-a-Kerberos-Principal_003f.html
+      kerberosPrincipal: ""
+      ## This is the filename of the keytab file
+      ## The contents of the variable keytabFileContents will be mounted as a secret to the specified path
+      ## essentially the file name, and it's contents.
+      ## [ Required if kerberos.enabled = True ]
+      ## For more information on kerberos keytabs please review the official kerberos documentation:
+      ## https://web.mit.edu/kerberos/krb5-devel/doc/basic/keytab_def.html
+      keytabFileName: "authenticator-keytab-file.keytab"
+      keytabFileContents: ""
+      ## Path(URI) to the krb5 config file location, needed to configure the KerberosAuthProvider in control-service
+      ## The contents of the variable will be mounted as a secret to the specified path.
+      ## [ Required if kerberos.enabled = True ]
+      ## For more information on kerberos configuration files please review the official kerberos documentation:
+      ## https://web.mit.edu/kerberos/krb5-1.12/doc/admin/conf_files/krb5_conf.html
+      krb5ConfigFileName: "krb5.conf"
+      krb5ConfigContents: ""
+
 
 
    ## Feature flag to enable/disable authorization

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -325,6 +325,8 @@ security:
       ## which get picked up by our spring application (contorl-service)
       ## on startup. More information about kerberos and spring can be found here:
       ## https://docs.spring.io/spring-security-kerberos/docs/current/reference/htmlsingle/index.html
+      ## More information on kerberos authentication can be found here:
+      ## https://docs.oracle.com/cd/E23941_01/E26092/html/kerberos-auth.html
       ## You only need to set the flag and property contents with correct values and kerberos authentication should work,
       ## provided global security is enabled.
       ##

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -334,13 +334,15 @@ security:
       ## authentication to work. If kerberos authentication is enabled make sure the kerberosKrb5Conf property is set in
       ## the credentials section as described in the documentation.
       ##
-      ## Flag to determine whether kerberos authorization should be enabled/disabled
+      ## Flag to determine whether kerberos authentication should be enabled/disabled
       enabled: false
+      ## The service principal of the application, for example
+      ## "HTTP/full-qualified-domain-name@DOMAIN".
       ## For more information on kerberos principal please review the official kerberos documentation:
       ## https://web.mit.edu/kerberos/krb5-1.5/krb5-1.5.4/doc/krb5-user/What-is-a-Kerberos-Principal_003f.html
       kerberosServicePrincipal: ""
       ## [ Required if kerberos.enabled = True ]
-      ## Contents of kerberos keytab used for authorization against control-service.
+      ## The keytab must contain the key for this principal.
       ## For more information on kerberos keytabs please review the official kerberos documentation:
       ## https://web.mit.edu/kerberos/krb5-devel/doc/basic/keytab_def.html
       ## You may use e.g. helm --set-file <filename.keytab> to set the contents of the file.

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -144,8 +144,9 @@ mail.smtp.host=smtp.vmware.com
 # See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
 datajobs.deployment.builder.imagePullPolicy=IfNotPresent
 
-#Settings for Kerberos authorization provider.
-datajobs.security.kerberos.kerberosPrincipal=${SECURITY_KERBEROS_KERBEROS_PRINCIPAL:""}
-datajobs.security.kerberos.keytabFileLocation=${SECURITY_KERBEROS_KEYTAB_FILE_LOCATION:}
-datajobs.security.kerberos.krb5ConfigLocation=${SECURITY_KERBEROS_KRB5_CONFIG_LOCATION:}
+# Settings for Kerberos authorization provider.
 datajobs.security.kerberos.enabled=${SECURITY_KERBEROS_ENABLED:false}
+# Properties mandatory if datajobs.security.kerberos.enabled=true
+datajobs.security.kerberos.kerberosPrincipal=${SECURITY_KERBEROS_SERVICE_PRINCIPAL:""}
+datajobs.security.kerberos.keytabFileLocation=${SECURITY_KERBEROS_SERVICE_KEYTAB_FILE_LOCATION:}
+datajobs.security.kerberos.krb5ConfigLocation=${SECURITY_KERBEROS_KRB5_CONFIG_LOCATION:}

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -146,7 +146,7 @@ mail.smtp.host=smtp.vmware.com
 # See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
 datajobs.deployment.builder.imagePullPolicy=IfNotPresent
 
-# Settings for Kerberos authorization provider.
+# Settings for Kerberos authentication provider.
 datajobs.security.kerberos.enabled=${SECURITY_KERBEROS_ENABLED:false}
 # Properties mandatory if datajobs.security.kerberos.enabled=true
 datajobs.security.kerberos.kerberosPrincipal=${SECURITY_KERBEROS_SERVICE_PRINCIPAL:""}

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -145,7 +145,7 @@ mail.smtp.host=smtp.vmware.com
 datajobs.deployment.builder.imagePullPolicy=IfNotPresent
 
 #Settings for Kerberos authorization provider.
-datajobs.security.kerberos.kerberosPrincipal=""
-datajobs.security.kerberos.keytabFileLocation=
-datajobs.security.kerberos.krb5ConfigLocation=
-datajobs.security.kerberos.enabled=false
+datajobs.security.kerberos.kerberosPrincipal=${SECURITY_KERBEROS_KERBEROS_PRINCIPAL:""}
+datajobs.security.kerberos.keytabFileLocation=${SECURITY_KERBEROS_KEYTAB_FILE_LOCATION:}
+datajobs.security.kerberos.krb5ConfigLocation=${SECURITY_KERBEROS_KRB5_CONFIG_LOCATION:}
+datajobs.security.kerberos.enabled=${SECURITY_KERBEROS_ENABLED:false}


### PR DESCRIPTION
what: Added new properties to the helm chart as requested here:
https://github.com/vmware/versatile-data-kit/pull/755#discussion_r820856704
The new properties expose kerberos authentication configuration properties
in the helm chart which are propagated to control-service.

why: We are introducing a new KerberosAuthProvider in control-service
and we need to expose configuration properties through the helm chart.

testing: Deployed on local minikube cluster. Made sure secret is created
and populated with correct files. Inspected control-service pods, made sure
the new env variables are present and that secrets exist.

Signed-off-by: Momchil Zhivkov <mzhivkov@vmware.com>