### PR TITLE
vdk-plugins: Introduce vdk-control-api-auth plugin

### DIFF
--- a/projects/vdk-plugins/vdk-control-api-auth/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-control-api-auth/.plugin-ci.yml
@@ -1,0 +1,34 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+image: "python:3.7"
+
+# TODO: Uncomment when committing new changes
+#.build-vdk-control-api-auth:
+#  variables:
+#    PLUGIN_NAME: vdk-control-api-auth
+#  extends: .build-plugin
+#
+#build-py37-vdk-control-api-auth:
+#  extends: .build-vdk-control-api-auth
+#  image: "python:3.7"
+#
+#
+#build-py38-vdk-control-api-auth:
+#  extends: .build-vdk-control-api-auth
+#  image: "python:3.8"
+#
+#
+#build-py39-vdk-control-api-auth:
+#  extends: .build-vdk-control-api-auth
+#  image: "python:3.9"
+#
+#build-py310-vdk-control-api-auth:
+#  extends: .build-vdk-control-api-auth
+#  image: "python:3.10"
+
+# TODO: Uncomment when plugin is ready for release
+#release-vdk-control-api-auth:
+#  variables:
+#    PLUGIN_NAME: vdk-control-api-auth
+#  extends: .release-plugin

--- a/projects/vdk-plugins/vdk-control-api-auth/README.md
+++ b/projects/vdk-plugins/vdk-control-api-auth/README.md
@@ -1,0 +1,13 @@
+# vdk-control-api-auth
+
+vdk-control-api-auth is a plugin library that implements authentication
+utilities used by vdk-control-cli and other plugins.
+
+## Usage
+
+This is a library plugin, not a runnable plugin, and it is intended to be
+used as a dependency for other plugins which need to authenticate users.
+
+## Build and testing
+
+In order to build and test a plugin go to the plugin directory and use `../build-plugin.sh` script to build it

--- a/projects/vdk-plugins/vdk-control-api-auth/requirements.txt
+++ b/projects/vdk-plugins/vdk-control-api-auth/requirements.txt
@@ -1,0 +1,4 @@
+pytest
+vdk-core
+
+vdk-test-utils

--- a/projects/vdk-plugins/vdk-control-api-auth/setup.py
+++ b/projects/vdk-plugins/vdk-control-api-auth/setup.py
@@ -1,0 +1,44 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import pathlib
+
+import setuptools
+
+"""
+Builds a package with the help of setuptools in order for this package to be imported in other projects
+
+"plugin-package-template" is the name of the package which contains the plugin/s.
+
+"plugin-template" is the name of the plugin contained within this package. Note that you can include
+more than one plugin in a single package. Also note that the contained plugin may have the same name as the package.
+
+"plugin_template" is the Python file which contains the plugin hooks for the corresponding plugin.
+"""
+
+__version__ = "0.1.0"
+
+setuptools.setup(
+    name="vdk-control-api-auth",
+    version=__version__,
+    url="https://github.com/vmware/versatile-data-kit",
+    description="Versatile Data Kit plugin library provides support for "
+    "authentication.",
+    long_description=pathlib.Path("README.md").read_text(),
+    long_description_content_type="text/markdown",
+    install_requires=[],
+    package_dir={"": "src"},
+    packages=setuptools.find_namespace_packages(where="src"),
+    entry_points={
+        "vdk.plugin.run": [
+            "vdk-control-api-auth = vdk.plugin.control_api_auth.control_api_auth_plugin"
+        ]
+    },
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+    ],
+)

--- a/projects/vdk-plugins/vdk-control-api-auth/src/vdk/plugin/control_api_auth/control_api_auth_plugin.py
+++ b/projects/vdk-plugins/vdk-control-api-auth/src/vdk/plugin/control_api_auth/control_api_auth_plugin.py
@@ -1,0 +1,13 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from vdk.api.plugin.hook_markers import hookimpl
+
+"""
+Include the plugin hooks here. For example:
+
+from vdk.internal.core.context import CoreContext
+
+@hookimpl
+def vdk_initialize(context: CoreContext):
+    pass
+"""

--- a/projects/vdk-plugins/vdk-control-api-auth/tests/test_vdk_auth_plugin.py
+++ b/projects/vdk-plugins/vdk-control-api-auth/tests/test_vdk_auth_plugin.py
@@ -1,0 +1,2 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
With the increase in plugins requiring authentication arises the need
for a dedicated utility that provides such functions.

This change introduces the initial structure of a library plugin, whose
purpose is to facilitate authentication with 3-rd party services.

Testing Done: None

Signed-off-by: Andon Andonov <andonova@vmware.com>