### PR TITLE
vdk-core: hide native cursor from execute hook

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/connection_hooks.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/connection_hooks.py
@@ -25,13 +25,12 @@ class DefaultConnectionHookImpl:
     @hookimpl(trylast=True)
     def db_connection_execute_operation(self, execution_cursor: ExecutionCursor) -> Any:
         managed_operation = execution_cursor.get_managed_operation()
-        native_cursor = execution_cursor.get_native_cursor()
         if managed_operation.get_parameters():
-            native_result = native_cursor.execute(
+            native_result = execution_cursor.execute(
                 managed_operation.get_operation(), managed_operation.get_parameters()
             )
         else:
-            native_result = native_cursor.execute(managed_operation.get_operation())
+            native_result = execution_cursor.execute(managed_operation.get_operation())
         return ExecuteOperationResult(native_result)
 
 

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/execution_cursor.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/execution_cursor.py
@@ -29,7 +29,7 @@ class ExecutionCursor(ProxyCursor):
         But it's useful to be exposed in case the native library used provide some extra features.
         For example Impala (impyla driver) provides a way to get the profile of a query after it's executed
         which can be printed to aid debugging.
-        * Give access to the result of execute operation (through) ExecuteOperationResult which in vendor specific.
+        * Give access to the result of execute operation (through) ExecuteOperationResult which is vendor specific.
 
     See connection_hook_spec#db_connection_execute_operation for more details and examples how to use it.
     """

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/execution_cursor.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/execution_cursor.py
@@ -23,7 +23,7 @@ class ExecuteOperationResult:
 
 class ExecutionCursor(ProxyCursor):
     """
-    Extends PEP249Cursor to provide:
+    Extends ProxyCursor to provide:
         * ability to directly access and execute operations with the native cursor.
         Generally it is not execpted to be used. Perhaps only if default implementation does not work (which should be almost never)
         But it's useful to be exposed in case the native library used provide some extra features.

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/execution_cursor.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/execution_cursor.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from vdk.internal.builtin_plugins.connection.decoration_cursor import ManagedOperation
 from vdk.internal.builtin_plugins.connection.pep249.interfaces import PEP249Cursor
+from vdk.internal.builtin_plugins.connection.proxy_cursor import ProxyCursor
 
 
 class ExecuteOperationResult:
@@ -20,12 +21,15 @@ class ExecuteOperationResult:
         return self.__native_result
 
 
-class ExecutionCursor(PEP249Cursor):
+class ExecutionCursor(ProxyCursor):
     """
     Extends PEP249Cursor to provide:
         * ability to directly access and execute operations with the native cursor.
-        Generally it should be used only if default implementation does not work (which should be almost never)
-         or more likely - to use some vendor specific features.
+        Generally it is not execpted to be used. Perhaps only if default implementation does not work (which should be almost never)
+        But it's useful to be exposed in case the native library used provide some extra features.
+        For example Impala (impyla driver) provides a way to get the profile of a query after it's executed
+        which can be printed to aid debugging.
+        * Give access to the result of execute operation (through) ExecuteOperationResult which in vendor specific.
 
     See connection_hook_spec#db_connection_execute_operation for more details and examples how to use it.
     """
@@ -39,21 +43,6 @@ class ExecutionCursor(PEP249Cursor):
         super().__init__(native_cursor, log)
         self.__managed_operation = managed_operation
         self.__native_cursor = native_cursor
-
-    def get_native_cursor(self) -> PEP249Cursor:
-        """
-        Get the underlying native cursor. Used to actually execute the operation.
-        Generally should not be accessed directly.
-        But it's useful to be exposed in case the native library used provide some extra features.
-        For example Impala (impyla driver) provides a way to get the profile of a query after it's executed
-        which can be printed to aid debugging.
-
-        Check the example usages in docstring of connection_hook_spec#db_connection_execute_operation .
-
-        :return: PEP249Cursor
-            the underlying native cursor being managed.
-        """
-        return self.__native_cursor
 
     def get_managed_operation(self) -> ManagedOperation:
         """

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
@@ -26,7 +26,7 @@ from vdk.internal.core import errors
 
 class ManagedCursor(ProxyCursor):
     """
-    PEP249 Managed Cursor. It takes and sits on the control and data path of SQL querie and client.
+    PEP249 Managed Cursor. It takes and sits on the control and data path of SQL queries and client.
     """
 
     def __init__(

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
@@ -19,14 +19,14 @@ from vdk.internal.builtin_plugins.connection.connection_hooks import (
 from vdk.internal.builtin_plugins.connection.decoration_cursor import DecorationCursor
 from vdk.internal.builtin_plugins.connection.decoration_cursor import ManagedOperation
 from vdk.internal.builtin_plugins.connection.execution_cursor import ExecutionCursor
-from vdk.internal.builtin_plugins.connection.pep249.interfaces import PEP249Cursor
+from vdk.internal.builtin_plugins.connection.proxy_cursor import ProxyCursor
 from vdk.internal.builtin_plugins.connection.recovery_cursor import RecoveryCursor
 from vdk.internal.core import errors
 
 
-class ManagedCursor(PEP249Cursor):
+class ManagedCursor(ProxyCursor):
     """
-    PEP249 Cursor
+    PEP249 Managed Cursor. It takes and sits on the control and data path of SQL querie and client.
     """
 
     def __init__(

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/proxy_cursor.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/proxy_cursor.py
@@ -1,0 +1,55 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+import types
+from typing import Any
+
+from vdk.internal.builtin_plugins.connection.pep249.interfaces import PEP249Cursor
+
+
+class ProxyCursor(PEP249Cursor):
+    """
+    PEP249 Proxy cursor.
+    It wraps all methods and proxies (non-override methods) to the passed native cursor.
+    Allowing the wrapped cursor to be used as a native cursor as well for native (vendor specific) methods.
+
+    """
+
+    def __init__(self, cursor: Any, log: logging.Logger = logging.getLogger(__name__)):
+        super().__init__(cursor, log)
+
+    def __getattr__(self, attr):
+        """
+        Dynamic interception and il of any (non-overridden) attribute access.
+        In case an attribute is not explicitly managed (customized by overriding e.g. execute()) -
+        this attribute is looked up then the call is delegated, ensuring default behaviour success path.
+
+        First, the non-managed attribute call is redirected to the wrapped native cursor if attribute available,
+        otherwise to the superclass if attribute is present.
+        If the attribute is not specified by both the native cursor nor the superclass, an AttributeError is raised.
+
+        Default behaviour availability unblocks various ManagedCursor usages that rely on
+        currently not explicitly defined in the scope of ManagedCursor attributes.
+        E.g. SQLAlchemy dependency that uses the ManagedCursor, does require some specific attributes available.
+
+        For more details on customizing attributes access, see PEP562.
+        """
+        # native cursor
+        if hasattr(self._cursor, attr):
+            if isinstance(getattr(self._cursor, attr), types.MethodType):
+
+                def method(*args, **kwargs):
+                    return getattr(self._cursor, attr)(*args, **kwargs)
+
+                return method
+            return getattr(self._cursor, attr)
+        # superclass
+        if hasattr(super(), attr):
+            if isinstance(getattr(super(), attr), types.MethodType):
+
+                def method(*args, **kwargs):
+                    return getattr(super(), attr)(*args, **kwargs)
+
+                return method
+            return getattr(super(), attr)
+        raise AttributeError


### PR DESCRIPTION
The current design was allowing users to access directly native cursor
unwrapped which defeat the purpose of being on data/control path of
queries as Iva correctly pointed out in earlier review.

It was necessary because user need to be able to invoke native vendor
specific methods (like get_profile of impala cursor).

But there's better approach where both users are allowed to call vendor
specific methods yet keep certain methods (like execute) curated/wrapped
by VDK. It's by introducing ProxyCursor (which is moving some
functionalith of ManagedCursor).

Testing Done: existing tests passed. I added explicit functional test to
test the proxying functionality

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>