### PR TITLE
vdk-core: show log_level_vdk in help

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/vdk_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/vdk_config.py
@@ -64,6 +64,7 @@ class CoreConfigDefinitionPlugin:
         config_builder.add(
             LOG_LEVEL_VDK,
             None,
+            True,
             "Logging verbosity of VDK code can be controlled from here. "
             "Allowed values: CRITICAL, ERROR, WARNING, INFO, DEBUG. "
             "If not set python default or one set by vdk -v LEVEL is used. ",


### PR DESCRIPTION
Due to small bug in defining LOG_LEVEL_VDK the description was not
showin in `vdk config-help`

Testing Done: Ran `vdk config-help` and saw it shows up correctly

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>