### PR TITLE
vdk-impala: Add support for lineage in vdk-impala

### DIFF
--- a/projects/vdk-plugins/vdk-impala/requirements.txt
+++ b/projects/vdk-plugins/vdk-impala/requirements.txt
@@ -8,4 +8,5 @@ pydantic
 pytest-docker
 tabulate
 vdk-core
+vdk-lineage-model
 vdk-test-utils

--- a/projects/vdk-plugins/vdk-impala/setup.py
+++ b/projects/vdk-plugins/vdk-impala/setup.py
@@ -5,7 +5,7 @@ import pathlib
 import setuptools
 
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 setuptools.setup(
     name="vdk-impala",
@@ -14,7 +14,14 @@ setuptools.setup(
     description="Versatile Data Kit SDK plugin provides support for Impala database.",
     long_description=pathlib.Path("README.md").read_text(),
     long_description_content_type="text/markdown",
-    install_requires=["vdk-core", "impyla", "tabulate", "pydantic", "pyarrow"],
+    install_requires=[
+        "vdk-core",
+        "vdk-lineage-model",
+        "impyla",
+        "tabulate",
+        "pydantic",
+        "pyarrow",
+    ],
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),
     include_package_data=True,

--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_connection.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_connection.py
@@ -67,6 +67,3 @@ class ImpalaConnection(ManagedConnectionBase):
         )
 
         return conn
-
-    def execute_query(self, query: str):
-        return super().execute_query(query)

--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_lineage_plugin.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_lineage_plugin.py
@@ -1,0 +1,111 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+import re
+import sys
+from typing import cast
+from typing import Optional
+from typing import Tuple
+
+from impala._thrift_gen.RuntimeProfile.ttypes import TRuntimeProfileFormat
+from impala.hiveserver2 import HiveServer2Cursor
+from vdk.api.lineage.model.logger.lineage_logger import ILineageLogger
+from vdk.api.lineage.model.sql.model import LineageData
+from vdk.api.lineage.model.sql.model import LineageTable
+from vdk.api.plugin.hook_markers import hookimpl
+from vdk.internal.builtin_plugins.connection.execution_cursor import ExecutionCursor
+from vdk.internal.core.context import CoreContext
+from vdk.internal.core.statestore import StoreKey
+
+LINEAGE_LOGGER_KEY = StoreKey[ILineageLogger]("impala-lineage-logger")
+
+log = logging.getLogger(__name__)
+
+
+class ImpalaLineagePlugin:
+    """
+    Calculates lineage information from the query plan of executed queries.
+    Lineage is calculated only if the query has finished successfully and has resulted actual data read or write from/to
+    the underlying storage.
+    """
+
+    def __init__(self, lineage_logger: ILineageLogger = None):
+        self._lineage_logger = lineage_logger
+
+    # the purpose of the below hook is to get reference to any registered lineage loggers by other plugins
+    @hookimpl(
+        trylast=True
+    )  # trylast because we want to have any lineage loggers already initialized
+    def vdk_initialize(self, context: CoreContext) -> None:
+        self._lineage_logger = context.state.get(LINEAGE_LOGGER_KEY)
+
+    # the purpose of the below hook is to calculate lineage information after a query has been successfully executed
+    @hookimpl(hookwrapper=True)
+    def db_connection_execute_operation(
+        self, execution_cursor: ExecutionCursor
+    ) -> Optional[int]:
+        yield  # let the query execute first
+        try:
+            if self._lineage_logger and sys.version_info < (3, 10):
+                # calculate and send lineage data only if there is a registered lineage logger
+                # at the time of writing SystemError occurs "PY_SSIZE_T_CLEAN macro must be defined for '#' formats"
+                # when trying to calculate lineage information, TODO resolve the above error for python 3.10
+                hive_cursor = cast(HiveServer2Cursor, execution_cursor)
+                lineage_data = self._get_lineage_data(hive_cursor)
+                if (
+                    lineage_data
+                ):  # some queries do not have data lineage - select 1, create table, compute stats, etc
+                    self._lineage_logger.send(lineage_data)
+        # do not stop job execution if error occurs during lineage processing
+        except Exception:
+            log.warning(
+                "Error occurred during lineage calculation. No lineage information will be generated."
+                " Job execution will continue",
+                exc_info=True,
+            )
+
+    def _get_lineage_data(self, cursor: HiveServer2Cursor) -> Optional[LineageData]:
+        query_statement = cursor._cursor.query_string
+        if self._is_keepalive_statement(query_statement):
+            return None  # do not capture lineage for connection keepalive queries like "select 1"
+        query_profile = cursor.get_profile(profile_format=TRuntimeProfileFormat.STRING)
+        if "Query Status: OK" not in query_profile:
+            return None  # do not capture lineage for failed queries
+        inputs, output = self._parse_inputs_outputs(query_profile)
+        if not inputs and not output:
+            return None  # no lineage was present in the query plan, e.g. select 1 query
+        return LineageData(
+            query=query_statement,
+            query_status="OK",
+            query_type=None,  # TODO specify query_type once there is clear spec for it
+            input_tables=[
+                self._get_lineage_table_from_table_name(table_name)
+                for table_name in inputs
+            ],
+            output_table=self._get_lineage_table_from_table_name(output),
+        )
+
+    @staticmethod
+    def _parse_inputs_outputs(query_profile: str) -> Tuple[list, str]:
+        inputs = []
+        output = None
+        for line in query_profile.splitlines():
+            match = re.search(r"(?<=SCAN HDFS \[)\S*(?=,)", line)
+            if match:
+                inputs.append(match.group(0))
+            else:
+                match = re.search(r"(?<=WRITE TO HDFS \[)\S*(?=,)", line)
+                if match:
+                    output = match.group(0)
+        return list(set(inputs)), output
+
+    @staticmethod
+    def _get_lineage_table_from_table_name(table_name: str) -> LineageTable:
+        split_name = table_name.split(".")
+        return LineageTable(schema=split_name[0], table=split_name[1], catalog=None)
+
+    @staticmethod
+    def _is_keepalive_statement(query_statement):
+        return query_statement.endswith(
+            "\n select 1 -- Testing if connection is alive."
+        )

