### PR TITLE
vdk-kerberos-auth: support kerberos auth for all CLI commands

### DIFF
--- a/projects/vdk-plugins/vdk-kerberos-auth/README.md
+++ b/projects/vdk-plugins/vdk-kerberos-auth/README.md
@@ -32,3 +32,16 @@ The following environment variables can be used to configure this plugin:
 | `VDK_KEYTAB_PRINCIPAL`  | Specifies the Kerberos principal. If left empty, the principal will be the job name prepended with 'pa__view_'.                                                |
 | `VDK_KEYTAB_REALM`      | Specifies the Kerberos realm. This value is used only with the 'minikerberos' authentication type. The default value is 'default_realm'.                       |
 | `VDK_KERBEROS_KDC_HOST` | Specifies the name of the Kerberos KDC (Key Distribution Center) host. This value is used only with the 'minikerberos' authentication type.                    |
+
+# Testing
+
+In order to run the tests you need pytest and docker and kerberos client (kadmin).
+
+You can use helper script `../build-plugin.sh` to build and test locally.
+
+On Mac OS kadmin may miss some options needed. In this case you can use kadmin in docker to run the tests
+```bash
+export VDK_TEST_USE_KADMIN_DOCKER=true
+cd /source/projects/vdk-plugins/vdk-kerberos-auth
+../build-plugin.sh
+```

--- a/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/kerberos_plugin.py
+++ b/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/kerberos_plugin.py
@@ -7,6 +7,7 @@ from vdk.api.plugin.hook_markers import hookimpl
 from vdk.api.plugin.plugin_registry import IPluginRegistry
 from vdk.internal.builtin_plugins.run.job_context import JobContext
 from vdk.internal.core.config import ConfigurationBuilder
+from vdk.internal.core.context import CoreContext
 from vdk.plugin.kerberos.authenticator_factory import KerberosAuthenticatorFactory
 from vdk.plugin.kerberos.kerberos_configuration import add_definitions
 from vdk.plugin.kerberos.kerberos_configuration import KerberosPluginConfiguration
@@ -18,32 +19,68 @@ class KerberosPlugin:
     def __init__(self):
         self.__authenticator = None
 
+    def __attempt_kerberos_authentication(
+        self, kerberos_configuration: KerberosPluginConfiguration
+    ):
+        authenticator_factory = KerberosAuthenticatorFactory(kerberos_configuration)
+        if kerberos_configuration.authentication_type() is not None:
+            log.debug("Creating authenticator for Kerberos and will kinit now.")
+            try:
+                self.__authenticator = authenticator_factory.create_authenticator(
+                    kerberos_configuration.authentication_type()
+                )
+                self.__authenticator.authenticate()
+            except Exception as e:
+                if kerberos_configuration.auth_fail_fast():
+                    raise
+                else:
+                    log.warning(
+                        "Kerberos was enabled but we failed to authenticate (kinit) and generate TGT."
+                        f"The error was: {e} "
+                        "This means potential future operations requiring "
+                        "valid kerberos authentication will fail. "
+                        "You may need to inspect the above error and try to fix it if that happens. "
+                        "If no kerberos related operations are done, ignore this warning."
+                        "If you prefer to fail fast (instead of this warning), enable krb_auth_fail_fast flag."
+                        "See vdk config-help for more information."
+                    )
+        else:
+            log.debug(
+                "no authentication for kerberos is attempted as it's not enabled."
+                "To enable set KRB_AUTH to the correct type. See vdk config-help for more infofrmation."
+            )
+
     @staticmethod
     @hookimpl
     def vdk_configure(config_builder: ConfigurationBuilder) -> None:
         add_definitions(config_builder)
 
+    @hookimpl
+    def vdk_initialize(self, context: CoreContext) -> None:
+        kerberos_configuration = KerberosPluginConfiguration(
+            None, None, context.configuration
+        )
+        if (
+            kerberos_configuration.keytab_filename()
+            and kerberos_configuration.keytab_principal()
+        ):
+            self.__attempt_kerberos_authentication(kerberos_configuration)
+        else:
+            log.debug(
+                "No keytab configuration found. "
+                "No attempt for kerberos authentication is done during vdk_initialize hook."
+            )
+
     @hookimpl(tryfirst=True)
     def initialize_job(self, context: JobContext) -> None:
+        """
+        This is called during vdk run (job execution) and here we know the job directory
+        and can try to infer where the keytab file is.
+        """
         kerberos_configuration = KerberosPluginConfiguration(
             context.name, str(context.job_directory), context.core_context.configuration
         )
