### PR TITLE
vdk-control-cli: add support for kerberos authentication

### DIFF
--- a/projects/vdk-control-cli/requirements.txt
+++ b/projects/vdk-control-cli/requirements.txt
@@ -2,6 +2,7 @@
 # Usually same (version may be different) as install_requires in setup.cfg
 click~=8.0
 click-spinner
+kerberos
 
 # Dependencies license report:
 pip-licenses

--- a/projects/vdk-control-cli/setup.cfg
+++ b/projects/vdk-control-cli/setup.cfg
@@ -65,8 +65,9 @@ exclude =
 
 [options.extras_require]
 # Add here additional requirements for extra features, to install with:
-# `pip install vdk-control-cli[PDF]` like:
-# PDF = ReportLab; RXP
+# `pip install vdk-control-cli[kerberos]` like:
+# If Kerberos authentication for REST API is necessary
+kerberos = kerberos
 
 [options.entry_points]
 console_scripts =

--- a/projects/vdk-control-cli/src/vdk/internal/control/auth/kerberos_client.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/auth/kerberos_client.py
@@ -1,0 +1,47 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+
+def is_kerberos_installed():
+    """
+    If Kerberos is installed we try to authenticate with it.
+    """
+    try:
+        import kerberos
+
+        return True
+    except ImportError:
+        return False
+
+
+class KerberosTicket:
+    """
+    Borrowed from http://python-notes.curiousefficiency.org/en/latest/python_kerberos.html
+    """
+
+    def __init__(self, service):
+        import kerberos
+
+        __, krb_context = kerberos.authGSSClientInit(service)
+        kerberos.authGSSClientStep(krb_context, "")
+        self._krb_context = krb_context
+        self.auth_header = "Negotiate " + kerberos.authGSSClientResponse(krb_context)
+
+    def verify_response(self, auth_header):
+        # Handle comma-separated lists of authentication fields
+        for field in auth_header.split(","):
+            kind, __, details = field.strip().partition(" ")
+            if kind.lower() == "negotiate":
+                auth_details = details.strip()
+                break
+        else:
+            raise ValueError("Negotiate not found in %s" % auth_header)
+        # Finish the Kerberos handshake
+        krb_context = self._krb_context
+        if krb_context is None:
+            raise RuntimeError("Ticket already used for verification")
+        self._krb_context = None
+        import kerberos
+
+        kerberos.authGSSClientStep(krb_context, auth_details)
+        kerberos.authGSSClientClean(krb_context)

--- a/projects/vdk-control-cli/src/vdk/internal/control/configuration/vdk_config.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/configuration/vdk_config.py
@@ -79,6 +79,31 @@ class VDKConfig:
         return os.getenv("VDK_API_TOKEN", None)
 
     @property
+    def kerberos_authentication_enabled(self) -> bool:
+        """
+        If set to true, it will try to use Kerberos authentication for API requests if it's possible
+        (If kerberos module is installed and authentication request succeeds)
+        """
+        return os.getenv(
+            "VDK_CONTROL_KERBEROS_AUTHENTICATION_ENABLED", "True"
+        ).lower() in (
+            "true",
+            "1",
+            "t",
+        )
+
+    @property
+    def kerberos_service_name(self) -> str:
+        """
+        Kerberos service name of the API Server.
+        It's a string containing the service principal (for the API server) in the form 'type@fqdn'
+        (e.g. 'http@server.vdk.com').
+        """
+        return os.getenv(
+            "VDK_CONTROL_KERBEROS_SERVICE_NAME", "HTTP@taurus-data-pipelines-service"
+        )
+
+    @property
     def http_connect_timeout_seconds(self) -> int:
         return int(os.getenv("VDK_CONTROL_HTTP_CONNECT_TIMEOUT_SECONDS", "30"))
 


### PR DESCRIPTION
We are adding support for Kerberos authentication in the Control REST
API . This is extending the support for the client to be able to make
authentication requests with kerberos.

The implementation builds on previous by trying to stay smart.

1. If valid Oauth2 token is detected and Oauth2 auth is not disabled
(e.g by vdk logout) it will be used
2. If No valid Oauth2 token is detected and kerberos ticket is detected
(this happen if KeberosTicket can generate auth_header) and kerberos is
not disabled (by flag VDK_CONTROL_KERBEROS_AUTHENTICATION_ENABLED)
3. If none is detected - then no Authenticaiton is used.

Testing Done: automated tests

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>