### PR TITLE
versatile-data-kit: allow commit with any newer version of python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-        language_version: python3.7
+        language_version: python3
   # ensure pydoc is up-to standard
   - repo: https://github.com/pycqa/pydocstyle
     rev: 6.1.1


### PR DESCRIPTION
If users run pre-commit hook locally they need python. Due to
https://github.com/pre-commit/pre-commit/issues/1375 it seems the
pre-commit hooks is failing if there's no python3.7 because we've
specified in black to use it. We are loosing the version to python 3.7
so that it's eaiser to develop with any version

Testing Done: ran git commit in docker container using only python 3.9
and saw (after the change) it no longer fails.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>x