### PR TITLE
[vdk-plugins] vdk-control-api-auth: Enable plugin release

### DIFF
--- a/projects/vdk-plugins/vdk-control-api-auth/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-control-api-auth/.plugin-ci.yml
@@ -26,8 +26,7 @@ build-py310-vdk-control-api-auth:
   extends: .build-vdk-control-api-auth
   image: "python:3.10"
 
-# TODO: Uncomment when plugin is ready for release
-#release-vdk-control-api-auth:
-#  variables:
-#    PLUGIN_NAME: vdk-control-api-auth
-#  extends: .release-plugin
+release-vdk-control-api-auth:
+  variables:
+    PLUGIN_NAME: vdk-control-api-auth
+  extends: .release-plugin


### PR DESCRIPTION
After finalizing the bulk of the work on the stand-alone authentication
plugin library, it is necessary to release the library so it can be used
by the various components of Versatile Data Kit

This change enables the release step of the CI/CD for the vdk-control-api-auth
package.

Testing Done: CI/CD

Signed-off-by: Andon Andonov <andonova@vmware.com>