--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_plugin.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_plugin.py
@@ -22,6 +22,7 @@ from vdk.plugin.impala.impala_configuration import ImpalaPluginConfiguration
 from vdk.plugin.impala.impala_connection import ImpalaConnection
 from vdk.plugin.impala.impala_error_classifier import is_impala_user_error
 from vdk.plugin.impala.impala_error_handler import ImpalaErrorHandler
+from vdk.plugin.impala.impala_lineage_plugin import ImpalaLineagePlugin
 
 
 def _connection_by_configuration(configuration: ImpalaPluginConfiguration):
@@ -149,6 +150,9 @@ class ImpalaPlugin:
 @hookimpl
 def vdk_start(plugin_registry: IPluginRegistry, command_line_args: List):
     plugin_registry.load_plugin_with_hooks_impl(ImpalaPlugin(), "impala-plugin")
+    plugin_registry.load_plugin_with_hooks_impl(
+        ImpalaLineagePlugin(), "impala-lineage-plugin"
+    )
 
 
 def get_jobs_parent_directory() -> pathlib.Path:

--- a/projects/vdk-plugins/vdk-impala/tests/conftest.py
+++ b/projects/vdk-plugins/vdk-impala/tests/conftest.py
@@ -51,6 +51,6 @@ def impala_service(docker_ip, docker_services):
     time.sleep(3)
 
     docker_services.wait_until_responsive(
-        timeout=90.0, pause=0.3, check=lambda: _is_responsive(runner)
+        timeout=120.0, pause=0.3, check=lambda: _is_responsive(runner)
     )
     time.sleep(10)

