### PR TITLE
vdk-core: new version check built-in plugin false positive fix

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/version/new_version_check_plugin.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/version/new_version_check_plugin.py
@@ -49,10 +49,13 @@ class NewVersionCheckPlugin:
         try:
             package_list = []
             cfg = context.configuration
-
             package_name = cfg.get_value(ConfigKey.PACKAGE_NAME.value)
             package_index = cfg.get_value(ConfigKey.PACKAGE_INDEX.value)
+
             if new_package(package_name, package_index).check():
+                log.debug(
+                    f"New version found for package {package_name} from index {package_index}"
+                )
                 package_list.append(package_name)
 
             if cfg.get_value(ConfigKey.VERSION_CHECK_PLUGINS.value):
@@ -61,7 +64,7 @@ class NewVersionCheckPlugin:
                     if new_package(dist_name, package_index).check():
                         package_list.append(dist_name)
 
-            self._check_version(package_list, package_index)
+            self._print_new_version_message(package_list, package_index)
         except Exception as e:
             log.debug(
                 f"Could not check for new version release. "
@@ -69,13 +72,15 @@ class NewVersionCheckPlugin:
             )
 
     @staticmethod
-    def _check_version(package_list: List[str], package_index: str) -> None:
+    def _print_new_version_message(package_list: List[str], package_index: str) -> None:
         """
         Prints out a new version message for the listed packages.
 
         :param package_list: list of package names
         :param package_index: package index included in the printed `pip install` command
         """
+        if not package_list:
+            return
         not_single_package = len(package_list) > 1
 
         # if package index is not specified that we fetch it from pip repo (pypi.org)

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/version/test_new_version_check_plugin.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/version/test_new_version_check_plugin.py
@@ -37,7 +37,37 @@ def build_core_context(plugin, config: Dict):
     autospec=True,
 )
 @patch(f"click.echo", autospec=True)
-def test_version_check(mock_click_echo, mock_list, mock_package):
+def test_no_new_version_check(mock_click_echo, mock_list, mock_package):
+    mock_package.return_value.check.return_value = False
+    mock_list.return_value = [("dist", "plugin")]
+
+    check_plugin = NewVersionCheckPlugin()
+    context = build_core_context(
+        check_plugin,
+        {
+            new_version_check_plugin.ConfigKey.PACKAGE_INDEX.value: "https://testing.package.index"
+        },
+    )
+    check_plugin.vdk_exit(context)
+
+    mock_package.assert_any_call(
+        package_index="https://testing.package.index", package_name="vdk-core"
+    )
+    mock_package.assert_any_call(
+        package_index="https://testing.package.index", package_name="dist"
+    )
+
+    # we verify no command is suggested to the user
+    assert not mock_click_echo.mock_calls
+
+
+@patch(f"{new_package.__module__}.{new_package.__name__}", autospec=True)
+@patch(
+    f"{version.list_installed_plugins.__module__}.{version.list_installed_plugins.__name__}",
+    autospec=True,
+)
+@patch(f"click.echo", autospec=True)
+def test_new_version_check(mock_click_echo, mock_list, mock_package):
     mock_list.return_value = [("dist", "plugin")]
 
     check_plugin = NewVersionCheckPlugin()
@@ -68,7 +98,7 @@ def test_version_check(mock_click_echo, mock_list, mock_package):
     f"{version.list_installed_plugins.__module__}.{version.list_installed_plugins.__name__}",
     autospec=True,
 )
-def test_version_check_skip_plugins(mock_list, mock_package):
+def test_new_version_check_skip_plugins(mock_list, mock_package):
     mock_list.return_value = [("dist", "plugin")]
 
     check_plugin = NewVersionCheckPlugin()
@@ -89,7 +119,9 @@ def test_version_check_skip_plugins(mock_list, mock_package):
     autospec=True,
 )
 @patch(f"click.echo", autospec=True)
-def test_version_check_empty_package_index(mock_click_echo, mock_list, mock_package):
+def test_new_version_check_empty_package_index(
+    mock_click_echo, mock_list, mock_package
+):
     mock_list.return_value = [("dist", "plugin")]
 
     check_plugin = NewVersionCheckPlugin()
@@ -110,7 +142,7 @@ def test_version_check_empty_package_index(mock_click_echo, mock_list, mock_pack
     f"{version.list_installed_plugins.__module__}.{version.list_installed_plugins.__name__}",
     autospec=True,
 )
-def test_version_check_error(mock_list, mock_package):
+def test_new_version_check_error(mock_list, mock_package):
     mock_list.return_value = [("dist", "plugin")]
 
     check_plugin = NewVersionCheckPlugin()


### PR DESCRIPTION
A bug detected when using custom new-version-check-plugin
configurations:
```
config_builder.set_value(key="PACKAGE_INDEX",value="https://some.repo")
config_builder.set_value(key="PACKAGE_NAME",
value="some-package-upgraded-to-latest-locally")
config_builder.set_value("VERSION_CHECK_PLUGINS", False)
```
That results in false-positive yet package-empty
upgrade message displayed:
```
************************************************************************
New version for   is available.
Please update to latest version by using:
 pip install --upgrade-strategy eager -U   --extra-index-url
 https://some.repo
************************************************************************
```

Changed `_check_version` method to `_print_new_version_message`,
matching the purpose described in its pydocs. Added handling of
use-case when no packages for upgrade detected.

Testing Done: added a `test_no_new_version_check` to cover that
use-case, the test detects the issue before the changes
and succeeds after applying the changes made.

Signed-off-by: ikoleva <ikoleva@vmware.com>