### PR TITLE
airflow-provider-vdk: VDKSensor initial structure

### DIFF
--- a/projects/vdk-plugins/airflow-provider-vdk/tests/sensors/test_vdksensor.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/tests/sensors/test_vdksensor.py
@@ -1,9 +1,20 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+from unittest import mock
+
 from vdk_provider.sensors.vdk import VDKSensor
 
 
+@mock.patch.dict(
+    "os.environ", AIRFLOW_CONN_TEST_CONN_ID="http://https%3A%2F%2Fwww.vdk-endpoint.org"
+)
 def test_dummy():
-    sensor = VDKSensor("test_conn_id", "test_job_name", "test_team_name")
+    sensor = VDKSensor(
+        conn_id="test_conn_id",
+        job_name="test_job_name",
+        team_name="test_team_name",
+        job_execution_id="test_id",
+        task_id="test_task_id",
+    )
 
     assert sensor

--- a/projects/vdk-plugins/airflow-provider-vdk/tests/sensors/test_vdksensor.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/tests/sensors/test_vdksensor.py
@@ -1,0 +1,9 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from vdk_provider.sensors.vdk import VDKSensor
+
+
+def test_dummy():
+    sensor = VDKSensor("test_conn_id", "test_job_name", "test_team_name")
+
+    assert sensor

--- a/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/sensors/vdk.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/sensors/vdk.py
@@ -1,2 +1,26 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+from typing import Any
+from typing import Dict
+
+from airflow.sensors.base import BaseSensorOperator
+from vdk_provider.hooks.vdk import VDKHook
+
+
+class VDKSensor(BaseSensorOperator):
+    def __init__(
+        self,
+        conn_id: str,
+        job_name: str,
+        team_name: str,
+        job_execution_id: str,
+        poke_interval_secs: int = 30,
+        timeout_secs: int = 24 * 60 * 60,
+    ):
+        super().__init__(poke_interval=poke_interval_secs, timeout=timeout_secs)
+        self.job_execution_id = job_execution_id
+
+        self.hook = VDKHook(conn_id, job_name, team_name)
+
+    def poke(self, context: Dict[Any, Any]) -> bool:
+        pass

--- a/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/sensors/vdk.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/sensors/vdk.py
@@ -16,8 +16,11 @@ class VDKSensor(BaseSensorOperator):
         job_execution_id: str,
         poke_interval_secs: int = 30,
         timeout_secs: int = 24 * 60 * 60,
+        **kwargs
     ):
-        super().__init__(poke_interval=poke_interval_secs, timeout=timeout_secs)
+        super().__init__(
+            poke_interval=poke_interval_secs, timeout=timeout_secs, **kwargs
+        )
         self.job_execution_id = job_execution_id
 
         self.hook = VDKHook(conn_id, job_name, team_name)

--- a/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/sensors/vdk.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/sensors/vdk.py
@@ -8,6 +8,18 @@ from vdk_provider.hooks.vdk import VDKHook
 
 
 class VDKSensor(BaseSensorOperator):
+    """
+    Sensor which serves to poke an instance of the VDK control-service to check the status of a deployed Data job.
+
+    :param conn_id: ID of the Airflow connection used for the VDKHook
+    :param job_name: name of the job which will be poked
+    :param team_name: team that the job belongs to
+    :param job_execution_id: execution_id of the job execution whose status will be checked
+    :param poke_interval_secs: time in seconds in between each individual poke
+    :param timeout_secs: time in seconds until the sensor times out
+    :param kwargs: extra parameters which will be passed to the BaseSensorOperator superclass
+    """
+
     def __init__(
         self,
         conn_id: str,
@@ -26,4 +38,11 @@ class VDKSensor(BaseSensorOperator):
         self.hook = VDKHook(conn_id, job_name, team_name)
 
     def poke(self, context: Dict[Any, Any]) -> bool:
+        """
+        This method pokes the control-service for the status of a particular job.
+        It is executed routinely every `poke_interval_secs` seconds.
+
+        :param context: Airflow context passed through the DAG
+        :return: True if some job status condition is met; False otherwise
+        """
         pass


### PR DESCRIPTION
This change lays out the initial structure for the VDK asynchronous
operator, a.k.a. the VDKSensor. The purpose of this sensor is to
routinely poke the VDK control-service and check the status of a
particular job, so that its completion/failure can trigger some
activity in an Airflow DAG, i.e. trigger another job.

Signed-off-by: Gabriel Georgiev <gageorgiev@vmware.com>