-        authenticator_factory = KerberosAuthenticatorFactory(kerberos_configuration)
-
-        try:
-            self.__authenticator = authenticator_factory.create_authenticator(
-                kerberos_configuration.authentication_type()
-            )
-        except Exception:
-            log.error(
-                "Kerberos authenticator cannot be created. You can provide configuration that specifies "
-                "keytab info using the following environment variables: VDK_KEYTAB_FOLDER, or "
-                "VDK_KEYTAB_FILENAME and VDK_KEYTAB_PRINCIPAL"
-            )
-            raise
-
-        if self.__authenticator:
-            self.__authenticator.authenticate()
+        self.__attempt_kerberos_authentication(kerberos_configuration)
 
 
 @hookimpl

--- a/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/minikerberos_authenticator.py
+++ b/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/minikerberos_authenticator.py
@@ -82,7 +82,7 @@ class MinikerberosGSSAPIAuthenticator(BaseAuthenticator):
                 f"and stored to file: {self._ccache_file}"
             )
         except Exception as e:
-            errors.log_and_throw(
+            errors.log_and_rethrow(
                 to_be_fixed_by=errors.ResolvableBy.CONFIG_ERROR,
                 log=log,
                 what_happened="Could not retrieve Kerberos TGT",
@@ -90,4 +90,6 @@ class MinikerberosGSSAPIAuthenticator(BaseAuthenticator):
                 consequences="Kerberos authentication will fail, and as a result the current process will fail.",
                 countermeasures="See stdout for details and fix the code, so that getting the TGT succeeds. "
                 "If you have custom Kerberos settings, set through environment variables make sure they are correct.",
+                exception=e,
+                wrap_in_vdk_error=True,
             )

--- a/projects/vdk-plugins/vdk-kerberos-auth/tests/test_kerberos.py
+++ b/projects/vdk-plugins/vdk-kerberos-auth/tests/test_kerberos.py
@@ -5,8 +5,10 @@ import pathlib
 import unittest
 from unittest import mock
 
+import click
 import pytest
 from click.testing import Result
+from vdk.api.plugin.hook_markers import hookimpl
 from vdk.plugin.kerberos import kerberos_plugin
 from vdk.plugin.test_utils.util_funcs import cli_assert_equal
 from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
@@ -14,25 +16,40 @@ from vdk.plugin.test_utils.util_funcs import get_caller_directory
 from vdk.plugin.test_utils.util_funcs import jobs_path_from_caller_directory
 
 
+@click.command("my-echo")
+@click.argument("value")
+def my_echo(value):
+    click.echo(value)
+
+
+class DummyCmdPlugin:
+    @staticmethod
+    @hookimpl(tryfirst=True)
+    def vdk_command_line(root_command: click.Group) -> None:
+        root_command.add_command(my_echo)
+
+
 @pytest.mark.usefixtures("kerberos_service")
-class TemplateRegressionTests(unittest.TestCase):
+class TestKerberosAuthentication(unittest.TestCase):
     def setUp(self) -> None:
-        self.__runner = CliEntryBasedTestRunner(kerberos_plugin)
+        self.__runner = CliEntryBasedTestRunner(kerberos_plugin, DummyCmdPlugin())
 
     def test_no_authentication(self):
-        result: Result = self.__runner.invoke(
-            ["run", jobs_path_from_caller_directory("test-job")]
-        )
+        with mock.patch.dict(
+            os.environ,
+            {"VDK_KRB_AUTH_FAIL_FAST": "true"},
+        ):
+            result: Result = self.__runner.invoke(
+                ["run", jobs_path_from_caller_directory("test-job")]
+            )
 
-        assert '"status": "success"' in result.output
-        cli_assert_equal(0, result)
+            assert '"status": "success"' in result.output
+            cli_assert_equal(0, result)
 
     def test_invalid_authentication_mode(self):
         with mock.patch.dict(
             os.environ,
-            {
-                "VDK_KRB_AUTH": "invalid",
-            },
+            {"VDK_KRB_AUTH": "invalid", "VDK_KRB_AUTH_FAIL_FAST": "true"},
         ):
             result: Result = self.__runner.invoke(
                 ["run", jobs_path_from_caller_directory("test-job")]
@@ -47,6 +64,7 @@ class TemplateRegressionTests(unittest.TestCase):
             os.environ,
             {
                 "VDK_KRB_AUTH": "kinit",
+                "VDK_KRB_AUTH_FAIL_FAST": "true",
                 "VDK_KRB5_CONF_FILENAME": krb5_conf_filename,
             },
         ):
@@ -54,7 +72,73 @@ class TemplateRegressionTests(unittest.TestCase):
                 ["run", jobs_path_from_caller_directory("test-job")]
             )
 
