### PR TITLE
vdk-control-cli: remove hidden flag for CLI commands

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/list.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/list.py
@@ -222,7 +222,6 @@ vdk list -t taurus -o json
 @click.option(
     "-m",
     "--more-details",
-    hidden=True,
     count=True,
     help="Include more details about the jobs. Specify the flag multiple times to make the output even more verbose .",
 )

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/properties.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/properties.py
@@ -222,7 +222,6 @@ class JobProperties:
      vdk properties --list
 
                     """,
-    hidden=True,
 )
 @click.option(
     "-n", "--name", prompt="Job Name", type=click.STRING, help="The job name."

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/show.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/show.py
@@ -72,7 +72,6 @@ Examples:
 # List all jobs for team taurus
 vdk show -n job-name -t team-name
                 """,
-    hidden=True,
 )
 @click.option(
     "-n", "--name", prompt="Job Name", type=click.STRING, help="The job name."


### PR DESCRIPTION
`vdk show`, `vdk properties` and `vdk list -m` were considered
experimental so that's why they are hidden. But they've been used enough
in VDK installations that it is no longer true.

Testing Done: They show in `vdk --help` and `vdk list --help`

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>