### PR TITLE
vdk-server: fix for vdk server crashing on startup

### DIFF
--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/installer.py
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/installer.py
@@ -693,6 +693,8 @@ class Installer:
             "--set",
             "extraEnvVars.DATAJOBS_DEPLOYMENT_BUILDER_EXTRAARGS=--insecure",
             "--set",
+            "extraEnvVars.SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI=http://localhost",
+            "--set",
             "datajobTemplate.template.spec.successfulJobsHistoryLimit=5",
             "--set",
             "datajobTemplate.template.spec.failedJobsHistoryLimit=5",


### PR DESCRIPTION
what: Added a missing env variable that was causing the control-service to crash on startup, because even though the authentication/authorization is disabled the variable is used in a bean (constructor) initialization and it crashes on spring boot initialization (before it enters our code). The env variable is found in some of our application.properties files, but it varies between prod, testing etc (not all have default values) and there are comments that say setting it is mandatory.

why: the vdk-server's vdk server --install command was failing.

testing: Tested locally with pip install -e option of a locally editable vdk-server plugin. Server was failing to start before the change. After the change - server starts up normally.
 
Signed-off-by: Momchil Zhivkov <mzhivkov@vmware.com>