### PR TITLE
vdk-control-cli: Fix command printed on successful deploy

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli_impl.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli_impl.py
@@ -201,7 +201,7 @@ class JobDeploy:
                 f"It would take a few minutes for the Data Job to be deployed in the server.\n"
                 f"If notified_on_job_deploy option in config.ini is configured then "
                 f"notification will be sent on successful deploy or in case of an error.\n\n"
-                f"You can also execute `vdk deploy --show -t {team} -n {name}` and compare the printed version "
+                f"You can also execute `vdk deploy --show -t '{team}' -n '{name}'` and compare the printed version "
                 f"to the one of the newly deployed job - {deployment.job_version} - to verify that the deployment "
                 f"was successful."
             )


### PR DESCRIPTION
When successfully deploying a job, vdk-control-cli
prints a command which can be used to check whether
the deployment version was successfully updated.
However, the printed command included the team name
without quotes around it, which can be an issue as
team names can have empty spaces in them, which meant
the command gets parsed wrongly and fails.

Command used to look like:
```
vdk deploy --show -t team_name -n job_name
```
Now it looks like:
```
vdk deploy --show -t 'team_name' -n 'job_name'
```

Signed-off-by: Gabriel Georgiev <gageorgiev@vmware.com>