### PR TITLE
control-service: Set TTLAfterFinished period for K8s CronJobs

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -172,8 +172,8 @@ public abstract class KubernetesService implements InitializingBean {
     @org.springframework.beans.factory.annotation.Value("${datajobs.control.k8s.data.job.template.file}")
     private String datajobTemplateFileLocation;
 
-    @org.springframework.beans.factory.annotation.Value("${datajobs.control.k8s.jobTTLAfterFinished}")
-    private int jobTTLAfterFinished;
+    @org.springframework.beans.factory.annotation.Value("${datajobs.control.k8s.jobTTLAfterFinishedSeconds}")
+    private int jobTTLAfterFinishedSeconds;
 
     private String namespace;
     private String kubeconfig;
@@ -549,7 +549,7 @@ public abstract class KubernetesService implements InitializingBean {
                 .map(V1beta1JobTemplateSpec::getSpec)
                 .orElseThrow(() -> new ApiException(String.format("K8S Cron Job '%s' does not exist or is not properly defined.", cronJobName)));
 
-        jobSpec.setTtlSecondsAfterFinished(jobTTLAfterFinished);
+        jobSpec.setTtlSecondsAfterFinished(jobTTLAfterFinishedSeconds);
 
         V1Container v1Container = Optional.ofNullable(jobSpec.getTemplate())
                 .map(V1PodTemplateSpec::getSpec)
@@ -593,7 +593,7 @@ public abstract class KubernetesService implements InitializingBean {
               .map(V1JobTemplateSpec::getSpec)
               .orElseThrow(() -> new ApiException(String.format("K8S Cron Job '%s' does not exist or is not properly defined.", cronJobName)));
 
-        jobSpec.setTtlSecondsAfterFinished(jobTTLAfterFinished);
+        jobSpec.setTtlSecondsAfterFinished(jobTTLAfterFinishedSeconds);
 
         V1Container v1Container = Optional.ofNullable(jobSpec.getTemplate())
               .map(V1PodTemplateSpec::getSpec)
@@ -821,7 +821,7 @@ public abstract class KubernetesService implements InitializingBean {
                 .build();
         var spec = new V1JobSpecBuilder()
                 .withBackoffLimit(3) //TODO configure
-                .withTtlSecondsAfterFinished(jobTTLAfterFinished)
+                .withTtlSecondsAfterFinished(jobTTLAfterFinishedSeconds)
                 .withTemplate(template)
                 .build();
         createNewJob(name, spec, Collections.emptyMap(), Collections.emptyMap());

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -172,6 +172,9 @@ public abstract class KubernetesService implements InitializingBean {
     @org.springframework.beans.factory.annotation.Value("${datajobs.control.k8s.data.job.template.file}")
     private String datajobTemplateFileLocation;
 
+    @org.springframework.beans.factory.annotation.Value("${datajobs.control.k8s.cronJobTTLAfterFinished}")
+    private int cronJobTTLAfterFinished;
+
     private String namespace;
     private String kubeconfig;
     private Logger log;
@@ -546,7 +549,7 @@ public abstract class KubernetesService implements InitializingBean {
                 .map(V1beta1JobTemplateSpec::getSpec)
                 .orElseThrow(() -> new ApiException(String.format("K8S Cron Job '%s' does not exist or is not properly defined.", cronJobName)));
 
-        jobSpec.setTtlSecondsAfterFinished(3600);
+        jobSpec.setTtlSecondsAfterFinished(cronJobTTLAfterFinished);
 
         V1Container v1Container = Optional.ofNullable(jobSpec.getTemplate())
                 .map(V1PodTemplateSpec::getSpec)
@@ -590,7 +593,7 @@ public abstract class KubernetesService implements InitializingBean {
               .map(V1JobTemplateSpec::getSpec)
               .orElseThrow(() -> new ApiException(String.format("K8S Cron Job '%s' does not exist or is not properly defined.", cronJobName)));
 
-        jobSpec.setTtlSecondsAfterFinished(3600);
+        jobSpec.setTtlSecondsAfterFinished(cronJobTTLAfterFinished);
 
         V1Container v1Container = Optional.ofNullable(jobSpec.getTemplate())
               .map(V1PodTemplateSpec::getSpec)
@@ -818,7 +821,7 @@ public abstract class KubernetesService implements InitializingBean {
                 .build();
         var spec = new V1JobSpecBuilder()
                 .withBackoffLimit(3) //TODO configure
-                .withTtlSecondsAfterFinished(3600)  //TODO configure
+                .withTtlSecondsAfterFinished(cronJobTTLAfterFinished)  //TODO configure
                 .withTemplate(template)
                 .build();
         createNewJob(name, spec, Collections.emptyMap(), Collections.emptyMap());

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -172,8 +172,8 @@ public abstract class KubernetesService implements InitializingBean {
     @org.springframework.beans.factory.annotation.Value("${datajobs.control.k8s.data.job.template.file}")
     private String datajobTemplateFileLocation;
 
-    @org.springframework.beans.factory.annotation.Value("${datajobs.control.k8s.cronJobTTLAfterFinished}")
-    private int cronJobTTLAfterFinished;
+    @org.springframework.beans.factory.annotation.Value("${datajobs.control.k8s.jobTTLAfterFinished}")
+    private int jobTTLAfterFinished;
 
     private String namespace;
     private String kubeconfig;
@@ -549,7 +549,7 @@ public abstract class KubernetesService implements InitializingBean {
                 .map(V1beta1JobTemplateSpec::getSpec)
                 .orElseThrow(() -> new ApiException(String.format("K8S Cron Job '%s' does not exist or is not properly defined.", cronJobName)));
 
-        jobSpec.setTtlSecondsAfterFinished(cronJobTTLAfterFinished);
+        jobSpec.setTtlSecondsAfterFinished(jobTTLAfterFinished);
 
         V1Container v1Container = Optional.ofNullable(jobSpec.getTemplate())
                 .map(V1PodTemplateSpec::getSpec)
@@ -593,7 +593,7 @@ public abstract class KubernetesService implements InitializingBean {
               .map(V1JobTemplateSpec::getSpec)
               .orElseThrow(() -> new ApiException(String.format("K8S Cron Job '%s' does not exist or is not properly defined.", cronJobName)));
 
-        jobSpec.setTtlSecondsAfterFinished(cronJobTTLAfterFinished);
+        jobSpec.setTtlSecondsAfterFinished(jobTTLAfterFinished);
 
         V1Container v1Container = Optional.ofNullable(jobSpec.getTemplate())
               .map(V1PodTemplateSpec::getSpec)
@@ -821,7 +821,7 @@ public abstract class KubernetesService implements InitializingBean {
                 .build();
         var spec = new V1JobSpecBuilder()
                 .withBackoffLimit(3) //TODO configure
-                .withTtlSecondsAfterFinished(cronJobTTLAfterFinished)
+                .withTtlSecondsAfterFinished(jobTTLAfterFinished)
                 .withTemplate(template)
                 .build();
         createNewJob(name, spec, Collections.emptyMap(), Collections.emptyMap());

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -546,6 +546,8 @@ public abstract class KubernetesService implements InitializingBean {
                 .map(V1beta1JobTemplateSpec::getSpec)
                 .orElseThrow(() -> new ApiException(String.format("K8S Cron Job '%s' does not exist or is not properly defined.", cronJobName)));
 
+        jobSpec.setTtlSecondsAfterFinished(3600);
+
         V1Container v1Container = Optional.ofNullable(jobSpec.getTemplate())
                 .map(V1PodTemplateSpec::getSpec)
                 .map(V1PodSpec::getContainers)
@@ -587,6 +589,8 @@ public abstract class KubernetesService implements InitializingBean {
         V1JobSpec jobSpec = jobTemplateSpec
               .map(V1JobTemplateSpec::getSpec)
               .orElseThrow(() -> new ApiException(String.format("K8S Cron Job '%s' does not exist or is not properly defined.", cronJobName)));
+
+        jobSpec.setTtlSecondsAfterFinished(3600);
 
         V1Container v1Container = Optional.ofNullable(jobSpec.getTemplate())
               .map(V1PodTemplateSpec::getSpec)

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -821,7 +821,7 @@ public abstract class KubernetesService implements InitializingBean {
                 .build();
         var spec = new V1JobSpecBuilder()
                 .withBackoffLimit(3) //TODO configure
-                .withTtlSecondsAfterFinished(cronJobTTLAfterFinished)  //TODO configure
+                .withTtlSecondsAfterFinished(cronJobTTLAfterFinished)
                 .withTemplate(template)
                 .build();
         createNewJob(name, spec, Collections.emptyMap(), Collections.emptyMap());

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -100,7 +100,7 @@ logging.level.io.swagger.models.parameters.AbstractSerializableParameter=ERROR
 datajobs.control.k8s.namespace=
 datajobs.control.k8s.kubeconfig=${HOME}/.kube/config
 datajobs.control.k8s.k8sSupportsV1CronJob=false
-datajobs.control.k8s.cronJobTTLAfterFinished=3600
+datajobs.control.k8s.jobTTLAfterFinished=3600
 # Location to a K8s cronjob yaml file which will be used as a template
 # for all data jobs. If the location is missing, the default internal
 # cronjob yaml resource will be used (see k8s-data-job-template.yaml).

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -100,6 +100,7 @@ logging.level.io.swagger.models.parameters.AbstractSerializableParameter=ERROR
 datajobs.control.k8s.namespace=
 datajobs.control.k8s.kubeconfig=${HOME}/.kube/config
 datajobs.control.k8s.k8sSupportsV1CronJob=false
+datajobs.control.k8s.cronJobTTLAfterFinished=3600
 # Location to a K8s cronjob yaml file which will be used as a template
 # for all data jobs. If the location is missing, the default internal
 # cronjob yaml resource will be used (see k8s-data-job-template.yaml).

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -100,7 +100,7 @@ logging.level.io.swagger.models.parameters.AbstractSerializableParameter=ERROR
 datajobs.control.k8s.namespace=
 datajobs.control.k8s.kubeconfig=${HOME}/.kube/config
 datajobs.control.k8s.k8sSupportsV1CronJob=false
-datajobs.control.k8s.jobTTLAfterFinished=3600
+datajobs.control.k8s.jobTTLAfterFinishedSeconds=3600
 # Location to a K8s cronjob yaml file which will be used as a template
 # for all data jobs. If the location is missing, the default internal
 # cronjob yaml resource will be used (see k8s-data-job-template.yaml).


### PR DESCRIPTION
To take advantage of the automatic jobs cleanup afforded by
the TTL Controller, we need to the the TTLAfterFinished setting
to some appropriate value. Here, we've chosen 1 hour.

Testing done: TBD

Signed-off-by: Gabriel Georgiev <gageorgiev@vmware.com>