### PR TITLE
vdk-control-cli: Validate cron schedule before deploying job

### DIFF
--- a/projects/vdk-control-cli/setup.cfg
+++ b/projects/vdk-control-cli/setup.cfg
@@ -54,6 +54,7 @@ install_requires =
     tabulate
     requests_oauthlib>=1.0
     urllib3>=1.26.5
+    croniter==1.3.4
 
 # Require a specific Python version
 python_requires = >=3.7, <3.11


### PR DESCRIPTION
This change ensures a job's cron schedule is a valid cron
expression before deploying it to the control-service, and
prints an appropriate message if it is not.

Testing done: attempted to deploy a job with a malformed
cron schedule and observed error; verified a job with a
correct cron schedule can still be deployed

Signed-off-by: Gabriel Georgiev <gageorgiev@vmware.com>