### PR TITLE
vdk-core: print query duration

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
@@ -89,13 +89,15 @@ class ManagedCursor(PEP249Cursor):
             result = super().execute(
                 *managed_operation.get_operation_parameters_tuple()
             )
-            self._log.info(f"Executing query SUCCEEDED. Query {self._get_query_duration(query_start_time)}")
+            self._log.info(
+                f"Executing query SUCCEEDED. Query {_get_query_duration(query_start_time)}"
+            )
             return result
         except Exception as e:
             try:
                 self._recover_operation(e, managed_operation)
                 self._log.info(
-                    f"Recovered query {self._get_query_duration(query_start_time)}"
+                    f"Recovered query {_get_query_duration(query_start_time)}"
                 )
             except Exception as e:
                 # todo: error classification
@@ -103,9 +105,7 @@ class ManagedCursor(PEP249Cursor):
                 blamee = errors.ResolvableBy.USER_ERROR
                 # else:
                 #     blamee = errors.ResolvableBy.PLATFORM_ERROR
-                self._log.info(
-                    f"Failed query {self._get_query_duration(query_start_time)}"
-                )
+                self._log.info(f"Failed query {_get_query_duration(query_start_time)}")
                 errors.log_and_rethrow(
                     blamee,
                     self._log,
@@ -155,11 +155,6 @@ class ManagedCursor(PEP249Cursor):
                     countermeasures=errors.MSG_COUNTERMEASURE_FIX_PARENT_EXCEPTION,
                     exception=e,
                 )
-    @staticmethod
-    def _get_query_duration(query_start_time: float):
-        query_end_time = timer()
-        difference = timedelta(seconds=query_end_time - query_start_time)
-        return f"duration H:M:S {difference}"
 
     def fetchall(self) -> Collection[Collection[Any]]:
         self._log.info("Fetching all results from query ...")
@@ -208,3 +203,9 @@ class ManagedCursor(PEP249Cursor):
             if type(e) is type(exception) and e.args == exception.args:  # re-raised
                 raise exception
             raise e from exception  # keep track of originating one
+
+
+def _get_query_duration(query_start_time: float):
+    query_end_time = timer()
+    difference = timedelta(seconds=query_end_time - query_start_time)
+    return f"duration H:M:S {difference}"

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
@@ -207,5 +207,8 @@ class ManagedCursor(PEP249Cursor):
 
 def _get_query_duration(query_start_time: float):
     query_end_time = timer()
-    difference = timedelta(seconds=query_end_time - query_start_time)
-    return f"duration H:M:S {difference}"
+    seconds = timedelta(seconds=query_end_time - query_start_time).total_seconds()
+    minutes, seconds = divmod(seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    difference = "{:02}h:{:02}m:{:02}s".format(int(hours), int(minutes), int(seconds))
+    return f"duration {difference}"

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
@@ -210,5 +210,5 @@ def _get_query_duration(query_start_time: float):
     seconds = timedelta(seconds=query_end_time - query_start_time).total_seconds()
     minutes, seconds = divmod(seconds, 60)
     hours, minutes = divmod(minutes, 60)
-    difference = "{:02}h:{:02}m:{:02}s".format(int(hours), int(minutes), int(seconds))
+    difference = f"{int(hours):02}h:{int(minutes):02}m:{int(seconds):02}s"
     return f"duration {difference}"

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_managed_cursor.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_managed_cursor.py
@@ -1,5 +1,6 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import unittest.mock as mock
 from unittest.mock import call
 
 import pytest
@@ -163,3 +164,54 @@ def test_recovery__failure__execute():
     assert "Could not handle execution exception" == e.value.args[0]
     mock_connection_hook_spec.db_connection_recover_operation.assert_called_once()
     mock_native_cursor.execute.assert_called_once()
+
+
+def test_query_timing_successful_query(caplog):
+    (
+        mock_native_cursor,
+        mock_managed_cursor,
+        _,
+        _,
+        mock_connection_hook_spec,
+    ) = populate_mock_managed_cursor()
+    # set logging level to info
+    mock_managed_cursor._log.level = 20
+    mock_managed_cursor.execute(_query)
+    assert "Successful query duration H:M:S 0:00:" in str(caplog.records)
+
+
+def test_query_timing_recovered_query(caplog):
+    (
+        mock_native_cursor,
+        mock_managed_cursor,
+        _,
+        _,
+        mock_connection_hook_spec,
+    ) = populate_mock_managed_cursor()
+    # set logging level to info
+    mock_managed_cursor._log.level = 20
+    mock_native_cursor.execute.side_effect = [Exception("Mock exception")]
+    mock_managed_cursor.execute(_query)
+    assert "Recovered query duration H:M:S 0:00:" in str(caplog.records)
+
+
+def test_query_timing_failed_query(caplog):
+    (
+        mock_native_cursor,
+        mock_managed_cursor,
+        _,
+        _,
+        mock_connection_hook_spec,
+    ) = populate_mock_managed_cursor()
+    # set logging level to info
+    with mock.patch.object(
+        mock_managed_cursor.__class__, "_recover_operation"
+    ) as mocked_recover:
+        mock_managed_cursor._log.level = 20
+        exception = Exception("Mock exception")
+        mock_native_cursor.execute.side_effect = [exception]
+        mocked_recover.side_effect = [exception]
+        with pytest.raises(Exception):
+            mock_managed_cursor.execute(_query)
+
+    assert "Failed query duration H:M:S 0:00:" in str(caplog.records)

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_managed_cursor.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_managed_cursor.py
@@ -176,7 +176,7 @@ def test_query_timing_successful_query(caplog):
     # set logging level to info
     mock_managed_cursor._log.level = 20
     mock_managed_cursor.execute(_query)
-    assert "Query duration H:M:S 0:00:" in str(caplog.records)
+    assert "Query duration 00h:00m:" in str(caplog.records)
 
 
 def test_query_timing_recovered_query(caplog):
@@ -191,7 +191,7 @@ def test_query_timing_recovered_query(caplog):
     mock_managed_cursor._log.level = 20
     mock_native_cursor.execute.side_effect = [Exception("Mock exception")]
     mock_managed_cursor.execute(_query)
-    assert "Recovered query duration H:M:S 0:00:" in str(caplog.records)
+    assert "Recovered query duration 00h:00m:" in str(caplog.records)
 
 
 def test_query_timing_failed_query(caplog):
@@ -211,4 +211,4 @@ def test_query_timing_failed_query(caplog):
     with pytest.raises(Exception):
         mock_managed_cursor.execute(_query)
 
-    assert "Failed query duration H:M:S 0:00:" in str(caplog.records)
+    assert "Failed query duration 00h:00m:" in str(caplog.records)


### PR DESCRIPTION
why: Users requested clearer examples on how long given operations took: 
"- In concrete case problems was with SQL query , it would be nice if we can
print profile details (especially if query fails)"

what: Added new log statements that show how long an SQL query took.

testing: Added unit tests.

Signed-off-by: Momchil Zhivkov <mzhivkov@vmware.com>