### PR TITLE
[vdk-plugins] vdk-control-api-auth: Fix query key type

### DIFF
--- a/projects/vdk-plugins/vdk-control-api-auth/src/vdk/plugin/control_api_auth/autorization_code_auth.py
+++ b/projects/vdk-plugins/vdk-control-api-auth/src/vdk/plugin/control_api_auth/autorization_code_auth.py
@@ -159,9 +159,9 @@ class LoginHandler:
         auth_code = ""
         state = ""
         if self.CODE_PARAMETER_KEY in query_components:
-            auth_code = query_components[bytes(self.CODE_PARAMETER_KEY)][0]
+            auth_code = query_components[self.CODE_PARAMETER_KEY][0]
         if self.STATE_PARAMETER_KEY in query_components:
-            state = query_components[bytes(self.STATE_PARAMETER_KEY)][0]
+            state = query_components[self.STATE_PARAMETER_KEY][0]
         if state != AuthRequestValues.STATE_PARAMETER_VALUE.value or not state:
             raise VDKAuthException(
                 what="Failed to login.",

--- a/projects/vdk-plugins/vdk-control-api-auth/tests/test_authorization_code_auth.py
+++ b/projects/vdk-plugins/vdk-control-api-auth/tests/test_authorization_code_auth.py
@@ -34,7 +34,7 @@ def test_verify_redirect_url():
     assert authorization_url[1] == "requested"
 
 
-def test_login_handler_exception(httpserver: PluginHTTPServer):
+def test_login_handler_exceptions(httpserver: PluginHTTPServer):
     allow_oauthlib_insecure_transport()
     httpserver.expect_request("/foo").respond_with_json(get_json_response_mock())
     in_mem_conf = InMemAuthConfiguration()
@@ -50,11 +50,20 @@ def test_login_handler_exception(httpserver: PluginHTTPServer):
     )
 
     with pytest.raises(VDKAuthException) as exc_info:
-        handler.login_with_authorization_code("dummy-path")
-
+        handler.login_with_authorization_code(
+            path="http://test-url?code=test-auth-code&client_id=client-id&redirect_uri=http%3A%2F%2F127.0.0.1%3A9999&prompt=login"
+        )
     raised_exception = exc_info.value
     assert "Failed to login." in raised_exception.message
     assert "Possibly the request was intercepted." in raised_exception.message
+
+    with pytest.raises(VDKAuthException) as exc_info2:
+        handler.login_with_authorization_code(
+            path="http://test-url?client_id=client-id&redirect_uri=http%3A%2F%2F127.0.0.1%3A9999&state=requested&prompt=login"
+        )
+    raised_exception2 = exc_info2.value
+    assert "Authentication code is empty" in raised_exception2.message
+    assert "The user failed to authenticate properly." in raised_exception2.message
 
 
 def test_authorization_code_no_secret(httpserver: PluginHTTPServer):


### PR DESCRIPTION
When parsing the query parameters from the redirect_url in the
authorization code authentication flow, we converted the key of
the parameter to bytes, which was causing TypeErrors due to missing
encoding. This regression was not caught by the unit tests.

This change fixes the regression by using plain strings as keys
and removing any conversions to bytes.

Additionally, unit test was fixed and extended to catch possible
future regressions.

Testing Done: Unit tests

Signed-off-by: Andon Andonov <andonova@vmware.com>