### PR TITLE
control-service: fix builder security context

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -29,9 +29,9 @@ deploymentBuilderImage:
 
 deploymentBuilder:
   securityContext:
-    runAsUser: 0
-    runAsGroup: 1000
-    fsGroup: 1000
+    runAsUser: "0"
+    runAsGroup: "1000"
+    fsGroup: "1000"
 
 
 ## String to partially override pipelines-control-service.fullname template (will maintain the release name)


### PR DESCRIPTION
Converted builder security context properties to String, because "if 0"
returns false and as a result the property is not present in control
service envs.

Testing Done: helm template

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com