### PR TITLE
airflow-provider-vdk: Job execution status and logs method

### DIFF
--- a/projects/vdk-plugins/airflow-provider-vdk/tests/hooks/test_vdkhook.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/tests/hooks/test_vdkhook.py
@@ -44,3 +44,12 @@ class TestVDKHook(unittest.TestCase):
         self.hook.get_job_execution_status("test_execution_id")
 
         assert mocked_api_client_request.call_args_list[0][0] == ("GET", request_url)
+
+    @mock.patch("taurus_datajob_api.api_client.ApiClient.deserialize")
+    @mock.patch("taurus_datajob_api.api_client.ApiClient.request")
+    def test_get_job_execution_log(self, mocked_api_client_request, mock_deserialize):
+        request_url = "https://www.vdk-endpoint.org/data-jobs/for-team/test_team/jobs/test_job/executions/test_execution_id/logs"
+
+        self.hook.get_job_execution_log("test_execution_id")
+
+        assert mocked_api_client_request.call_args_list[0][0] == ("GET", request_url)

--- a/projects/vdk-plugins/airflow-provider-vdk/tests/hooks/test_vdkhook.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/tests/hooks/test_vdkhook.py
@@ -33,3 +33,14 @@ class TestVDKHook(unittest.TestCase):
         self.hook.cancel_job_execution("test_execution_id")
 
         assert mocked_api_client_request.call_args_list[0][0] == ("DELETE", request_url)
+
+    @mock.patch("taurus_datajob_api.api_client.ApiClient.deserialize")
+    @mock.patch("taurus_datajob_api.api_client.ApiClient.request")
+    def test_get_job_execution_status(
+        self, mocked_api_client_request, mock_deserialize
+    ):
+        request_url = "https://www.vdk-endpoint.org/data-jobs/for-team/test_team/jobs/test_job/executions/test_execution_id"
+
+        self.hook.get_job_execution_status("test_execution_id")
+
+        assert mocked_api_client_request.call_args_list[0][0] == ("GET", request_url)

--- a/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/hooks/vdk.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/hooks/vdk.py
@@ -94,7 +94,7 @@ class VDKHook(HttpHook):
         Returns the execution status for a particular job execution.
 
         :param execution_id: ID of the job execution
-        :return: Execution status; either SUCCESS, NOT_RUNNABLE or ERROR
+        :return: The execution status object listing details about the status of this particular execution
         """
         return self.__execution_api.data_job_execution_read(
             team_name=self.team_name, job_name=self.job_name, execution_id=execution_id

--- a/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/hooks/vdk.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/hooks/vdk.py
@@ -1,6 +1,5 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
-import json
 import logging
 import os
 import uuid

--- a/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/hooks/vdk.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/hooks/vdk.py
@@ -80,23 +80,18 @@ class VDKHook(HttpHook):
 
     def get_job_execution_log(self, execution_id: str) -> str:
         """
+        Returns the stored execution logs for a particular job execution.
 
         :param execution_id: ID of the job execution
         :return: job execution logs
-
-        self.method = "GET"
-
-        endpoint = f"/data-jobs/for-team/{self.team_name}/jobs/{self.job_name}/executions/{execution_id}/logs"
-        return self.run_with_advanced_retry(
-            self._retry_dict, endpoint=endpoint, headers=self.headers
-        )
         """
-        self.method = "DELETE"
-
-        return ""  # included this to ignore faulty codacy check
+        return self.__execution_api.data_job_logs_download(
+            team_name=self.team_name, job_name=self.job_name, execution_id=execution_id
+        ).logs
 
     def get_job_execution_status(self, execution_id: str) -> DataJobExecution:
         """
+        Returns the execution status for a particular job execution.
 
         :param execution_id: ID of the job execution
         :return: Execution status; either SUCCESS, NOT_RUNNABLE or ERROR

--- a/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/hooks/vdk.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/hooks/vdk.py
@@ -81,9 +81,12 @@ class VDKHook(HttpHook):
 
     def get_job_execution_log(self, execution_id: str) -> str:
         """
+
         :param execution_id: ID of the job execution
         :return: job execution logs
+
         self.method = "GET"
+
         endpoint = f"/data-jobs/for-team/{self.team_name}/jobs/{self.job_name}/executions/{execution_id}/logs"
         return self.run_with_advanced_retry(
             self._retry_dict, endpoint=endpoint, headers=self.headers

--- a/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/hooks/vdk.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/hooks/vdk.py
@@ -1,5 +1,6 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import json
 import logging
 import os
 import uuid
@@ -7,6 +8,7 @@ import uuid
 from airflow.providers.http.hooks.http import HttpHook
 from taurus_datajob_api import ApiClient
 from taurus_datajob_api import Configuration
+from taurus_datajob_api import DataJobExecution
 from taurus_datajob_api import DataJobExecutionRequest
 from taurus_datajob_api import DataJobsExecutionApi
 from urllib3 import Retry
@@ -79,12 +81,9 @@ class VDKHook(HttpHook):
 
     def get_job_execution_log(self, execution_id: str) -> str:
         """
-
         :param execution_id: ID of the job execution
         :return: job execution logs
-
         self.method = "GET"
-
         endpoint = f"/data-jobs/for-team/{self.team_name}/jobs/{self.job_name}/executions/{execution_id}/logs"
         return self.run_with_advanced_retry(
             self._retry_dict, endpoint=endpoint, headers=self.headers
@@ -94,22 +93,15 @@ class VDKHook(HttpHook):
 
         return ""  # included this to ignore faulty codacy check
 
-    def get_job_execution_status(self, execution_id: str):  # -> ExecutionStatus:
+    def get_job_execution_status(self, execution_id: str) -> DataJobExecution:
         """
 
         :param execution_id: ID of the job execution
         :return: Execution status; either SUCCESS, NOT_RUNNABLE or ERROR
-
-        self.method = "GET"
-
-        endpoint = f"/data-jobs/for-team/{self.team_name}/jobs/{self.job_name}/deployments/{self.deployment_id}/executions/{execution_id}"
-        return self.run_with_advanced_retry(
-            self._retry_dict, endpoint=endpoint, data=dict(), headers=self.headers
-        )
         """
-        self.method = "DELETE"
-
-        return None  # included this to ignore faulty codacy check
+        return self.__execution_api.data_job_execution_read(
+            team_name=self.team_name, job_name=self.job_name, execution_id=execution_id
+        )
 
     def _get_rest_api_url_from_connection(self):
         conn = self.get_connection(self.http_conn_id)


### PR DESCRIPTION
This change implements a method for the VDK connection hook which
allows a user to check the status of a job execution in the VDK
control-service. It also implements a method which allows a user to
download the stored job execution logs for a particular execution.

Testing done: locally tested and verified that the correct object
and correct log string are returned, implemented 2 unit tests

Signed-off-by: Gabriel Georgiev <gageorgiev@vmware.com>