### PR TITLE
support: increase builder memory limits

### DIFF
--- a/support/gitlab-runners/values.yaml
+++ b/support/gitlab-runners/values.yaml
@@ -73,9 +73,9 @@ runners:
   ## TODO: Have runners for big and small jobs.
   builds:
     cpuLimit: 1000m
-    memoryLimit: 4Gi
+    memoryLimit: 6Gi
     cpuRequests: 500m
-    memoryRequests: 2Gi
+    memoryRequests: 4Gi
 
   ## Service Container specific configuration
   ##


### PR DESCRIPTION
why: Recently our builds have been failing with out of memory errors.
As a first step remediation we decided to increase the memory limits.

what: Increased the builder limit from 4 to 6 gb.

testing: trivial.

Signed-off-by: Momchil Zhivkov <mzhivkov@vmware.com>