--- a/projects/vdk-plugins/vdk-impala/tests/functional/test_impala_lineage.py
+++ b/projects/vdk-plugins/vdk-impala/tests/functional/test_impala_lineage.py
@@ -1,0 +1,369 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import json
+import os
+import sys
+from unittest import mock
+from unittest import TestCase
+from unittest.mock import patch
+
+import pytest
+from click.testing import Result
+from vdk.api.lineage.model.logger.lineage_logger import ILineageLogger
+from vdk.api.lineage.model.sql.model import LineageData
+from vdk.api.lineage.model.sql.model import LineageTable
+from vdk.api.plugin.hook_markers import hookimpl
+from vdk.plugin.impala import impala_plugin
+from vdk.plugin.impala.impala_lineage_plugin import LINEAGE_LOGGER_KEY
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_funcs import jobs_path_from_caller_directory
+
+VDK_DB_DEFAULT_TYPE = "VDK_DB_DEFAULT_TYPE"
+VDK_IMPALA_HOST = "VDK_IMPALA_HOST"
+VDK_IMPALA_PORT = "VDK_IMPALA_PORT"
+VDK_IMPALA_SYNC_DDL = "VDK_IMPALA_SYNC_DDL"
+VDK_IMPALA_QUERY_POOL = "VDK_IMPALA_QUERY_POOL"
+
+
+class TestConfigPlugin:
+    def __init__(self, lineage_logger: ILineageLogger):
+        self.lineage_logger = lineage_logger
+
+    @hookimpl
+    def vdk_initialize(self, context):
+        # register a lineage logger which will be used to validate if correct lineage data was emitted
+        context.state.set(LINEAGE_LOGGER_KEY, self.lineage_logger)
+
+
+def execute_query(runner, query: str):
+    result: Result = runner.invoke(["impala-query", "--query", query])
+    cli_assert_equal(0, result)
+
+
+@pytest.mark.skipif(
+    sys.version_info >= (3, 10),
+    reason="Lineage collection is not supported in python 3.10."
+    "See impala_lineage_plugin.py for more details",
+)
+@pytest.mark.usefixtures("impala_service")
+class ImpalaLineageTest(TestCase):
+    @patch.dict(
+        os.environ,
+        {
+            VDK_DB_DEFAULT_TYPE: "IMPALA",
+            VDK_IMPALA_HOST: "localhost",
+            VDK_IMPALA_PORT: "21050",
+        },
+    )
+    def test_lineage_not_collected_for_invalid_query(self):
+        mock_lineage_logger = mock.MagicMock(ILineageLogger)
+        runner = CliEntryBasedTestRunner(
+            TestConfigPlugin(mock_lineage_logger), impala_plugin
+        )
+        result: Result = runner.invoke(
+            ["run", jobs_path_from_caller_directory("sql-job-syntax-error")]
+        )
+        cli_assert_equal(1, result)
+        assert not mock_lineage_logger.send.called
+
+    @patch.dict(
+        os.environ,
+        {
+            VDK_DB_DEFAULT_TYPE: "IMPALA",
+            VDK_IMPALA_HOST: "localhost",
+            VDK_IMPALA_PORT: "21050",
+        },
+    )
+    def test_lineage_for_create_and_insert_queries(self):
+        mock_lineage_logger = mock.MagicMock(ILineageLogger)
+        runner = CliEntryBasedTestRunner(
+            TestConfigPlugin(mock_lineage_logger), impala_plugin
+        )
+        result: Result = runner.invoke(
+            ["run", jobs_path_from_caller_directory("sql-job")]
+        )
+        cli_assert_equal(0, result)
+
+        class InsertLineageDataMatcher:
+            def __eq__(self, lineage_data: LineageData):
+                # the query is different on every run of the test as it has the opid (which is unique) prepended
+                assert "INSERT INTO stocks VALUES" in lineage_data.query
+                assert lineage_data.query_type is None
+                assert lineage_data.query_status == "OK"
+                assert lineage_data.output_table.catalog is None
+                assert lineage_data.output_table.schema == "default"
+                assert lineage_data.output_table.table == "stocks"
+                assert len(lineage_data.input_tables) == 0  # no inputs for insert query
+                return True
+
+        # create table and select 1 queries should not result in sending lineage, hence test with called_once to verify
+        # that only one lineage payload has been emitted
+        mock_lineage_logger.send.assert_called_once_with(InsertLineageDataMatcher())
+
+    @patch.dict(
+        os.environ,
+        {
+            VDK_DB_DEFAULT_TYPE: "IMPALA",
+            VDK_IMPALA_HOST: "localhost",
+            VDK_IMPALA_PORT: "21050",
+        },
+    )
+    def test_lineage_for_scd1_template(self):
+        mock_lineage_logger = mock.MagicMock(ILineageLogger)
+        runner = CliEntryBasedTestRunner(
+            TestConfigPlugin(mock_lineage_logger), impala_plugin
+        )
+        schema = "default"
+        source = "scd1_source"
+        target = "scd1_target"
+        args = {
+            "source_schema": schema,
+            "source_view": source,
+            "target_schema": schema,
+            "target_table": target,
+        }
+        result: Result = runner.invoke(
+            [
+                "run",
+                jobs_path_from_caller_directory("load_dimension_scd1_template_job"),
+                "--arguments",
+                json.dumps(args),
+            ]
+        )
+        cli_assert_equal(0, result)
+
+        class SCD1LineageDataMatcher:
+            def __init__(self, outer_instance: ImpalaLineageTest):
+                self.outer_instance = outer_instance
+
+            def __eq__(self, lineage_data: LineageData):
+                assert (
+                    "INSERT OVERWRITE TABLE default.scd1_target" in lineage_data.query
+                )
+                assert "SELECT * FROM default.scd1_source" in lineage_data.query
+                assert lineage_data.query_type is None
+                assert lineage_data.query_status == "OK"
+                assert lineage_data.output_table.catalog is None
+                assert lineage_data.output_table.schema == schema
+                assert lineage_data.output_table.table == target
+                expected_inputs = [LineageTable(None, schema, source)]
+                self.outer_instance.assertCountEqual(
+                    lineage_data.input_tables, expected_inputs
+                )
+                return True
+
+        # the last emitted payload is expected to contain the lineage about the template (there are few lineage payloads
+        # that describe the insert into queries used to prepare the tables for the test)
+        mock_lineage_logger.send.assert_called_with(SCD1LineageDataMatcher(self))
+
+    @patch.dict(
+        os.environ,
+        {
+            VDK_DB_DEFAULT_TYPE: "IMPALA",
+            VDK_IMPALA_HOST: "localhost",
+            VDK_IMPALA_PORT: "21050",
+        },
+    )
+    def test_lineage_for_scd2_template(self):
+        mock_lineage_logger = mock.MagicMock(ILineageLogger)
+        runner = CliEntryBasedTestRunner(
+            TestConfigPlugin(mock_lineage_logger), impala_plugin
+        )
+        schema = "default"
+        source_table = "scd2_source"
+        target_table = "scd2_target"
+        args = {
+            "source_schema": schema,
+            "source_view": source_table,
+            "target_schema": schema,
+            "target_table": target_table,
+            "staging_schema": schema,
+            "expect_schema": "default",
+            "expect_table": "scd2_expected",
+            "start_time_column": "start_time",
+            "end_time_column": "end_time",
+            "end_time_default_value": "9999-12-31",
+            "surrogate_key_column": "sk",
+            "id_column": "id",
+        }
+        result: Result = runner.invoke(
+            [
+                "run",
+                jobs_path_from_caller_directory("load_dimension_scd2_template_job"),
+                "--arguments",
+                json.dumps(args),
+            ]
+        )
+        cli_assert_equal(0, result)
+
+        class SCD2LineageDataMatcher:
+            def __init__(self, outer_instance: ImpalaLineageTest):
+                self.outer_instance = outer_instance
+
+            def __eq__(self, lineage_data: LineageData):
+                assert (
+                    "INSERT OVERWRITE TABLE default.scd2_target" in lineage_data.query
+                )
+                assert lineage_data.query_type is None
+                assert lineage_data.query_status == "OK"
+                assert lineage_data.output_table.catalog is None
+                assert lineage_data.output_table.schema == schema
+                assert lineage_data.output_table.table == target_table
+                expected_inputs = [
+                    LineageTable(None, schema, source_table),
+                    LineageTable(None, schema, target_table),
+                ]
+                self.outer_instance.assertCountEqual(
+                    lineage_data.input_tables, expected_inputs
+                )
+                return True
+
+        # the last emitted payload is expected to contain the lineage about the template (there are few lineage payloads
+        # that describe the insert into queries used to prepare the tables for the test)
+        mock_lineage_logger.send.assert_called_with(SCD2LineageDataMatcher(self))
+
+    @patch.dict(
+        os.environ,
+        {
+            VDK_DB_DEFAULT_TYPE: "IMPALA",
+            VDK_IMPALA_HOST: "localhost",
+            VDK_IMPALA_PORT: "21050",
+        },
+    )
+    def test_lineage_for_fact_snapshot_template(self):
+        mock_lineage_logger = mock.MagicMock(ILineageLogger)
+        runner = CliEntryBasedTestRunner(
+            TestConfigPlugin(mock_lineage_logger), impala_plugin
+        )
+        schema = "default"
+        source_table = "fact_source"
+        target_table = "fact_target"
+        args = {
+            "source_schema": schema,
+            "source_view": source_table,
+            "target_schema": schema,
+            "target_table": target_table,
+            "expect_schema": schema,
+            "expect_table": "fact_expected",
+            "last_arrival_ts": "updated_at",
+        }
+        result: Result = runner.invoke(
+            [
+                "run",
+                jobs_path_from_caller_directory("load_fact_snapshot_template_job"),
+                "--arguments",
+                json.dumps(args),
+            ]
+        )
+        cli_assert_equal(0, result)
+
+        class FactSnapshotLineageDataMatcher:
+            def __init__(self, outer_instance: ImpalaLineageTest):
+                self.outer_instance = outer_instance
+
+            def __eq__(self, lineage_data: LineageData):
+                assert (
+                    "INSERT OVERWRITE TABLE default.fact_target" in lineage_data.query
+                )
+                assert lineage_data.query_type is None
+                assert lineage_data.query_status == "OK"
+                assert lineage_data.output_table.catalog is None
+                assert lineage_data.output_table.schema == schema
+                assert lineage_data.output_table.table == target_table
+                expected_inputs = [
+                    LineageTable(None, schema, source_table),
+                    LineageTable(None, schema, target_table),
+                ]
+                self.outer_instance.assertCountEqual(
+                    lineage_data.input_tables, expected_inputs
+                )
+                return True
+
+        # the last emitted payload is expected to contain the lineage about the template (there are few lineage payloads
+        # that describe the insert into queries used to prepare the tables for the test)
+        mock_lineage_logger.send.assert_called_with(
+            FactSnapshotLineageDataMatcher(self)
+        )
+
+    @patch.dict(
+        os.environ,
+        {
+            VDK_DB_DEFAULT_TYPE: "IMPALA",
+            VDK_IMPALA_HOST: "localhost",
+            VDK_IMPALA_PORT: "21050",
+        },
+    )
+    def test_lineage_for_load_versioned_template(self):
+        mock_lineage_logger = mock.MagicMock(ILineageLogger)
+        runner = CliEntryBasedTestRunner(
+            TestConfigPlugin(mock_lineage_logger), impala_plugin
+        )
+        schema = "default"
+        source_table = "versioned_source"
+        target_table = "versioned_target"
+        args = {
+            "source_schema": schema,
+            "source_view": source_table,
+            "target_schema": schema,
+            "target_table": target_table,
+            "expect_schema": schema,
+            "expect_table": "versioned_expect",
+            "id_column": "sddc_id",
+            "sk_column": "sddc_sk",
+            "value_columns": [
+                "updated_by_user_id",
+                "state",
+                "is_nsxt",
+                "cloud_vendor",
+                "version",
+            ],
+            "tracked_columns": [
+                "updated_by_user_id",
+                "state",
+                "is_nsxt",
+                "version",
+            ],
+            "active_from_column": "active_from",
+            "active_to_column": "active_to",
+            "active_to_max_value": "9999-12-31",
+            "updated_at_column": "updated_at",
+        }
+        result: Result = runner.invoke(
+            [
+                "run",
+                jobs_path_from_caller_directory("load_versioned_template_job"),
+                "--arguments",
+                json.dumps(args),
+            ]
+        )
+        cli_assert_equal(0, result)
+
+        class VersionedTemplateLineageDataMatcher:
+            def __init__(self, outer_instance: ImpalaLineageTest):
+                self.outer_instance = outer_instance
+
+            def __eq__(self, lineage_data: LineageData):
+                assert (
+                    "INSERT OVERWRITE TABLE default.versioned_target"
+                    in lineage_data.query
+                )
+                assert lineage_data.query_type is None
+                assert lineage_data.query_status == "OK"
+                assert lineage_data.output_table.catalog is None
+                assert lineage_data.output_table.schema == schema
+                assert lineage_data.output_table.table == target_table
+                expected_inputs = [
+                    LineageTable(None, schema, source_table),
+                    LineageTable(None, schema, target_table),
+                ]
+                self.outer_instance.assertCountEqual(
+                    lineage_data.input_tables, expected_inputs
+                )
+                return True
+
+        # the last emitted payload is expected to contain the lineage about the template (there are few lineage payloads
+        # that describe the insert into queries used to prepare the tables for the test)
+        mock_lineage_logger.send.assert_called_with(
+            VersionedTemplateLineageDataMatcher(self)
+        )


### PR DESCRIPTION
Add support for calculating data lineage for jobs that execute SQL queries
against impala.

Lineage is calculated by examining the query plan of the executed query. The
query plan is accessible from the cursor that executed the query, hence no
additional load is present on the target query engine. As this is not very
official way to obtain the query plan there is a risk that this implentation
may break in future impala releases.However the only option was to execute
additional explain statements that would practically double the amount of
executed queries, which could be problematic for loaded environments. Lineage
is calculated only for successfully executed queries that have actually read
or written data from/to the underlying storage.

Implemented functional tests that verify the behaviour with all templates and
simple jobs. As I hit problems starting impala with pytest, I have manually
run the docker compose file and run the tests against that instance.

New feature (non-breaking change which adds functionality)

Signed-off-by: Vladimir Petkov <petkovv@vmware.com>