### PR TITLE
vdk-core: Add printed output to set-default and reset-default

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/common_group/default.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/common_group/default.py
@@ -1,5 +1,7 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import logging
+
 import click
 from vdk.internal.control.configuration.defaults_config import (
     reset_default_rest_api_url,
@@ -10,6 +12,7 @@ from vdk.internal.control.configuration.defaults_config import (
 )
 from vdk.internal.control.configuration.defaults_config import write_default_team_name
 
+log = logging.getLogger(__name__)
 
 # Default command implies parity for set-default and reset-default sections bellow.
 # Each option that supports set-default is expected to implement reset-default.
@@ -35,8 +38,10 @@ from vdk.internal.control.configuration.defaults_config import write_default_tea
 def set_default_command(ctx, team: str, rest_api_url: str):
     if team is not None:
         write_default_team_name(team)
+        log.info(f"Default team name has been set to `{team}`.")
     if rest_api_url is not None:
         write_default_rest_api_url(rest_api_url)
+        log.info(f"Default REST API URL has been set to `{rest_api_url}`.")
 
 
 @click.command(
@@ -64,5 +69,7 @@ def set_default_command(ctx, team: str, rest_api_url: str):
 def reset_default_command(ctx, team: bool, rest_api_url: bool):
     if team:
         reset_default_team_name()
+        log.info("Default team name has been reset.")
     if rest_api_url:
         reset_default_rest_api_url()
+        log.info("Default REST API URL has been reset.")


### PR DESCRIPTION
The set-default and reset-default commands do not print
any output when invoked. This PR adds a printed message
for both to ensure the user that the commands have been
executed successfully.

Testing done: tested locally

Signed-off-by: Gabriel Georgiev <gageorgiev@vmware.com>