### PR TITLE
control-service: configurable builder job service account

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -228,6 +228,10 @@ spec:
             - name: DATAJOBS_DEPLOYMENT_BUILDER_SECURITY_CONTEXT_FS_GROUP
               value: "{{ .Values.deploymentBuilder.securityContext.fsGroup }}"
             {{- end }}
+            {{- if .Values.deploymentBuilder.serviceAccountName }}
+            - name: DATAJOBS_DEPLOYMENT_BUILDER_SERVICE_ACCOUNT_NAME
+              value: "{{ .Values.deploymentBuilder.serviceAccountName }}"
+            {{- end }}
 {{- if .Values.extraVars }}
 {{ toYaml .Values.extraVars | indent 12 }}
 {{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -32,6 +32,8 @@ deploymentBuilder:
     runAsUser: "0"
     runAsGroup: "1000"
     fsGroup: "1000"
+  ## The name of the ServiceAccount to use.
+  # serviceAccountName: ""
 
 
 ## String to partially override pipelines-control-service.fullname template (will maintain the release name)

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
@@ -73,6 +73,9 @@ public class JobImageBuilder {
    @Value("${datajobs.deployment.builder.securitycontext.fsGroup}")
    private long  builderSecurityContextFsGroup;
 
+   @Value("${datajobs.deployment.builder.serviceAccountName}")
+   private String  builderServiceAccountName;
+
    private final ControlKubernetesService controlKubernetesService;
    private final DockerRegistryService dockerRegistryService;
    private final DeploymentNotificationHelper notificationHelper;
@@ -166,7 +169,8 @@ public class JobImageBuilder {
             kubernetesResources.builderLimits(),
             builderSecurityContextRunAsUser,
             builderSecurityContextRunAsGroup,
-            builderSecurityContextFsGroup);
+            builderSecurityContextFsGroup,
+            builderServiceAccountName);
 
       log.debug("Waiting for builder job {} for data job version {}", builderJobName, jobDeployment.getGitCommitSha());
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -171,3 +171,5 @@ datajobs.deployment.builder.imagePullPolicy=IfNotPresent
 datajobs.deployment.builder.securitycontext.runAsUser=${DATAJOBS_DEPLOYMENT_BUILDER_SECURITY_CONTEXT_RUN_AS_USER:0}
 datajobs.deployment.builder.securitycontext.runAsGroup=${DATAJOBS_DEPLOYMENT_BUILDER_SECURITY_CONTEXT_RUN_AS_GROUP:1000}
 datajobs.deployment.builder.securitycontext.fsGroup=${DATAJOBS_DEPLOYMENT_BUILDER_SECURITY_CONTEXT_FS_GROUP:1000}
+
+datajobs.deployment.builder.serviceAccountName=${DATAJOBS_DEPLOYMENT_BUILDER_SERVICE_ACCOUNT_NAME:}

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/MockKubernetes.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/MockKubernetes.java
@@ -102,7 +102,8 @@ public class MockKubernetes {
 
 
       doAnswer(inv -> jobs.put(inv.getArgument(0), inv)).when(mock)
-              .createJob(anyString(), anyString(), anyBoolean(), any(), any(), any(), any(), anyString(), any(), any(), anyLong(), anyLong(), anyLong());
+              .createJob(anyString(), anyString(), anyBoolean(), any(), any(), any(), any(),
+                    anyString(), any(), any(), anyLong(), anyLong(), anyLong(), anyString());
       doAnswer(inv -> jobs.keySet()).when(mock).listCronJobs();
       doAnswer(inv -> jobs.remove(inv.getArgument(0))).when(mock).deleteJob(anyString());
 

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
@@ -88,7 +88,7 @@ public class JobImageBuilderTest {
 
       verify(kubernetesService).createJob(
             eq(TEST_BUILDER_JOB_NAME), eq(TEST_BUILDER_IMAGE_NAME), eq(false), any(), any(),
-            any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong());
+            any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong(), anyString());
 
       verify(kubernetesService).deleteJob(TEST_BUILDER_JOB_NAME);
       Assertions.assertTrue(result);
@@ -114,7 +114,7 @@ public class JobImageBuilderTest {
       verify(kubernetesService, times(2)).deleteJob(TEST_BUILDER_IMAGE_NAME);
       verify(kubernetesService).createJob(
             eq(TEST_BUILDER_JOB_NAME), eq(TEST_BUILDER_IMAGE_NAME), eq(false), any(), any(),
-            any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong());
+            any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong(), anyString());
       Assertions.assertTrue(result);
    }
 
@@ -131,7 +131,7 @@ public class JobImageBuilderTest {
 
       verify(kubernetesService, never()).createJob(
             anyString(), anyString(), anyBoolean(), any(), any(),
-            any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong());
+            any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong(), anyString());
       verify(notificationHelper, never())
             .verifyBuilderResult(anyString(), any(), any(), any(), anyString(), anyBoolean());
       Assertions.assertTrue(result);
@@ -156,7 +156,7 @@ public class JobImageBuilderTest {
 
       verify(kubernetesService).createJob(
             eq(TEST_BUILDER_JOB_NAME), eq(TEST_BUILDER_IMAGE_NAME), eq(false), any(), any(),
-            any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong());
+            any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong(), anyString());
 
 
       // verify(kubernetesService).deleteJob(TEST_BUILDER_JOB_NAME); // not called in case of an error


### PR DESCRIPTION
Currently, the builder job is based on Kaniko and requires root privileges.
In some cases, Pod Security Policy can be configured based on namespace and service account.
However, Control Service does not provide the ability to set a service account to the Builder Job.

This change aims to provide an ability to set a service account through the Helm Chart.

spec.template.spec.serviceAccountName: "account_name"

Testing done: unit tests and helm template

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com