### PR TITLE
vdk-control-cli: Adopt new auth exceptions

### DIFF
--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/login_group/test_login.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/login_group/test_login.py
@@ -166,6 +166,7 @@ def test_login_credentials_exceptions(httpserver: PluginHTTPServer):
                 "client_secret",
             ],
         )
+        test_utils.assert_click_status(result, 1)
         assert (
             "requires arguments:, --client-secret, --client-id, --oauth2-exchange-url, --oauth2-discovery-url"
             in result.output
@@ -185,6 +186,7 @@ def test_login_credentials_exceptions(httpserver: PluginHTTPServer):
                 "client_secret",
             ],
         )
+        test_utils.assert_click_status(result, 1)
         assert (
             "requires arguments:, --client-secret, --client-id, --oauth2-exchange-url, --oauth2-discovery-url"
             in result.output
@@ -204,6 +206,7 @@ def test_login_credentials_exceptions(httpserver: PluginHTTPServer):
                 "client_secret",
             ],
         )
+        test_utils.assert_click_status(result, 1)
         assert (
             "requires arguments:, --client-secret, --client-id, --oauth2-exchange-url, --oauth2-discovery-url"
             in result.output


### PR DESCRIPTION
After the introduction of new exception types in the
`vdk-control-api-auth` plugin, more granular exception handling
is now possible.

This change adopts the new exception types in `vdk-control-cli`,
and removes unnecessary error message parsing.

Additionally, the exit status code when authentication failes was
changed from 0 to 1 to better reflect the fact that something unexpected
has happened.

Testing Done: Unit tests

Signed-off-by: Andon Andonov <andonova@vmware.com>