### PR TITLE
vdk-kerberos-auth: add KerberosClient for authenticating API calls

### DIFF
--- a/projects/vdk-plugins/vdk-kerberos-auth/README.md
+++ b/projects/vdk-plugins/vdk-kerberos-auth/README.md
@@ -8,10 +8,12 @@ To install the plugin, run:
 pip install vdk-kerberos-auth
 ```
 
-After it's installed the following happens:
+After it's install what happens:
 
-1. Upon installation and if KEYTAB_FILENAME and KEYTAB_PRINCIPAL are configured, it will try to authenticate ("kinit") at the start of every VDK command.
-2. Then when a client needs to talk to a kerberos provision server they would use the KerberosClient class to generate the header:
+1. Upon installation and if KEYTAB_FILENAME and KEYTAB_PRINCIPAL are configured, it will try to authenticate ("kinit") at the start of very VDK command.
+2. Then when a client needs to talk to kerberos provision server they would use KerberosClient class to generate header:
+With requests library, you'd use https://pypi.org/pypi/requests-kerberos.
+The following can be used if another http library does not support kerberos to generate Authorization header:
 ```python
 auth = KebrerosClient("http@server.fqdn.com")
 headers['Authorization'] =  auth.read_kerberos_auth_header()

--- a/projects/vdk-plugins/vdk-kerberos-auth/README.md
+++ b/projects/vdk-plugins/vdk-kerberos-auth/README.md
@@ -11,7 +11,7 @@ pip install vdk-kerberos-auth
 After it's installed the following happens:
 
 1. Upon installation and if KEYTAB_FILENAME and KEYTAB_PRINCIPAL are configured, it will try to authenticate ("kinit") at the start of every VDK command.
-2. Then when a client needs to talk to kerberos provision server they would use KerberosClient class to generate header:
+2. Then when a client needs to talk to a kerberos provision server they would use the KerberosClient class to generate the header:
 ```python
 auth = KebrerosClient("http@server.fqdn.com")
 headers['Authorization'] =  auth.read_kerberos_auth_header()

--- a/projects/vdk-plugins/vdk-kerberos-auth/README.md
+++ b/projects/vdk-plugins/vdk-kerberos-auth/README.md
@@ -8,6 +8,17 @@ To install the plugin, run:
 pip install vdk-kerberos-auth
 ```
 
+After it's install what happens:
+
+1. Upon installation and if KEYTAB_FILENAME and KEYTAB_PRINCIPAL are configured, it will try to authenticate ("kinit") at the start of very VDK command.
+2. Then when a client needs to talk to kerberos provision server they would use KerberosClient class to generate header:
+```python
+auth = KebrerosClient("http@server.fqdn.com")
+headers['Authorization'] =  auth.read_kerberos_auth_header()
+```
+
+## Known issues
+
 The plugin dependency `requests-kerberos==0.12.0` may fail to install on Ubuntu with the following error:
 
 ```
@@ -22,16 +33,19 @@ If this is the case, install `libkrb5-dev` with the command below and try reinst
 sudo apt-get install -y libkrb5-dev
 ```
 
+## Configuration
+
 The following environment variables can be used to configure this plugin:
 
 | name                    | description                                                                                                                                                    |
 |-------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `VDK_KRB_AUTH`          | Specifies the Kerberos authentication type to use. Possible values are 'minikerberos' and 'kinit'. If left empty, the authentication is disabled.              |
-| `VDK_KEYTAB_FILENAME`   | Specifies the name of the keytab file. If left empty, the name of the keytab file is assumed to be the same as the name of the data job with '.keytab' suffix. |
+| `KRB_AUTH`          | Specifies the Kerberos authentication type to use. Possible values are 'minikerberos' and 'kinit'. If left empty, the authentication is disabled.              |
+| `KEYTAB_FILENAME`   | Specifies the name of the keytab file. If left empty, the name of the keytab file is assumed to be the same as the name of the data job with '.keytab' suffix. |
 | `KEYTAB_FOLDER`         | Specifies the folder containing the keytab file. If left empty, the keytab file is expected to be located inside the data job folder.                          |
-| `VDK_KEYTAB_PRINCIPAL`  | Specifies the Kerberos principal. If left empty, the principal will be the job name prepended with 'pa__view_'.                                                |
-| `VDK_KEYTAB_REALM`      | Specifies the Kerberos realm. This value is used only with the 'minikerberos' authentication type. The default value is 'default_realm'.                       |
-| `VDK_KERBEROS_KDC_HOST` | Specifies the name of the Kerberos KDC (Key Distribution Center) host. This value is used only with the 'minikerberos' authentication type.                    |
+| `KEYTAB_PRINCIPAL`  | Specifies the Kerberos principal. If left empty, the principal will be the job name prepended with 'pa__view_'.                                                |
+| `KEYTAB_REALM`      | Specifies the Kerberos realm. This value is used only with the 'minikerberos' authentication type. The default value is 'default_realm'.                       |
+| `KERBEROS_KDC_HOST` | Specifies the name of the Kerberos KDC (Key Distribution Center) host. This value is used only with the 'minikerberos' authentication type.                    |
+
 
 # Testing
 

