### PR TITLE
versatile-data-kit: make easier slack instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ If you are interested in contributing as a developer, visit [CONTRIBUTING.md](CO
 # Contacts
 Feedback is very welcome via the [GitHub site as issues](https://github.com/vmware/versatile-data-kit/issues) or [pull requests](https://github.com/vmware/versatile-data-kit/pulls)
 
-- [Join our mailing list](mailto:join-versatiledatakit@groups.vmware.com?subject=Invite%20me%20to%20the%20VDK%20mailing%20list)
 - [Follow us on twitter](https://twitter.com/intent/follow?screen_name=VDKProject).
 - Subscribe to the [Versatile Data Kit YouTube Channel](https://www.youtube.com/channel/UCasf2Q7X8nF7S4VEmcTHJ0Q).
-- [Join our dedicated Slack channel](https://cloud-native.slack.com/archives/C033PSLKCPR) on the [CNCF Slack workspace](https://events.linuxfoundation.org/archive/2020/kubecon-cloudnativecon-europe/attend/slack-guidelines/#getting-started) - simply search for #versatile-data-kit or [click here to join the channel](https://cloud-native.slack.com/archives/C033PSLKCPR)
+- [Join our dedicated Slack channel on the CNCF Slack workspace](https://communityinviter.com/apps/cloud-native/cncf)  - simply search for #versatile-data-kit or [click here to join the channel](https://cloud-native.slack.com/archives/C033PSLKCPR)
+- [Join our mailing list](mailto:join-versatiledatakit@groups.vmware.com?subject=Invite%20me%20to%20the%20VDK%20mailing%20list)
 
 # How to use Versatile Data Kit?
 - Video [Data Ingestion with Versatile Data Kit](https://youtu.be/JRV_5cxVQDU)


### PR DESCRIPTION
Add a link to Slack inviter (https://communityinviter.com/apps/cloud-native/cncf) to make it easier for people to join CNCF slack. 
Otherwise, they need to read the docs and it becomes more complex.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>