+            cli_assert_equal(0, result)
             assert '"status": "success"' in result.output
+
+    def test_kinit_authentication_cli_command_no_auth(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "VDK_KRB_AUTH": "",
+                "VDK_KRB_AUTH_FAIL_FAST": "true",
+            },
+        ):
+            result: Result = self.__runner.invoke(["my-echo", "hi"])
+
+            cli_assert_equal(0, result)
+
+    def test_kinit_authentication_cli_command(self):
+        data_job_path = jobs_path_from_caller_directory("test-job")
+        krb5_conf_filename = str(get_caller_directory().joinpath("krb5.conf"))
+        with mock.patch.dict(
+            os.environ,
+            {
+                "VDK_KRB_AUTH": "kinit",
+                "VDK_KRB_AUTH_FAIL_FAST": "true",
+                "VDK_KEYTAB_REALM": "EXAMPLE.COM",
+                "VDK_KERBEROS_KDC_HOST": "localhost",
+                "VDK_KRB5_CONF_FILENAME": krb5_conf_filename,
+                "VDK_KEYTAB_FOLDER": str(pathlib.Path(data_job_path).parent),
+                "VDK_KEYTAB_FILENAME": "test-job.keytab",
+                "VDK_KEYTAB_PRINCIPAL": "pa__view_test-job",
+            },
+        ):
+            result: Result = self.__runner.invoke(["my-echo", "hi"])
+
+            cli_assert_equal(0, result)
+
+    def test_minikerberos_authentication_cli_command(self):
+        krb5_conf_filename = str(get_caller_directory().joinpath("krb5.conf"))
+        with mock.patch.dict(
+            os.environ,
+            {
+                "VDK_KRB_AUTH": "minikerberos",
+                "VDK_KRB_AUTH_FAIL_FAST": "true",
+                "VDK_KEYTAB_REALM": "EXAMPLE.COM",
+                "VDK_KERBEROS_KDC_HOST": "localhost",
+                "VDK_KRB5_CONF_FILENAME": krb5_conf_filename,
+                "VDK_KEYTAB_FOLDER": str(get_caller_directory().joinpath("jobs")),
+                "VDK_KEYTAB_FILENAME": "test-job.keytab",
+                "VDK_KEYTAB_PRINCIPAL": "pa__view_test-job",
+            },
+        ):
+            result: Result = self.__runner.invoke(["my-echo", "hi"])
+
+            cli_assert_equal(0, result)
+
+    def test_minikerberos_authentication_cli_command_no_keytab_file(self):
+        krb5_conf_filename = str(get_caller_directory().joinpath("krb5.conf"))
+        with mock.patch.dict(
+            os.environ,
+            {
+                "VDK_KRB_AUTH": "minikerberos",
+                "VDK_KRB_AUTH_FAIL_FAST": "true",
+                "VDK_KRB5_CONF_FILENAME": krb5_conf_filename,
+                "VDK_KEYTAB_PRINCIPAL": "pa__view_test-job",
+            },
+        ):
+            result: Result = self.__runner.invoke(["my-echo", "hi"])
+
             cli_assert_equal(0, result)
 
     def test_kinit_authentication_with_wrong_credentials(self):
