### PR TITLE
vdk-csv: add export-csv command

### DIFF
--- a/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_export_job/csv_export_step.py
+++ b/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_export_job/csv_export_step.py
@@ -1,7 +1,7 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
-import logging
 import csv
+import logging
 
 from vdk.api.job_input import IJobInput
 from vdk.internal.core import errors
@@ -28,9 +28,7 @@ class CsvExporter:
             writer = csv.writer(f, lineterminator="\n")
             for row in query_result:
                 writer.writerow(row)
-        log.info(
-            f"Exported data successfully.You can find the result here: {fullpath}"
-        )
+        log.info(f"Exported data successfully.You can find the result here: {fullpath}")
 
 
 def run(job_input: IJobInput) -> None:

--- a/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_export_job/csv_export_step.py
+++ b/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_export_job/csv_export_step.py
@@ -1,0 +1,40 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+import csv
+
+from vdk.api.job_input import IJobInput
+from vdk.internal.core import errors
+
+log = logging.getLogger(__name__)
+
+
+class CsvExporter:
+    def __init__(self, job_input: IJobInput):
+        self.__job_input = job_input
+
+    def export(self, query: str, fullpath: str):
+        query_result = self.__job_input.execute_query(query)
+        if not query_result:
+            errors.log_and_throw(
+                errors.ResolvableBy.USER_ERROR,
+                log,
+                "Cannot create the result csv file.",
+                f"""No data was found """,
+                "Will not proceed with exporting",
+                "Try with another query or check the database explicitly.",
+            )
+        with open(fullpath, "w", encoding="UTF8", newline="") as f:
+            writer = csv.writer(f, lineterminator="\n")
+            for row in query_result:
+                writer.writerow(row)
+        log.info(
+            f"Exported data successfully.You can find the result here: {fullpath}"
+        )
+
+
+def run(job_input: IJobInput) -> None:
+    query = job_input.get_arguments().get("query")
+    fullpath = job_input.get_arguments().get("fullpath")
+    exporter = CsvExporter(job_input)
+    exporter.export(query, fullpath)

--- a/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_plugin.py
@@ -7,19 +7,14 @@ import csv
 import json
 import logging
 import os
-import pathlib
 
 import click
 from click import Context
-from tabulate import tabulate
+from vdk.internal.core import errors
 from vdk.api.plugin.hook_markers import hookimpl
 from vdk.internal.builtin_plugins.run.cli_run import run
-from vdk.internal.builtin_plugins.run.job_context import JobContext
-from vdk.internal.core.config import ConfigurationBuilder
 from vdk.internal.util.decorators import closing_noexcept_on_close
 from vdk.plugin.csv.csv_ingest_job import csv_ingest_step
-from vdk.plugin.sqlite import sqlite_configuration
-from vdk.plugin.sqlite.ingest_to_sqlite import IngestToSQLite
 from vdk.plugin.sqlite.sqlite_configuration import SQLiteConfiguration
 from vdk.plugin.sqlite.sqlite_connection import SQLiteConnection
 
@@ -29,7 +24,7 @@ log = logging.getLogger(__name__)
 @click.command(
     name="ingest-csv",
     help="Ingest CSV file."
-    """
+         """
 The ingestion destination depends on how vdk has been configured.
 See vdk config-help  - search for "ingest" to check for possible ingestion configurations.
 
@@ -71,7 +66,7 @@ vdk ingest-csv -f revenue.csv --options='{"names": ["gender", "os", "visits", "a
     default=None,
     type=click.STRING,
     help="The table in which the csv file will be ingested into."
-    "If not specified, it will default to the csv file name without the extension",
+         "If not specified, it will default to the csv file name without the extension",
 )
 @click.option(
     "-o",
@@ -79,8 +74,8 @@ vdk ingest-csv -f revenue.csv --options='{"names": ["gender", "os", "visits", "a
     default="{}",
     type=click.STRING,
     help="""Pass extra options when reading CSV file formatted as json. For example {"sep": ";", "verbose": true} """
-    "Those are the same options as passed to pandas.read_csv. See "
-    "https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html.",
+         "Those are the same options as passed to pandas.read_csv. See "
+         "https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html.",
 )
 @click.pass_context
 def ingest_csv(ctx: Context, file: str, table_name: str, options: str) -> None:
@@ -93,27 +88,6 @@ def ingest_csv(ctx: Context, file: str, table_name: str, options: str) -> None:
     click.echo(f"Ingesting csv file {file} finished.")
 
 
