### PR TITLE
versatile-data-kit: Fix pre-commit Black hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     hooks:
       - id: gitlint
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3.7


### PR DESCRIPTION
The Black styling pre-commit hook 22.1.0 which we use has an
incompatibility with click 8.1.0 as described here -
https://github.com/psf/black/issues/2964
This issue can be seen in this pre-commit log - 
https://results.pre-commit.ci/run/github/387724608/1648974199.QWpiWQJSSm6aM3PRKPdqMg
in this PR - 
https://github.com/vmware/versatile-data-kit/pull/778


Signed-off-by: Gabriel Georgiev <gageorgiev@vmware.com>