### PR TITLE
[vdk-core][vdk-control-cli] Adopt click version 8.0

### DIFF
--- a/projects/vdk-control-cli/requirements.txt
+++ b/projects/vdk-control-cli/requirements.txt
@@ -1,6 +1,6 @@
 # install dependencies used during development:
 # Usually same (version may be different) as install_requires in setup.cfg
-click~=7.1.2
+click~=8.0
 click-spinner
 
 # Dependencies license report:

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli.py
@@ -73,7 +73,7 @@ vdk deploy --update --job-version <job-version-here> -n example-job -t job-team
 @click.option(
     "--create",
     "operation",
-    flag_value=DeployOperation.CREATE,
+    flag_value=DeployOperation.CREATE.value,
     default=True,
     help="Create a new deployment of a Data Job. "
     "You must set job path (--job-path) with the directory of the Data Job. "
@@ -86,7 +86,7 @@ vdk deploy --update --job-version <job-version-here> -n example-job -t job-team
 @click.option(
     "--remove",
     "operation",
-    flag_value=DeployOperation.REMOVE,
+    flag_value=DeployOperation.REMOVE.value,
     help="Remove a deployment, so job will not be scheduled any more for execution. "
     "Currently running job will be allowed to finish.",
 )
@@ -94,7 +94,7 @@ vdk deploy --update --job-version <job-version-here> -n example-job -t job-team
     "--update",
     "operation",
     hidden=True,
-    flag_value=DeployOperation.UPDATE,
+    flag_value=DeployOperation.UPDATE.value,
     help="Update specified deployment version of a Data Job for a cloud execution. "
     "It is used to revert to previous version. "
     "Deploy specific configuration will not be updated. "
@@ -119,7 +119,7 @@ vdk deploy --update --job-version <job-version-here> -n example-job -t job-team
 @click.option(
     "--show",
     "operation",
-    flag_value=DeployOperation.SHOW,
+    flag_value=DeployOperation.SHOW.value,
     help="Shows details about deployed job.",
 )
 @click.option(
@@ -172,7 +172,7 @@ def deploy(
     output: str,
 ):
     cmd = JobDeploy(rest_api_url, output)
-    if operation == DeployOperation.UPDATE or enabled is not None:
+    if operation == DeployOperation.UPDATE.value or enabled is not None:
         name = get_or_prompt("Job Name", name)
         team = get_or_prompt("Job Team", team)
         # default to ask for job version to update
@@ -185,15 +185,15 @@ def deploy(
             )
         else:
             return cmd.update(name, team, enabled, job_version, vdk_version, output)
-    if operation == DeployOperation.REMOVE:
+    if operation == DeployOperation.REMOVE.value:
         name = get_or_prompt("Job Name", name)
         team = get_or_prompt("Job Team", team)
         return cmd.remove(name, team)
-    if operation == DeployOperation.SHOW:
+    if operation == DeployOperation.SHOW.value:
         name = get_or_prompt("Job Name", name)
         team = get_or_prompt("Job Team", team)
         return cmd.show(name, team, output)
-    if operation == DeployOperation.CREATE:
+    if operation == DeployOperation.CREATE.value:
         job_path = get_or_prompt("Job Path", job_path)
         default_name = os.path.basename(job_path)
         name = get_or_prompt("Job Name", name, default_name)

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/execute.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/execute.py
@@ -233,14 +233,14 @@ vdk execute --logs -n example-job -t "Example Team" --execution-id example-job-1
 @click.option(
     "--start",
     "operation",
-    flag_value=ExecuteOperation.START,
+    flag_value=ExecuteOperation.START.value,
     help="Start execution of a Data Job. ",
 )
 @click.option(
     "--wait",
     "operation",
     hidden=True,
-    flag_value=ExecuteOperation.WAIT,
+    flag_value=ExecuteOperation.WAIT.value,
     help="Wait for current job execution (if any) to finish "
     "(if specified execution id wait for execution with given id to finish)."
     "Require --execution-id to be provided. "
@@ -249,27 +249,27 @@ vdk execute --logs -n example-job -t "Example Team" --execution-id example-job-1
 @click.option(
     "--cancel",
     "operation",
-    flag_value=ExecuteOperation.CANCEL,
+    flag_value=ExecuteOperation.CANCEL.value,
     help="Cancels a running or submitted Data Job execution. Requires --execution-id to be provided. "
     "Should be printed when using vdk execute --start",
 )
 @click.option(
     "--list",
     "operation",
-    flag_value=ExecuteOperation.LIST,
+    flag_value=ExecuteOperation.LIST.value,
     help="List recent and/or current executions of the Data Job. ",
 )
 @click.option(
     "--show",
     "operation",
-    flag_value=ExecuteOperation.SHOW,
+    flag_value=ExecuteOperation.SHOW.value,
     help="Shows details Data Job Executions. Requires --execution-id to be provided. "
     "Should be printed when using vdk execute --start",
 )
 @click.option(
     "--logs",
     "operation",
-    flag_value=ExecuteOperation.LOGS,
+    flag_value=ExecuteOperation.LOGS.value,
     help="Shows logs about Data Job Execution. It will either provide link to central logging system or"
     " print the logs locally."
     "If --execution-id is omitted, it will fetch logs from more recently started job execution."
@@ -292,26 +292,26 @@ def execute(
     name, team, execution_id, operation, rest_api_url, output, arguments
 ) -> None:
     cmd = JobExecute(rest_api_url)
-    if operation == ExecuteOperation.START:
+    if operation == ExecuteOperation.START.value:
         name = get_or_prompt("Job Name", name)
         cmd.start(name, team, output, arguments)
-    elif operation == ExecuteOperation.SHOW:
+    elif operation == ExecuteOperation.SHOW.value:
         name = get_or_prompt("Job Name", name)
         execution_id = get_or_prompt("Job Execution ID", execution_id)
         cmd.show(name, team, execution_id, output)
-    elif operation == ExecuteOperation.LIST:
+    elif operation == ExecuteOperation.LIST.value:
         name = get_or_prompt("Job Name", name)
         cmd.list(name, team, output)
-    elif operation == ExecuteOperation.CANCEL:
+    elif operation == ExecuteOperation.CANCEL.value:
         name = get_or_prompt("Job Name", name)
         team = get_or_prompt("Job Team", team)
         execution_id = get_or_prompt("Job Execution ID", execution_id)
         cmd.cancel(name, team, execution_id)
-    elif operation == ExecuteOperation.LOGS:
+    elif operation == ExecuteOperation.LOGS.value:
         name = get_or_prompt("Job Name", name)
         team = get_or_prompt("Job Team", team)
         cmd.logs(name, team, execution_id)
-    elif operation == ExecuteOperation.WAIT:
+    elif operation == ExecuteOperation.WAIT.value:
         name = get_or_prompt("Job Name", name)
         # cmd.wait(name, team)
         click.echo("Operation wait not implemented")

--- a/projects/vdk-core/setup.cfg
+++ b/projects/vdk-core/setup.cfg
@@ -45,7 +45,7 @@ package_dir =
 install_requires =
     # click 8 has some breaking changes that break vdk-control-cli
     # https://github.com/pallets/click/issues/1960
-    click==7.*
+    click==8.*
     pluggy==0.*
     click_log
     click-plugins

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/version/new_version_check_plugin.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/version/new_version_check_plugin.py
@@ -29,17 +29,17 @@ class NewVersionCheckPlugin:
     @hookimpl(tryfirst=True)
     def vdk_configure(self, config_builder: ConfigurationBuilder) -> None:
         config_builder.add(
-            key=ConfigKey.PACKAGE_NAME,
+            key=ConfigKey.PACKAGE_NAME.value,
             default_value="vdk-core",
             description="Set distribution package name of the library to check for new version",
         )
         config_builder.add(
-            key=ConfigKey.PACKAGE_INDEX,
+            key=ConfigKey.PACKAGE_INDEX.value,
             default_value="https://pypi.org",
             description="Set distribution package name of the library to check for new version",
         )
         config_builder.add(
-            key=ConfigKey.VERSION_CHECK_PLUGINS,
+            key=ConfigKey.VERSION_CHECK_PLUGINS.value,
             default_value=True,
             description="Set to true if plugins should be checked for new version otherwise false",
         )
@@ -50,12 +50,12 @@ class NewVersionCheckPlugin:
             package_list = []
             cfg = context.configuration
 
-            package_name = cfg.get_value(ConfigKey.PACKAGE_NAME)
-            package_index = cfg.get_value(ConfigKey.PACKAGE_INDEX)
+            package_name = cfg.get_value(ConfigKey.PACKAGE_NAME.value)
+            package_index = cfg.get_value(ConfigKey.PACKAGE_INDEX.value)
             if new_package(package_name, package_index).check():
                 package_list.append(package_name)
 
-            if cfg.get_value(ConfigKey.VERSION_CHECK_PLUGINS):
+            if cfg.get_value(ConfigKey.VERSION_CHECK_PLUGINS.value):
                 log.debug("Will check for newer versions for all installed plugins.")
                 for dist_name, _ in version.list_installed_plugins():
                     if new_package(dist_name, package_index).check():

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/version/test_new_version_check_plugin.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/version/test_new_version_check_plugin.py
@@ -44,7 +44,7 @@ def test_version_check(mock_click_echo, mock_list, mock_package):
     context = build_core_context(
         check_plugin,
         {
-            new_version_check_plugin.ConfigKey.PACKAGE_INDEX: "https://testing.package.index"
+            new_version_check_plugin.ConfigKey.PACKAGE_INDEX.value: "https://testing.package.index"
         },
     )
     check_plugin.vdk_exit(context)
@@ -73,7 +73,8 @@ def test_version_check_skip_plugins(mock_list, mock_package):
 
     check_plugin = NewVersionCheckPlugin()
     context = build_core_context(
-        check_plugin, {new_version_check_plugin.ConfigKey.VERSION_CHECK_PLUGINS: False}
+        check_plugin,
+        {new_version_check_plugin.ConfigKey.VERSION_CHECK_PLUGINS.value: False},
     )
     check_plugin.vdk_exit(context)
 
@@ -93,7 +94,7 @@ def test_version_check_empty_package_index(mock_click_echo, mock_list, mock_pack
 
     check_plugin = NewVersionCheckPlugin()
     context = build_core_context(
-        check_plugin, {new_version_check_plugin.ConfigKey.PACKAGE_INDEX: ""}
+        check_plugin, {new_version_check_plugin.ConfigKey.PACKAGE_INDEX.value: ""}
     )
     check_plugin.vdk_exit(context)
 


### PR DESCRIPTION
Currently, Versatile Data Kit uses click version 7.X in vdk-core and
vdk-control-cli, due to an issue of flag values not being converted to
enum, but rather to string.

This change adopts click 8.X and fixes the issues with click flag values by
always using strings and string representations of enum values where comparisons
are needed.

Testing Done: unit tests

Signed-off-by: Andon Andonov <andonova@vmware.com>