### PR TITLE
vdk-core: Allow logs to be sent to an endpoint using SysLog

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/log_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/log_config.py
@@ -70,7 +70,7 @@ def configure_loggers(
 
     syslog_url, syslog_port, syslog_sock_type, syslog_enabled = syslog_args
 
-    if syslog_sock_type not in SYSLOG_SOCK_TYPE_VALUES_DICT.keys():
+    if syslog_sock_type not in SYSLOG_SOCK_TYPE_VALUES_DICT:
         errors.log_and_throw(
             to_be_fixed_by=errors.ResolvableBy.CONFIG_ERROR,
             log=log,

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/log_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/log_config.py
@@ -35,7 +35,7 @@ def configure_loggers(
     :param attempt_id: the id of the current job run attempt
     :param log_config_type: where the job is executed: CLOUD or LOCAL
     :param vdk_logging_level: The level for vdk specific logs.
-    :param log_endpoint: The URL and port of the endpoint to which logs are sent.
+    :param syslog_args: Arguments necessary for SysLog logging.
     """
 
     import logging.config

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/log_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/log_config.py
@@ -162,8 +162,9 @@ class LoggingPlugin:
     Define the logging plugin
     """
 
+    @staticmethod
     @hookimpl
-    def vdk_configure(self, config_builder: ConfigurationBuilder):
+    def vdk_configure(config_builder: ConfigurationBuilder):
         config_builder.add(
             key=SYSLOG_URL,
             default_value="localhost",

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/log_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/log_config.py
@@ -69,7 +69,6 @@ def configure_loggers(
     }
 
     syslog_url, syslog_port, syslog_sock_type, syslog_enabled = syslog_args
-    print(f"HERE {syslog_sock_type}")
 
     if syslog_sock_type not in SYSLOG_SOCK_TYPE_VALUES_DICT.keys():
         errors.log_and_throw(
@@ -78,7 +77,7 @@ def configure_loggers(
             what_happened=f"Provided configuration variable for {SYSLOG_SOCK_TYPE} has invalid value.",
             why_it_happened=f"VDK was run with {SYSLOG_SOCK_TYPE}={syslog_sock_type}, however {syslog_sock_type} is invalid value for this variable.",
             consequences=errors.MSG_CONSEQUENCE_DELEGATING_TO_CALLER__LIKELY_EXECUTION_FAILURE,
-            countermeasures=f"Please provide a valid value for {SYSLOG_SOCK_TYPE}."
+            countermeasures=f"Provide a valid value for {SYSLOG_SOCK_TYPE}."
             f"Currently possible values are {list(SYSLOG_SOCK_TYPE_VALUES_DICT.keys())}",
         )
 
@@ -168,7 +167,7 @@ class LoggingPlugin:
         config_builder.add(
             key=SYSLOG_URL,
             default_value="localhost",
-            description="The URL of the endpoint to which VDK logs will be sent through SysLog.",
+            description="The hostname of the endpoint to which VDK logs will be sent through SysLog.",
         )
         config_builder.add(
             key=SYSLOG_PORT,

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_log_config.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_log_config.py
@@ -2,13 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 import pathlib
-from unittest.mock import MagicMock
+from unittest import mock
 
 import pytest
 from vdk.api.plugin.plugin_registry import IPluginRegistry
 from vdk.internal.builtin_plugins.config import vdk_config
 from vdk.internal.builtin_plugins.config.log_config import LoggingPlugin
+from vdk.internal.builtin_plugins.config.log_config import SYSLOG_ENABLED
+from vdk.internal.builtin_plugins.config.log_config import SYSLOG_PORT
 from vdk.internal.builtin_plugins.config.log_config import SYSLOG_SOCK_TYPE
+from vdk.internal.builtin_plugins.config.log_config import SYSLOG_URL
 from vdk.internal.builtin_plugins.run.data_job import JobArguments
 from vdk.internal.builtin_plugins.run.job_context import JobContext
 from vdk.internal.builtin_plugins.templates.template_impl import TemplatesImpl
@@ -29,33 +32,37 @@ from vdk.internal.core.statestore import StateStore
     ),
 )
 def test_log_plugin(log_type, vdk_level, expected_vdk_level):
-    logging.getLogger().setLevel(logging.DEBUG)  # root level
-    logging.getLogger("vdk").setLevel(logging.NOTSET)  # reset vdk log level
+    with mock.patch("socket.socket.connect") as mock_connect:
+        logging.getLogger().setLevel(logging.DEBUG)  # root level
+        logging.getLogger("vdk").setLevel(logging.NOTSET)  # reset vdk log level
 
-    log_plugin = LoggingPlugin()
+        log_plugin = LoggingPlugin()
 
-    store = StateStore()
-    store.set(CommonStoreKeys.ATTEMPT_ID, "attempt_id")
+        store = StateStore()
+        store.set(CommonStoreKeys.ATTEMPT_ID, "attempt_id")
 
-    conf = (
-        ConfigurationBuilder()
-        .add(vdk_config.LOG_CONFIG, log_type)
-        .add(vdk_config.LOG_LEVEL_VDK, vdk_level)
-        .add(SYSLOG_SOCK_TYPE, "UDP")
-        .build()
-    )
-    core_context = CoreContext(MagicMock(spec=IPluginRegistry), conf, store)
+        conf = (
+            ConfigurationBuilder()
+            .add(vdk_config.LOG_CONFIG, log_type)
+            .add(vdk_config.LOG_LEVEL_VDK, vdk_level)
+            .add(SYSLOG_URL, "localhost")
+            .add(SYSLOG_PORT, 514)
+            .add(SYSLOG_ENABLED, True)
+            .add(SYSLOG_SOCK_TYPE, "UDP")
+            .build()
+        )
+        core_context = CoreContext(mock.MagicMock(spec=IPluginRegistry), conf, store)
 
-    job_context = JobContext(
-        "foo",
-        pathlib.Path("foo"),
-        core_context,
-        JobArguments([]),
-        TemplatesImpl("foo", core_context),
-    )
+        job_context = JobContext(
+            "foo",
+            pathlib.Path("foo"),
+            core_context,
+            JobArguments([]),
+            TemplatesImpl("foo", core_context),
+        )
 
-    log_plugin.initialize_job(job_context)
+        log_plugin.initialize_job(job_context)
 
-    assert (
-        logging.getLogger("vdk").getEffectiveLevel() == expected_vdk_level
-    ), "internal vdk logs must be set according to configuration option LOG_LEVEL_VDK but are not"
+        assert (
+            logging.getLogger("vdk").getEffectiveLevel() == expected_vdk_level
+        ), "internal vdk logs must be set according to configuration option LOG_LEVEL_VDK but are not"

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_log_config.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_log_config.py
@@ -8,6 +8,7 @@ import pytest
 from vdk.api.plugin.plugin_registry import IPluginRegistry
 from vdk.internal.builtin_plugins.config import vdk_config
 from vdk.internal.builtin_plugins.config.log_config import LoggingPlugin
+from vdk.internal.builtin_plugins.config.log_config import SYSLOG_SOCK_TYPE
 from vdk.internal.builtin_plugins.run.data_job import JobArguments
 from vdk.internal.builtin_plugins.run.job_context import JobContext
 from vdk.internal.builtin_plugins.templates.template_impl import TemplatesImpl
@@ -40,6 +41,7 @@ def test_log_plugin(log_type, vdk_level, expected_vdk_level):
         ConfigurationBuilder()
         .add(vdk_config.LOG_CONFIG, log_type)
         .add(vdk_config.LOG_LEVEL_VDK, vdk_level)
+        .add(SYSLOG_SOCK_TYPE, "UDP")
         .build()
     )
     core_context = CoreContext(MagicMock(spec=IPluginRegistry), conf, store)

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_log_config.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_log_config.py
@@ -32,7 +32,7 @@ from vdk.internal.core.statestore import StateStore
     ),
 )
 def test_log_plugin(log_type, vdk_level, expected_vdk_level):
-    with mock.patch("socket.socket.connect") as mock_connect:
+    with mock.patch("socket.socket.connect"):
         logging.getLogger().setLevel(logging.DEBUG)  # root level
         logging.getLogger("vdk").setLevel(logging.NOTSET)  # reset vdk log level
 


### PR DESCRIPTION
This change makes it so an cloud executions of jobs can have an
endpoint configured, where logs will be sent automatically using
SysLog.

Testing done: ran job with a configured endpoint and observed logs
in the endpoint

Signed-off-by: Gabriel Georgiev <gageorgiev@vmware.com>