### PR TITLE
[vdk-plugins] airflow-provider-vdk: Adopt auth plugin

### DIFF
--- a/projects/vdk-plugins/airflow-provider-vdk/setup.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/setup.py
@@ -28,7 +28,7 @@ setup(
     install_requires=[
         "apache-airflow>=2.0",
         "tenacity>=6.2.0",
-        "vdk-control-cli",  # TODO: drop this dependency and replace it with vdk-control-api-auth once that is complete
+        "vdk-control-api-auth",
         "vdk-control-service-api",
     ],
     setup_requires=["setuptools", "wheel"],

--- a/projects/vdk-plugins/airflow-provider-vdk/tests/hooks/test_vdkhook_auth.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/tests/hooks/test_vdkhook_auth.py
@@ -1,0 +1,55 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+import unittest
+from unittest import mock
+
+from vdk.plugin.control_api_auth.auth_exception import VDKInvalidAuthParamError
+from vdk_provider.hooks.vdk import VDKHook
+
+log = logging.getLogger(__name__)
+
+
+class TestVDKHookAuth(unittest.TestCase):
+    @mock.patch.dict(
+        "os.environ",
+        AIRFLOW_CONN_CONN_VDK="http://https%3A%2F%2Fwww.vdk-endpoint.org?auth_type=api_token&token=test1token",
+    )
+    def test_missing_auth_server_from_conn(self):
+        with self.assertRaises(
+            VDKInvalidAuthParamError,
+            msg="VDKInvalidAuthParamError should be raised for missing auth_server in connection.",
+        ):
+            self.hook = VDKHook(
+                conn_id="conn_vdk", job_name="test_job", team_name="test_team"
+            )
+
+    @mock.patch.dict(
+        "os.environ",
+        AIRFLOW_CONN_CONN_VDK="http://https%3A%2F%2Fwww.vdk-endpoint.org?auth_server=example.com&token=test1token",
+    )
+    def test_missing_auth_type_from_conn(self):
+        with self.assertRaises(
+            VDKInvalidAuthParamError,
+            msg="VDKInvalidAuthParamError should be raised for missing auth_type in connection.",
+        ) as exc_info:
+            self.hook = VDKHook(
+                conn_id="conn_vdk", job_name="test_job", team_name="test_team"
+            )
+
+        self.assertIn("auth_type was not specified", exc_info.exception.message)
+
+    @mock.patch.dict(
+        "os.environ",
+        AIRFLOW_CONN_CONN_VDK="http://https%3A%2F%2Fwww.vdk-endpoint.org?auth_server=example.com&auth_type=wrong_auth&token=test1token",
+    )
+    def test_missing_unrecognised_auth_type_from_conn(self):
+        with self.assertRaises(
+            VDKInvalidAuthParamError,
+            msg="VDKInvalidAuthParamError should be raised for missing auth_type in connection.",
+        ) as exc_info:
+            self.hook = VDKHook(
+                conn_id="conn_vdk", job_name="test_job", team_name="test_team"
+            )
+
+        self.assertIn("Unexpected authentication type", exc_info.exception.message)

--- a/projects/vdk-plugins/airflow-provider-vdk/tests/operators/test_vdkoperator.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/tests/operators/test_vdkoperator.py
@@ -3,10 +3,9 @@
 from unittest import mock
 from unittest import TestCase
 
-from taurus_datajob_api import ApiClient
 from taurus_datajob_api import DataJobExecution
 from taurus_datajob_api import DataJobExecutionLogs
-from taurus_datajob_api import DataJobsExecutionApi
+from vdk_provider.hooks.vdk import VDKHook
 from vdk_provider.operators.vdk import VDKOperator
 
 
@@ -67,9 +66,11 @@ class TestVDKOperator(TestCase):
     @mock.patch(
         "taurus_datajob_api.ApiClient.call_api", side_effect=call_api_return_func
     )
-    def test_execute(self, mock_call_api):
+    @mock.patch.object(VDKHook, "_get_access_token", return_value="test1token")
+    def test_execute(self, mock_access_token, mock_call_api):
         self.operator.execute({})
 
+        mock_access_token.assert_called_once()
         assert (
             (
                 mock_call_api.call_args_list[0][0][0]

--- a/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/operators/vdk.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/operators/vdk.py
@@ -50,7 +50,9 @@ class VDKOperator(BaseOperator):
         :param context: Airflow context passed through the DAG
         :return: The job execution ID
         """
-        vdk_hook = VDKHook(self.conn_id, self.job_name, self.team_name)
+        vdk_hook = VDKHook(
+            conn_id=self.conn_id, job_name=self.job_name, team_name=self.team_name
+        )
 
         execution_id = vdk_hook.start_job_execution()
         log.info(f"Started job execution {execution_id}.")

--- a/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/sensors/vdk.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/sensors/vdk.py
@@ -51,7 +51,9 @@ class VDKSensor(BaseSensorOperator):
         :param context: Airflow context passed through the DAG
         :return: True if some job status condition is met; False otherwise
         """
-        vdk_hook = VDKHook(self.conn_id, self.job_name, self.team_name)
+        vdk_hook = VDKHook(
+            conn_id=self.conn_id, job_name=self.job_name, team_name=self.team_name
+        )
 
         job_execution = vdk_hook.get_job_execution_status(self.job_execution_id)
         job_status = job_execution.status


### PR DESCRIPTION
After the release of the `vdk-control-api-auth` plugin, which acts as
the de-facto authentication package for Versatile Data Kit, we no longer
need to depend on `vdk-control-cli` and all its unnecessary dependencies.

With this change, we adopt the `vdk-control-api-auth` package and its
authentication capabilities, and drop any dependency on `vdk-control-cli`.

Testing Done: Unit tests.

Signed-off-by: Andon Andonov <andonova@vmware.com>