### PR TITLE
vdk-heartbeat: null datetime conversion fix

### DIFF
--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
@@ -383,14 +383,18 @@ class JobController:
             (self._datetime_from_iso_format(e["end_time"]), e["status"])
             for e in execution_list
         ]
-        end_datetime_list = [
-            e[0] for e in end_datetime_status_tuples if e[0] is not None
+
+        # latest status, where end_time is yet about to be populated
+        status_end_datetime_none_list = [
+            e[1] for e in end_datetime_status_tuples if e[0] is None
         ]
-        if not end_datetime_list:
-            return None
+        if status_end_datetime_none_list:
+            return status_end_datetime_none_list.pop()
 
-        end_datetime_latest = max(end_datetime_list)
-
+        # latest status by datetime, since no unpopulated end_time
+        end_datetime_latest = max(
+            e[0] for e in end_datetime_status_tuples if e[0] is not None
+        )
         return [
             e[1] for e in end_datetime_status_tuples if e[0] == end_datetime_latest
         ].pop()

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
@@ -383,9 +383,13 @@ class JobController:
             (self._datetime_from_iso_format(e["end_time"]), e["status"])
             for e in execution_list
         ]
-        end_datetime_latest = max(
+        end_datetime_list = [
             e[0] for e in end_datetime_status_tuples if e[0] is not None
-        )
+        ]
+        if not end_datetime_list:
+            return None
+
+        end_datetime_latest = max(end_datetime_list)
 
         return [
             e[1] for e in end_datetime_status_tuples if e[0] == end_datetime_latest

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
@@ -379,13 +379,16 @@ class JobController:
         if not execution_list:
             return None
 
-        latest_end_date = max(
-            self._datetime_from_iso_format(str(e["end_time"])) for e in execution_list
-        )
-        return [
-            e["status"]
+        end_datetime_status_tuples = [
+            (self._datetime_from_iso_format(e["end_time"]), e["status"])
             for e in execution_list
-            if self._datetime_from_iso_format(str(e["end_time"])) == latest_end_date
+        ]
+        end_datetime_latest = max(
+            e[0] for e in end_datetime_status_tuples if e[0] is not None
+        )
+
+        return [
+            e[1] for e in end_datetime_status_tuples if e[0] == end_datetime_latest
         ].pop()
 
     def _update_config_ini(self, heartbeat_job_dir):
@@ -460,14 +463,13 @@ def run(job_input):
             pyfile.write(python_script)
 
     @staticmethod
-    def _datetime_from_iso_format(datetime_string: str):
+    def _datetime_from_iso_format(datetime_string):
         try:
             return datetime.fromisoformat(datetime_string)
-        except ValueError as e:
+        except Exception as e:
             log.info(
                 "An exception occurred while converting datetime string "
                 f"value of -- {datetime_string} -- to "
                 f"a datetime object. The exception was {e}"
             )
-
         return None

--- a/projects/vdk-heartbeat/tests/vdk/internal/test_job_controller.py
+++ b/projects/vdk-heartbeat/tests/vdk/internal/test_job_controller.py
@@ -37,6 +37,11 @@ def test_check_job_execution_finished_no_exceptions_for_value_errors(patched_met
     res = test_controller.check_job_execution_finished()
     assert res == "finished"
 
+    # non-populated end_time
+    patched_method.return_value = '[{"status": "finished", "end_time": null}]'
+    res = test_controller.check_job_execution_finished()
+    assert res == "finished"
+
     patched_method.return_value = '[{"status": "finished", "end_time": ' "12345}]"
 
     res = test_controller.check_job_execution_finished()


### PR DESCRIPTION
We've noticed an occasional error occurs, applying the stack trace:
File "/opt/buildenv/lib/python3.7/site-packages/vdk/internal/heartbeat/
job_controller.py", line 383, in check_job_execution_finished
self._datetime_from_iso_format(str(e["end_time"])) for e in
execution_list
TypeError: '>' not supported between instances of 'NoneType' and
'datetime.datetime'

The error seems to reproduce in case execution end_time is not yet
populated, and `max()` is attempting to compare datetime with NoneType.
The fix includes filtering out any empty end_times, so that we rely on
statuses and end_times populated only.
A broader Exception is added for handling during datetime conversion,
like a preventive step.

Testing done: did retrieve the Execution API response, did reproduce
same TypeError error via local code snippet, then verified the newly
introduced fix applied is operational.

Signed-off-by: ikoleva <ikoleva@vmware.com>