### PR TITLE
control-service: fix job builder unit tests

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
@@ -88,7 +88,7 @@ public class JobImageBuilderTest {
 
       verify(kubernetesService).createJob(
             eq(TEST_BUILDER_JOB_NAME), eq(TEST_BUILDER_IMAGE_NAME), eq(false), any(), any(),
-            any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong(), anyString());
+            any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong(), any());
 
       verify(kubernetesService).deleteJob(TEST_BUILDER_JOB_NAME);
       Assertions.assertTrue(result);
@@ -114,7 +114,7 @@ public class JobImageBuilderTest {
       verify(kubernetesService, times(2)).deleteJob(TEST_BUILDER_IMAGE_NAME);
       verify(kubernetesService).createJob(
             eq(TEST_BUILDER_JOB_NAME), eq(TEST_BUILDER_IMAGE_NAME), eq(false), any(), any(),
-            any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong(), anyString());
+            any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong(), any());
       Assertions.assertTrue(result);
    }
 
@@ -156,7 +156,7 @@ public class JobImageBuilderTest {
 
       verify(kubernetesService).createJob(
             eq(TEST_BUILDER_JOB_NAME), eq(TEST_BUILDER_IMAGE_NAME), eq(false), any(), any(),
-            any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong(), anyString());
+            any(), any(), any(), any(), any(), anyLong(), anyLong(), anyLong(), any());
 
 
       // verify(kubernetesService).deleteJob(TEST_BUILDER_JOB_NAME); // not called in case of an error


### PR DESCRIPTION
The unit tests have been failed due to the wrong expected type. They
expect String but the value is NULL.

Testing done: unit tests

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com