-@hookimpl
-def vdk_configure(config_builder: ConfigurationBuilder) -> None:
-    """
-    Here we define what configuration settings are needed for sqlite with reasonable defaults
-    """
-    sqlite_configuration.add_definitions(config_builder)
-
-
-@hookimpl
-def initialize_job(context: JobContext) -> None:
-    conf = SQLiteConfiguration(context.core_context.configuration)
-    context.connections.add_open_connection_factory_method(
-        "SQLITE",
-        lambda: SQLiteConnection(pathlib.Path(conf.get_sqlite_file())).new_connection(),
-    )
-
-    context.ingester.add_ingester_factory_method(
-        "sqlite", (lambda: IngestToSQLite(conf))
-    )
-
-
 @click.command(
     name="export-csv",
     help="Execute a SQL query against a configured database and export the result to a local CSV file.",
@@ -123,32 +97,38 @@ def initialize_job(context: JobContext) -> None:
 @click.option("-p", "--path", type=click.STRING, default="", required=False)
 @click.pass_context
 def export_csv(ctx: click.Context, query, name: str, path: str):
+    if not path:
+        path = os.path.abspath(os.getcwd())
+    fullpath = os.path.join(path, name)
+    if os.path.exists(fullpath):
+        errors.log_and_throw(
+            errors.ResolvableBy.USER_ERROR,
+            log,
+            "Cannot create the result csv file.",
+            f"""File with name {name} already exists in {path} """,
+            "Will not proceed with exporting",
+            "Use another name or choose another location for the file",
+        )
     conf = SQLiteConfiguration(ctx.obj.configuration)
     conn = SQLiteConnection(conf.get_sqlite_file())
-
     with closing_noexcept_on_close(conn.new_connection().cursor()) as cursor:
         cursor.execute(query)
-        column_names = (
-            [column_info[0] for column_info in cursor.description]
-            if cursor.description
-            else ()  # same as the default value for the headers parameter of the tabulate function
-        )
         res = cursor.fetchall()
-        if not path:
-            path = os.path.abspath(os.getcwd())
-        fullpath = os.path.join(path, name)
-        if os.path.exists(fullpath):
-            click.echo(
-                f"Already existing path: {fullpath}. Try again with another path or file name."
+        if not res:
+            errors.log_and_throw(
+                errors.ResolvableBy.USER_ERROR,
+                log,
+                "Cannot create the result csv file.",
+                f"""No data was found """,
+                "Will not proceed with exporting",
+                "Try with another query or check the database explicitly.",
             )
-        else:
-            with open(fullpath, "w", encoding="UTF8", newline="") as f:
-                writer = csv.writer(f, lineterminator="\n")
-                for row in res:
-                    writer.writerow(row)
-            click.echo(f"You can find the result here: {fullpath}")
-            click.echo(tabulate(res, headers=column_names))
-            raise Exception(f"You can find the result here: {fullpath}")
+
+        with open(fullpath, "w", encoding="UTF8", newline="") as f:
+            writer = csv.writer(f, lineterminator="\n")
+            for row in res:
+                writer.writerow(row)
+        click.echo(f"You can find the result here: {fullpath}")
 
 
 @hookimpl

--- a/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_plugin.py
@@ -10,9 +10,9 @@ import os
 
 import click
 from click import Context
-from vdk.internal.core import errors
 from vdk.api.plugin.hook_markers import hookimpl
 from vdk.internal.builtin_plugins.run.cli_run import run
+from vdk.internal.core import errors
 from vdk.internal.util.decorators import closing_noexcept_on_close
 from vdk.plugin.csv.csv_ingest_job import csv_ingest_step
 from vdk.plugin.sqlite.sqlite_configuration import SQLiteConfiguration
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 @click.command(
     name="ingest-csv",
     help="Ingest CSV file."
-         """
+    """
 The ingestion destination depends on how vdk has been configured.
 See vdk config-help  - search for "ingest" to check for possible ingestion configurations.
 
@@ -66,7 +66,7 @@ vdk ingest-csv -f revenue.csv --options='{"names": ["gender", "os", "visits", "a
     default=None,
     type=click.STRING,
     help="The table in which the csv file will be ingested into."
-         "If not specified, it will default to the csv file name without the extension",
+    "If not specified, it will default to the csv file name without the extension",
 )
 @click.option(
     "-o",
@@ -74,8 +74,8 @@ vdk ingest-csv -f revenue.csv --options='{"names": ["gender", "os", "visits", "a
     default="{}",
     type=click.STRING,
     help="""Pass extra options when reading CSV file formatted as json. For example {"sep": ";", "verbose": true} """
-         "Those are the same options as passed to pandas.read_csv. See "
-         "https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html.",
+    "Those are the same options as passed to pandas.read_csv. See "
+    "https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html.",
 )
 @click.pass_context
 def ingest_csv(ctx: Context, file: str, table_name: str, options: str) -> None:

--- a/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_plugin.py
@@ -15,8 +15,8 @@ from vdk.internal.builtin_plugins.run.cli_run import run
 from vdk.internal.core import errors
 from vdk.internal.core.errors import UserCodeError
 from vdk.internal.util.decorators import closing_noexcept_on_close
-from vdk.plugin.csv.csv_ingest_job import csv_ingest_step
 from vdk.plugin.csv.csv_export_job import csv_export_step
+from vdk.plugin.csv.csv_ingest_job import csv_ingest_step
 from vdk.plugin.sqlite.sqlite_configuration import SQLiteConfiguration
 from vdk.plugin.sqlite.sqlite_connection import SQLiteConnection
 
@@ -114,9 +114,9 @@ def export_csv(ctx: click.Context, query, name: str, path: str):
     args = dict(query=query, fullpath=fullpath)
     try:
         ctx.invoke(
-                run,
-                data_job_directory=os.path.dirname(csv_export_step.__file__),
-                arguments=json.dumps(args),
+            run,
+            data_job_directory=os.path.dirname(csv_export_step.__file__),
+            arguments=json.dumps(args),
         )
     except UserCodeError as e:
         raise e

--- a/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_plugin.py
@@ -3,21 +3,21 @@
 """
 VDK CSV plugin script.
 """
+import csv
 import json
 import logging
 import os
-import csv
 import pathlib
 
 import click
 from click import Context
+from tabulate import tabulate
 from vdk.api.plugin.hook_markers import hookimpl
 from vdk.internal.builtin_plugins.run.cli_run import run
-from vdk.plugin.csv.csv_ingest_job import csv_ingest_step
-from tabulate import tabulate
 from vdk.internal.builtin_plugins.run.job_context import JobContext
 from vdk.internal.core.config import ConfigurationBuilder
 from vdk.internal.util.decorators import closing_noexcept_on_close
+from vdk.plugin.csv.csv_ingest_job import csv_ingest_step
 from vdk.plugin.sqlite import sqlite_configuration
 from vdk.plugin.sqlite.ingest_to_sqlite import IngestToSQLite
 from vdk.plugin.sqlite.sqlite_configuration import SQLiteConfiguration
@@ -115,7 +115,8 @@ def initialize_job(context: JobContext) -> None:
 
 
 @click.command(
-    name="export-csv", help="Execute a SQL query against a local SQLite database and export to a local CSV file."
+    name="export-csv",
+    help="Execute a SQL query against a local SQLite database and export to a local CSV file.",
 )
 @click.option("-q", "--query", type=click.STRING, required=True)
 @click.option("-n", "--name", type=click.STRING, default="result.csv", required=False)
@@ -137,10 +138,12 @@ def export_csv(ctx: click.Context, query, name: str, path: str):
             path = os.path.abspath(os.getcwd())
         fullpath = os.path.join(path, name)
         if os.path.exists(fullpath):
-            click.echo(f"Already existing path: {fullpath}. Try again with another path or file name.")
+            click.echo(
+                f"Already existing path: {fullpath}. Try again with another path or file name."
+            )
         else:
-            with open(fullpath, 'w', encoding='UTF8', newline='') as f:
-                writer = csv.writer(f, lineterminator='\n')
+            with open(fullpath, "w", encoding="UTF8", newline="") as f:
+                writer = csv.writer(f, lineterminator="\n")
                 for row in res:
                     writer.writerow(row)
             click.echo(f"You can find the result here: {fullpath}")

--- a/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_plugin.py
@@ -6,12 +6,22 @@ VDK CSV plugin script.
 import json
 import logging
 import os
+import csv
+import pathlib
 
 import click
 from click import Context
 from vdk.api.plugin.hook_markers import hookimpl
 from vdk.internal.builtin_plugins.run.cli_run import run
 from vdk.plugin.csv.csv_ingest_job import csv_ingest_step
+from tabulate import tabulate
+from vdk.internal.builtin_plugins.run.job_context import JobContext
+from vdk.internal.core.config import ConfigurationBuilder
+from vdk.internal.util.decorators import closing_noexcept_on_close
+from vdk.plugin.sqlite import sqlite_configuration
+from vdk.plugin.sqlite.ingest_to_sqlite import IngestToSQLite
+from vdk.plugin.sqlite.sqlite_configuration import SQLiteConfiguration
+from vdk.plugin.sqlite.sqlite_connection import SQLiteConnection
 
 log = logging.getLogger(__name__)
 
@@ -84,5 +94,61 @@ def ingest_csv(ctx: Context, file: str, table_name: str, options: str) -> None:
 
 
 @hookimpl
+def vdk_configure(config_builder: ConfigurationBuilder) -> None:
+    """
+    Here we define what configuration settings are needed for sqlite with reasonable defaults
+    """
+    sqlite_configuration.add_definitions(config_builder)
+
+
+@hookimpl
+def initialize_job(context: JobContext) -> None:
+    conf = SQLiteConfiguration(context.core_context.configuration)
+    context.connections.add_open_connection_factory_method(
+        "SQLITE",
+        lambda: SQLiteConnection(pathlib.Path(conf.get_sqlite_file())).new_connection(),
+    )
+
+    context.ingester.add_ingester_factory_method(
+        "sqlite", (lambda: IngestToSQLite(conf))
+    )
+
+
+@click.command(
+    name="export-csv", help="Execute a SQL query against a local SQLite database and export to a local CSV file."
+)
+@click.option("-q", "--query", type=click.STRING, required=True)
+@click.option("-n", "--name", type=click.STRING, default="result.csv", required=False)
+@click.option("-p", "--path", type=click.STRING, default="", required=False)
+@click.pass_context
+def export_csv(ctx: click.Context, query, name: str, path: str):
+    conf = SQLiteConfiguration(ctx.obj.configuration)
+    conn = SQLiteConnection(conf.get_sqlite_file())
+
+    with closing_noexcept_on_close(conn.new_connection().cursor()) as cursor:
+        cursor.execute(query)
+        column_names = (
+            [column_info[0] for column_info in cursor.description]
+            if cursor.description
+            else ()  # same as the default value for the headers parameter of the tabulate function
+        )
+        res = cursor.fetchall()
+        if not path:
+            path = os.path.abspath(os.getcwd())
+        fullpath = os.path.join(path, name)
+        if os.path.exists(fullpath):
+            click.echo(f"Already existing path: {fullpath}. Try again with another path or file name.")
+        else:
+            with open(fullpath, 'w', encoding='UTF8', newline='') as f:
+                writer = csv.writer(f, lineterminator='\n')
+                for row in res:
+                    writer.writerow(row)
+            click.echo(f"You can find the result here: {fullpath}")
+            click.echo(tabulate(res, headers=column_names))
+            raise Exception(f"You can find the result here: {fullpath}")
+
+
+@hookimpl
 def vdk_command_line(root_command: click.Group) -> None:
     root_command.add_command(ingest_csv)
+    root_command.add_command(export_csv)

--- a/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_plugin.py
@@ -116,7 +116,7 @@ def initialize_job(context: JobContext) -> None:
 
 @click.command(
     name="export-csv",
-    help="Execute a SQL query against a local SQLite database and export to a local CSV file.",
+    help="Execute a SQL query against a configured database and export the result to a local CSV file.",
 )
 @click.option("-q", "--query", type=click.STRING, required=True)
 @click.option("-n", "--name", type=click.STRING, default="result.csv", required=False)

--- a/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
@@ -2,12 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
 from unittest import mock
+import csv
 
 from click.testing import Result
 from vdk.plugin.csv import csv_plugin
 from vdk.plugin.test_utils.util_funcs import cli_assert_equal
 from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
 from vdk.plugin.test_utils.util_plugins import IngestIntoMemoryPlugin
+from vdk.plugin.sqlite import sqlite_configuration
+from vdk.plugin.sqlite import sqlite_plugin
+from vdk.plugin.sqlite.ingest_to_sqlite import IngestToSQLite
+from vdk.plugin.sqlite.sqlite_configuration import SQLiteConfiguration
+from vdk.plugin.sqlite.sqlite_connection import SQLiteConnection
+
 
 
 def _get_file(filename):
@@ -76,3 +83,46 @@ def test_ingestion_csv_with_options():
 
     assert len(ingest_plugin.payloads) > 0
     assert ingest_plugin.payloads[0].payload[0]["US Zip"] == "08056"
+
+
+def test_csv_export(tmpdir):
+    db_dir = str(tmpdir) + "vdk-sqlite.db"
+    with mock.patch.dict(
+            os.environ,
+            {
+                "VDK_DB_DEFAULT_TYPE": "SQLITE",
+                "VDK_SQLITE_FILE": db_dir,
+            },
+    ):
+        # create table first, as the ingestion fails otherwise
+        runner = CliEntryBasedTestRunner(sqlite_plugin, csv_plugin)
+        runner.invoke(
+            [
+                "sqlite-query",
+                "--query",
+                "CREATE TABLE test_table (some_data TEXT, more_data TEXT)",
+            ]
+        )
+
+        mock_sqlite_conf = mock.MagicMock(SQLiteConfiguration)
+        sqlite_ingest = IngestToSQLite(mock_sqlite_conf)
+        payload = [{"some_data": "some_test_data", "more_data": "more_test_data"},
+                   {"some_data": "some_test_data_copy", "more_data": "more_test_data_copy"}]
+
+        sqlite_ingest.ingest_payload(
+            payload=payload,
+            destination_table="test_table",
+            target=db_dir,
+        )
+
+        runner.invoke(
+            ["export-csv", "--query", "SELECT * FROM test_table"]
+        )
+        output = []
+        with open(os.path.join(os.path.abspath(os.getcwd()), "result.csv"), 'r') as file:
+            reader = csv.reader(file, delimiter=',')
+            for row in reader:
+                output.append(row)
+
+        assert output[0] == ['some_test_data', 'more_test_data']
+        assert output[1] == ['some_test_data_copy', 'more_test_data_copy']

--- a/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
@@ -5,9 +5,9 @@ import os
 from unittest import mock
 
 from click import ClickException
+from click.testing import Result
 from pytest import raises
 from vdk.internal.core.errors import UserCodeError
-from click.testing import Result
 from vdk.plugin.csv import csv_plugin
 from vdk.plugin.sqlite import sqlite_plugin
 from vdk.plugin.sqlite.ingest_to_sqlite import IngestToSQLite
@@ -122,7 +122,7 @@ def test_csv_export(tmpdir):
             reader = csv.reader(file, delimiter=",")
             for row in reader:
                 output.append(row)
-        raise Exception(output) 
+        raise Exception(output)
         assert output[0] == ["some_test_data", "more_test_data"]
         assert output[1] == ["some_test_data_copy", "more_test_data_copy"]
 
@@ -160,4 +160,3 @@ def test_csv_export_with_no_data(tmpdir):
         )
         with raises(UserCodeError):
             runner.invoke(["export-csv", "--query", "SELECT * FROM test_table"])
-

--- a/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
@@ -86,13 +86,13 @@ def test_ingestion_csv_with_options():
 
 
 def test_csv_export(tmpdir):
-    db_dir = "vdk-sqlite.db"
+    db_dir = str(tmpdir) + "vdk-sqlite.db"
     with mock.patch.dict(
-        os.environ,
-        {
-            "VDK_DB_DEFAULT_TYPE": "SQLITE",
-            "VDK_SQLITE_FILE": db_dir,
-        },
+            os.environ,
+            {
+                "VDK_DB_DEFAULT_TYPE": "SQLITE",
+                "VDK_SQLITE_FILE": db_dir,
+            },
     ):
         runner = CliEntryBasedTestRunner(sqlite_plugin, csv_plugin)
         runner.invoke(
@@ -122,25 +122,37 @@ def test_csv_export(tmpdir):
             reader = csv.reader(file, delimiter=",")
             for row in reader:
                 output.append(row)
+<<<<<<< HEAD
         raise Exception(output)
+=======
+
+>>>>>>> ea6bf9f (Added asserts for stdout to tests)
         assert output[0] == ["some_test_data", "more_test_data"]
         assert output[1] == ["some_test_data_copy", "more_test_data_copy"]
 
 
 def test_export_csv_with_already_existing_file():
+    path = os.path.abspath(os.getcwd())
+    open(os.path.join(path, 'result2.csv'), 'w')
     runner = CliEntryBasedTestRunner(csv_plugin)
-    with raises(UserCodeError):
-        runner.invoke(["export-csv", "--query", "SELECT * FROM test_table"])
+    assert runner.invoke(["export-csv", "--query", "SELECT * FROM test_table", "--name", "result2.csv"]).output == (
+        'Error: An error in data job code  occurred. The error should be resolved by '
+        'User Error. Here are the details:\n'
+        '  WHAT HAPPENED : Cannot create the result csv file.\n'
+        'WHY IT HAPPENED : File with name result2.csv already exists in '
+        f'{path}\n'
+        '   CONSEQUENCES : Will not proceed with exporting\n'
+        'COUNTERMEASURES : Use another name or choose another location for the file\n')
 
 
 def test_csv_export_with_no_data(tmpdir):
     db_dir = str(tmpdir) + "vdk-sqlite.db"
     with mock.patch.dict(
-        os.environ,
-        {
-            "VDK_DB_DEFAULT_TYPE": "SQLITE",
-            "VDK_SQLITE_FILE": db_dir,
-        },
+            os.environ,
+            {
+                "VDK_DB_DEFAULT_TYPE": "SQLITE",
+                "VDK_SQLITE_FILE": db_dir,
+            },
     ):
         runner = CliEntryBasedTestRunner(sqlite_plugin, csv_plugin)
         runner.invoke(
@@ -158,5 +170,15 @@ def test_csv_export_with_no_data(tmpdir):
             destination_table="test_table",
             target=db_dir,
         )
+<<<<<<< HEAD
         with raises(UserCodeError):
             runner.invoke(["export-csv", "--query", "SELECT * FROM test_table"])
+=======
+        assert runner.invoke(["export-csv", "--query", "SELECT * FROM test_table", "--name", "result3.csv"]).output == (
+            'Error: An error in data job code  occurred. The error should be resolved by '
+            'User Error. Here are the details:\n'
+            '  WHAT HAPPENED : Cannot create the result csv file.\n'
+            'WHY IT HAPPENED : No data was found\n'
+            '   CONSEQUENCES : Will not proceed with exporting\n'
+            'COUNTERMEASURES : Try with another query or check the database explicitly.\n')
+>>>>>>> ea6bf9f (Added asserts for stdout to tests)

--- a/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
@@ -4,10 +4,7 @@ import csv
 import os
 from unittest import mock
 
-from click import ClickException
 from click.testing import Result
-from pytest import raises
-from vdk.internal.core.errors import UserCodeError
 from vdk.plugin.csv import csv_plugin
 from vdk.plugin.sqlite import sqlite_plugin
 from vdk.plugin.sqlite.ingest_to_sqlite import IngestToSQLite
@@ -122,11 +119,6 @@ def test_csv_export(tmpdir):
             reader = csv.reader(file, delimiter=",")
             for row in reader:
                 output.append(row)
-<<<<<<< HEAD
-        raise Exception(output)
-=======
-
->>>>>>> ea6bf9f (Added asserts for stdout to tests)
         assert output[0] == ["some_test_data", "more_test_data"]
         assert output[1] == ["some_test_data_copy", "more_test_data_copy"]
 
@@ -136,13 +128,13 @@ def test_export_csv_with_already_existing_file():
     open(os.path.join(path, 'result2.csv'), 'w')
     runner = CliEntryBasedTestRunner(csv_plugin)
     assert runner.invoke(["export-csv", "--query", "SELECT * FROM test_table", "--name", "result2.csv"]).output == (
-        'Error: An error in data job code  occurred. The error should be resolved by '
-        'User Error. Here are the details:\n'
-        '  WHAT HAPPENED : Cannot create the result csv file.\n'
-        'WHY IT HAPPENED : File with name result2.csv already exists in '
-        f'{path}\n'
-        '   CONSEQUENCES : Will not proceed with exporting\n'
-        'COUNTERMEASURES : Use another name or choose another location for the file\n')
+            'Error: An error in data job code  occurred. The error should be resolved by '
+            'User Error. Here are the details:\n'
+            '  WHAT HAPPENED : Cannot create the result csv file.\n'
+            'WHY IT HAPPENED : File with name result2.csv already exists in '
+            f'{path}\n'
+            '   CONSEQUENCES : Will not proceed with exporting\n'
+            'COUNTERMEASURES : Use another name or choose another location for the file\n')
 
 
 def test_csv_export_with_no_data(tmpdir):
@@ -159,6 +151,13 @@ def test_csv_export_with_no_data(tmpdir):
             [
                 "sqlite-query",
                 "--query",
+                "DROP TABLE IF EXISTS test_table",
+            ]
+        )
+        runner.invoke(
+            [
+                "sqlite-query",
+                "--query",
                 "CREATE TABLE test_table (some_data TEXT, more_data TEXT)",
             ]
         )
