### PR TITLE
control-service: clear execution fail alert when failing with user error 

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
@@ -230,11 +230,11 @@ public class JobExecutionService {
               jobExecutionRepository.findById(jobExecution.getExecutionId());
 
       //This set contains all the statuses that should not be changed to something else if present in the DB.
+      //All the elements in this list should therefore be a final status. Meaning non retryable statuses.
       //Using a hash set, because it allows null elements, no NullPointer when contains method called with null.
       var finalStatusSet = new HashSet<>(List.of(
             ExecutionStatus.CANCELLED,
             ExecutionStatus.USER_ERROR,
-            ExecutionStatus.PLATFORM_ERROR,
             ExecutionStatus.SUCCEEDED,
             ExecutionStatus.SKIPPED));
       ExecutionStatus executionStatus = executionResult.getExecutionStatus();
@@ -242,7 +242,8 @@ public class JobExecutionService {
       // Optimization:
       // if there is an existing execution in the database and
       // the status has not changed (the new status is equal to the old one)
-      // do not update the record
+      // do not update the record. Does not update record if previous status is
+      // in the list above.
       if (dataJobExecutionPersistedOptional.isPresent() &&
               (dataJobExecutionPersistedOptional.get().getStatus() == executionResult.getExecutionStatus() ||
                       finalStatusSet.contains(dataJobExecutionPersistedOptional.get().getStatus()))) {


### PR DESCRIPTION
what: Bugfix on internal logic which dictates when a retried status can change.
Previously statuses which had Platform Error could not be changed, but in some
edge cases when a job is retried with the same execution-id (pod retried but
execution id remains the same in control-service) and the subsequent run fails
due to user error that status would remain the same in the DB.

why: This bug was noticed during normal operation of control-service.

testing: Added unit test that reproduces the issue.

Signed-off-by: Momchil Zhivkov <mzhivkov@vmware.com>