### PR TITLE
[vdk-plugins] vdk-kerberos-auth: Separate async event loop

### DIFF
--- a/projects/vdk-plugins/vdk-kerberos-auth/tests/jobs/test-job/20_async_test.py
+++ b/projects/vdk-plugins/vdk-kerberos-auth/tests/jobs/test-job/20_async_test.py
@@ -1,0 +1,13 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import asyncio
+import logging
+
+from vdk.api.job_input import IJobInput
+
+log = logging.getLogger(__name__)
+
+
+def run(job_input: IJobInput):
+    log.info("Test Async step")
+    _ = asyncio.Semaphore(2)


### PR DESCRIPTION
The minikerberos authenticator relies on an async kerberos client to speed up some of its
processes. This client uses `asyncio.run()` to execute async operations. As can be seen from the source
code of asyncio, https://github.com/python/cpython/blob/3.10/Lib/asyncio/runners.py, the `run()` method
creates a new event loop and sets it as the [default loop](https://github.com/python/cpython/blob/3.10/Lib/asyncio/runners.py#L41).
When all async operations are finished, the loop it terminated and all tasks are cleaned. This is fine
in general, as long as other components don't rely on the main event loop.
    
If they do, however, we could end up in a situation, where the kerberos plugin closes the asyncio
main event loop, and breaks the other components that rely on the same thread.
    
To avoid issues with multiple components relying on the asyncio main event loop, this change introduces
a separate event loop for the minikerberos authenticator, thus keeping kerberos operations away of the main
event loop.
    
Testing done: Functional test added.
    
Signed-off-by: Andon Andonov <andonova@vmware.com>