### PR TITLE
[vdk-plugins] vdk-server: Pin kubernetes API version

### DIFF
--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/installer.py
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/installer.py
@@ -480,6 +480,8 @@ class Installer:
                         "--config=kind-cluster-config.yaml",
                         "--name",
                         self.kind_cluster_name,
+                        "--image",
+                        "kindest/node:v1.20.15",
                     ],
                     capture_output=True,
                 )


### PR DESCRIPTION
Currently, due to the fact that the control service's helm chart uses some
outdated APIs, `vdk server --install` cannot complete successfully, and throws
the below error:
```
Installing Control Service in Kind cluster...
-error: Stderr output: W0613 14:09:42.750230   43383 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
error: W0613 14:09:42.812327   43383 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
error: W0613 14:14:43.166567   43383 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
error: Error: INSTALLATION FAILED: release vdk failed, and has been uninstalled due to atomic being set: timed out waiting for the condition
```

In order for vdk-server to properly install the control service, we need to use older
kubernetes version

This change pins the version of kubernetes used by the kind cluster to **1.20.15** until
we adopt the new APIs in the control service helm chart.

Testing Done: Did `vdk server --install` locally and verified the control service is installed
correctly.

Signed-off-by: Andon Andonov <andonova@vmware.com>