### PR TITLE
vdk-trino: fix broken tests

### DIFF
--- a/projects/vdk-plugins/vdk-trino/tests/docker-compose.yml
+++ b/projects/vdk-plugins/vdk-trino/tests/docker-compose.yml
@@ -3,6 +3,6 @@
 
 services:
   trino:
-    image: "trinodb/trino"
+    image: "trinodb/trino:372"
     ports:
       - "8080:8080"


### PR DESCRIPTION
Recent change in trino library broke our tests -

After https://github.com/trinodb/trino/issues/9129  trino would fail
`drop view if not exists` query if table with that name exists instead
of silently proceeding.

which is problem for us since our tests seem to rely on us they execute
both drop view and drop table to make sure a table or view is deleted.

So now I am pinning to old version of trino to hopefully fix the issue
as a quick workaround. Will create separate ticket to fix it in a way
that works against latest version of trino.

Testing Done: this PR CICD :)

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>