### PR TITLE
[vdk-plugins] airflow-provider-vdk: Add hidden fields to VDK Connection

### DIFF
--- a/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/hooks/vdk.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/hooks/vdk.py
@@ -248,7 +248,7 @@ class VDKHook(HttpHook):
             token=self.conn.extra_dejson.get("token", None),
             authorization_url=self.conn.extra_dejson.get("auth_server", None),
             auth_type=self.conn.extra_dejson.get("auth_type", None),
-            cache_locally=True,
+            cache_locally=False,
         )
         self.auth.authenticate()
 
@@ -261,4 +261,5 @@ class VDKHook(HttpHook):
         """
         return {
             "relabeling": {"login": "Username", "host": "REST Api URL"},
+            "hidden_fields": ["schema"],
         }


### PR DESCRIPTION
In the Airflow UI, users can create new connections manually from the Admin section. When
done this way a web form is shown, where they can fill in host, port, username, password,
etc. needed to establish a new connection to third-party services.

The fields shown in the web form can be customised by overwriting the `get_ui_field_behaviour()`
method from the **BaseHook**. In the vdk airflow provider, we do some field relabeling to make
the user experience more consistent with our project.

This, however, caused some issues, as apperantly the dictionary where the changes to the connection
fields' behaviour is specified, needs to have a `hidden_fields` key/value pair.

This change introduces a `hidden_fields` key/value pair, and we use it to hide the schema field, which
is not really used by vdk.

Testing Done: Tested with local airflow instance and veryfied no errors in logs and correct web form
is shown to users.

Signed-off-by: Andon Andonov <andonova@vmware.com>