### PR TITLE
vdk-core: termination message now idempotent

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/termination_message/file_util.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/termination_message/file_util.py
@@ -23,7 +23,7 @@ class WriteToFileAction:
             return
 
         try:
-            with open(self.filename, "a") as file:
+            with open(self.filename, "w") as file:
                 file.write(message)
         except OSError as e:
             if self.show_log_messages:

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/termination_message/file_util.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/termination_message/file_util.py
@@ -18,7 +18,16 @@ class WriteToFileAction:
         self.filename = filename
         self.show_log_messages = show_log_messages
 
-    def append_to_file(self, message):
+    def write_to_file(self, message) -> None:
+        """
+        This method is intended to be used by the termination message plugin.
+        Writes a message to the configured filename (truncating it first).
+        This means that if two or more messages are writen only the latest one
+        will be the actual data job termination messsage.
+
+        :param message: Json formatted string with the termination message
+        :return: None
+        """
         if not self.filename:
             return
 

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/termination_message/writer.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/termination_message/writer.py
@@ -84,4 +84,4 @@ class TerminationMessageWriterPlugin:
             status = "Platform error"
 
         termination_message["status"] = status
-        file_util.append_to_file(json.dumps(termination_message))
+        file_util.write_to_file(json.dumps(termination_message))

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/termination_message/test_writer.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/termination_message/test_writer.py
@@ -1,5 +1,7 @@
 # Copyright 2021 VMware, Inc.
+# Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import os
 import unittest
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -14,6 +16,95 @@ from vdk.internal.core.config import ConfigurationBuilder
 from vdk.internal.core.context import CoreContext
 from vdk.internal.core.errors import get_blamee_overall
 from vdk.internal.core.statestore import StateStore
+
+
+class TestWriterIdempotence(unittest.TestCase):
+    def setUp(self) -> None:
+        self.termination_plugin = TerminationMessageWriterPlugin()
+        configuration_builder = ConfigurationBuilder()
+        self.termination_plugin.vdk_configure(configuration_builder)
+
+        self.configuration = (
+            configuration_builder.add(
+                key="TERMINATION_MESSAGE_WRITER_OUTPUT_FILE",
+                default_value="filename.txt",
+            )
+            .add(
+                key=vdk_config.LOG_CONFIG,
+                default_value="local",
+            )
+            .build()
+        )
+
+    def tearDown(self) -> None:
+        os.remove(
+            self.configuration.get_value("TERMINATION_MESSAGE_WRITER_OUTPUT_FILE")
+        )
+
+    def test_double_write(self):
+        # write a success message
+        self.termination_plugin.write_termination_message(
+            False, False, self.configuration, False
+        )
+        # check message was written successfully
+        self._check_message("Success")
+        # write another message
+        self.termination_plugin.write_termination_message(
+            False, False, self.configuration, False
+        )
+        # check idempotence
+        self._check_message("Success")
+
+    def test_last_message_persisted(self):
+        # write a success message
+        self.termination_plugin.write_termination_message(
+            False, False, self.configuration, False
+        )
+        # check message was written successfully
+        self._check_message("Success")
+        # write failure message
+        self.termination_plugin.write_termination_message(
+            True, False, self.configuration, False
+        )
+        # check fail message is present
+        self._check_message("Platform error")
+
+    def test_user_error_message(self):
+        # write user error message
+        self.termination_plugin.write_termination_message(
+            True, True, self.configuration, False
+        )
+        # check message was written successfully
+        self._check_message("User error")
+        # write user error message
+        self.termination_plugin.write_termination_message(
+            True, True, self.configuration, False
+        )
+        # check message idempotent
+        self._check_message("User error")
+
+    def test_execution_skipped_message(self):
+        # write execution skipped
+        self.termination_plugin.write_termination_message(
+            False, False, self.configuration, True
+        )
+        # check message was written successfully
+        self._check_message("Skipped")
+        # check idempotence
+        self.termination_plugin.write_termination_message(
+            False, False, self.configuration, True
+        )
+        # check message was written successfully
+        self._check_message("Skipped")
+
+    def _check_message(self, expected_message):
+        expected_message = (
+            f'{{"vdk_version": "{get_version()}", "status": "{expected_message}"}}'
+        )
+        with open(
+            self.configuration.get_value("TERMINATION_MESSAGE_WRITER_OUTPUT_FILE")
+        ) as file:
+            assert file.read() == expected_message
 
 
 class WriterTest(unittest.TestCase):

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/termination_message/test_writer.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/termination_message/test_writer.py
@@ -97,14 +97,14 @@ class TestTerminationMessageWriterPlugin(unittest.TestCase):
         # check message was written successfully
         self._check_message_status("Skipped")
 