@@ -65,6 +149,7 @@ class TemplateRegressionTests(unittest.TestCase):
             os.environ,
             {
                 "VDK_KRB_AUTH": "kinit",
+                "VDK_KRB_AUTH_FAIL_FAST": "true",
                 "VDK_KRB5_CONF_FILENAME": krb5_conf_filename,
                 "VDK_KEYTAB_FILENAME": str(
                     pathlib.Path(data_job_path).parent.joinpath(
@@ -78,6 +163,24 @@ class TemplateRegressionTests(unittest.TestCase):
             assert "kinit returned exitcode 1" in result.output
             cli_assert_equal(1, result)
 
+    def test_kinit_authentication_error_fail_fast_is_false(self):
+        # Try to authenticate a data job using a missing keytab.
+        krb5_conf_filename = str(get_caller_directory().joinpath("krb5.conf"))
+        data_job_path = jobs_path_from_caller_directory("test-job")
+        with mock.patch.dict(
+            os.environ,
+            {
+                "VDK_KRB_AUTH": "kinit",
+                "VDK_KRB_AUTH_FAIL_FAST": "false",
+                "VDK_KRB5_CONF_FILENAME": krb5_conf_filename,
+                "VDK_KEYTAB_FILENAME": str(
+                    pathlib.Path(data_job_path).parent.joinpath("non_existent.keytab")
+                ),
+            },
+        ):
+            result: Result = self.__runner.invoke(["run", data_job_path])
+            cli_assert_equal(0, result)
+
     def test_kinit_authentication_with_missing_keytab(self):
         # Try to authenticate a data job using a missing keytab.
         krb5_conf_filename = str(get_caller_directory().joinpath("krb5.conf"))
@@ -86,10 +189,10 @@ class TemplateRegressionTests(unittest.TestCase):
             os.environ,
             {
                 "VDK_KRB_AUTH": "kinit",
+                "VDK_KRB_AUTH_FAIL_FAST": "true",
                 "VDK_KRB5_CONF_FILENAME": krb5_conf_filename,
-                "VDK_KEYTAB_FILENAME": str(
-                    pathlib.Path(data_job_path).parent.joinpath("non_existent.keytab")
-                ),
+                "VDK_KEYTAB_FOLDER": str(pathlib.Path(data_job_path).parent),
+                "VDK_KEYTAB_FILENAME": "non_existent.keytab",
             },
         ):
             result: Result = self.__runner.invoke(["run", data_job_path])
@@ -103,6 +206,7 @@ class TemplateRegressionTests(unittest.TestCase):
             os.environ,
             {
                 "VDK_KRB_AUTH": "minikerberos",
+                "VDK_KRB_AUTH_FAIL_FAST": "true",
                 "VDK_KEYTAB_REALM": "EXAMPLE.COM",
                 "VDK_KERBEROS_KDC_HOST": "localhost",
                 "VDK_KRB5_CONF_FILENAME": krb5_conf_filename,
@@ -123,12 +227,10 @@ class TemplateRegressionTests(unittest.TestCase):
             os.environ,
             {
                 "VDK_KRB_AUTH": "minikerberos",
+                "VDK_KRB_AUTH_FAIL_FAST": "true",
                 "VDK_KRB5_CONF_FILENAME": krb5_conf_filename,
-                "VDK_KEYTAB_FILENAME": str(
-                    pathlib.Path(data_job_path).parent.joinpath(
-                        "different_principal.keytab"
-                    )
-                ),
+                "VDK_KEYTAB_FOLDER": str(pathlib.Path(data_job_path).parent),
+                "VDK_KEYTAB_FILENAME": "different_principal.keytab",
             },
         ):
             result: Result = self.__runner.invoke(["run", data_job_path])
@@ -144,6 +246,7 @@ class TemplateRegressionTests(unittest.TestCase):
             os.environ,
             {
                 "VDK_KRB_AUTH": "minikerberos",
+                "VDK_KRB_AUTH_FAIL_FAST": "true",
                 "VDK_KRB5_CONF_FILENAME": krb5_conf_filename,
                 "VDK_KEYTAB_FILENAME": str(
                     pathlib.Path(data_job_path).parent.joinpath("non_existent.keytab")


### PR DESCRIPTION
vdk-control-cli commands also may require Kerberos authentication so
here we are adding support. Currently, we only authenticate during vdk
run (part of initialize_job). But with support for Kerberos for the
Control Service we'd need it for all operations. E.g `vdk properties`

Now authentication is always attempted as long as it's explicitly
enabled (KRB_AUTH is set to some valid value). 
There's new flag "KRB_AUTH_FAIL_FAST" (false by default) 
which would cause the plugin to fail if auth fails but otherwise only a warning would be logged. 
It's necessary because only small subsets of features would use kerberos. 
And vdk should work even if those feature do not.


Alternatives considered: 

I was considering adding a new decorator/annotation to vdk-kerberos-auth 
which "users" can use to denote that their method needs Kerberos authentication
 (and would be authenticated on demand) 

e.g  
```
@kerberos 
def get_property(team, name): 
```

when get_property is called then Authenticator.authenticate is triggered. But for now I've discarded 
a) it's more expensive 
b) How do we deal with multiple auth mechanisms (as weh ave Oauth2 and kerberos) - 
e.g when do we fail?, do we attempt both , etc. 
c) caching of authentication
But it's nice idea and I am reserving it for the future.

Testing Done: extended the automated test of the plugin (see
test_kerberos).

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>