### PR TITLE
control-service: fix concatAddresses NPE

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/notification/EmailNotification.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/notification/EmailNotification.java
@@ -5,20 +5,24 @@
 
 package com.vmware.taurus.service.notification;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.stereotype.Component;
-
-import javax.mail.*;
+import javax.mail.Address;
+import javax.mail.MessagingException;
+import javax.mail.SendFailedException;
+import javax.mail.Session;
+import javax.mail.Transport;
 import javax.mail.internet.MimeMessage;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
 
 /**
  * The EmailNotification class is responsible for implementing the email notifications functionality.
@@ -97,10 +101,12 @@ public class EmailNotification {
         return true;
     }
 
-    private String concatAddresses(Address[] addresses) {
-        return Arrays.asList(addresses)
-                .stream()
-                .map(addr -> addr.toString())
-                .collect(Collectors.joining(" "));
+    String concatAddresses(Address[] addresses) {
+        return addresses == null ?
+              null :
+              Arrays.asList(addresses)
+                    .stream()
+                    .map(addr -> addr.toString())
+                    .collect(Collectors.joining(" "));
     }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/notification/EmailNotificationTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/notification/EmailNotificationTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.notification;
+
+import javax.mail.Address;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.vmware.taurus.ControlplaneApplication;
+
+@SpringBootTest(classes = ControlplaneApplication.class)
+public class EmailNotificationTest {
+
+   @Autowired
+   private EmailNotification emailNotification;
+
+   @Test
+   public void testConcatAddresses_nullAddresses_shouldReturnNull() {
+      String result = emailNotification.concatAddresses(null);
+      Assertions.assertNull(result);
+   }
+
+   @Test
+   public void testConcatAddresses_validAddresses_shouldReturnNull() {
+      String address1 = "a@a.a";
+      String address2 = "b@b.b";
+      String result = emailNotification.concatAddresses(
+            new Address[]{createAddress(address1), createAddress(address2)});
+
+      Assertions.assertEquals(address1 + " " + address2, result);
+   }
+
+   private static Address createAddress(String address) {
+      return new Address() {
+         @Override
+         public String getType() {
+            return null;
+         }
+
+         @Override
+         public String toString() {
+            return address;
+         }
+
+         @Override
+         public boolean equals(Object address) {
+            return false;
+         }
+      };
+   }
+}


### PR DESCRIPTION
This change aims to fix the NPE when null is passed to EmailNotification.concatAddresses().

Testing done: unit tests

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com