### PR TITLE
cicd: increase memory limits for cicd runner

### DIFF
--- a/support/gitlab-runners/values.yaml
+++ b/support/gitlab-runners/values.yaml
@@ -73,9 +73,9 @@ runners:
   ## TODO: Have runners for big and small jobs.
   builds:
     cpuLimit: 1000m
-    memoryLimit: 4Gi
+    memoryLimit: 6Gi
     cpuRequests: 500m
-    memoryRequests: 2Gi
+    memoryRequests: 4Gi
 
   ## Service Container specific configuration
   ##

--- a/support/gitlab-runners/values.yaml
+++ b/support/gitlab-runners/values.yaml
@@ -75,7 +75,7 @@ runners:
     cpuLimit: 1000m
     memoryLimit: 6Gi
     cpuRequests: 500m
-    memoryRequests: 4Gi
+    memoryRequests: 2Gi
 
   ## Service Container specific configuration
   ##


### PR DESCRIPTION
what: We intend to increase the limits to our cicd containers.Updated values.yaml file. The script "install-runners.sh" has to be manually triggered for changes to take effect.

why: Control Service Integration Tests have been failing with OOM errors. Although this doesn't directly update the values
it servers as a reference point for future changes.

testing: n/a

Signed-off-by: Momchil Zhivkov <mzhivkov@vmware.com>