### PR TITLE
versatile-data-kit: update logo for dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-![Versatile Data Kit](./support/images/versatile-data-kit.svg)
+![Versatile Data Kit](./support/images/versatile-data-kit.svg#gh-light-mode-only)
+![Versatile Data Kit](./support/images/versatile-data-kit-dark-background.svg#gh-dark-mode-only)
 
 <p align="center">
     <a href="https://github.com/vmware/versatile-data-kit/pulse" alt="Activity">


### PR DESCRIPTION
As suggested by Gabriel (https://github.com/vmware/versatile-data-kit/pull/877#pullrequestreview-1018547035): change the readme to change the logo based on whether the user has dark or light mode enabled, following: https://dev.to/arnavkr/using-darklight-mode-specific-images-in-github-markdown-3iln


Testing Done:  change theme and verified https://github.com/vmware/versatile-data-kit/tree/person/aivanov/images-readme looks appropriate

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>