### PR TITLE
vdk-core: Fix destination_table referenced early

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_base.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_base.py
@@ -270,7 +270,7 @@ class IngesterBase(IIngester):
                 ) = self._queue_payload_for_posting(
                     aggregated_payload,
                     number_of_payloads,
-                    destination_table,
+                    current_destination_table,
                     method,
                     current_target,
                     current_collection_id,


### PR DESCRIPTION
In the IngesterBase class, we currently pass `destination_table` to the
call to `_queue_payload_for_posting` in cases when the objects queue is empty.
However, at this point, the destination_table is not defined, which causes an
UnboundLocalError to be raised.

This change fixes the issue by replacing `destination_table` with `current_destination_table`
(set to None by default) which is defined before the call to `_queue_payload_for_posting`.

Testing Done: All existing tests pass

Signed-off-by: Andon Andonov <andonova@vmware.com>