--- a/projects/vdk-plugins/vdk-kerberos-auth/README.md
+++ b/projects/vdk-plugins/vdk-kerberos-auth/README.md
@@ -10,7 +10,7 @@ pip install vdk-kerberos-auth
 
 After it's installed the following happens:
 
-1. Upon installation and if KEYTAB_FILENAME and KEYTAB_PRINCIPAL are configured, it will try to authenticate ("kinit") at the start of very VDK command.
+1. Upon installation and if KEYTAB_FILENAME and KEYTAB_PRINCIPAL are configured, it will try to authenticate ("kinit") at the start of every VDK command.
 2. Then when a client needs to talk to kerberos provision server they would use KerberosClient class to generate header:
 ```python
 auth = KebrerosClient("http@server.fqdn.com")

--- a/projects/vdk-plugins/vdk-kerberos-auth/README.md
+++ b/projects/vdk-plugins/vdk-kerberos-auth/README.md
@@ -8,7 +8,7 @@ To install the plugin, run:
 pip install vdk-kerberos-auth
 ```
 
-After it's install what happens:
+After it's installed the following happens:
 
 1. Upon installation and if KEYTAB_FILENAME and KEYTAB_PRINCIPAL are configured, it will try to authenticate ("kinit") at the start of very VDK command.
 2. Then when a client needs to talk to kerberos provision server they would use KerberosClient class to generate header:

--- a/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/api/kerberos_client.py
+++ b/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/api/kerberos_client.py
@@ -8,7 +8,7 @@ class KerberosClient:
     Use this class to access prepared Kerberos Negotiate header that can be used in HTTP API requests.
     It's expected to be set as an "Authorization header"
     It's recommended to use request-kerberos or similar library.
-    Use this if the http library doesn't support natively Kerberos.
+    Use this if the http library doesn't support Kerberos natively.
     But note that it has less advanced features and generally is less reliable than request-kerberos
 
     Example usage

--- a/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/api/kerberos_client.py
+++ b/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/api/kerberos_client.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 class KerberosClient:
     """
-    Use this class to access prepared Kerberos Negotate header that can be used in HTTP API requests.
+    Use this class to access prepared Kerberos Negotiate header that can be used in HTTP API requests.
     It's expected to be set as an "Authorization header"
     Example usage
 

--- a/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/api/kerberos_client.py
+++ b/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/api/kerberos_client.py
@@ -7,6 +7,10 @@ class KerberosClient:
     """
     Use this class to access prepared Kerberos Negotiate header that can be used in HTTP API requests.
     It's expected to be set as an "Authorization header"
+    It's recommended to use request-kerberos or similar library.
+    Use this if the http library doesn't support natively Kerberos.
+    But note that it has less advanced features and generally is less reliable than request-kerberos
+
     Example usage
 
     auth = KerberosClient("HTTP@vdk.fqdn.com")

--- a/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/api/kerberos_client.py
+++ b/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/api/kerberos_client.py
@@ -1,0 +1,33 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from typing import Optional
+
+
+class KerberosClient:
+    """
+    Use this class to access prepared Kerberos Negotate header that can be used in HTTP API requests.
+    It's expected to be set as an "Authorization header"
+    Example usage
+
+    auth = KerberosClient("HTTP@vdk.fqdn.com")
+    api_call_headers["Authorization"] = auth.read_kerberos_auth_header()
+    """
+
+    def __init__(self, api_server_kerberos_service_name: str):
+        """
+        :param api_server_kerberos_service_name: the kerberos service name of the API Server we want to connect to.
+        """
+        self.__kerberos_service_name = api_server_kerberos_service_name
+
+    def acquire_kerberos_auth_header(self) -> Optional[str]:
+        """
+        Return the header to be used by API requests to server supporting kerberos authentication.
+        You can see more details here http://python-notes.curiousefficiency.org/en/latest/python_kerberos.html
+        :return:
+        """
+        if self.__kerberos_service_name:
+            from vdk.plugin.kerberos.kerberos_ticket import KerberosTicket
+
+            client = KerberosTicket(self.__kerberos_service_name)
+            return client.auth_header
+        return None

--- a/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/api/kerberos_client.py
+++ b/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/api/kerberos_client.py
@@ -26,7 +26,7 @@ class KerberosClient:
     def acquire_kerberos_auth_header(self) -> Optional[str]:
         """
         Return the Authorization Negotiate header value to be used by API requests to server supporting kerberos authentication.
-        You can see more details here http://python-notes.curiousefficiency.org/en/latest/python_kerberos.html 
+        You can see more details here http://python-notes.curiousefficiency.org/en/latest/python_kerberos.html
         """
         if self.__kerberos_service_name:
             from vdk.plugin.kerberos.kerberos_ticket import KerberosTicket

--- a/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/api/kerberos_client.py
+++ b/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/api/kerberos_client.py
@@ -14,7 +14,7 @@ class KerberosClient:
     Example usage
 
     auth = KerberosClient("HTTP@vdk.fqdn.com")
