### PR TITLE
vdk-test-utils: enable back tests

### DIFF
--- a/projects/vdk-plugins/vdk-test-utils/tests/test_vdk_test_utils.py
+++ b/projects/vdk-plugins/vdk-test-utils/tests/test_vdk_test_utils.py
@@ -5,6 +5,5 @@ from vdk.plugin.test_utils import util_plugins
 
 
 def test_vdk_test_utils():
-    assert 1 == 1
-    # assert util_plugins
-    # assert util_funcs
+    assert util_plugins
+    assert util_funcs


### PR DESCRIPTION
I had to disable tests in order to merge PR that chagned both vdk-core
and vdk-test-utils.

Now I am enabling them back.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>