### PR TITLE
vdk-control-cli: Adopt click version 8

### DIFF
--- a/projects/vdk-control-cli/setup.cfg
+++ b/projects/vdk-control-cli/setup.cfg
@@ -46,7 +46,7 @@ package_dir =
 install_requires =
     # click 8 has some breaking changes that break vdk-control-cli
     # https://github.com/pallets/click/issues/1960
-    click==7.*
+    click==8.*
     click-log==0.*
     click-spinner==0.*
     requests>=2.25

--- a/projects/vdk-control-cli/setup.cfg
+++ b/projects/vdk-control-cli/setup.cfg
@@ -44,8 +44,6 @@ package_dir =
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 # by default set them to latest minor (non-breaking) version unless more limited version is specifically required.
 install_requires =
-    # click 8 has some breaking changes that break vdk-control-cli
-    # https://github.com/pallets/click/issues/1960
     click==8.*
     click-log==0.*
     click-spinner==0.*


### PR DESCRIPTION
Did notice a conflict:
```
The conflict is caused by:
vdk-control-cli 1.2.494451234 depends on click==7.*
vdk-core 0.1.494451234 depends on click==8.*
```
A follow-up to
https://github.com/vmware/versatile-data-kit/pull/769/

Updated a pinned version from 7.* to 8.*

Testing Done: ci/cd

Signed-off-by: ikoleva <ikoleva@vmware.com>