### PR TITLE
versatile-data-kit: link examples wiki in the git examples 

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,8 @@
 # Versatile Data Kit Examples
 
-This section provides a set of examples that explore some of the features provided by Versatile Data Kit.
+This section provides the source code for examples that explore some of the features provided by Versatile Data Kit.
+
+For the full tutorials (articles about each example) please visit [Versatile Data Kit examples documentation](https://github.com/vmware/versatile-data-kit/wiki/Examples) 
 
 ## Basic Examples
 Tutorials to get started with generic ingestion tasks in VDK:

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 This section provides the source code for examples that explore some of the features provided by Versatile Data Kit.
 
-For the full tutorials (articles about each example) please visit [Versatile Data Kit examples documentation](https://github.com/vmware/versatile-data-kit/wiki/Examples) 
+For the full tutorials (articles about each example) please visit [Versatile Data Kit examples documentation](https://github.com/vmware/versatile-data-kit/wiki/Examples)
 
 ## Basic Examples
 Tutorials to get started with generic ingestion tasks in VDK:


### PR DESCRIPTION


The examples directory in git contains generally the source code. And the examples tutorial/articles are written in a wiki currently. 

Signed-off-by: Antoni Ivanov's avatarAntoni Ivanov <aivanov@vmware.com>