### PR TITLE
airflow-provider-vdk: Example DAG

### DIFF
--- a/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/example_dags/example_vdk.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/example_dags/example_vdk.py
@@ -1,0 +1,29 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from datetime import datetime
+
+from airflow import DAG
+from vdk_provider.operators.vdk import VDKOperator
+
+with DAG(
+    "example_vdk",
+    schedule_interval=None,
+    start_date=datetime(2022, 1, 1),
+    catchup=False,
+    tags=["example"],
+) as dag:
+    op1 = VDKOperator(
+        conn_id="example_vdk_connection",
+        job_name="example_vdk_job1",
+        team_name="team_name",
+        task_id="job1",
+    )
+
+    op2 = VDKOperator(
+        conn_id="tms-example_vdk_connection",
+        job_name="gg-example_vdk_job2",
+        team_name="team_name",
+        task_id="job2",
+    )
+
+    op1 >> op2

--- a/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/example_dags/vdk.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/example_dags/vdk.py
@@ -1,2 +1,0 @@
-# Copyright 2021 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
This change includes an example DAG demonstrating
how to use the VDKOperator to run a data job through
an Airflow DAG.

Testing done: executed through Airflow UI against
deployed control-service successfully

Signed-off-by: Gabriel Georgiev <gageorgiev@vmware.com>