@@ -170,15 +169,10 @@ def test_csv_export_with_no_data(tmpdir):
             destination_table="test_table",
             target=db_dir,
         )
-<<<<<<< HEAD
-        with raises(UserCodeError):
-            runner.invoke(["export-csv", "--query", "SELECT * FROM test_table"])
-=======
-        assert runner.invoke(["export-csv", "--query", "SELECT * FROM test_table", "--name", "result3.csv"]).output == (
-            'Error: An error in data job code  occurred. The error should be resolved by '
-            'User Error. Here are the details:\n'
-            '  WHAT HAPPENED : Cannot create the result csv file.\n'
-            'WHY IT HAPPENED : No data was found\n'
-            '   CONSEQUENCES : Will not proceed with exporting\n'
-            'COUNTERMEASURES : Try with another query or check the database explicitly.\n')
->>>>>>> ea6bf9f (Added asserts for stdout to tests)
+        assert str(runner.invoke(["export-csv", "--query", "SELECT * FROM test_table", "--name", "result3.csv"]).output).__contains__(
+                       'Error: An error in data job code  occurred. The error should be resolved by '
+                       'User Error. Here are the details:\n'
+                       '  WHAT HAPPENED : Cannot create the result csv file.\n'
+                       'WHY IT HAPPENED : No data was found\n'
+                       '   CONSEQUENCES : Will not proceed with exporting\n'
+                       'COUNTERMEASURES : Try with another query or check the database explicitly.\n')

