### PR TITLE
vdk-heartbeat: pipelines-control-service-integration-tests image rebuild

### DIFF
--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -265,6 +265,7 @@ control_service_release:
       - main
     changes: *control_service_change_locations
 
+# TODO: automatically rebuild image on vdk-heartbeat change
 control_service_vdk_heartbeat_release:
   image: docker:19.03.8
   services:

--- a/projects/vdk-heartbeat/README.md
+++ b/projects/vdk-heartbeat/README.md
@@ -62,7 +62,7 @@ Releases are made to PyPI. <br>
 Versioning follows https://semver.org.
 
 * A release step in Gitlab CI is automatically triggered after merging changes if build/tests are successful.
-* To trigger a control-service integration tests image rebuild, commit any `control_service_change_locations`-defined change in [CONTRIBUTING.md](../control-service/cicd/.gitlab-ci.yml) - until automated
+* To trigger a control-service integration tests image rebuild, commit any `control_service_change_locations`-defined change in [CONTRIBUTING.md](../control-service/cicd/.gitlab-ci.yml) except [version.txt](../control-service/projects/helm_charts/pipelines-control-service/version.txt)- until automated
 * Update major or minor version when necessary only.
 
 ## Tests

--- a/projects/vdk-heartbeat/README.md
+++ b/projects/vdk-heartbeat/README.md
@@ -62,6 +62,7 @@ Releases are made to PyPI. <br>
 Versioning follows https://semver.org.
 
 * A release step in Gitlab CI is automatically triggered after merging changes if build/tests are successful.
+* To trigger a control-service integration tests image rebuild, commit any `control_service_change_locations`-defined change in [CONTRIBUTING.md](../control-service/cicd/.gitlab-ci.yml) - until automated
 * Update major or minor version when necessary only.
 
 ## Tests


### PR DESCRIPTION
The vdk-heartbeat release documentation required a merge to master, for
triggering the release process. However, the control-service CI/CD that
depends on vdk-heartbeat, does not consider new vdk-heartbeat versions.
Also, changing pipelines_control_service `version.txt` does not trigger
release nor rebuild, for example 
https://github.com/vmware/versatile-data-kit/pull/814

Added a comment to control-service `.gitlab-ci.yml` to trigger an IT
image update. Documented a workaround in `README.md` until automated.

Testing Done: will monitor the pipelines for image rebuild