### PR TITLE
control-service: Introduce job termination status counter

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMetrics.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMetrics.java
@@ -15,11 +15,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -29,90 +25,184 @@ import static com.vmware.taurus.service.Utilities.join;
 @Slf4j
 @Component
 public class DataJobMetrics {
-  public static final String TAURUS_DATAJOB_INFO_METRIC_NAME = "taurus.datajob.info";
-  public static final String TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME =
-      "taurus.datajob.notification.delay";
-  public static final String TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME =
-      "taurus.datajob.termination.status";
-  public static final String TAURUS_DATAJOB_WATCH_TASK_INVOCATIONS_COUNTER_NAME =
-      "taurus.datajob.watch.task.invocations.counter";
-  public static final String TAG_DATA_JOB = "data_job";
-  public static final String TAG_EXECUTION_ID = "execution_id";
-  public static final String TAG_TEAM = "team";
-  public static final String TAG_EMAIL_NOTIFIED_ON_SUCCESS = "email_notified_on_success";
-  public static final String TAG_EMAIL_NOTIFIED_ON_USER_ERROR = "email_notified_on_user_error";
-  public static final String TAG_EMAIL_NOTIFIED_ON_PLATFORM_ERROR =
-      "email_notified_on_platform_error";
+    public static final String TAURUS_DATAJOB_INFO_METRIC_NAME = "taurus.datajob.info";
+    public static final String TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME = "taurus.datajob.notification.delay";
+    public static final String TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME = "taurus.datajob.termination.status";
+    public static final String TAURUS_DATAJOB_TERMINATION_STATUS_COUNTER_NAME = "taurus.datajob.termination.status.counter";
+    public static final String TAURUS_DATAJOB_WATCH_TASK_INVOCATIONS_COUNTER_NAME = "taurus.datajob.watch.task.invocations.counter";
+    public static final String TAG_DATA_JOB = "data_job";
+    public static final String TAG_EXECUTION_ID = "execution_id";
+    public static final String TAG_TEAM = "team";
+    public static final String TAG_STATUS = "status";
+    public static final String TAG_EMAIL_NOTIFIED_ON_SUCCESS = "email_notified_on_success";
+    public static final String TAG_EMAIL_NOTIFIED_ON_USER_ERROR = "email_notified_on_user_error";
+    public static final String TAG_EMAIL_NOTIFIED_ON_PLATFORM_ERROR = "email_notified_on_platform_error";
 
-  public static final Integer GAUGE_METRIC_VALUE = 1;
-  public static final int DEFAULT_NOTIFICATION_DELAY_PERIOD_MINUTES = 240;
+    public static final Integer GAUGE_METRIC_VALUE = 1;
+    public static final int DEFAULT_NOTIFICATION_DELAY_PERIOD_MINUTES = 240;
 
-  private final MeterRegistry meterRegistry;
-  private final Counter watchTaskInvocationsCounter;
-  private final Map<String, Gauge> infoGauges = new ConcurrentHashMap<>();
-  private final Map<String, Gauge> delayGauges = new ConcurrentHashMap<>();
-  private final Map<String, Gauge> statusGauges = new ConcurrentHashMap<>();
-  private final Map<String, Integer> currentDelays = new ConcurrentHashMap<>();
-  private final Map<String, Integer> currentStatuses = new ConcurrentHashMap<>();
+    private final MeterRegistry meterRegistry;
+    private final Counter watchTaskInvocationsCounter;
+    private final Map<String, Gauge> infoGauges = new ConcurrentHashMap<>();
+    private final Map<String, Gauge> delayGauges = new ConcurrentHashMap<>();
+    private final Map<String, Gauge> statusGauges = new ConcurrentHashMap<>();
+    private final Map<String, Counter> statusCounters = new ConcurrentHashMap<>();
+    private final Map<String, Integer> currentDelays = new ConcurrentHashMap<>();
+    private final Map<String, Integer> currentStatuses = new ConcurrentHashMap<>();
 
-  @Autowired
-  public DataJobMetrics(MeterRegistry meterRegistry) {
-    this.meterRegistry = meterRegistry;
+    @Autowired
+    public DataJobMetrics(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
 
-    watchTaskInvocationsCounter =
-        Counter.builder(TAURUS_DATAJOB_WATCH_TASK_INVOCATIONS_COUNTER_NAME)
-            .description("Counts the number of times the data jobs watching task is called.")
-            .register(this.meterRegistry);
-  }
-
-  /**
-   * Increments the counter used to track the number of times the {@link DataJobMonitor#watchJobs}
-   * method was invoked.
-   */
-  public void incrementWatchTaskInvocations() {
-    try {
-      watchTaskInvocationsCounter.increment();
-    } catch (Exception e) {
-      log.warn("Error while trying to increment counter.", e);
+        watchTaskInvocationsCounter = Counter.builder(TAURUS_DATAJOB_WATCH_TASK_INVOCATIONS_COUNTER_NAME)
+                .description("Counts the number of times the data jobs watching task is called.")
+                .register(this.meterRegistry);
     }
-  }
 
-  /**
-   * Creates a "taurus.datajob.info" and a "taurus.datajob.notification.delay" gauge for the
-   * specified data job if they do not exist. If a gauge already exists, but it has different tags,
-   * the existing gauge is deleted and a new one is created. If the data job does not have a
-   * configuration, no gauges are created.
-   *
-   * @param dataJob The data job for which to update the gauges.
-   */
-  public void updateInfoGauges(final DataJob dataJob) {
-    Objects.requireNonNull(dataJob);
+    /**
+     * Increments the counter used to track the number of times the {@link DataJobMonitor#watchJobs} method was invoked.
+     */
+    public void incrementWatchTaskInvocations() {
+        try {
+            watchTaskInvocationsCounter.increment();
+        } catch (Exception e) {
+            log.warn("Error while trying to increment counter.", e);
+        }
+    }
 
-    updateInfoGauge(dataJob);
-    updateNotificationDelayGauge(dataJob);
-  }
+    /**
+     * Creates a "taurus.datajob.info" and a "taurus.datajob.notification.delay" gauge for the specified data job
+     * if they do not exist. If a gauge already exists, but it has different tags, the existing gauge is deleted
+     * and a new one is created. If the data job does not have a configuration, no gauges are created.
+     *
+     * @param dataJob The data job for which to update the gauges.
+     */
+    public void updateInfoGauges(final DataJob dataJob) {
+        Objects.requireNonNull(dataJob);
 
-  /**
-   * Creates a "taurus.datajob.info" gauge for the specified data job if one does not exist. If a
-   * gauge already exists, but it has different tags, the existing gauge is deleted and a new one is
-   * created. If the data job does not have a configuration, no gauge is created.
-   *
-   * @param dataJob The data job for which to update the gauge.
-   */
-  private void updateInfoGauge(final DataJob dataJob) {
-    Objects.requireNonNull(dataJob);
+        updateInfoGauge(dataJob);
+        updateNotificationDelayGauge(dataJob);
+    }
 
-    try {
-      var dataJobName = dataJob.getName();
-      if (dataJob.getJobConfig() == null) {
-        log.debug("The data job {} does not have configuration", dataJobName);
-        return;
-      }
+    /**
+     * Creates a "taurus.datajob.info" gauge for the specified data job if one does not exist.
+     * If a gauge already exists, but it has different tags, the existing gauge is deleted and a new one is created.
+     * If the data job does not have a configuration, no gauge is created.
+     *
+     * @param dataJob The data job for which to update the gauge.
+     */
+    private void updateInfoGauge(final DataJob dataJob) {
+        Objects.requireNonNull(dataJob);
 
-      var gauge = infoGauges.getOrDefault(dataJobName, null);
-      var newTags = createInfoGaugeTags(dataJob);
-      if (isGaugeChanged(gauge, newTags)) {
-        log.info("The configuration of data job {} has changed", dataJobName);
+        try {
+            var dataJobName = dataJob.getName();
+            if (dataJob.getJobConfig() == null) {
+                log.debug("The data job {} does not have configuration", dataJobName);
+                return;
+            }
+
+            var gauge = infoGauges.getOrDefault(dataJobName, null);
+            var newTags = createInfoGaugeTags(dataJob);
+            if (isGaugeChanged(gauge, newTags)) {
+                log.info("The configuration of data job {} has changed", dataJobName);
+                removeInfoGauge(dataJobName);
+            }
+
+            infoGauges.computeIfAbsent(dataJobName, name -> createInfoGauge(name, newTags));
+        } catch (Exception e) {
+            log.warn("An exception occurred while updating the info gauge of data job {}", dataJob.getName(), e);
+        }
+    }
+
+    /**
+     * Creates a "taurus.datajob.notification.delay" gauge for the specified data job if one does not exist.
+     * If a gauge already exists, its value is updated.
+     * If the data job does not have a configuration, no gauge is created.
+     *
+     * @param dataJob The data job for which to update the gauge.
+     */
+    private void updateNotificationDelayGauge(final DataJob dataJob) {
+        Objects.requireNonNull(dataJob);
+
+        try {
+            var dataJobName = dataJob.getName();
+            if (dataJob.getJobConfig() == null) {
+                log.debug("The data job {} does not have configuration", dataJobName);
+                return;
+            }
+
+            currentDelays.put(dataJobName,
+                    Optional.ofNullable(dataJob.getJobConfig().getNotificationDelayPeriodMinutes()).orElse(DEFAULT_NOTIFICATION_DELAY_PERIOD_MINUTES));
+            delayGauges.computeIfAbsent(dataJobName, this::createNotificationDelayGauge);
+        } catch (Exception e) {
+            log.warn("An exception occurred while updating the notification delay gauge of data job {}", dataJob.getName(), e);
+        }
+    }
+
+    /**
+     * Creates a "taurus.datajob.termination.status" gauge for the specified data job if one does not exist.
+     * If a gauge already exists, its value is updated.
+     *
+     * @param dataJob The data job for which to update the gauge.
+     */
+    public void updateTerminationStatusGauge(final DataJob dataJob) {
+        Objects.requireNonNull(dataJob);
+
+        try {
+            var dataJobName = dataJob.getName();
+            var gauge = statusGauges.getOrDefault(dataJobName, null);
+            var newTags = createStatusGaugeTags(dataJob);
+            if (isGaugeChanged(gauge, newTags)) {
+                log.info("The last termination status of data job {} has changed", dataJobName);
+                removeTerminationStatusGauge(dataJobName);
+            }
+
+            Integer previousTerminationStatus = currentStatuses.get(dataJobName);
+            Integer newTerminationStatus = dataJob.getLatestJobTerminationStatus().getAlertValue();
+            currentStatuses.put(dataJobName, newTerminationStatus);
+            statusGauges.computeIfAbsent(dataJobName, name -> createTerminationStatusGauge(name, newTags));
+            if (!Objects.equals(previousTerminationStatus, newTerminationStatus)) {
+                log.debug("The termination status gauge value for data job {} with execution {} was changed from {} to {}",
+                        dataJobName, dataJob.getLatestJobExecutionId(), previousTerminationStatus, newTerminationStatus);
+            }
+        } catch (Exception e) {
+            log.warn("An exception occurred while updating the termination status gauge of data job {}", dataJob.getName(), e);
+        }
+    }
+
+    /**
+     * Creates a "taurus.datajob.termination.status.counter" counter for the specified
+     * data job and execution status, if one does not exist. If a counter already
+     * exists, its value is incremented.
+     *
+     * @param dataJob The data job for which to increment the counter.
+     * */
+    public void incrementTerminationStatusCounter(final DataJob dataJob) {
+        Objects.requireNonNull(dataJob);
+
+        try {
+            var dataJobName = dataJob.getName();
+            var dataJobStatus = dataJob.getLatestJobTerminationStatus().getAlertValue().toString();
+            var jobStatusKey = dataJobName + "__" + dataJobStatus;
+            var counter = statusCounters.getOrDefault(jobStatusKey, null);
+            var tags = createStatusCounterTags(dataJob);
+
+            if (counter == null) {
+                statusCounters.computeIfAbsent(jobStatusKey, name -> createTerminationStatusCounter(dataJobName, tags, dataJobStatus));
+            } else {
+                counter.increment();
+            }
+        } catch (Exception e) {
+            log.warn("An exception occurred while incrementing the termination status counter of data job {} and status {}", dataJob.getName(), dataJob.getLatestJobTerminationStatus().getAlertValue().toString());
+        }
+    }
+
+    /**
+     * Removes all gauges associated with the specified data job.
+     *
+     * @param dataJobName The name of the data job for which to clear all gauges.
+     */
+    public void clearGauges(final String dataJobName) {
         removeInfoGauge(dataJobName);
       }
 
@@ -123,35 +213,52 @@ public class DataJobMetrics {
           dataJob.getName(),
           e);
     }
-  }
 
-  /**
-   * Creates a "taurus.datajob.notification.delay" gauge for the specified data job if one does not
-   * exist. If a gauge already exists, its value is updated. If the data job does not have a
-   * configuration, no gauge is created.
-   *
-   * @param dataJob The data job for which to update the gauge.
-   */
-  private void updateNotificationDelayGauge(final DataJob dataJob) {
-    Objects.requireNonNull(dataJob);
+    /**
+     * Removes all counters associated with the specified data job.
+     *
+     * @param dataJobName The name of the data job for which to clear all counters.
+     */
+    public void clearCounters(final String dataJobName) {
+        removeTerminationStatusCounters(dataJobName);
+    }
 
-    try {
-      var dataJobName = dataJob.getName();
-      if (dataJob.getJobConfig() == null) {
-        log.debug("The data job {} does not have configuration", dataJobName);
-        return;
-      }
+    /**
+     * Removes all gauges associated with data jobs that are not present in the specified iterable.
+     *
+     * @param dataJobNames The names of the data jobs which will still have gauges.
+     */
+    public void clearGaugesNotIn(final Set<String> dataJobNames) {
+        var absentEntries = filterByKeyNotIn(infoGauges, dataJobNames);
+        absentEntries.forEach(e -> removeInfoGauge(e.getKey()));
 
-      currentDelays.put(
-          dataJobName,
-          Optional.ofNullable(dataJob.getJobConfig().getNotificationDelayPeriodMinutes())
-              .orElse(DEFAULT_NOTIFICATION_DELAY_PERIOD_MINUTES));
-      delayGauges.computeIfAbsent(dataJobName, this::createNotificationDelayGauge);
-    } catch (Exception e) {
-      log.warn(
-          "An exception occurred while updating the notification delay gauge of data job {}",
-          dataJob.getName(),
-          e);
+        absentEntries = filterByKeyNotIn(delayGauges, dataJobNames);
+        absentEntries.forEach(e -> removeNotificationDelayGauge(e.getKey()));
+
+        absentEntries = filterByKeyNotIn(statusGauges, dataJobNames);
+        absentEntries.forEach(e -> removeTerminationStatusGauge(e.getKey()));
+    }
+
+    /**
+     * Returns a list consisting of the entries of the specified map, that do not have their keys in the specified set.
+     *
+     * @param from The map to filter.
+     * @param set A set containing keys for the elements that should <b>NOT</b> be returned.
+     * @return A list of all Map.Entry objects with keys inside {@code set}.
+     */
+    private <K> List<Map.Entry<K, ?>> filterByKeyNotIn(final Map<K, ?> from, final Set<K> set) {
+        return from.entrySet().stream()
+                .filter(e -> !set.contains(e.getKey()))
+                .collect(Collectors.toList());
+    }
+
+    private Gauge createInfoGauge(final String dataJobName, final Tags tags) {
+        var gauge = Gauge.builder(TAURUS_DATAJOB_INFO_METRIC_NAME, GAUGE_METRIC_VALUE, value -> value)
+                .tags(tags)
+                .description("Info about data jobs")
+                .register(meterRegistry);
+        log.info("The info gauge for data job {} was created", dataJobName);
+        return gauge;
     }
   }
 
@@ -305,36 +412,59 @@ public class DataJobMetrics {
           dataJobName,
           e);
     }
-  }
 
-  private Gauge createTerminationStatusGauge(final String dataJobName, final Tags tags) {
-    var gauge =
-        Gauge.builder(
-                TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME,
-                currentStatuses,
-                map -> map.getOrDefault(dataJobName, -1))
-            .tags(tags)
-            .description(
-                "Termination status of data job executions (0 - Success, 1 - Platform error, 3 -"
-                    + " User error)")
-            .register(meterRegistry);
-    log.info("The termination status gauge for data job {} was created", dataJobName);
-    return gauge;
-  }
+    private Counter createTerminationStatusCounter(final String dataJobName, final Tags tags, final String status) {
+        var counter = Counter.builder(TAURUS_DATAJOB_TERMINATION_STATUS_COUNTER_NAME)
+                .description("Counts the number of specific statuses per job")
+                .tags(tags)
+                .register(meterRegistry);
+        counter.increment();
+        log.info("Counter for data job {} and status {} was created.", dataJobName, status);
+        return counter;
+    }
 
-  private void removeTerminationStatusGauge(final String dataJobName) {
-    try {
-      if (StringUtils.isNotBlank(dataJobName)) {
-        var gauge = statusGauges.getOrDefault(dataJobName, null);
-        if (gauge != null) {
-          meterRegistry.remove(gauge);
-          statusGauges.remove(dataJobName);
-          currentStatuses.remove(dataJobName);
-          log.info("The termination status gauge for data job {} was removed", dataJobName);
-        } else {
-          log.info(
-              "The termination status gauge for data job {} cannot be removed: gauge not found",
-              dataJobName);
+    /**
+     * Removes all termination status counters associated with a data job.
+     * Status counters for each data job are stored in the statusCounters
+     * hash map, in the form:
+     *    `<data-job-name>__<execution-status> : <counter-object>`
+     * and we need to iterate over the hash map, in order to find all instances
+     * that need to be removed.
+     *
+     * @param dataJobName the name of the data job
+     * */
+    private void removeTerminationStatusCounters(final String dataJobName) {
+        try {
+            if (StringUtils.isNotBlank(dataJobName)) {
+                Set<String> toBeDeleted = new HashSet<>();
+                String filter = dataJobName + "__";
+
+                for (Map.Entry<String, Counter> pair : statusCounters.entrySet()) {
+                    if (pair.getKey().contains(filter)) {
+                        toBeDeleted.add(pair.getKey());
+                    }
+                }
+
+                if (!toBeDeleted.isEmpty()) {
+                    for (String key : toBeDeleted) {
+                        var counter = statusCounters.getOrDefault(key, null);
+                        meterRegistry.remove(counter);
+                        statusCounters.remove(key);
+                    }
+                } else {
+                    log.info("No termination status counters found for data job: {}", dataJobName);
+                }
+            } else {
+                log.warn("The termination status counters cannot be removed: data job name is empty.");
+            }
+        } catch (Exception e) {
+            log.warn("An exception occurred while removing a termination status counter of data job {}", dataJobName);
+        }
+    }
+
+    private boolean isGaugeChanged(final Gauge gauge, final Tags newTags) {
+        if (gauge == null) {
+            return false;
         }
       } else {
         log.warn("The termination status gauge cannot be removed: data job name is empty");
@@ -352,35 +482,21 @@ public class DataJobMetrics {
       return false;
     }
 
-    var existingTags = gauge.getId().getTags();
-    return !newTags.stream().allMatch(existingTags::contains);
-  }
+    private Tags createStatusGaugeTags(final DataJob dataJob) {
+        Objects.requireNonNull(dataJob);
 
-  private Tags createInfoGaugeTags(final DataJob dataJob) {
-    Objects.requireNonNull(dataJob);
+        return Tags.of(
+                TAG_DATA_JOB, dataJob.getName(),
+                TAG_EXECUTION_ID, dataJob.getLatestJobExecutionId());
+    }
 
-    var jobConfig = dataJob.getJobConfig();
-    boolean enableExecutionNotifications =
-        jobConfig.getEnableExecutionNotifications() == null
-            || jobConfig.getEnableExecutionNotifications();
-    return Tags.of(
-        TAG_DATA_JOB, dataJob.getName(),
-        TAG_TEAM, StringUtils.defaultString(jobConfig.getTeam()),
-        TAG_EMAIL_NOTIFIED_ON_SUCCESS,
-            enableExecutionNotifications ? join(jobConfig.getNotifiedOnJobSuccess()) : "",
-        TAG_EMAIL_NOTIFIED_ON_USER_ERROR,
-            enableExecutionNotifications ? join(jobConfig.getNotifiedOnJobFailureUserError()) : "",
-        TAG_EMAIL_NOTIFIED_ON_PLATFORM_ERROR,
-            enableExecutionNotifications
-                ? join(jobConfig.getNotifiedOnJobFailurePlatformError())
-                : "");
-  }
+    private Tags createStatusCounterTags(final DataJob dataJob) {
+        Objects.requireNonNull(dataJob);
 
-  private Tags createStatusGaugeTags(final DataJob dataJob) {
-    Objects.requireNonNull(dataJob);
-
-    return Tags.of(
-        TAG_DATA_JOB, dataJob.getName(),
-        TAG_EXECUTION_ID, dataJob.getLatestJobExecutionId());
-  }
+        return Tags.of(
+                TAG_DATA_JOB, dataJob.getName(),
+                TAG_TEAM, Objects.requireNonNullElse(dataJob.getJobConfig().getTeam(), "none"),
+                TAG_STATUS, dataJob.getLatestJobTerminationStatus().getAlertValue().toString()
+        );
+    }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DataJobMonitorTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DataJobMonitorTest.java
@@ -46,175 +46,149 @@ import static org.mockito.Mockito.doThrow;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class DataJobMonitorTest {
 
-  @Autowired private MeterRegistry meterRegistry;
+    @Autowired
+    private MeterRegistry meterRegistry;
 
-  @Autowired private JobsRepository jobsRepository;
+    @Autowired
+    private JobsRepository jobsRepository;
 
-  @Autowired private JobExecutionRepository jobExecutionRepository;
+    @Autowired
+    private JobExecutionRepository jobExecutionRepository;
 
-  @MockBean private DataJobsKubernetesService dataJobsKubernetesService;
+    @MockBean
+    private DataJobsKubernetesService dataJobsKubernetesService;
 
-  @Autowired private DataJobMonitor dataJobMonitor;
+    @Autowired
+    private DataJobMonitor dataJobMonitor;
 
-  @Test
-  @Order(1)
-  public void testUpdateDataJobTerminationStatusSuccess() {
-    var dataJob =
-        new DataJob(
-            "data-job",
-            new JobConfig(),
-            DeploymentStatus.NONE,
-            ExecutionStatus.SUCCEEDED,
-            randomId("data-job-"));
+    @Test
+    @Order(1)
+    public void testUpdateDataJobTerminationStatusSuccess() {
+        var dataJob = new DataJob("data-job", new JobConfig(),
+                DeploymentStatus.NONE, ExecutionStatus.SUCCEEDED, randomId("data-job-"));
 
-    dataJobMonitor.updateDataJobTerminationStatusGauge(jobsRepository.save(dataJob));
+        dataJobMonitor.updateDataJobTerminationStatusMetrics(jobsRepository.save(dataJob));
 
-    var gauges =
-        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-    Assertions.assertEquals(1, gauges.size());
-    Assertions.assertEquals(
-        ExecutionStatus.SUCCEEDED.getAlertValue().doubleValue(),
-        gauges.stream().findFirst().get().value());
+        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+        Assertions.assertEquals(1, gauges.size());
+        Assertions.assertEquals(ExecutionStatus.SUCCEEDED.getAlertValue().doubleValue(), gauges.stream().findFirst().get().value());
 
-    var expectedJob = jobsRepository.findById(dataJob.getName());
-    Assertions.assertTrue(expectedJob.isPresent());
-    Assertions.assertEquals(
-        ExecutionStatus.SUCCEEDED, expectedJob.get().getLatestJobTerminationStatus());
-  }
+        var counters = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_COUNTER_NAME).counters();
+        Assertions.assertEquals(1, counters.size());
+        Assertions.assertEquals("0", counters.stream().findFirst().get().getId().getTag("status"));
+        Assertions.assertEquals(1.0, counters.stream().findFirst().get().measure().iterator().next().getValue());
 
-  @Test
-  @Order(2)
-  public void testUpdateDataJobTerminationStatusPlatformError() {
-    var dataJob =
-        new DataJob(
-            "data-job",
-            new JobConfig(),
-            DeploymentStatus.NONE,
-            ExecutionStatus.PLATFORM_ERROR,
-            randomId("data-job-"));
+        var expectedJob = jobsRepository.findById(dataJob.getName());
+        Assertions.assertTrue(expectedJob.isPresent());
+        Assertions.assertEquals(ExecutionStatus.SUCCEEDED, expectedJob.get().getLatestJobTerminationStatus());
+    }
 
-    dataJobMonitor.updateDataJobTerminationStatusGauge(jobsRepository.save(dataJob));
+    @Test
+    @Order(2)
+    public void testUpdateDataJobTerminationStatusPlatformError() {
+        var dataJob = new DataJob("data-job", new JobConfig(),
+                DeploymentStatus.NONE, ExecutionStatus.PLATFORM_ERROR, randomId("data-job-"));
 
-    var gauges =
-        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-    Assertions.assertEquals(1, gauges.size());
-    Assertions.assertEquals(
-        ExecutionStatus.PLATFORM_ERROR.getAlertValue().doubleValue(),
-        gauges.stream().findFirst().get().value());
+        dataJobMonitor.updateDataJobTerminationStatusMetrics(jobsRepository.save(dataJob));
 
-    var expectedJob = jobsRepository.findById(dataJob.getName());
-    Assertions.assertTrue(expectedJob.isPresent());
-    Assertions.assertEquals(
-        ExecutionStatus.PLATFORM_ERROR, expectedJob.get().getLatestJobTerminationStatus());
-  }
+        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+        Assertions.assertEquals(1, gauges.size());
+        Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR.getAlertValue().doubleValue(), gauges.stream().findFirst().get().value());
 
-  @Test
-  @Order(3)
-  public void testUpdateDataJobTerminationStatusSkipped() {
-    var dataJob =
-        new DataJob(
-            "data-job",
-            new JobConfig(),
-            DeploymentStatus.NONE,
-            ExecutionStatus.SKIPPED,
-            randomId("data-job-"));
+        var counters = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_COUNTER_NAME).counters();
+        Assertions.assertEquals(2, counters.size());
+        Assertions.assertEquals("1", counters.stream().findFirst().get().getId().getTag("status"));
+        Assertions.assertEquals(1.0, counters.stream().findFirst().get().measure().iterator().next().getValue());
 
-    dataJobMonitor.updateDataJobTerminationStatusGauge(jobsRepository.save(dataJob));
+        var expectedJob = jobsRepository.findById(dataJob.getName());
+        Assertions.assertTrue(expectedJob.isPresent());
+        Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, expectedJob.get().getLatestJobTerminationStatus());
+    }
 
-    var gauges =
-        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-    Assertions.assertEquals(1, gauges.size());
-    Assertions.assertEquals(
-        ExecutionStatus.SKIPPED.getAlertValue().doubleValue(),
-        gauges.stream().findFirst().get().value());
+    @Test
+    @Order(3)
+    public void testUpdateDataJobTerminationStatusSkipped() {
+        var dataJob = new DataJob("data-job", new JobConfig(),
+                DeploymentStatus.NONE, ExecutionStatus.SKIPPED, randomId("data-job-"));
 
-    var expectedJob = jobsRepository.findById(dataJob.getName());
-    Assertions.assertTrue(expectedJob.isPresent());
-    Assertions.assertEquals(
-        ExecutionStatus.SKIPPED, expectedJob.get().getLatestJobTerminationStatus());
-  }
+        dataJobMonitor.updateDataJobTerminationStatusMetrics(jobsRepository.save(dataJob));
 
-  @Test
-  @Order(4)
-  public void testUpdateDataJobTerminationStatusStatusUserError() {
-    var dataJob =
-        new DataJob(
-            "data-job",
-            new JobConfig(),
-            DeploymentStatus.NONE,
-            ExecutionStatus.USER_ERROR,
-            randomId("data-job-"));
+        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+        Assertions.assertEquals(1, gauges.size());
+        Assertions.assertEquals(ExecutionStatus.SKIPPED.getAlertValue().doubleValue(), gauges.stream().findFirst().get().value());
 
-    dataJobMonitor.updateDataJobTerminationStatusGauge(jobsRepository.save(dataJob));
+        var counters = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_COUNTER_NAME).counters();
+        Assertions.assertEquals(3, counters.size());
+        Assertions.assertEquals("4", counters.stream().findFirst().get().getId().getTag("status"));
+        Assertions.assertEquals(1.0, counters.stream().findFirst().get().measure().iterator().next().getValue());
 
-    var gauges =
-        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-    Assertions.assertEquals(1, gauges.size());
-    Assertions.assertEquals(
-        ExecutionStatus.USER_ERROR.getAlertValue().doubleValue(),
-        gauges.stream().findFirst().get().value());
+        var expectedJob = jobsRepository.findById(dataJob.getName());
+        Assertions.assertTrue(expectedJob.isPresent());
+        Assertions.assertEquals(ExecutionStatus.SKIPPED, expectedJob.get().getLatestJobTerminationStatus());
+    }
 
-    var expectedJob = jobsRepository.findById(dataJob.getName());
-    Assertions.assertTrue(expectedJob.isPresent());
-    Assertions.assertEquals(
-        ExecutionStatus.USER_ERROR, expectedJob.get().getLatestJobTerminationStatus());
-  }
+    @Test
+    @Order(4)
+    public void testUpdateDataJobTerminationStatusStatusUserError() {
+        var dataJob = new DataJob("data-job", new JobConfig(),
+                DeploymentStatus.NONE, ExecutionStatus.USER_ERROR, randomId("data-job-"));
 
-  @Test
-  @Order(5)
-  public void testUpdateDataJobsGaugesWithoutJobs() {
-    dataJobMonitor.updateDataJobsGauges(Collections.emptyList());
+        dataJobMonitor.updateDataJobTerminationStatusMetrics(jobsRepository.save(dataJob));
 
-    var gauges =
-        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-    Assertions.assertEquals(1, gauges.size());
-  }
+        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+        Assertions.assertEquals(1, gauges.size());
+        Assertions.assertEquals(ExecutionStatus.USER_ERROR.getAlertValue().doubleValue(), gauges.stream().findFirst().get().value());
 
-  @Test
-  @Order(6)
-  public void testWatchJobs() throws IOException, ApiException {
-    var jobStatuses =
-        List.of(
-            buildJobExecutionStatus(
-                randomId("datajob-"), randomId("job-"), ExecutionStatus.SUCCEEDED.getPodStatus()),
-            buildJobExecutionStatus(
-                randomId("datajob-"),
-                randomId("job-"),
-                ExecutionStatus.USER_ERROR.getPodStatus(),
-                false),
-            buildJobExecutionStatus(
-                randomId("datajob-"),
-                randomId("job-"),
-                ExecutionStatus.PLATFORM_ERROR.getPodStatus(),
-                false),
-            buildJobExecutionStatus(
-                randomId("datajob-"), randomId("job-"), ExecutionStatus.SKIPPED.getPodStatus()));
-    doAnswer(
-            inv -> {
-              jobStatuses.forEach(inv.getArgument(1));
-              return null;
-            })
-        .when(dataJobsKubernetesService)
-        .watchJobs(anyMap(), any(), any(), anyLong());
-    jobStatuses.forEach(s -> jobsRepository.save(new DataJob(s.getJobName(), new JobConfig())));
+        var counters = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_COUNTER_NAME).counters();
+        Assertions.assertEquals(4, counters.size());
+        Assertions.assertEquals("3", counters.stream().findFirst().get().getId().getTag("status"));
+        Assertions.assertEquals(1.0, counters.stream().findFirst().get().measure().iterator().next().getValue());
 
-    dataJobMonitor.watchJobs();
+        var expectedJob = jobsRepository.findById(dataJob.getName());
+        Assertions.assertTrue(expectedJob.isPresent());
+        Assertions.assertEquals(ExecutionStatus.USER_ERROR, expectedJob.get().getLatestJobTerminationStatus());
+    }
 
-    var gauges =
-        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-    // We had 1 gauge from previous tests and added 4 more; but data jobs with last termination
-    // status SKIPPED
-    // have no metrics exposed; so effectively the expected number of gauges is 4
-    Assertions.assertEquals(4, gauges.size());
-    jobStatuses.forEach(
-        s -> {
-          var expectedJob = jobsRepository.findById(s.getJobName());
-          Assertions.assertTrue(expectedJob.isPresent());
-          ExecutionStatus expectedStatus = getTerminationStatus(s);
-          if (expectedStatus != ExecutionStatus.SKIPPED) {
-            Assertions.assertEquals(
-                expectedStatus, expectedJob.get().getLatestJobTerminationStatus());
-          }
+    @Test
+    @Order(5)
+    public void testUpdateDataJobsGaugesWithoutJobs() {
+        dataJobMonitor.updateDataJobsGauges(Collections.emptyList());
+
+        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+        Assertions.assertEquals(1, gauges.size());
+
+        var counters = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_COUNTER_NAME).counters();
+        Assertions.assertEquals(4, counters.size());
+    }
+
+    @Test
+    @Order(6)
+    public void testWatchJobs() throws IOException, ApiException {
+        var jobStatuses = List.of(
+              buildJobExecutionStatus(randomId("datajob-"), randomId("job-"), ExecutionStatus.SUCCEEDED.getPodStatus()),
+              buildJobExecutionStatus(randomId("datajob-"), randomId("job-"), ExecutionStatus.USER_ERROR.getPodStatus(), false),
+              buildJobExecutionStatus(randomId("datajob-"), randomId("job-"), ExecutionStatus.PLATFORM_ERROR.getPodStatus(), false),
+              buildJobExecutionStatus(randomId("datajob-"), randomId("job-"), ExecutionStatus.SKIPPED.getPodStatus())
+        );
+        doAnswer(inv -> {
+            jobStatuses.forEach(inv.getArgument(1));
+            return null;
+        }).when(dataJobsKubernetesService).watchJobs(anyMap(), any(), any(), anyLong());
+        jobStatuses.forEach(s -> jobsRepository.save(new DataJob(s.getJobName(), new JobConfig())));
+
+        dataJobMonitor.watchJobs();
+
+        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+        // We had 1 gauge from previous tests and added 4 more; but data jobs with last termination status SKIPPED
+        // have no metrics exposed; so effectively the expected number of gauges is 4
+        Assertions.assertEquals(4, gauges.size());
+        jobStatuses.forEach(s -> {
+            var expectedJob = jobsRepository.findById(s.getJobName());
+            Assertions.assertTrue(expectedJob.isPresent());
+            ExecutionStatus expectedStatus = getTerminationStatus(s);
+            if (expectedStatus != ExecutionStatus.SKIPPED) {
+                Assertions.assertEquals(expectedStatus, expectedJob.get().getLatestJobTerminationStatus());
+            }
         });
   }
 
@@ -333,601 +307,451 @@ public class DataJobMonitorTest {
           Assertions.assertEquals(
               ExecutionStatus.SUCCEEDED, expectedJob.get().getLatestJobTerminationStatus());
         });
-  }
-
-  @Test
-  @Order(11)
-  public void testUpdateDataJobTerminationStatusWithoutExecutionId() {
-    var dataJob = new DataJob("data-job", new JobConfig(), DeploymentStatus.NONE);
-
-    dataJobMonitor.updateDataJobTerminationStatusGauge(jobsRepository.save(dataJob));
-
-    var gauges =
-        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-    Assertions.assertEquals(5, gauges.size());
-  }
-
-  @Test
-  @Order(12)
-  public void testWatchJobsWhenExceptionIsThrown() throws IOException, ApiException {
-    doThrow(new ApiException())
-        .when(dataJobsKubernetesService)
-        .watchJobs(anyMap(), any(), any(), anyLong());
-
-    Assertions.assertDoesNotThrow(() -> dataJobMonitor.watchJobs());
-  }
-
-  @Test
-  @Order(13)
-  public void testRecordJobExecutionStatus_nullDataJobName_shouldNotRecordExecution() {
-    JobExecution jobExecution =
-        buildJobExecutionStatus(null, randomId("job-"), ExecutionStatus.SUCCEEDED.getPodStatus());
-    dataJobMonitor.recordJobExecutionStatus(jobExecution);
-    Optional<DataJobExecution> actualJobExecution =
-        jobExecutionRepository.findById(jobExecution.getExecutionId());
-
-    Assertions.assertTrue(actualJobExecution.isEmpty());
-  }
-
-  @Test
-  @Order(14)
-  public void testRecordJobExecutionStatus_emptyDataJobName_shouldNotRecordExecution() {
-    JobExecution jobExecution =
-        buildJobExecutionStatus("", randomId("job-"), ExecutionStatus.SUCCEEDED.getPodStatus());
-    dataJobMonitor.recordJobExecutionStatus(jobExecution);
-    Optional<DataJobExecution> actualJobExecution =
-        jobExecutionRepository.findById(jobExecution.getExecutionId());
-
-    Assertions.assertTrue(actualJobExecution.isEmpty());
-  }
-
-  @Test
-  @Order(15)
-  public void
-      testRecordJobExecutionStatus_existingDataJobAndNonExistingExecution_shouldRecordExecution() {
-    JobExecution expectedJobExecution =
-        buildJobExecutionStatus(
-            "data-job", "execution-id", ExecutionStatus.SUCCEEDED.getPodStatus(), true);
-    dataJobMonitor.recordJobExecutionStatus(expectedJobExecution);
-    Optional<DataJobExecution> actualJobExecution =
-        jobExecutionRepository.findById(expectedJobExecution.getExecutionId());
-
-    assertDataJobExecutionValid(expectedJobExecution, actualJobExecution);
-  }
-
-  @Test
-  @Order(16)
-  public void
-      testRecordJobExecutionStatus_existingDataJobAndExistingExecution_shouldUpdateExecution() {
-    DataJobExecution jobExecutionBeforeUpdate =
-        jobExecutionRepository.findById("execution-id").get();
-    JobExecution expectedJobExecution =
-        JobExecution.builder()
-            .jobName(jobExecutionBeforeUpdate.getDataJob().getName())
-            .executionId(jobExecutionBeforeUpdate.getId())
-            .podTerminationMessage(ExecutionStatus.SUCCEEDED.getPodStatus())
-            .executionType("scheduled")
-            .opId("opId")
-            .startTime(jobExecutionBeforeUpdate.getStartTime())
-            .endTime(jobExecutionBeforeUpdate.getEndTime())
-            .jobVersion("jobVersion")
-            .jobSchedule("jobSchedule")
-            .resourcesCpuRequest(1F)
-            .resourcesCpuLimit(2F)
-            .resourcesMemoryRequest(500)
-            .resourcesMemoryLimit(1000)
-            .deployedDate(jobExecutionBeforeUpdate.getLastDeployedDate())
-            .deployedBy("lastDeployedBy")
-            .succeeded(true)
-            .build();
-
-    dataJobMonitor.recordJobExecutionStatus(expectedJobExecution);
-    Optional<DataJobExecution> actualJobExecution =
-        jobExecutionRepository.findById(expectedJobExecution.getExecutionId());
-
-    assertDataJobExecutionValid(expectedJobExecution, actualJobExecution);
-  }
-
-  @Test
-  @Order(17)
-  public void
-      testRecordJobExecutionStatusSkipped_existingDataJobAndNonExistingExecution_shouldRecordExecution() {
-    JobExecution expectedJobExecution =
-        buildJobExecutionStatus(
-            "data-job", "different-execution-id", ExecutionStatus.RUNNING.getPodStatus(), null);
-    dataJobMonitor.recordJobExecutionStatus(expectedJobExecution);
-    Optional<DataJobExecution> actualJobExecution =
-        jobExecutionRepository.findById(expectedJobExecution.getExecutionId());
-
-    assertDataJobExecutionValid(expectedJobExecution, actualJobExecution);
-  }
-
-  @Test
-  @Order(18)
-  public void
-      testRecordJobExecutionStatusSkipped_existingDataJobAndExistingExecution_shouldRecordExecution() {
-    var expectedExecutionMessage =
-        "Skipping job execution due to another parallel running execution.";
-    JobExecution expectedJobExecution =
-        buildJobExecutionStatus(
-            "data-job", "different-execution-id", ExecutionStatus.SKIPPED.getPodStatus(), true);
-    Optional<DataJobExecution> jobExecutionBeforeUpdate =
-        jobExecutionRepository.findById(expectedJobExecution.getExecutionId());
-    dataJobMonitor.recordJobExecutionStatus(expectedJobExecution);
-    Optional<DataJobExecution> actualJobExecution =
-        jobExecutionRepository.findById(expectedJobExecution.getExecutionId());
-
-    assertDataJobExecutionValid(
-        expectedJobExecution,
-        actualJobExecution,
-        expectedExecutionMessage,
-        jobExecutionBeforeUpdate.get().getStartTime());
-  }
-
-  @Test
-  @Order(19)
-  public void
-      testRecordJobExecutionStatus_nonExistingDataJobAndNonExistingExecution_shouldNotRecordExecution() {
-    JobExecution jobExecution =
-        buildJobExecutionStatus(
-            randomId("data-job-"), randomId("job-"), ExecutionStatus.SUCCEEDED.getPodStatus());
-    dataJobMonitor.recordJobExecutionStatus(jobExecution);
-    Optional<DataJobExecution> actualJobExecution =
-        jobExecutionRepository.findById(jobExecution.getExecutionId());
-
-    Assertions.assertTrue(actualJobExecution.isEmpty());
-  }
-
-  @Test
-  @Order(20)
-  void testUpdateDataJobInfoGauges() {
-    var dataJob =
-        new DataJob(
-            "data-job",
-            new JobConfig(),
-            DeploymentStatus.NONE,
-            ExecutionStatus.SUCCEEDED,
-            randomId("data-job-"));
-
-    dataJobMonitor.updateDataJobInfoGauges(jobsRepository.save(dataJob));
-
-    var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
-    Assertions.assertEquals(1, gauges.size());
-    gauges =
-        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
-    Assertions.assertEquals(1, gauges.size());
-  }
-
-  @Test
-  @Order(21)
-  void testUpdateDataJobInfoGauges_withNullDataJob_throwsException() {
-    Assertions.assertThrows(
-        NullPointerException.class, () -> dataJobMonitor.updateDataJobInfoGauges(null));
-  }
-
-  @Test
-  @Order(22)
-  void testClearDataJobsGaugesNotIn() {
-    var dataJobs =
-        Arrays.asList(
-            new DataJob(
-                "data-job1",
-                new JobConfig(),
-                DeploymentStatus.NONE,
-                ExecutionStatus.SUCCEEDED,
-                randomId("data-job1-")),
-            new DataJob(
-                "data-job2",
-                new JobConfig(),
-                DeploymentStatus.NONE,
-                ExecutionStatus.SUCCEEDED,
-                randomId("data-job2-")),
-            new DataJob(
-                "data-job3",
-                new JobConfig(),
-                DeploymentStatus.NONE,
-                ExecutionStatus.SUCCEEDED,
-                randomId("data-job3-")));
-
-    // Clean up from previous tests
-    jobsRepository.deleteAll();
-    dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
-
-    // Add some more gauges
-    dataJobMonitor.updateDataJobsGauges(jobsRepository.saveAll(dataJobs));
-
-    var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
-    Assertions.assertEquals(3, gauges.size());
-    gauges =
-        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
-    Assertions.assertEquals(3, gauges.size());
-    gauges =
-        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-    Assertions.assertEquals(3, gauges.size());
-
-    // Delete a data job and verify that its gauges are removed as a result
-    jobsRepository.deleteById(dataJobs.get(0).getName());
-    dataJobMonitor.clearDataJobsGaugesNotIn(Arrays.asList(dataJobs.get(1), dataJobs.get(2)));
-
-    gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
-    Assertions.assertEquals(2, gauges.size());
-    gauges =
-        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
-    Assertions.assertEquals(2, gauges.size());
-    gauges =
-        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-    Assertions.assertEquals(2, gauges.size());
-  }
-
-  @Test
-  @Order(23)
-  void testRecordJobExecutionStatus_withStatusSkipped_shouldNotUpdateTerminationStatus() {
-    // Clean up from previous tests
-    jobsRepository.deleteAll();
-    dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
-
-    var dataJob =
-        new DataJob("new-job", new JobConfig(), DeploymentStatus.NONE, null, "old-execution-id");
-    jobsRepository.save(dataJob);
-
-    JobExecution jobExecution =
-        buildJobExecutionStatus(
-            "new-job", "new-execution-id", ExecutionStatus.SKIPPED.getPodStatus(), true);
-    dataJobMonitor.recordJobExecutionStatus(jobExecution);
-    Optional<DataJob> actualJob = jobsRepository.findById(dataJob.getName());
-
-    Assertions.assertTrue(actualJob.isPresent());
-    Assertions.assertEquals("old-execution-id", actualJob.get().getLatestJobExecutionId());
-  }
-
-  @Test
-  @Order(24)
-  void testRecordJobExecutionStatus_withDifferentStatus_shouldUpdateTerminationStatus() {
-    // Clean up from previous tests
-    jobsRepository.deleteAll();
-    dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
-
-    var dataJob =
-        new DataJob(
-            "new-job",
-            new JobConfig(),
-            DeploymentStatus.NONE,
-            ExecutionStatus.PLATFORM_ERROR,
-            "old-execution-id");
-    jobsRepository.save(dataJob);
-
-    JobExecution jobExecution =
-        buildJobExecutionStatus(
-            "new-job", "old-execution-id", ExecutionStatus.SUCCEEDED.getPodStatus());
-
-    dataJobMonitor.recordJobExecutionStatus(jobExecution);
-
-    Optional<DataJob> actualJob = jobsRepository.findById(dataJob.getName());
-    Assertions.assertTrue(actualJob.isPresent());
-    Assertions.assertEquals("old-execution-id", actualJob.get().getLatestJobExecutionId());
-    Assertions.assertEquals(
-        ExecutionStatus.SUCCEEDED, actualJob.get().getLatestJobTerminationStatus());
-  }
-
-  @Test
-  @Order(25)
-  void testRecordJobExecutionStatus_withDifferentExecutionId_shouldUpdateTerminationStatus() {
-    // Clean up from previous tests
-    jobsRepository.deleteAll();
-    dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
-
-    var dataJob =
-        new DataJob("new-job", new JobConfig(), DeploymentStatus.NONE, null, "old-execution-id");
-    jobsRepository.save(dataJob);
-
-    JobExecution jobExecution =
-        buildJobExecutionStatus(
-            "new-job", "new-execution-id", ExecutionStatus.USER_ERROR.getPodStatus(), true);
-
-    dataJobMonitor.recordJobExecutionStatus(jobExecution);
-
-    Optional<DataJob> actualJob = jobsRepository.findById(dataJob.getName());
-    Assertions.assertTrue(actualJob.isPresent());
-    Assertions.assertEquals("new-execution-id", actualJob.get().getLatestJobExecutionId());
-    Assertions.assertEquals(
-        ExecutionStatus.USER_ERROR, actualJob.get().getLatestJobTerminationStatus());
-  }
-
-  @Test
-  @Order(26)
-  void testRecordJobExecutionStatus_shouldUpdateLastExecution() {
-    // Clean up from previous tests
-    jobsRepository.deleteAll();
-    dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
-
-    var dataJob =
-        new DataJob(
-            "new-job",
-            new JobConfig(),
-            DeploymentStatus.NONE,
-            ExecutionStatus.PLATFORM_ERROR,
-            "old-execution-id");
-    dataJob.setLastExecutionStatus(ExecutionStatus.PLATFORM_ERROR);
-    dataJob.setLastExecutionEndTime(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
-    dataJob.setLastExecutionDuration(1000);
-    jobsRepository.save(dataJob);
-
-    JobExecution jobExecution =
-        buildJobExecutionStatus(
-            "new-job", "old-execution-id", ExecutionStatus.PLATFORM_ERROR.getPodStatus(), false);
-
-    dataJobMonitor.recordJobExecutionStatus(jobExecution);
-
-    Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
-    Assertions.assertFalse(actualJob.isEmpty());
-    Assertions.assertEquals(
-        ExecutionStatus.PLATFORM_ERROR, actualJob.get().getLastExecutionStatus());
-  }
-
-  @Test
-  @Order(27)
-  void testRecordJobExecutionStatus_withNullExecutionId_shouldNotUpdateLastExecution() {
-    JobExecution jobExecution =
-        buildJobExecutionStatus("new-job", null, ExecutionStatus.SUCCEEDED.getPodStatus());
-
-    dataJobMonitor.recordJobExecutionStatus(jobExecution);
-
-    Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
-    Assertions.assertFalse(actualJob.isEmpty());
-    Assertions.assertEquals(
-        ExecutionStatus.PLATFORM_ERROR, actualJob.get().getLastExecutionStatus());
-  }
-
-  @Test
-  @Order(28)
-  void testRecordJobExecutionStatus_withEmptyExecutionId_shouldNotUpdateLastExecution() {
-    JobExecution jobExecution =
-        buildJobExecutionStatus("new-job", "", ExecutionStatus.SUCCEEDED.getPodStatus());
-
-    dataJobMonitor.recordJobExecutionStatus(jobExecution);
-
-    Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
-    Assertions.assertFalse(actualJob.isEmpty());
-    Assertions.assertEquals(
-        ExecutionStatus.PLATFORM_ERROR, actualJob.get().getLastExecutionStatus());
-  }
-
-  @Test
-  @Order(29)
-  void testRecordJobExecutionStatus_withSameExecutionIdAndNewStatus_shouldUpdateLastExecution() {
-    // Status gets updated from PLATFORM_ERROR to Succeeded with the same ID.
-    JobExecution jobExecution =
-        buildJobExecutionStatus(
-            "new-job", "old-execution-id", ExecutionStatus.SUCCEEDED.getPodStatus());
-
-    dataJobMonitor.recordJobExecutionStatus(jobExecution);
-
-    Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
-    Assertions.assertFalse(actualJob.isEmpty());
-    Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualJob.get().getLastExecutionStatus());
-  }
-
-  @Test
-  @Order(30)
-  void testRecordJobExecutionStatus_withNewExecutionIdAndNewStatus_shouldUpdateLastExecution() {
-    JobExecution jobExecution =
-        buildJobExecutionStatus(
-            "new-job", "new-execution-id", ExecutionStatus.SUCCEEDED.getPodStatus());
-
-    dataJobMonitor.recordJobExecutionStatus(jobExecution);
-
-    Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
-    Assertions.assertFalse(actualJob.isEmpty());
-    Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualJob.get().getLastExecutionStatus());
-    Assertions.assertEquals(jobExecution.getEndTime(), actualJob.get().getLastExecutionEndTime());
-  }
-
-  @Test
-  @Order(31)
-  void
-      testRecordJobExecutionStatus_withSameExecutionIdAndOldStatusIsFinal_shouldNotUpdateTerminationStatus() {
-    JobExecution jobExecution =
-        buildJobExecutionStatus(
-            "new-job", "new-execution-id", ExecutionStatus.USER_ERROR.getPodStatus());
-
-    dataJobMonitor.recordJobExecutionStatus(jobExecution);
-
-    Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
-    Assertions.assertFalse(actualJob.isEmpty());
-    // The termination status should not have changed from SUCCESS to USER_ERROR because SUCCESS is
-    // a final status
-    Assertions.assertEquals(
-        ExecutionStatus.SUCCEEDED, actualJob.get().getLatestJobTerminationStatus());
-  }
-
-  @Test
-  @Order(32)
-  void testRecordJobExecutionStatus_withAnOlderExecution_shouldNotUpdateLastExecution() {
-    JobExecution jobExecution =
-        buildJobExecutionStatus(
-            "new-job",
-            "newer-execution-id",
-            ExecutionStatus.USER_ERROR.getPodStatus(),
-            false,
-            OffsetDateTime.now().minus(Duration.ofDays(2)),
-            OffsetDateTime.now().minus(Duration.ofDays(1)));
-
-    dataJobMonitor.recordJobExecutionStatus(jobExecution);
-
-    Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
-    Assertions.assertFalse(actualJob.isEmpty());
-    // The last execution status should not have changed from SUCCEEDED to USER_ERROR because the
-    // execution is not recent
-    Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualJob.get().getLastExecutionStatus());
-  }
-
-  @Test
-  @Order(33)
-  void testJobExecutionStatus_fromPlatformToUser_shouldUpdateExecution() {
-    // Clean up from previous tests
-    jobsRepository.deleteAll();
-    dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
-    // Create data job
-    String jobId = "job-id-test";
-    var dataJob =
-        new DataJob(
-            jobId,
-            new JobConfig(),
-            DeploymentStatus.NONE,
-            ExecutionStatus.SUCCEEDED,
-            "old-execution-id");
-    jobsRepository.save(dataJob);
-    // Change status to PLATFORM_ERROR
-    JobExecution jobExecution =
-        buildJobExecutionStatus(
-            jobId,
-            "last-execution-id",
-            ExecutionStatus.PLATFORM_ERROR.getPodStatus(),
-            false,
-            OffsetDateTime.now().minus(Duration.ofDays(2)),
-            OffsetDateTime.now().minus(Duration.ofDays(1)));
-    dataJobMonitor.recordJobExecutionStatus(jobExecution);
-    // Check status is saved OK.
-    Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
-    Assertions.assertFalse(actualJob.isEmpty());
-    Assertions.assertEquals(
-        ExecutionStatus.PLATFORM_ERROR, actualJob.get().getLastExecutionStatus());
-    // Check gauge status
-    var gauges =
-        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-    Assertions.assertEquals(1, gauges.size());
-    Assertions.assertEquals(
-        ExecutionStatus.PLATFORM_ERROR.getAlertValue().doubleValue(),
-        gauges.stream().findFirst().get().value());
-    // Change status to USER_ERROR, same execution ID simulating retry. Different ID's change
-    // without issues.
-    jobExecution =
-        buildJobExecutionStatus(
-            jobId,
-            "last-execution-id",
-            ExecutionStatus.USER_ERROR.getPodStatus(),
-            false,
-            OffsetDateTime.now().minus(Duration.ofDays(2)),
-            OffsetDateTime.now().minus(Duration.ofDays(1)));
-    dataJobMonitor.recordJobExecutionStatus(jobExecution);
-    // Check status is saved OK.
-    actualJob = jobsRepository.findById(jobExecution.getJobName());
-    Assertions.assertFalse(actualJob.isEmpty());
-    Assertions.assertEquals(ExecutionStatus.USER_ERROR, actualJob.get().getLastExecutionStatus());
-    // Check gauge status is changed OK.
-    gauges =
-        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
-    Assertions.assertEquals(1, gauges.size());
-    Assertions.assertEquals(
-        ExecutionStatus.USER_ERROR.getAlertValue().doubleValue(),
-        gauges.stream().findFirst().get().value());
-  }
-
-  private static String randomId(String prefix) {
-    return prefix + UUID.randomUUID();
-  }
-
-  private static ExecutionStatus getTerminationStatus(JobExecution jobExecution) {
-    return JobExecutionResultManager.getResult(jobExecution).getExecutionStatus();
-  }
-
-  private static JobExecution buildJobExecutionStatus(
-      String jobName, String executionId, String terminationMessage) {
-    return buildJobExecutionStatus(jobName, executionId, terminationMessage, true);
-  }
-
-  private static JobExecution buildJobExecutionStatus(
-      String jobName, String executionId, String terminationMessage, Boolean executionSucceeded) {
-    return buildJobExecutionStatus(
-        jobName,
-        executionId,
-        terminationMessage,
-        executionSucceeded,
-        OffsetDateTime.now(),
-        OffsetDateTime.now());
-  }
-
-  private static JobExecution buildJobExecutionStatus(
-      String jobName,
-      String executionId,
-      String terminationMessage,
-      Boolean executionSucceeded,
-      OffsetDateTime startTime,
-      OffsetDateTime endTime) {
-    return JobExecution.builder()
-        .jobName(jobName)
-        .executionId(executionId)
-        .podTerminationMessage(terminationMessage)
-        .executionType("scheduled")
-        .opId("opId")
-        .startTime(startTime)
-        .endTime(endTime)
-        .jobVersion("jobVersion")
-        .jobSchedule("jobSchedule")
-        .resourcesCpuRequest(1F)
-        .resourcesCpuLimit(2F)
-        .resourcesMemoryRequest(500)
-        .resourcesMemoryLimit(1000)
-        .deployedDate(OffsetDateTime.now())
-        .deployedBy("lastDeployedBy")
-        .succeeded(executionSucceeded)
-        .build();
-  }
-
-  private void assertDataJobExecutionValid(
-      JobExecution expectedJobExecution, Optional<DataJobExecution> actualJobExecution) {
-    assertDataJobExecutionValid(expectedJobExecution, actualJobExecution, null, null);
-  }
-
-  private void assertDataJobExecutionValid(
-      JobExecution expectedJobExecution,
-      Optional<DataJobExecution> actualJobExecution,
-      OffsetDateTime startTime) {
-    assertDataJobExecutionValid(expectedJobExecution, actualJobExecution, null, startTime);
-  }
-
-  private void assertDataJobExecutionValid(
-      JobExecution expectedJobExecution,
-      Optional<DataJobExecution> actualJobExecution,
-      String expectedExecutionMessage,
-      OffsetDateTime startTime) {
-    Assertions.assertTrue(actualJobExecution.isPresent());
-
-    DataJobExecution actualDataJobExecution = actualJobExecution.get();
-    Assertions.assertEquals(expectedJobExecution.getExecutionId(), actualDataJobExecution.getId());
-    Assertions.assertEquals(
-        expectedJobExecution.getJobName(), actualDataJobExecution.getDataJob().getName());
-    MatcherAssert.assertThat(
-        expectedJobExecution.getExecutionType(),
-        IsEqualIgnoringCase.equalToIgnoringCase(actualDataJobExecution.getType().name()));
-    Assertions.assertEquals(
-        expectedJobExecution.getJobVersion(), actualDataJobExecution.getJobVersion());
-    Assertions.assertEquals(
-        expectedJobExecution.getJobSchedule(), actualDataJobExecution.getJobSchedule());
-    Assertions.assertEquals(
-        startTime == null ? expectedJobExecution.getStartTime() : startTime,
-        actualDataJobExecution.getStartTime());
-    Assertions.assertEquals(expectedJobExecution.getEndTime(), actualDataJobExecution.getEndTime());
-    Assertions.assertEquals(expectedJobExecution.getOpId(), actualDataJobExecution.getOpId());
-    Assertions.assertEquals(
-        expectedJobExecution.getResourcesCpuRequest(),
-        actualDataJobExecution.getResourcesCpuRequest());
-    Assertions.assertEquals(
-        expectedJobExecution.getResourcesCpuLimit(), actualDataJobExecution.getResourcesCpuLimit());
-    Assertions.assertEquals(
-        expectedJobExecution.getResourcesMemoryRequest(),
-        actualDataJobExecution.getResourcesMemoryRequest());
-    Assertions.assertEquals(
-        expectedJobExecution.getResourcesMemoryLimit(),
-        actualDataJobExecution.getResourcesMemoryLimit());
-    Assertions.assertEquals(
-        expectedExecutionMessage == null
-            ? expectedJobExecution.getPodTerminationMessage()
-            : expectedExecutionMessage,
-        actualDataJobExecution.getMessage());
-    Assertions.assertEquals(
-        expectedJobExecution.getDeployedBy(), actualDataJobExecution.getLastDeployedBy());
-    Assertions.assertEquals(
-        expectedJobExecution.getDeployedDate(), actualDataJobExecution.getLastDeployedDate());
-  }
+    }
+
+    @Test
+    @Order(11)
+    public void testUpdateDataJobTerminationStatusWithoutExecutionId() {
+        var dataJob = new DataJob("data-job", new JobConfig(), DeploymentStatus.NONE);
+
+        dataJobMonitor.updateDataJobTerminationStatusMetrics(jobsRepository.save(dataJob));
+
+        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+        Assertions.assertEquals(5, gauges.size());
+    }
+
+    @Test
+    @Order(12)
+    public void testWatchJobsWhenExceptionIsThrown() throws IOException, ApiException {
+        doThrow(new ApiException()).when(dataJobsKubernetesService).watchJobs(anyMap(), any(), any(), anyLong());
+
+        Assertions.assertDoesNotThrow(() -> dataJobMonitor.watchJobs());
+    }
+
+    @Test
+    @Order(13)
+    public void testRecordJobExecutionStatus_nullDataJobName_shouldNotRecordExecution() {
+        JobExecution jobExecution = buildJobExecutionStatus(null, randomId("job-"), ExecutionStatus.SUCCEEDED.getPodStatus());
+        dataJobMonitor.recordJobExecutionStatus(jobExecution);
+        Optional<DataJobExecution> actualJobExecution = jobExecutionRepository.findById(jobExecution.getExecutionId());
+
+        Assertions.assertTrue(actualJobExecution.isEmpty());
+    }
+
+    @Test
+    @Order(14)
+    public void testRecordJobExecutionStatus_emptyDataJobName_shouldNotRecordExecution() {
+        JobExecution jobExecution = buildJobExecutionStatus("", randomId("job-"), ExecutionStatus.SUCCEEDED.getPodStatus());
+        dataJobMonitor.recordJobExecutionStatus(jobExecution);
+        Optional<DataJobExecution> actualJobExecution = jobExecutionRepository.findById(jobExecution.getExecutionId());
+
+        Assertions.assertTrue(actualJobExecution.isEmpty());
+    }
+
+    @Test
+    @Order(15)
+    public void testRecordJobExecutionStatus_existingDataJobAndNonExistingExecution_shouldRecordExecution() {
+        JobExecution expectedJobExecution = buildJobExecutionStatus("data-job", "execution-id", ExecutionStatus.SUCCEEDED.getPodStatus(), true);
+        dataJobMonitor.recordJobExecutionStatus(expectedJobExecution);
+        Optional<DataJobExecution> actualJobExecution = jobExecutionRepository.findById(expectedJobExecution.getExecutionId());
+
+        assertDataJobExecutionValid(expectedJobExecution, actualJobExecution);
+    }
+
+    @Test
+    @Order(16)
+    public void testRecordJobExecutionStatus_existingDataJobAndExistingExecution_shouldUpdateExecution() {
+        DataJobExecution jobExecutionBeforeUpdate = jobExecutionRepository.findById("execution-id").get();
+        JobExecution expectedJobExecution = JobExecution.builder()
+              .jobName(jobExecutionBeforeUpdate.getDataJob().getName())
+              .executionId(jobExecutionBeforeUpdate.getId())
+              .podTerminationMessage(ExecutionStatus.SUCCEEDED.getPodStatus())
+              .executionType("scheduled")
+              .opId("opId")
+              .startTime(jobExecutionBeforeUpdate.getStartTime())
+              .endTime(jobExecutionBeforeUpdate.getEndTime())
+              .jobVersion("jobVersion")
+              .jobSchedule("jobSchedule")
+              .resourcesCpuRequest(1F)
+              .resourcesCpuLimit(2F)
+              .resourcesMemoryRequest(500)
+              .resourcesMemoryLimit(1000)
+              .deployedDate(jobExecutionBeforeUpdate.getLastDeployedDate())
+              .deployedBy("lastDeployedBy")
+              .succeeded(true)
+              .build();
+
+        dataJobMonitor.recordJobExecutionStatus(expectedJobExecution);
+        Optional<DataJobExecution> actualJobExecution = jobExecutionRepository.findById(expectedJobExecution.getExecutionId());
+
+        assertDataJobExecutionValid(expectedJobExecution, actualJobExecution);
+    }
+
+    @Test
+    @Order(17)
+    public void testRecordJobExecutionStatusSkipped_existingDataJobAndNonExistingExecution_shouldRecordExecution() {
+        JobExecution expectedJobExecution = buildJobExecutionStatus("data-job", "different-execution-id", ExecutionStatus.RUNNING.getPodStatus(), null);
+        dataJobMonitor.recordJobExecutionStatus(expectedJobExecution);
+        Optional<DataJobExecution> actualJobExecution = jobExecutionRepository.findById(expectedJobExecution.getExecutionId());
+
+        assertDataJobExecutionValid(expectedJobExecution, actualJobExecution);
+    }
+
+    @Test
+    @Order(18)
+    public void testRecordJobExecutionStatusSkipped_existingDataJobAndExistingExecution_shouldRecordExecution() {
+        var expectedExecutionMessage = "Skipping job execution due to another parallel running execution.";
+        JobExecution expectedJobExecution = buildJobExecutionStatus("data-job", "different-execution-id", ExecutionStatus.SKIPPED.getPodStatus(), true);
+        Optional<DataJobExecution> jobExecutionBeforeUpdate = jobExecutionRepository.findById(expectedJobExecution.getExecutionId());
+        dataJobMonitor.recordJobExecutionStatus(expectedJobExecution);
+        Optional<DataJobExecution> actualJobExecution = jobExecutionRepository.findById(expectedJobExecution.getExecutionId());
+
+        assertDataJobExecutionValid(expectedJobExecution, actualJobExecution, expectedExecutionMessage, jobExecutionBeforeUpdate.get().getStartTime());
+    }
+
+    @Test
+    @Order(19)
+    public void testRecordJobExecutionStatus_nonExistingDataJobAndNonExistingExecution_shouldNotRecordExecution() {
+        JobExecution jobExecution = buildJobExecutionStatus(randomId("data-job-"), randomId("job-"), ExecutionStatus.SUCCEEDED.getPodStatus());
+        dataJobMonitor.recordJobExecutionStatus(jobExecution);
+        Optional<DataJobExecution> actualJobExecution = jobExecutionRepository.findById(jobExecution.getExecutionId());
+
+        Assertions.assertTrue(actualJobExecution.isEmpty());
+    }
+
+    @Test
+    @Order(20)
+    void testUpdateDataJobInfoGauges() {
+        var dataJob = new DataJob("data-job", new JobConfig(),
+                DeploymentStatus.NONE, ExecutionStatus.SUCCEEDED, randomId("data-job-"));
+
+        dataJobMonitor.updateDataJobInfoGauges(jobsRepository.save(dataJob));
+
+        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
+        Assertions.assertEquals(1, gauges.size());
+        gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
+        Assertions.assertEquals(1, gauges.size());
+    }
+
+    @Test
+    @Order(21)
+    void testUpdateDataJobInfoGauges_withNullDataJob_throwsException() {
+        Assertions.assertThrows(NullPointerException.class, () -> dataJobMonitor.updateDataJobInfoGauges(null));
+    }
+
+    @Test
+    @Order(22)
+    void testClearDataJobsGaugesNotIn() {
+        var dataJobs = Arrays.asList(
+                new DataJob("data-job1", new JobConfig(), DeploymentStatus.NONE, ExecutionStatus.SUCCEEDED, randomId("data-job1-")),
+                new DataJob("data-job2", new JobConfig(), DeploymentStatus.NONE, ExecutionStatus.SUCCEEDED, randomId("data-job2-")),
+                new DataJob("data-job3", new JobConfig(), DeploymentStatus.NONE, ExecutionStatus.SUCCEEDED, randomId("data-job3-")));
+
+        // Clean up from previous tests
+        jobsRepository.deleteAll();
+        dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
+
+        // Add some more gauges
+        dataJobMonitor.updateDataJobsGauges(jobsRepository.saveAll(dataJobs));
+
+        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
+        Assertions.assertEquals(3, gauges.size());
+        gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
+        Assertions.assertEquals(3, gauges.size());
+        gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+        Assertions.assertEquals(3, gauges.size());
+
+        // Delete a data job and verify that its gauges are removed as a result
+        jobsRepository.deleteById(dataJobs.get(0).getName());
+        dataJobMonitor.clearDataJobsGaugesNotIn(Arrays.asList(dataJobs.get(1), dataJobs.get(2)));
+
+        gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_INFO_METRIC_NAME).gauges();
+        Assertions.assertEquals(2, gauges.size());
+        gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
+        Assertions.assertEquals(2, gauges.size());
+        gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+        Assertions.assertEquals(2, gauges.size());
+    }
+
+    @Test
+    @Order(23)
+    void testRecordJobExecutionStatus_withStatusSkipped_shouldNotUpdateTerminationStatus() {
+        // Clean up from previous tests
+        jobsRepository.deleteAll();
+        dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
+
+        var dataJob = new DataJob("new-job", new JobConfig(),
+                DeploymentStatus.NONE, null, "old-execution-id");
+        jobsRepository.save(dataJob);
+
+        JobExecution jobExecution = buildJobExecutionStatus("new-job", "new-execution-id", ExecutionStatus.SKIPPED.getPodStatus(), true);
+        dataJobMonitor.recordJobExecutionStatus(jobExecution);
+        Optional<DataJob> actualJob = jobsRepository.findById(dataJob.getName());
+
+        Assertions.assertTrue(actualJob.isPresent());
+        Assertions.assertEquals("old-execution-id", actualJob.get().getLatestJobExecutionId());
+    }
+
+    @Test
+    @Order(24)
+    void testRecordJobExecutionStatus_withDifferentStatus_shouldUpdateTerminationStatus() {
+        // Clean up from previous tests
+        jobsRepository.deleteAll();
+        dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
+
+        var dataJob = new DataJob("new-job", new JobConfig(),
+                DeploymentStatus.NONE, ExecutionStatus.PLATFORM_ERROR, "old-execution-id");
+        jobsRepository.save(dataJob);
+
+        JobExecution jobExecution = buildJobExecutionStatus("new-job", "old-execution-id", ExecutionStatus.SUCCEEDED.getPodStatus());
+
+        dataJobMonitor.recordJobExecutionStatus(jobExecution);
+
+        Optional<DataJob> actualJob = jobsRepository.findById(dataJob.getName());
+        Assertions.assertTrue(actualJob.isPresent());
+        Assertions.assertEquals("old-execution-id", actualJob.get().getLatestJobExecutionId());
+        Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualJob.get().getLatestJobTerminationStatus());
+    }
+
+    @Test
+    @Order(25)
+    void testRecordJobExecutionStatus_withDifferentExecutionId_shouldUpdateTerminationStatus() {
+        // Clean up from previous tests
+        jobsRepository.deleteAll();
+        dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
+
+        var dataJob = new DataJob("new-job", new JobConfig(),
+                DeploymentStatus.NONE, null, "old-execution-id");
+        jobsRepository.save(dataJob);
+
+        JobExecution jobExecution = buildJobExecutionStatus("new-job", "new-execution-id", ExecutionStatus.USER_ERROR.getPodStatus(), true);
+
+        dataJobMonitor.recordJobExecutionStatus(jobExecution);
+
+        Optional<DataJob> actualJob = jobsRepository.findById(dataJob.getName());
+        Assertions.assertTrue(actualJob.isPresent());
+        Assertions.assertEquals("new-execution-id", actualJob.get().getLatestJobExecutionId());
+        Assertions.assertEquals(ExecutionStatus.USER_ERROR, actualJob.get().getLatestJobTerminationStatus());
+    }
+
+    @Test
+    @Order(26)
+    void testRecordJobExecutionStatus_shouldUpdateLastExecution() {
+        // Clean up from previous tests
+        jobsRepository.deleteAll();
+        dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
+
+        var dataJob = new DataJob("new-job", new JobConfig(),
+                DeploymentStatus.NONE, ExecutionStatus.PLATFORM_ERROR, "old-execution-id");
+        dataJob.setLastExecutionStatus(ExecutionStatus.PLATFORM_ERROR);
+        dataJob.setLastExecutionEndTime(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
+        dataJob.setLastExecutionDuration(1000);
+        jobsRepository.save(dataJob);
+
+        JobExecution jobExecution = buildJobExecutionStatus("new-job", "old-execution-id", ExecutionStatus.PLATFORM_ERROR.getPodStatus(), false);
+
+        dataJobMonitor.recordJobExecutionStatus(jobExecution);
+
+        Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
+        Assertions.assertFalse(actualJob.isEmpty());
+        Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualJob.get().getLastExecutionStatus());
+    }
+
+    @Test
+    @Order(27)
+    void testRecordJobExecutionStatus_withNullExecutionId_shouldNotUpdateLastExecution() {
+        JobExecution jobExecution = buildJobExecutionStatus("new-job", null, ExecutionStatus.SUCCEEDED.getPodStatus());
+
+        dataJobMonitor.recordJobExecutionStatus(jobExecution);
+
+        Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
+        Assertions.assertFalse(actualJob.isEmpty());
+        Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualJob.get().getLastExecutionStatus());
+    }
+
+    @Test
+    @Order(28)
+    void testRecordJobExecutionStatus_withEmptyExecutionId_shouldNotUpdateLastExecution() {
+        JobExecution jobExecution = buildJobExecutionStatus("new-job", "", ExecutionStatus.SUCCEEDED.getPodStatus());
+
+        dataJobMonitor.recordJobExecutionStatus(jobExecution);
+
+        Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
+        Assertions.assertFalse(actualJob.isEmpty());
+        Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualJob.get().getLastExecutionStatus());
+    }
+
+
+    @Test
+    @Order(29)
+    void testRecordJobExecutionStatus_withSameExecutionIdAndNewStatus_shouldUpdateLastExecution() {
+        //Status gets updated from PLATFORM_ERROR to Succeeded with the same ID.
+        JobExecution jobExecution = buildJobExecutionStatus("new-job", "old-execution-id", ExecutionStatus.SUCCEEDED.getPodStatus());
+
+        dataJobMonitor.recordJobExecutionStatus(jobExecution);
+
+        Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
+        Assertions.assertFalse(actualJob.isEmpty());
+        Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualJob.get().getLastExecutionStatus());
+    }
+
+    @Test
+    @Order(30)
+    void testRecordJobExecutionStatus_withNewExecutionIdAndNewStatus_shouldUpdateLastExecution() {
+        JobExecution jobExecution = buildJobExecutionStatus("new-job", "new-execution-id", ExecutionStatus.SUCCEEDED.getPodStatus());
+
+        dataJobMonitor.recordJobExecutionStatus(jobExecution);
+
+        Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
+        Assertions.assertFalse(actualJob.isEmpty());
+        Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualJob.get().getLastExecutionStatus());
+        Assertions.assertEquals(jobExecution.getEndTime(), actualJob.get().getLastExecutionEndTime());
+    }
+
+    @Test
+    @Order(31)
+    void testRecordJobExecutionStatus_withSameExecutionIdAndOldStatusIsFinal_shouldNotUpdateTerminationStatus() {
+        JobExecution jobExecution = buildJobExecutionStatus("new-job", "new-execution-id", ExecutionStatus.USER_ERROR.getPodStatus());
+
+        dataJobMonitor.recordJobExecutionStatus(jobExecution);
+
+        Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
+        Assertions.assertFalse(actualJob.isEmpty());
+        // The termination status should not have changed from SUCCESS to USER_ERROR because SUCCESS is a final status
+        Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualJob.get().getLatestJobTerminationStatus());
+    }
+
+    @Test
+    @Order(32)
+    void testRecordJobExecutionStatus_withAnOlderExecution_shouldNotUpdateLastExecution() {
+        JobExecution jobExecution = buildJobExecutionStatus("new-job", "newer-execution-id",
+                ExecutionStatus.USER_ERROR.getPodStatus(), false,
+                OffsetDateTime.now().minus(Duration.ofDays(2)),
+                OffsetDateTime.now().minus(Duration.ofDays(1)));
+
+        dataJobMonitor.recordJobExecutionStatus(jobExecution);
+
+        Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
+        Assertions.assertFalse(actualJob.isEmpty());
+        // The last execution status should not have changed from SUCCEEDED to USER_ERROR because the execution is not recent
+        Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualJob.get().getLastExecutionStatus());
+    }
+
+    @Test
+    @Order(33)
+    void testJobExecutionStatus_fromPlatformToUser_shouldUpdateExecution() {
+        // Clean up from previous tests
+        jobsRepository.deleteAll();
+        dataJobMonitor.clearDataJobsGaugesNotIn(Collections.emptyList());
+        // Create data job
+        String jobId = "job-id-test";
+        var dataJob = new DataJob(jobId, new JobConfig(),
+              DeploymentStatus.NONE, ExecutionStatus.SUCCEEDED, "old-execution-id");
+        jobsRepository.save(dataJob);
+        // Change status to PLATFORM_ERROR
+        JobExecution jobExecution = buildJobExecutionStatus(jobId, "last-execution-id",
+              ExecutionStatus.PLATFORM_ERROR.getPodStatus(), false,
+              OffsetDateTime.now().minus(Duration.ofDays(2)),
+              OffsetDateTime.now().minus(Duration.ofDays(1)));
+        dataJobMonitor.recordJobExecutionStatus(jobExecution);
+        // Check status is saved OK.
+        Optional<DataJob> actualJob = jobsRepository.findById(jobExecution.getJobName());
+        Assertions.assertFalse(actualJob.isEmpty());
+        Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualJob.get().getLastExecutionStatus());
+        // Check gauge status
+        var gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+        Assertions.assertEquals(1, gauges.size());
+        Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR.getAlertValue().doubleValue(), gauges.stream().findFirst().get().value());
+        // Change status to USER_ERROR, same execution ID simulating retry. Different ID's change without issues.
+        jobExecution = buildJobExecutionStatus(jobId, "last-execution-id",
+              ExecutionStatus.USER_ERROR.getPodStatus(), false,
+              OffsetDateTime.now().minus(Duration.ofDays(2)),
+              OffsetDateTime.now().minus(Duration.ofDays(1)));
+        dataJobMonitor.recordJobExecutionStatus(jobExecution);
+        // Check status is saved OK.
+        actualJob = jobsRepository.findById(jobExecution.getJobName());
+        Assertions.assertFalse(actualJob.isEmpty());
+        Assertions.assertEquals(ExecutionStatus.USER_ERROR, actualJob.get().getLastExecutionStatus());
+        // Check gauge status is changed OK.
+        gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+        Assertions.assertEquals(1, gauges.size());
+        Assertions.assertEquals(ExecutionStatus.USER_ERROR.getAlertValue().doubleValue(), gauges.stream().findFirst().get().value());
+    }
+
+    private static String randomId(String prefix) {
+        return prefix + UUID.randomUUID();
+    }
+
+    private static ExecutionStatus getTerminationStatus(JobExecution jobExecution) {
+        return JobExecutionResultManager.getResult(jobExecution).getExecutionStatus();
+    }
+
+    private static JobExecution buildJobExecutionStatus(String jobName, String executionId, String terminationMessage) {
+        return buildJobExecutionStatus(jobName, executionId, terminationMessage, true);
+    }
+
+    private static JobExecution buildJobExecutionStatus(
+            String jobName,
+            String executionId,
+            String terminationMessage,
+            Boolean executionSucceeded) {
+        return buildJobExecutionStatus(jobName, executionId, terminationMessage,
+                executionSucceeded, OffsetDateTime.now(), OffsetDateTime.now());
+    }
+
+    private static JobExecution buildJobExecutionStatus(
+          String jobName,
+          String executionId,
+          String terminationMessage,
+          Boolean executionSucceeded,
+          OffsetDateTime startTime,
+          OffsetDateTime endTime) {
+        return JobExecution.builder()
+              .jobName(jobName)
+              .executionId(executionId)
+              .podTerminationMessage(terminationMessage)
+              .executionType("scheduled")
+              .opId("opId")
+              .startTime(startTime)
+              .endTime(endTime)
+              .jobVersion("jobVersion")
+              .jobSchedule("jobSchedule")
+              .resourcesCpuRequest(1F)
+              .resourcesCpuLimit(2F)
+              .resourcesMemoryRequest(500)
+              .resourcesMemoryLimit(1000)
+              .deployedDate(OffsetDateTime.now())
+              .deployedBy("lastDeployedBy")
+              .succeeded(executionSucceeded)
+              .build();
+    }
+
+    private void assertDataJobExecutionValid(JobExecution expectedJobExecution, Optional<DataJobExecution> actualJobExecution) {
+        assertDataJobExecutionValid(expectedJobExecution, actualJobExecution, null, null);
+    }
+
+    private void assertDataJobExecutionValid(JobExecution expectedJobExecution, Optional<DataJobExecution> actualJobExecution, OffsetDateTime startTime) {
+        assertDataJobExecutionValid(expectedJobExecution, actualJobExecution, null, startTime);
+    }
+
+    private void assertDataJobExecutionValid(JobExecution expectedJobExecution, Optional<DataJobExecution> actualJobExecution, String expectedExecutionMessage, OffsetDateTime startTime) {
+        Assertions.assertTrue(actualJobExecution.isPresent());
+
+        DataJobExecution actualDataJobExecution = actualJobExecution.get();
+        Assertions.assertEquals(expectedJobExecution.getExecutionId(), actualDataJobExecution.getId());
+        Assertions.assertEquals(expectedJobExecution.getJobName(), actualDataJobExecution.getDataJob().getName());
+        MatcherAssert.assertThat(expectedJobExecution.getExecutionType(), IsEqualIgnoringCase.equalToIgnoringCase(actualDataJobExecution.getType().name()));
+        Assertions.assertEquals(expectedJobExecution.getJobVersion(), actualDataJobExecution.getJobVersion());
+        Assertions.assertEquals(expectedJobExecution.getJobSchedule(), actualDataJobExecution.getJobSchedule());
+        Assertions.assertEquals(startTime == null ? expectedJobExecution.getStartTime() : startTime, actualDataJobExecution.getStartTime());
+        Assertions.assertEquals(expectedJobExecution.getEndTime(), actualDataJobExecution.getEndTime());
+        Assertions.assertEquals(expectedJobExecution.getOpId(), actualDataJobExecution.getOpId());
+        Assertions.assertEquals(expectedJobExecution.getResourcesCpuRequest(), actualDataJobExecution.getResourcesCpuRequest());
+        Assertions.assertEquals(expectedJobExecution.getResourcesCpuLimit(), actualDataJobExecution.getResourcesCpuLimit());
+        Assertions.assertEquals(expectedJobExecution.getResourcesMemoryRequest(), actualDataJobExecution.getResourcesMemoryRequest());
+        Assertions.assertEquals(expectedJobExecution.getResourcesMemoryLimit(), actualDataJobExecution.getResourcesMemoryLimit());
+        Assertions.assertEquals(expectedExecutionMessage == null ? expectedJobExecution.getPodTerminationMessage() : expectedExecutionMessage, actualDataJobExecution.getMessage());
+        Assertions.assertEquals(expectedJobExecution.getDeployedBy(), actualDataJobExecution.getLastDeployedBy());
+        Assertions.assertEquals(expectedJobExecution.getDeployedDate(), actualDataJobExecution.getLastDeployedDate());
+    }
 }


### PR DESCRIPTION
Currently, we expose "gauge" metrics for data job termination statuses, which
we can then use to moonitor the operability of data jobs deployed in kubernetes
clusters. This works fine for simple monitoring when we are looking for the current
execution status of a job or its change over time.

However, if we want to aggregate data for all data jobs that we have deployed, for
example check what percentage of all jobs fail with user or platform error compared
to all job executions, things can get complicated.

This change introduces "counter" metrics that measure the number of specific statuses
observed for each data job to help with situations when high-level picture of data job
executions is needed.

Testing Done: Unit tests and existing tests.

Signed-off-by: Andon Andonov <andonova@vmware.com>