### PR TITLE
vdk-core: vdk_exception hook exit code fix

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/execution_results.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/execution_results.py
@@ -7,6 +7,7 @@ from typing import Any
 from typing import List
 from typing import Optional
 
+from click import ClickException
 from vdk.internal.builtin_plugins.run.run_status import ExecutionStatus
 from vdk.internal.core import errors
 from vdk.internal.core.errors import ErrorMessage
@@ -77,7 +78,11 @@ class ExecutionResult:
         Returns main exception to be used as a failure reason for the data job.
         """
         if self.exception:
-            return self.exception
+            return (
+                Exception(self.exception.message)
+                if isinstance(self.exception, ClickException)
+                else self.exception
+            )
         step_exceptions = map(lambda x: x.exception, self.steps_list)
         step_exception = next(filter(lambda e: e is not None, step_exceptions), None)
         if step_exception:

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/standalone_data_job.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/standalone_data_job.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import logging
 import pathlib
 import sys
 from pathlib import Path
@@ -25,6 +26,8 @@ from vdk.internal.core.config import ConfigurationBuilder
 from vdk.internal.core.context import CoreContext
 from vdk.internal.core.statestore import StateStore
 from vdk.internal.plugin.plugin import PluginRegistry
+
+log = logging.getLogger(__name__)
 
 
 class NoOpStepDataJobHookImplPlugin(DataJobDefaultHookImplPlugin):
@@ -141,12 +144,17 @@ class StandaloneDataJob(IStandaloneDataJob):
     def __exit__(self, exc_type, exc_value, exc_traceback):
         exit_code = 0
         if exc_type:
-            cast(CoreHookSpecs, self._plugin_registry.hook()).vdk_exception(
+            handled = cast(CoreHookSpecs, self._plugin_registry.hook()).vdk_exception(
                 exception=exc_value
             )
-            exit_code = (
-                exc_value.exit_code if isinstance(exc_value, ClickException) else 1
-            )
+            # if at least one hook implementation returned handled, means we do not need to log the exception
+            if not (True in handled):
+                log.exception("Exiting with exception.")
+                exit_code = (
+                    exc_value.exit_code if isinstance(exc_value, ClickException) else 1
+                )
+            else:
+                exit_code = 0
         else:
             cast(JobRunHookSpecs, self._plugin_registry.hook()).finalize_job(
                 context=self._job_context


### PR DESCRIPTION
In case of StandaloneDataJob, the vdk_exception hook was always
returning exit code 1, no matter if exception was successfully handled
or not. Also, in case of empty job, vdk_exception was not triggered.

Fixed the StandaloneDataJob return status to 0 in case exception was
successfully handled. Fixed the case with ClickException not propagating
to vdk_exception hook.

Testing Done: run tests locally; did verify manually that an empty job
does evaluate vdk_exception hook, and in case exception is successfully
handled then the data job exit code is 0.

Signed-off-by: ikoleva <ikoleva@vmware.com>