--- a/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
@@ -85,11 +85,11 @@ def test_ingestion_csv_with_options():
 def test_csv_export(tmpdir):
     db_dir = str(tmpdir) + "vdk-sqlite.db"
     with mock.patch.dict(
-            os.environ,
-            {
-                "VDK_DB_DEFAULT_TYPE": "SQLITE",
-                "VDK_SQLITE_FILE": db_dir,
-            },
+        os.environ,
+        {
+            "VDK_DB_DEFAULT_TYPE": "SQLITE",
+            "VDK_SQLITE_FILE": db_dir,
+        },
     ):
         runner = CliEntryBasedTestRunner(sqlite_plugin, csv_plugin)
         runner.invoke(
@@ -125,26 +125,29 @@ def test_csv_export(tmpdir):
 
 def test_export_csv_with_already_existing_file():
     path = os.path.abspath(os.getcwd())
-    open(os.path.join(path, 'result2.csv'), 'w')
+    open(os.path.join(path, "result2.csv"), "w")
     runner = CliEntryBasedTestRunner(csv_plugin)
-    assert runner.invoke(["export-csv", "--query", "SELECT * FROM test_table", "--name", "result2.csv"]).output == (
-            'Error: An error in data job code  occurred. The error should be resolved by '
-            'User Error. Here are the details:\n'
-            '  WHAT HAPPENED : Cannot create the result csv file.\n'
-            'WHY IT HAPPENED : File with name result2.csv already exists in '
-            f'{path}\n'
-            '   CONSEQUENCES : Will not proceed with exporting\n'
-            'COUNTERMEASURES : Use another name or choose another location for the file\n')
+    assert runner.invoke(
+        ["export-csv", "--query", "SELECT * FROM test_table", "--name", "result2.csv"]
+    ).output == (
+        "Error: An error in data job code  occurred. The error should be resolved by "
+        "User Error. Here are the details:\n"
+        "  WHAT HAPPENED : Cannot create the result csv file.\n"
+        "WHY IT HAPPENED : File with name result2.csv already exists in "
+        f"{path}\n"
+        "   CONSEQUENCES : Will not proceed with exporting\n"
+        "COUNTERMEASURES : Use another name or choose another location for the file\n"
+    )
 
 
 def test_csv_export_with_no_data(tmpdir):
     db_dir = str(tmpdir) + "vdk-sqlite.db"
     with mock.patch.dict(
-            os.environ,
-            {
-                "VDK_DB_DEFAULT_TYPE": "SQLITE",
-                "VDK_SQLITE_FILE": db_dir,
-            },
+        os.environ,
+        {
+            "VDK_DB_DEFAULT_TYPE": "SQLITE",
+            "VDK_SQLITE_FILE": db_dir,
+        },
     ):
         runner = CliEntryBasedTestRunner(sqlite_plugin, csv_plugin)
         runner.invoke(
@@ -169,10 +172,21 @@ def test_csv_export_with_no_data(tmpdir):
             destination_table="test_table",
             target=db_dir,
         )
-        assert str(runner.invoke(["export-csv", "--query", "SELECT * FROM test_table", "--name", "result3.csv"]).output).__contains__(
-                       'Error: An error in data job code  occurred. The error should be resolved by '
-                       'User Error. Here are the details:\n'
-                       '  WHAT HAPPENED : Cannot create the result csv file.\n'
-                       'WHY IT HAPPENED : No data was found\n'
-                       '   CONSEQUENCES : Will not proceed with exporting\n'
-                       'COUNTERMEASURES : Try with another query or check the database explicitly.\n')
+        assert str(
+            runner.invoke(
+                [
+                    "export-csv",
+                    "--query",
+                    "SELECT * FROM test_table",
+                    "--name",
+                    "result3.csv",
+                ]
+            ).output
+        ).__contains__(
+            "Error: An error in data job code  occurred. The error should be resolved by "
+            "User Error. Here are the details:\n"
+            "  WHAT HAPPENED : Cannot create the result csv file.\n"
+            "WHY IT HAPPENED : No data was found\n"
+            "   CONSEQUENCES : Will not proceed with exporting\n"
+            "COUNTERMEASURES : Try with another query or check the database explicitly.\n"
+        )

--- a/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
@@ -1,20 +1,19 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import csv
 import os
 from unittest import mock
-import csv
 
 from click.testing import Result
 from vdk.plugin.csv import csv_plugin
-from vdk.plugin.test_utils.util_funcs import cli_assert_equal
-from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
-from vdk.plugin.test_utils.util_plugins import IngestIntoMemoryPlugin
 from vdk.plugin.sqlite import sqlite_configuration
 from vdk.plugin.sqlite import sqlite_plugin
 from vdk.plugin.sqlite.ingest_to_sqlite import IngestToSQLite
 from vdk.plugin.sqlite.sqlite_configuration import SQLiteConfiguration
 from vdk.plugin.sqlite.sqlite_connection import SQLiteConnection
-
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_plugins import IngestIntoMemoryPlugin
 
 
 def _get_file(filename):
@@ -88,11 +87,11 @@ def test_ingestion_csv_with_options():
 def test_csv_export(tmpdir):
     db_dir = str(tmpdir) + "vdk-sqlite.db"
     with mock.patch.dict(
-            os.environ,
-            {
-                "VDK_DB_DEFAULT_TYPE": "SQLITE",
-                "VDK_SQLITE_FILE": db_dir,
-            },
+        os.environ,
+        {
+            "VDK_DB_DEFAULT_TYPE": "SQLITE",
+            "VDK_SQLITE_FILE": db_dir,
+        },
     ):
         # create table first, as the ingestion fails otherwise
         runner = CliEntryBasedTestRunner(sqlite_plugin, csv_plugin)
@@ -106,8 +105,10 @@ def test_csv_export(tmpdir):
 
         mock_sqlite_conf = mock.MagicMock(SQLiteConfiguration)
         sqlite_ingest = IngestToSQLite(mock_sqlite_conf)
-        payload = [{"some_data": "some_test_data", "more_data": "more_test_data"},
-                   {"some_data": "some_test_data_copy", "more_data": "more_test_data_copy"}]
+        payload = [
+            {"some_data": "some_test_data", "more_data": "more_test_data"},
+            {"some_data": "some_test_data_copy", "more_data": "more_test_data_copy"},
+        ]
 
         sqlite_ingest.ingest_payload(
             payload=payload,
@@ -115,14 +116,13 @@ def test_csv_export(tmpdir):
             target=db_dir,
         )
 
-        runner.invoke(
-            ["export-csv", "--query", "SELECT * FROM test_table"]
-        )
+        runner.invoke(["export-csv", "--query", "SELECT * FROM test_table"])
         output = []
-        with open(os.path.join(os.path.abspath(os.getcwd()), "result.csv"), 'r') as file:
-            reader = csv.reader(file, delimiter=',')
+        with open(
+            os.path.join(os.path.abspath(os.getcwd()), "result.csv")) as file:
+            reader = csv.reader(file, delimiter=",")
             for row in reader:
                 output.append(row)
 
-        assert output[0] == ['some_test_data', 'more_test_data']
-        assert output[1] == ['some_test_data_copy', 'more_test_data_copy']
+        assert output[0] == ["some_test_data", "more_test_data"]
+        assert output[1] == ["some_test_data_copy", "more_test_data_copy"]

--- a/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
@@ -6,11 +6,9 @@ from unittest import mock
 
 from click.testing import Result
 from vdk.plugin.csv import csv_plugin
-from vdk.plugin.sqlite import sqlite_configuration
 from vdk.plugin.sqlite import sqlite_plugin
 from vdk.plugin.sqlite.ingest_to_sqlite import IngestToSQLite
 from vdk.plugin.sqlite.sqlite_configuration import SQLiteConfiguration
-from vdk.plugin.sqlite.sqlite_connection import SQLiteConnection
 from vdk.plugin.test_utils.util_funcs import cli_assert_equal
 from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
 from vdk.plugin.test_utils.util_plugins import IngestIntoMemoryPlugin

--- a/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
@@ -116,8 +116,7 @@ def test_csv_export(tmpdir):
 
         runner.invoke(["export-csv", "--query", "SELECT * FROM test_table"])
         output = []
-        with open(
-            os.path.join(os.path.abspath(os.getcwd()), "result.csv")) as file:
+        with open(os.path.join(os.path.abspath(os.getcwd()), "result.csv")) as file:
             reader = csv.reader(file, delimiter=",")
             for row in reader:
                 output.append(row)


### PR DESCRIPTION
vdk-csv: add export-csv command

What: Extended vdk-csv by adding a new command called vdk export-csv which can export from the default database to a local file.

Why: Often users would need to export result of some query to CSV file so they can send it to a colleague or to analyse it with other excel files they already have or to import it somewhere else. 

Testing Done: added an unit test

Signed-off-by: Duygu Hasan hduygu@vmware.com