### PR TITLE
vdk-core: vdk_exception hook exit code fix

### DIFF
--- a/projects/vdk-core/src/vdk/api/plugin/core_hook_spec.py
+++ b/projects/vdk-core/src/vdk/api/plugin/core_hook_spec.py
@@ -105,7 +105,7 @@ class CoreHookSpecs:
         """
         Called in case the CLI is about to exit with error.
 
-        :return: True if exception is handled and does not need to be logged by main
+        :return: True if exception is handled and does not need to be logged by main, nor affect the exit code
         """
         pass
 

--- a/projects/vdk-core/src/vdk/internal/cli_entry.py
+++ b/projects/vdk-core/src/vdk/internal/cli_entry.py
@@ -143,7 +143,9 @@ class CliEntry:
             # if at least one hook implementation returned handled, means we do not need to log the exception
             if not (True in handled):
                 log.exception("Exiting with exception.")
-            exit_code = e.exit_code if isinstance(e, ClickException) else 1
+                exit_code = e.exit_code if isinstance(e, ClickException) else 1
+            else:
+                exit_code = 0
             return exit_code
         finally:
             cast(CoreHookSpecs, plugin_registry.hook()).vdk_exit(


### PR DESCRIPTION
The hook was always returning exit code 1, no matter if exception was
successfully handled or not.

Elaborated the vdk_exception hookspec API documentation on exit code
expectations. Fixed the return status to 0 in case exception was
successfully handled.

Testing Done: ci/cd

Signed-off-by: ikoleva <ikoleva@vmware.com>