### PR TITLE
vdk-impala: unify names of templates betwen trino and impala

### DIFF
--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_plugin.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_plugin.py
@@ -86,7 +86,7 @@ class ImpalaPlugin:
         )
 
         context.templates.add_template(
-            "scd2", pathlib.Path(get_job_path("load/dimension/scd2"))
+            "scd2_simple", pathlib.Path(get_job_path("load/dimension/scd2"))
         )
 
         context.templates.add_template(
@@ -94,15 +94,14 @@ class ImpalaPlugin:
         )
 
         context.templates.add_template(
-            "snapshot", pathlib.Path(get_job_path("load/fact/snapshot"))
+            "periodic_snapshot", pathlib.Path(get_job_path("load/fact/snapshot"))
         )
 
         context.templates.add_template(
             "load/versioned", pathlib.Path(get_job_path("load/versioned"))
         )
-
         context.templates.add_template(
-            "versioned", pathlib.Path(get_job_path("load/versioned"))
+            "scd2", pathlib.Path(get_job_path("load/versioned"))
         )
 
     @staticmethod

--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/dimension/scd1/README.md
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/dimension/scd1/README.md
@@ -8,7 +8,7 @@ In summary, it overwrites the target table with the source data.
 
 ### Template Name (template_name):
 
-- "load/dimension/scd1"
+- "scd1"
 
 ### Template Parameters (template_args):
 
@@ -41,3 +41,7 @@ def run(job_input):
     job_input.execute_template("load/dimension/scd1", template_args)
     # . . .
 ```
+
+### Example
+
+See full example of how to use the template in [our example documentation](https://github.com/vmware/versatile-data-kit/wiki/SQL-Data-Processing-templates-examples#overwrite-strategy-slowly-changing-dimension-type-1).

--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/dimension/scd2/README.md
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/dimension/scd2/README.md
@@ -1,6 +1,8 @@
 ### Purpose:
 
 Template used to load raw data from a Data Lake to target 'Slowly Changing Dimension Type 2' table in a Data Warehouse.
+This is very simple implementation whic overrides rows based on updated timestamp and ID. It's generally not recommended to use.
+Prefer to use ["sdc2" template instead](https://github.com/vmware/versatile-data-kit/wiki/SQL-Data-Processing-templates-examples#versioned-strategy--slowly-changing-dimension-type-2)
 
 ### Details:
 
@@ -8,7 +10,7 @@ Explanation of SCD type 2 can be seen here: <https://en.wikipedia.org/wiki/Slowl
 
 ### Template Name (template_name):
 
-- "load/dimension/scd2"
+- "scd2_simple"
 
 ### Template Parameters (template_args):
 

--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/fact/snapshot/README.md
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/fact/snapshot/README.md
@@ -10,7 +10,7 @@ truncating all present target table records observed after t1.
 
 ### Template Name (template_name):
 
-- "load/fact/snapshot"
+- "periodic_snapshot"
 
 ### Template Parameters (template_args):
 
@@ -46,3 +46,7 @@ def run(job_input):
     job_input.execute_template('load/fact/snapshot', template_args)
     # . . .
 ```
+
+### Example
+
+See full example of how to use the template in [our example documentation](https://github.com/vmware/versatile-data-kit/wiki/SQL-Data-Processing-templates-examples#append-strategy-periodic-snapshot-fact).

--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/versioned/README.md
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/versioned/README.md
@@ -9,7 +9,7 @@ Explanation of SCD type 2 can be seen here: <https://en.wikipedia.org/wiki/Slowl
 
 ### Template Name (template_name):
 
-- "load/versioned"
+- "scd2"
 
 ### Template Parameters (template_args):
 
@@ -18,7 +18,7 @@ Explanation of SCD type 2 can be seen here: <https://en.wikipedia.org/wiki/Slowl
 - source_schema          - SC Data Lake schema containing the source view.
 - source_view            - SC Data Lake view where source data is loaded from.
 - id_column              - Column that holds the natural key of the target table.
-- value_columns          - A list of columns from the source that are considered errors. Present both in the source and the target tables.
+- value_columns          - A list of columns from the source that are copied. Present both in the source and the target tables.
 - tracked_columns        - A sublist of the value columns that are tracked for changes. Present both in the source and the target tables.
 - updated_at_column      - A column containing the update time of a record. Present in the source table. Optional (default value is "updated_at").
 - sk_column              - A surrogate key column that is automatically generated in the target table. Optional (default value is "sk").
@@ -54,3 +54,7 @@ def run(job_input):
     job_input.execute_template('load/versioned', template_args)
     # . . .
 ```
+
+### Example
+
+See full example of how to use the template in [our example documentation](https://github.com/vmware/versatile-data-kit/wiki/SQL-Data-Processing-templates-examples#versioned-strategy--slowly-changing-dimension-type-2).


### PR DESCRIPTION
The "load/dimension/scd2" is simple implementation of SCD2 which is less
optimial and flexible than "load/versioned" which is the recommendd one
to use.

The "versioned" template correspond to scd2 in vdk-trino plugin for
example (vdk-trino/src/vdk/plugin/trino/templates/load/dimension/scd2) .
And there there's no scd2_simple implementation at all.

So this PR is changing the name of "load/dimension/scd2" to
"scd2_simple", It's keeping an alias (alternative) name of
"load/dimension/scd2" for backwards compatible reasons.

It's also setting as main name of load/versioned to be "scd2" (which is
the one used in vdk-trino)

Also in vdk-trino Periodic snapshot template is called
"periodic_snapshot" so renaming it to match.

Testing Done: automated tests

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>