### PR TITLE
control-service: fix vdk-server startup issues

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application-prod.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application-prod.properties
@@ -89,9 +89,9 @@ datajobs.security.oauth2.enabled=true
 # The JSON Web Key Set (JWKS) is a set of keys which contains the public keys
 # used to verify any JSON Web Token (JWT) issued by the authorization server
 # It is required.
-# spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI}
+ spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI:http://localhost}
 
-spring.security.oauth2.resourceserver.jwt.issuer-uri=${SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI:"http://localhost"}
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI:http://localhost}
 
 # The CSP Auth Token doesn't contain the user permissions in the default location - the authorities
 # field of the JWT token. This property specifies a custom location for the authorities field.

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application-prod.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application-prod.properties
@@ -91,7 +91,7 @@ datajobs.security.oauth2.enabled=true
 # It is required.
  spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI:http://localhost}
 
-spring.security.oauth2.resourceserver.jwt.issuer-uri=${SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI}
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI:http://localhost}
 
 # The CSP Auth Token doesn't contain the user permissions in the default location - the authorities
 # field of the JWT token. This property specifies a custom location for the authorities field.

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application-prod.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application-prod.properties
@@ -91,7 +91,7 @@ datajobs.security.oauth2.enabled=true
 # It is required.
  spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI:http://localhost}
 
-spring.security.oauth2.resourceserver.jwt.issuer-uri=${SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI:http://localhost}
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI}
 
 # The CSP Auth Token doesn't contain the user permissions in the default location - the authorities
 # field of the JWT token. This property specifies a custom location for the authorities field.

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -54,7 +54,7 @@ datajobs.security.oauth2.enabled=true
 # The JSON Web Key Set (JWKS) is a set of keys which contains the public keys
 # used to verify any JSON Web Token (JWT) issued by the authorization server
 # It is required.
-spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI}
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI:http://localhost}
 # spring.security.oauth2.resourceserver.jwt.issuer-uri=${SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI}
 
 # Authorization configuration. Note if you enable authorization you should


### PR DESCRIPTION
what: Added default values for env variable that was causing the control-service to crash on startup, because even though the authentication/authorization is disabled the variables are used in a bean (constructor) initialization and it crashes on spring boot initialization (before it enters our code). The env variable is found in some of our application.properties files, but it varies between prod, testing etc (not all have default values) and there are comments that say setting it is mandatory.

why: the vdk-server's vdk server --install command was failing.

testing: Tested locally with pip install -e option of a locally editable vdk-server plugin. Server was failing to start without the variable. After the change - server starts up normally.

Signed-off-by: Momchil Zhivkov [mzhivkov@vmware.com](mailto:mzhivkov@vmware.com)