### PR TITLE
airflow-provider-vdk: Fix CICD release step

### DIFF
--- a/projects/vdk-plugins/airflow-provider-vdk/.airflow-ci.yml
+++ b/projects/vdk-plugins/airflow-provider-vdk/.airflow-ci.yml
@@ -36,6 +36,7 @@ release-airflow-provider-vdk:
   stage: release
   image: "python:3.7"
   script:
+    - export VDK_PATCH_VERSION=${CI_PIPELINE_ID}
     - cd projects/vdk-plugins/
     - echo "Releasing airflow-provider-vdk..."
     - cd airflow-provider-vdk/ || exit 1
@@ -46,6 +47,6 @@ release-airflow-provider-vdk:
     - twine upload --repository-url $PIP_REPO_UPLOAD_URL -u "$PIP_REPO_UPLOAD_USER_NAME" -p "$PIP_REPO_UPLOAD_USER_PASSWORD" dist/*tar.gz --verbose
   retry: !reference [.retry, retry_options]
   rules:
-    - if: '$CI_COMMIT_BRANCH == "main"'
+    - if: '$CI_COMMIT_BRANCH == "main" || $CI_PIPELINE_SOURCE == "external_pull_request_event"'
       changes:
         - "projects/vdk-plugins/airflow-provider-vdk/**/*"


### PR DESCRIPTION
The CICD release step was broken due to a missing env variable.
This change adds it.

Signed-off-by: Gabriel Georgiev <gageorgiev@vmware.com>