### PR TITLE
vdk-core: add memory properties client

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/job_properties/inmemproperties.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/job_properties/inmemproperties.py
@@ -22,5 +22,9 @@ class InMemPropertiesServiceClient(IPropertiesServiceClient):
         return res
 
     def write_properties(self, job_name: str, team_name: str, properties: Dict) -> Dict:
+        log.warning(
+            "You are using In Memory Properties client. "
+            "That means the properties will not be persisted past the Data Job run."
+        )
         self._props = deepcopy(properties)
         return self._props

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/job_properties/properties_api_plugin.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/job_properties/properties_api_plugin.py
@@ -1,6 +1,6 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
-from src.vdk.internal.builtin_plugins.job_properties.inmemproperties import (
+from vdk.internal.builtin_plugins.job_properties.inmemproperties import (
     InMemPropertiesServiceClient,
 )
 from vdk.api.plugin.hook_markers import hookimpl

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/job_properties/properties_api_plugin.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/job_properties/properties_api_plugin.py
@@ -1,10 +1,10 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+from vdk.api.plugin.hook_markers import hookimpl
+from vdk.internal.builtin_plugins.job_properties import properties_config
 from vdk.internal.builtin_plugins.job_properties.inmemproperties import (
     InMemPropertiesServiceClient,
 )
-from vdk.api.plugin.hook_markers import hookimpl
-from vdk.internal.builtin_plugins.job_properties import properties_config
 from vdk.internal.builtin_plugins.run.job_context import JobContext
 from vdk.internal.core.config import ConfigurationBuilder
 

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/job_properties/properties_api_plugin.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/job_properties/properties_api_plugin.py
@@ -1,7 +1,11 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+from src.vdk.internal.builtin_plugins.job_properties.inmemproperties import (
+    InMemPropertiesServiceClient,
+)
 from vdk.api.plugin.hook_markers import hookimpl
 from vdk.internal.builtin_plugins.job_properties import properties_config
+from vdk.internal.builtin_plugins.run.job_context import JobContext
 from vdk.internal.core.config import ConfigurationBuilder
 
 
@@ -13,3 +17,9 @@ class PropertiesApiPlugin:
     @hookimpl(tryfirst=True)
     def vdk_configure(self, config_builder: ConfigurationBuilder) -> None:
         properties_config.add_definitions(config_builder)
+
+    @hookimpl
+    def initialize_job(self, context: JobContext) -> None:
+        context.properties.set_properties_factory_method(
+            "memory", lambda: InMemPropertiesServiceClient()
+        )


### PR DESCRIPTION
In case Control Service is not available, for demo purposes, it would be
good to be able to use some simple client so that jobs that stil use
properties would work.
To make it clear that it's not recommended for production (after all
properties are supposed to be used to store state, so in memory client
may be misleading) we write warning each  time write proerties is
called.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>