-    api_call_headers["Authorization"] = auth.read_kerberos_auth_header()
+    api_call_headers["Authorization"] = auth.acquire_kerberos_auth_header()
     """
 
     def __init__(self, api_server_kerberos_service_name: str):
@@ -25,9 +25,8 @@ class KerberosClient:
 
     def acquire_kerberos_auth_header(self) -> Optional[str]:
         """
-        Return the header to be used by API requests to server supporting kerberos authentication.
-        You can see more details here http://python-notes.curiousefficiency.org/en/latest/python_kerberos.html
-        :return:
+        Return the Authorization Negotiate header value to be used by API requests to server supporting kerberos authentication.
+        You can see more details here http://python-notes.curiousefficiency.org/en/latest/python_kerberos.html 
         """
         if self.__kerberos_service_name:
             from vdk.plugin.kerberos.kerberos_ticket import KerberosTicket

--- a/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/kerberos_configuration.py
+++ b/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/kerberos_configuration.py
@@ -18,6 +18,8 @@ KEYTAB_REALM = "KEYTAB_REALM"
 KERBEROS_KDC_HOST = "KERBEROS_KDC_HOST"
 KRB_AUTH_FAIL_FAST = "KRB_AUTH_FAIL_FAST"
 
+API_SERVER_KERBEROS_SERVICE_NAME = "API_SERVER_KERBEROS_SERVICE_NAME"
+
 
 class KerberosPluginConfiguration:
     def __init__(
@@ -81,6 +83,9 @@ class KerberosPluginConfiguration:
     def auth_fail_fast(self) -> bool:
         return self.__config.get_value(KRB_AUTH_FAIL_FAST)
 
+    def api_server_kerberos_service_name(self) -> str:
+        return self.__config.get_value(API_SERVER_KERBEROS_SERVICE_NAME)
+
 
 def add_definitions(config_builder: ConfigurationBuilder) -> None:
     config_builder.add(
@@ -136,4 +141,13 @@ def add_definitions(config_builder: ConfigurationBuilder) -> None:
         "If set to false, only warning will be logged on authentication failure. "
         "Subsequent kerberos related requests may fail but that'd fail lazily (on demand) "
         "that makes it possible for non-kerberos related features to work.",
+    )
+    config_builder.add(
+        key=API_SERVER_KERBEROS_SERVICE_NAME,
+        default_value=None,
+        description="""
+    Kerberos service name of the API Server.
+    It's a string containing the service principal (for the API server) in the form 'type@fqdn'
+    (for example, 'http@server.vdk.com').
+    """,
     )

--- a/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/kerberos_ticket.py
+++ b/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/kerberos_ticket.py
@@ -1,5 +1,6 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import kerberos
 
 
 class KerberosTicket:
@@ -8,8 +9,6 @@ class KerberosTicket:
     """
 
     def __init__(self, service):
-        import kerberos
-
         __, krb_context = kerberos.authGSSClientInit(service)
         kerberos.authGSSClientStep(krb_context, "")
         self._krb_context = krb_context
@@ -34,7 +33,6 @@ class KerberosTicket:
         if krb_context is None:
             raise RuntimeError("Ticket already used for verification")
         self._krb_context = None
-        import kerberos
 
         kerberos.authGSSClientStep(krb_context, auth_details)
         kerberos.authGSSClientClean(krb_context)

--- a/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/kerberos_ticket.py
+++ b/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/kerberos_ticket.py
@@ -1,0 +1,40 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+
+class KerberosTicket:
+    """
+    Adapted from http://python-notes.curiousefficiency.org/en/latest/python_kerberos.html
+    """
+
+    def __init__(self, service):
+        import kerberos
+
+        __, krb_context = kerberos.authGSSClientInit(service)
+        kerberos.authGSSClientStep(krb_context, "")
+        self._krb_context = krb_context
+        self.auth_header = "Negotiate " + kerberos.authGSSClientResponse(krb_context)
+
+    def verify_response(self, auth_header):
+        """
+        Optionally use this method to verify response in case the server is not trusted fully.
+
+        :param auth_header:
+        """
+        # Handle comma-separated lists of authentication fields
+        for field in auth_header.split(","):
+            kind, __, details = field.strip().partition(" ")
+            if kind.lower() == "negotiate":
+                auth_details = details.strip()
+                break
+        else:
+            raise ValueError("Negotiate not found in %s" % auth_header)
+        # Finish the Kerberos handshake
+        krb_context = self._krb_context
+        if krb_context is None:
+            raise RuntimeError("Ticket already used for verification")
+        self._krb_context = None
+        import kerberos
+
+        kerberos.authGSSClientStep(krb_context, auth_details)
+        kerberos.authGSSClientClean(krb_context)


### PR DESCRIPTION
We are adding support for Kerberos authentication in the Control REST
API . This is extending the support for the client to be able to make
authentication requests with kerberos.

This is part 1 adding KerberosClient "API" for the purpose of clients
using it to get Kerberos authentication header.

In a follow-up MR I will adopt it in vdk-control-cli

Testing Done: automated tests

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>