### PR TITLE
New VDK Auth exceptions

### DIFF
--- a/projects/vdk-plugins/vdk-control-api-auth/src/vdk/plugin/control_api_auth/auth_config.py
+++ b/projects/vdk-plugins/vdk-control-api-auth/src/vdk/plugin/control_api_auth/auth_config.py
@@ -6,7 +6,7 @@ import pathlib
 from pathlib import Path
 from typing import Optional
 
-from vdk.plugin.control_api_auth.auth_exception import VDKAuthException
+from vdk.plugin.control_api_auth.auth_exception import VDKAuthOSError
 
 log = logging.getLogger(__name__)
 
@@ -87,7 +87,7 @@ class AuthConfigFolder:
             base_dir, AuthConfigFolder.CONFIG_FOLDER_NAME
         )
         if os.path.isfile(self.vdk_config_folder):
-            raise VDKAuthException(
+            raise VDKAuthOSError(
                 what="Credentials file was not created",
                 why=f"There is a file named {self.vdk_config_folder}",
                 consequence="User won't be able to access Control Service",
@@ -102,7 +102,7 @@ class AuthConfigFolder:
                         parents=True, exist_ok=True
                     )
                 except Exception as e:
-                    raise VDKAuthException(
+                    raise VDKAuthOSError(
                         what="Configuration folder was not created and user is not logged in",
                         why=f"Cannot create: {self.vdk_config_folder} configuration folder: {str(e)}",
                         consequence="User won't be able to access Control Service",
@@ -116,7 +116,7 @@ class AuthConfigFolder:
             with open(credentials_file_path, "w+") as temp_file:
                 temp_file.write(content)
         except OSError as e:
-            raise VDKAuthException(
+            raise VDKAuthOSError(
                 what="Credentials file was not created",
                 why=f"Cannot create credentials file: {str(e)}",
                 consequence="User won't be able to access Control Service",
@@ -130,7 +130,7 @@ class AuthConfigFolder:
             try:
                 os.remove(credentials_file_path)
             except OSError as e:
-                raise VDKAuthException(
+                raise VDKAuthOSError(
                     what="Credentials file was not deleted",
                     why=f"Cannot delete credentials file in .vdk folder in home directory: {str(e)}",
                     consequence="User is not logged out",
@@ -146,7 +146,7 @@ class AuthConfigFolder:
                     return temp_file.read()
             return ""
         except OSError as e:
-            raise VDKAuthException(
+            raise VDKAuthOSError(
                 what="Credentials file cannot be accessed.",
                 why=f"Most likely not login. Error was: {str(e)}",
                 consequence="User won't be able to authenticate against Control Service",

--- a/projects/vdk-plugins/vdk-control-api-auth/src/vdk/plugin/control_api_auth/auth_exception.py
+++ b/projects/vdk-plugins/vdk-control-api-auth/src/vdk/plugin/control_api_auth/auth_exception.py
@@ -18,3 +18,43 @@ class VDKAuthException(Exception):
             f"countermeasures: {countermeasure}\n"
         )
         super().__init__(self.message)
+
+
+class VDKInvalidAuthParamError(VDKAuthException):
+    """
+    The VDKInvalidAuthParamError is a custom exception type derived from
+    the base VDKAuthException type. It is raised when a parameter needed
+    for authentication is missing/not provided or otherwise invalid.
+    """
+
+    def __init__(self, what, why, consequence, countermeasure):
+        super().__init__(
+            what=what, why=why, consequence=consequence, countermeasure=countermeasure
+        )
+
+
+class VDKLoginFailedError(VDKAuthException):
+    """
+    The VDKLoginFailedError is a custom exception type derived from the
+    base VDKAuthException type. It is raised when an error occurs while
+    going through the actual authentication flow, i.e., when something
+    happens while connecting to a third party endpoint.
+    """
+
+    def __init__(self, what, why, consequence, countermeasure):
+        super().__init__(
+            what=what, why=why, consequence=consequence, countermeasure=countermeasure
+        )
+
+
+class VDKAuthOSError(VDKAuthException):
+    """
+    The VDKAuthOSError is a custom exception type derived from the base
+    VDKAuthException type. It is raised when an error in the underlying
+    Operating System arises.
+    """
+
+    def __init__(self, what, why, consequence, countermeasure):
+        super().__init__(
+            what=what, why=why, consequence=consequence, countermeasure=countermeasure
+        )

--- a/projects/vdk-plugins/vdk-control-api-auth/src/vdk/plugin/control_api_auth/authentication.py
+++ b/projects/vdk-plugins/vdk-control-api-auth/src/vdk/plugin/control_api_auth/authentication.py
@@ -1,7 +1,7 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 from vdk.plugin.control_api_auth.auth_config import InMemAuthConfiguration
-from vdk.plugin.control_api_auth.auth_exception import VDKAuthException
+from vdk.plugin.control_api_auth.auth_exception import VDKInvalidAuthParamError
 from vdk.plugin.control_api_auth.autorization_code_auth import RedirectAuthentication
 from vdk.plugin.control_api_auth.base_auth import BaseAuth
 from vdk.plugin.control_api_auth.login_types import LoginTypes
@@ -62,7 +62,7 @@ class Authentication:
 
     def authenticate(self) -> None:
         if not self._auth_type:
-            raise VDKAuthException(
+            raise VDKInvalidAuthParamError(
                 what="Unable to log in.",
                 why="auth_type was not specified.",
                 consequence="Subsequent requests to Control Service will not "
@@ -70,7 +70,7 @@ class Authentication:
                 countermeasure="Specify what type of authentication is to be " "used.",
             )
         if not self._auth_url:
-            raise VDKAuthException(
+            raise VDKInvalidAuthParamError(
                 what="Unable to log in.",
                 why="auth_url was not specified.",
                 consequence="Authentication is not possible. All subsequent "
@@ -83,7 +83,7 @@ class Authentication:
         elif self._auth_type == LoginTypes.CREDENTIALS.value:
             self.__authenticate_with_authorization_code()
         else:
-            raise VDKAuthException(
+            raise VDKInvalidAuthParamError(
                 what="Unexpected authentication type.",
                 why=f"Unknown auth_type {self._auth_type} was used.",
                 consequence="Authentication is not possible.",
@@ -113,7 +113,7 @@ class Authentication:
         :return:
         """
         if not self._client_id or not self._auth_discovery_url:
-            raise VDKAuthException(
+            raise VDKInvalidAuthParamError(
                 what="Unable to log in.",
                 why=f"Login type {self._auth_type} requires client_id and "
                 "auth_discovery_url to be specified.",

--- a/projects/vdk-plugins/vdk-control-api-auth/src/vdk/plugin/control_api_auth/autorization_code_auth.py
+++ b/projects/vdk-plugins/vdk-control-api-auth/src/vdk/plugin/control_api_auth/autorization_code_auth.py
@@ -22,7 +22,7 @@ from requests import HTTPError
 from requests import post
 from requests.auth import HTTPBasicAuth
 from requests_oauthlib import OAuth2Session
-from vdk.plugin.control_api_auth.auth_exception import VDKAuthException
+from vdk.plugin.control_api_auth.auth_exception import VDKLoginFailedError
 from vdk.plugin.control_api_auth.auth_request_values import AuthRequestValues
 from vdk.plugin.control_api_auth.base_auth import BaseAuth
 from vdk.plugin.control_api_auth.login_types import LoginTypes
@@ -133,7 +133,7 @@ class LoginHandler:
             response.raise_for_status()
             json_data = json.loads(response.text)
         except HTTPError as http_exception:
-            raise VDKAuthException(
+            raise VDKLoginFailedError(
                 what="Failed to login.",
                 why="HTTP error occurred during authorization workflow. "
                 f"Error was: HTTP error {http_exception.response.status_code}: {http_exception.response.content}",
@@ -145,7 +145,7 @@ class LoginHandler:
                 "and commands executed.",
             )
         except Exception as e:
-            raise VDKAuthException(
+            raise VDKLoginFailedError(
                 what=f"Failed to login: {str(e)}.",
                 why="Problem in the configuration or service. Cannot acquire tokens.",
                 consequence="Cannot login user.",
@@ -163,14 +163,14 @@ class LoginHandler:
         if self.STATE_PARAMETER_KEY in query_components:
             state = query_components[self.STATE_PARAMETER_KEY][0]
         if state != AuthRequestValues.STATE_PARAMETER_VALUE.value or not state:
-            raise VDKAuthException(
+            raise VDKLoginFailedError(
                 what="Failed to login.",
                 why="Possibly the request was intercepted.",
                 consequence="Cannot login user.",
                 countermeasure="Try to login again.",
             )
         if not auth_code:
-            raise VDKAuthException(
+            raise VDKLoginFailedError(
                 what="Authentication code is empty",
                 why="The user failed to authenticate properly.",
                 consequence="User will not be logged in.",

--- a/projects/vdk-plugins/vdk-control-api-auth/tests/test_api_token_auth.py
+++ b/projects/vdk-plugins/vdk-control-api-auth/tests/test_api_token_auth.py
@@ -4,7 +4,7 @@ import pytest
 from pytest_httpserver.pytest_plugin import PluginHTTPServer
 from test_core_auth import allow_oauthlib_insecure_transport
 from test_core_auth import get_json_response_mock
-from vdk.plugin.control_api_auth.auth_exception import VDKAuthException
+from vdk.plugin.control_api_auth.auth_exception import VDKInvalidAuthParamError
 from vdk.plugin.control_api_auth.authentication import Authentication
 
 
@@ -25,7 +25,7 @@ def test_api_token_success_authentication(httpserver: PluginHTTPServer):
 def test_api_token_no_auth_url():
     auth = Authentication(token="apitoken", auth_type="api-token")
 
-    with pytest.raises(VDKAuthException) as exc_info:
+    with pytest.raises(VDKInvalidAuthParamError) as exc_info:
         auth.authenticate()
 
     raised_exception = exc_info.value
@@ -38,7 +38,7 @@ def test_api_token_no_auth_type_specified(httpserver: PluginHTTPServer):
         token="apitoken", authorization_url=httpserver.url_for("/foo")
     )
 
-    with pytest.raises(VDKAuthException) as exc_info:
+    with pytest.raises(VDKInvalidAuthParamError) as exc_info:
         auth.authenticate()
     raised_exception = exc_info.value
 

--- a/projects/vdk-plugins/vdk-control-api-auth/tests/test_authorization_code_auth.py
+++ b/projects/vdk-plugins/vdk-control-api-auth/tests/test_authorization_code_auth.py
@@ -4,7 +4,8 @@ import pytest
 from pytest_httpserver.pytest_plugin import PluginHTTPServer
 from test_core_auth import allow_oauthlib_insecure_transport
 from test_core_auth import get_json_response_mock
-from vdk.plugin.control_api_auth.auth_exception import VDKAuthException
+from vdk.plugin.control_api_auth.auth_exception import VDKInvalidAuthParamError
+from vdk.plugin.control_api_auth.auth_exception import VDKLoginFailedError
 from vdk.plugin.control_api_auth.authentication import Authentication
 from vdk.plugin.control_api_auth.autorization_code_auth import LoginHandler
 from vdk.plugin.control_api_auth.autorization_code_auth import RedirectAuthentication
@@ -49,7 +50,7 @@ def test_login_handler_exceptions(httpserver: PluginHTTPServer):
         auth=auth,
     )
 
-    with pytest.raises(VDKAuthException) as exc_info:
+    with pytest.raises(VDKLoginFailedError) as exc_info:
         handler.login_with_authorization_code(
             path="http://test-url?code=test-auth-code&client_id=client-id&redirect_uri=http%3A%2F%2F127.0.0.1%3A9999&prompt=login"
         )
@@ -57,7 +58,7 @@ def test_login_handler_exceptions(httpserver: PluginHTTPServer):
     assert "Failed to login." in raised_exception.message
     assert "Possibly the request was intercepted." in raised_exception.message
 
-    with pytest.raises(VDKAuthException) as exc_info2:
+    with pytest.raises(VDKLoginFailedError) as exc_info2:
         handler.login_with_authorization_code(
             path="http://test-url?client_id=client-id&redirect_uri=http%3A%2F%2F127.0.0.1%3A9999&state=requested&prompt=login"
         )
@@ -75,7 +76,7 @@ def test_authorization_code_no_secret(httpserver: PluginHTTPServer):
         authorization_url=httpserver.url_for("/foo"),
         auth_type="credentials",
     )
-    with pytest.raises(VDKAuthException) as exc_info:
+    with pytest.raises(VDKInvalidAuthParamError) as exc_info:
         auth.authenticate()
 
     raised_exception = exc_info.value


### PR DESCRIPTION
[vdk-plugins] vdk-control-api-auth: Redefine exceptions

Currently, we have one top-level exception class, `VDKAuthException` which
is invoked every time some error occurs during the authentication process.
This approach works in general, but a downside is that it does not allow for
more granular error handling.

Additionally, if a user wants to integrate their project with the library,
and they want to implement different behaviours based on different errors,
they would need to parse the error message, which may not be considered a
good practice.

This change introduces a new exception hierarchy, which defines child exceptions
to the top-level `VDKAuthException` and facilitates more robust error-handling,
both at the plugin level, as well as by client applications that integrate with
the plugin.

Testing Done: Unit tests