-    def _check_message_status(self, expected_message):
-        expected_message = (
-            f'{{"vdk_version": "{get_version()}", "status": "{expected_message}"}}'
+    def _check_message_status(self, expected_status):
+        expected_status = (
+            f'{{"vdk_version": "{get_version()}", "status": "{expected_status}"}}'
         )
         with open(
             self.configuration.get_value("TERMINATION_MESSAGE_WRITER_OUTPUT_FILE")
         ) as file:
-            assert file.read() == expected_message
+            assert file.read() == expected_status
 
 
 class WriterTest(unittest.TestCase):

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/termination_message/test_writer.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/termination_message/test_writer.py
@@ -18,7 +18,7 @@ from vdk.internal.core.errors import get_blamee_overall
 from vdk.internal.core.statestore import StateStore
 
 
-class TestWriterIdempotence(unittest.TestCase):
+class TestTerminationMessageWriterPlugin(unittest.TestCase):
     def setUp(self) -> None:
         self.termination_plugin = TerminationMessageWriterPlugin()
         configuration_builder = ConfigurationBuilder()
@@ -47,13 +47,13 @@ class TestWriterIdempotence(unittest.TestCase):
             False, False, self.configuration, False
         )
         # check message was written successfully
-        self._check_message("Success")
+        self._check_message_status("Success")
         # write another message
         self.termination_plugin.write_termination_message(
             False, False, self.configuration, False
         )
         # check idempotence
-        self._check_message("Success")
+        self._check_message_status("Success")
 
     def test_last_message_persisted(self):
         # write a success message
@@ -61,13 +61,13 @@ class TestWriterIdempotence(unittest.TestCase):
             False, False, self.configuration, False
         )
         # check message was written successfully
-        self._check_message("Success")
+        self._check_message_status("Success")
         # write failure message
         self.termination_plugin.write_termination_message(
             True, False, self.configuration, False
         )
         # check fail message is present
-        self._check_message("Platform error")
+        self._check_message_status("Platform error")
 
     def test_user_error_message(self):
         # write user error message
@@ -75,13 +75,13 @@ class TestWriterIdempotence(unittest.TestCase):
             True, True, self.configuration, False
         )
         # check message was written successfully
-        self._check_message("User error")
+        self._check_message_status("User error")
         # write user error message
         self.termination_plugin.write_termination_message(
             True, True, self.configuration, False
         )
         # check message idempotent
-        self._check_message("User error")
+        self._check_message_status("User error")
 
     def test_execution_skipped_message(self):
         # write execution skipped
@@ -89,15 +89,15 @@ class TestWriterIdempotence(unittest.TestCase):
             False, False, self.configuration, True
         )
         # check message was written successfully
-        self._check_message("Skipped")
+        self._check_message_status("Skipped")
         # check idempotence
         self.termination_plugin.write_termination_message(
             False, False, self.configuration, True
         )
         # check message was written successfully
-        self._check_message("Skipped")
+        self._check_message_status("Skipped")
 
-    def _check_message(self, expected_message):
+    def _check_message_status(self, expected_message):
         expected_message = (
             f'{{"vdk_version": "{get_version()}", "status": "{expected_message}"}}'
         )


### PR DESCRIPTION
what: termination message plugin now overrides the previous message.

why: Some data jobs that make use of the [Standalone Data Job](https://github.com/vmware/versatile-data-kit/blob/main/projects/vdk-core/src/vdk/internal/builtin_plugins/run/standalone_data_job.py) end up with double termination message, e.g.,

'{"vdk_version": "0.3.572339461", "status": "Success"}{"vdk_version": "0.3.572339461", "status": "Success"}'

This confuses the Control Service, which therefore classifies the execution as Platform Error, even if the job is executed successfully.

testing: added unit tests

Signed-off-by: Momchil Zhivkov <mzhivkov@vmware.com>