### PR TITLE
vdk-core: encapsulate router-specific properties logic

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_router.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_router.py
@@ -6,6 +6,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
+from vdk.api.job_input import IIngester
 from vdk.api.plugin.plugin_input import IIngesterPlugin
 from vdk.api.plugin.plugin_input import IIngesterRegistry
 from vdk.internal.builtin_plugins.ingestion.ingester_base import IngesterBase
@@ -30,7 +31,7 @@ IngesterPluginFactory = Callable[[], IIngesterPlugin]
 log = logging.getLogger(__name__)
 
 
-class IngesterRouter(IIngesterRegistry):
+class IngesterRouter(IIngesterRegistry, IIngester):
     """
     Router class for the core Ingestion API. It takes care of routing the
     payloads to their respective ingestion plugins.

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/job_input.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/job_input.py
@@ -70,25 +70,19 @@ class JobInput(IJobInput):
     # Properties
 
     def get_property(self, name, default_value=None):
-        return self.__properties_router.get_properties_impl().get_property(
-            name, default_value
-        )
+        return self.__properties_router.get_property(name, default_value)
 
     def get_all_properties(self):
-        return self.__properties_router.get_properties_impl().get_all_properties()
+        return self.__properties_router.get_all_properties()
 
     def set_all_properties(self, properties):
-        return self.__properties_router.get_properties_impl().set_all_properties(
-            properties
-        )
+        return self.__properties_router.set_all_properties(properties)
 
     def _substitute_query_params(self, sql: str):
         sql = textwrap.dedent(sql).strip("\n") + "\n"
         query = sql
         sql_susbstitute_args = {}
-        if isinstance(
-            self.__properties_router.get_properties_impl(), PropertiesNotAvailable
-        ):
+        if not self.__properties_router.has_properties_impl():
             logging.getLogger(__name__).info(
                 "Data Job Properties has not been initialized., "
                 "so I won't be able to provide query properties substitution capabilities from job properties."

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/job_properties/test_properties_router.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/job_properties/test_properties_router.py
@@ -19,10 +19,10 @@ def test_routing():
     mock_client = MagicMock(spec=IPropertiesServiceClient)
     router.set_properties_factory_method("default", lambda: mock_client)
 
-    router.get_properties_impl().set_all_properties({"a": "b"})
+    router.set_all_properties({"a": "b"})
     mock_client.write_properties.assert_called_with("foo", "test-team", {"a": "b"})
 
-    router.get_properties_impl().get_all_properties()
+    router.get_all_properties()
     mock_client.read_properties.assert_called_with("foo", "test-team")
 
 
@@ -35,14 +35,14 @@ def test_routing_error():
     router.set_properties_factory_method("default", raise_error)
 
     with pytest.raises(VdkConfigurationError):
-        router.get_properties_impl().set_all_properties({"a": "b"})
+        router.set_all_properties({"a": "b"})
 
 
 def test_routing_empty_error():
     router = PropertiesRouter("foo", Configuration({}, {}))
 
     with pytest.raises(VdkConfigurationError):
-        router.get_properties_impl().set_all_properties({"a": "b"})
+        router.set_all_properties({"a": "b"})
 
 
 def test_routing_choose_single_registered():
@@ -50,7 +50,7 @@ def test_routing_choose_single_registered():
     mock_client = MagicMock(spec=IPropertiesServiceClient)
     router.set_properties_factory_method("foo", lambda: mock_client)
 
-    router.get_properties_impl().set_all_properties({"a": "b"})
+    router.set_all_properties({"a": "b"})
     mock_client.write_properties.assert_called_with("foo", "test-team", {"a": "b"})
 
 
@@ -63,7 +63,7 @@ def test_routing_choose_default_type_chosen():
     router.set_properties_factory_method("foo", lambda: foo_mock_client)
     router.set_properties_factory_method("bar", lambda: bar_mock_client)
 
-    router.get_properties_impl().set_all_properties({"a": "b"})
+    router.set_all_properties({"a": "b"})
     foo_mock_client.write_properties.assert_called_with("foo", None, {"a": "b"})
     bar_mock_client.assert_not_called()
 
@@ -76,4 +76,4 @@ def test_routing_choose_too_many_choices():
     router.set_properties_factory_method("bar", lambda: bar_mock_client)
 
     with pytest.raises(VdkConfigurationError):
-        router.get_properties_impl().set_all_properties({"a": "b"})
+        router.set_all_properties({"a": "b"})


### PR DESCRIPTION
This MR attempts to simplify outer usages of PropertiesRouter,
in equivalent to IngesterRouter. The reason is IngesterRouter does
support multiple ingesters evaluated in a sequence, and PropertiesRouter
supports singleton properties back-end implementation yet.

PropertiesRouter interface surface no more exposes a singleton
implementation, instead implements the IProperties interface and
does the routing internally.
Also IngesterRouter already implements IIngester methods, so elaborated
the class definition on that explicitly, so it is effectively coupled
with the interfaces evolution.

Testing Done: ci/cd. No functional changes made, except interface
surface improvements and encapsulation.

Signed-off-by: ikoleva <ikoleva@vmware.com>