### PR TITLE
vdk-csv: add export-csv command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
         args: [ --py37-plus, '--application-directories=.:src' ]
   # use latest python syntax
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.2
+    rev: v2.37.3
     hooks:
       - id: pyupgrade
         args: [ --py37-plus ]

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ If you are interested in contributing as a developer, visit [CONTRIBUTING.md](CO
 # Contacts
 Feedback is very welcome via the [GitHub site as issues](https://github.com/vmware/versatile-data-kit/issues) or [pull requests](https://github.com/vmware/versatile-data-kit/pulls)
 
-- [Join our mailing list](mailto:join-versatiledatakit@groups.vmware.com?subject=Invite%20me%20to%20the%20VDK%20mailing%20list)
 - [Follow us on twitter](https://twitter.com/intent/follow?screen_name=VDKProject).
 - Subscribe to the [Versatile Data Kit YouTube Channel](https://www.youtube.com/channel/UCasf2Q7X8nF7S4VEmcTHJ0Q).
-- [Join our dedicated Slack channel](https://cloud-native.slack.com/archives/C033PSLKCPR) on the [CNCF Slack workspace](https://events.linuxfoundation.org/archive/2020/kubecon-cloudnativecon-europe/attend/slack-guidelines/#getting-started) - simply search for #versatile-data-kit or [click here to join the channel](https://cloud-native.slack.com/archives/C033PSLKCPR)
+- [Join our dedicated Slack channel on the CNCF Slack workspace](https://communityinviter.com/apps/cloud-native/cncf)  - simply search for #versatile-data-kit or [click here to join the channel](https://cloud-native.slack.com/archives/C033PSLKCPR)
+- [Join our mailing list](mailto:join-versatiledatakit@groups.vmware.com?subject=Invite%20me%20to%20the%20VDK%20mailing%20list)
 
 # How to use Versatile Data Kit?
 - Video [Data Ingestion with Versatile Data Kit](https://youtu.be/JRV_5cxVQDU)

--- a/examples/ingest-and-anonymize-plugin/README.md
+++ b/examples/ingest-and-anonymize-plugin/README.md
@@ -1,0 +1,13 @@
+# Jobs and Anonymization POC
+
+This repositories contains sample jobs and plugin used to demonstrate how to create automated data pipeline:
+
+![ingest-and-anonymization-poc](https://user-images.githubusercontent.com/2536458/182483829-51ad1618-f36d-4ac1-93ca-d3d6a1c7085a.png)
+
+1. Ingest data in XML format . We ingest currency rate of USD to Polish Zloty for last year from Polish Bank APIs (but could be any source)
+2. Prior to writing the data to a cloud storage it de-personalize it based on configuration (provided by plugin). The POC uses sha256 but that easily could be changed (see [anonymizer.py](https://github.com/vmware/versatile-data-kit/blob/main/examples/ingest-and-anonymize-plugin/plugins/vdk-poc-anonymize/src/vdk/plugin/anonymize/anonymizer.py) )
+3. The data is written into relation database as different tables (again configurable)
+
+This repo structure:
+- Directory "jobs" contains a sample data job that can be implemented by data engineers.
+- Directory "plugins" contains a plugin expected to be developed and once installed it will be automatically applied for all data jobs created by all data engineers in the company.

--- a/examples/ingest-and-anonymize-plugin/jobs/ingest-currency-exchange-rate/README.md
+++ b/examples/ingest-and-anonymize-plugin/jobs/ingest-currency-exchange-rate/README.md
@@ -1,0 +1,94 @@
+# Ingest Example Job
+
+## Overview
+
+This is an example data job that will fetch data from https://api.nbp.pl/api (National Bank of Poland) , the conversation rate of EURO to Polish zloty in last year in XML format.
+
+For example the data is https://api.nbp.pl/api/exchangerates/rates/c/eur/2011-01-01/2012-01-01/?format=xml
+
+And it will be ingested automatically in Database tables.
+
+![ingest](https://user-images.githubusercontent.com/2536458/182484154-d346cfa6-66b5-4e0a-8f5e-6db35a6c823b.jpg)
+
+
+## Demo
+
+Install VDK:
+```
+pip install quickstart-vdk
+```
+
+Now we can run the data job, it will ingest data into local (sqlite db). This can be changed by changing ingest_method_default in config.ini
+```bash
+cd jobs
+# Install jobs dependecies locally (those are automatically installed upon 'cloud' deploy)
+pip install -r ingest-currency-exchange-rate/requirements.txt
+# run the job
+vdk run ingest-currency-exchange-rate
+```
+
+Now we can query the data from the database
+```bash
+vdk sqlite-query -q "select * from exchange_rates_series"
+```
+It would look something like
+```
+No              EffectiveDate       Bid     Ask
+--------------  ---------------  ------  ------
+246/C/NBP/2011  2011-12-21       4.408   4.497
+247/C/NBP/2011  2011-12-22       4.4015  4.4905
+```
+
+Later, we can install the plugin. Go to [../plugins/vdk-poc-anonymize](../../plugins/vdk-poc-anonymize) for more info
+```
+pip install ../plugins/vdk-poc-anonymize
+```
+and uncomment in config.ini (that can also be set system wide - applied for all jobs but that's separate topic) so it looks liek this:
+```
+ingest_payload_preprocess_sequence=anonymize
+anonymization_fields={"exchange_rates_series": ["No"]}
+```
+
+If we re-ran the job we'd see that now the "No" column is anonymized.
+
+```
+No              EffectiveDate       Bid     Ask
+--------------  ---------------  ------  ------
+86b04e00dda412  2011-01-03       3.9207  3.9999
+920505d46208ba  2011-01-04       3.9115  3.9905
+```
+
+
+## Short VDK Data Job creation and writing tutorial
+
+Versatile Data Kit feature allows you to implement automated pull ingestion and batch data processing.
+
+### Create the data job Files
+
+Data Job directory can contain any files, however there are some files that are treated in a specific way:
+
+* SQL files (.sql) - called SQL steps - are directly executed as queries against your configured database;
+* Python files (.py) - called Python steps - are Python scripts that define run function that takes as argument the job_input object;
+* config.ini is needed in order to configure the Job. This is the only file required to deploy a Data Job;
+* requirements.txt is an optional file needed when your Python steps use external python libraries.
+
+Delete all files you do not need and replace them with your own.
+
+### Data Job Code
+
+VDK supports having many Python and/or SQL steps in a single Data Job. Steps are executed in ascending alphabetical order based on file names.
+Prefixing file names with numbers makes it easy to have meaningful file names while maintaining the steps' execution order.
+
+Run the Data Job from a Terminal:
+* Make sure you have vdk installed. See Platform documentation on how to install it.
+```
+vdk run <path to Data Job directory>
+```
+
+### Deploy Data Job
+
+When a Job is ready to be deployed in a Versatile Data Kit runtime (cloud):
+Run the command below and follow its instructions (you can see its options with `vdk --help`)
+```python
+vdk deploy
+```

--- a/examples/ingest-and-anonymize-plugin/jobs/ingest-currency-exchange-rate/aa_ingest_rates.py
+++ b/examples/ingest-and-anonymize-plugin/jobs/ingest-currency-exchange-rate/aa_ingest_rates.py
@@ -1,0 +1,35 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+import requests
+import xmltodict
+from vdk.api.job_input import IJobInput
+
+log = logging.getLogger(__name__)
+
+
+def run(job_input: IJobInput):
+    """
+    Function named `run` is required in order for a python script to be recognized as a Data Job Python step and executed.
+
+    VDK provides to every python step an object - job_input - that has methods for:
+
+    * executing queries to OLAP Database;
+    * ingesting data into a database;
+    * processing data into a database.
+    See IJobInput documentation for more details.
+    """
+
+    # we are using http just as an example. But in reality the source could be anything - S3, file share, database, etc.)
+    response = requests.get(
+        "https://api.nbp.pl/api/exchangerates/rates/c/eur/2011-01-01/2012-01-01/?format=xml"
+    )
+
+    def ingest(_, data):
+        job_input.send_object_for_ingestion(
+            payload=data, destination_table="exchange_rates_series"
+        )
+        return True
+
+    xmltodict.parse(response.content, item_depth=3, item_callback=ingest)

--- a/examples/ingest-and-anonymize-plugin/jobs/ingest-currency-exchange-rate/config.ini
+++ b/examples/ingest-and-anonymize-plugin/jobs/ingest-currency-exchange-rate/config.ini
@@ -1,0 +1,27 @@
+; Supported format: https://docs.python.org/3/library/configparser.html#supported-ini-file-structure
+
+; This is the only file required to deploy a Data Job.
+; Read more to understand what each option means:
+
+; Information about the owner of the Data Job
+[owner]
+
+; Team is a way to group Data Jobs that belonged to the same team.
+team = vdk
+
+; Configuration related to running data jobs
+[job]
+; For format see https://en.wikipedia.org/wiki/Cron
+; The cron expression is evaluated in UTC time.
+; If it is time for a new job run and the previous job run hasn’t finished yet,
+; the cron job waits until the previous execution has finished.
+schedule_cron =
+
+
+[vdk]
+; Key value pairs of any configuration options that can be passed to vdk.
+; For possible options in your vdk installation execute command vdk config-help
+db_default_type=SQLITE
+ingest_method_default=SQLITE
+#ingest_payload_preprocess_sequence=anonymize
+#anonymization_fields={"exchange_rates_series": ["No"]}

--- a/examples/ingest-and-anonymize-plugin/jobs/ingest-currency-exchange-rate/requirements.txt
+++ b/examples/ingest-and-anonymize-plugin/jobs/ingest-currency-exchange-rate/requirements.txt
@@ -1,0 +1,5 @@
+# Python jobs can specify extra library dependencies in requirements.txt file.
+# See https://pip.readthedocs.io/en/stable/user_guide/#requirements-files
+# The file is optional and can be deleted if no extra library dependencies are necessary.
+
+xmltodict

--- a/examples/ingest-and-anonymize-plugin/plugins/vdk-poc-anonymize/README.md
+++ b/examples/ingest-and-anonymize-plugin/plugins/vdk-poc-anonymize/README.md
@@ -1,0 +1,30 @@
+# POC Anonymization plugin
+
+(Created from https://github.com/vmware/versatile-data-kit/tree/main/projects/vdk-plugins/plugin-template/src/vdk/plugin/plugin_template)
+
+
+POC Anonymization plugin automatically all data being ingested using Versatile Data Kit
+![anonymization-poc-plugin](https://user-images.githubusercontent.com/2536458/175018358-f671df82-8459-47a9-8dce-85f79e68133a.png)
+
+
+## Usage
+
+```
+pip install vdk-poc-anonymize
+```
+
+### Configuration
+
+(`vdk config-help` is useful command to browse all config options of your installation of vdk)
+
+| Name | Description | (example)  Value |
+|---|---|---|
+| anonymization_fields | What fields to be ingested should be anonymized.  In format of { "table/entity_name": [ <list of entity fields/columns> ] } | { "table": [ "col", "mol" ] } |
+| ingest_payload_preprocess_sequence | Must be set to "anonymize" either in job config or as environment variable  or global vdk options of the VDK Server (Control Service).  | anonymize |
+
+
+## Build and testing
+
+```
+pytest
+```

--- a/examples/ingest-and-anonymize-plugin/plugins/vdk-poc-anonymize/requirements.txt
+++ b/examples/ingest-and-anonymize-plugin/plugins/vdk-poc-anonymize/requirements.txt
@@ -1,0 +1,4 @@
+# testing dependencies
+
+pytest
+vdk-test-utils

--- a/examples/ingest-and-anonymize-plugin/plugins/vdk-poc-anonymize/setup.py
+++ b/examples/ingest-and-anonymize-plugin/plugins/vdk-poc-anonymize/setup.py
@@ -1,0 +1,21 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import pathlib
+
+import setuptools
+
+setuptools.setup(
+    name="vdk-poc-anonymize",
+    version="0.1",
+    description="POC Anonymization plugin",
+    long_description=pathlib.Path("README.md").read_text(),
+    long_description_content_type="text/markdown",
+    install_requires=["vdk-core"],
+    package_dir={"": "src"},
+    packages=setuptools.find_namespace_packages(where="src"),
+    entry_points={
+        "vdk.plugin.run": [
+            "vdk-poc-anonymize-plugin = vdk.plugin.anonymize.anonymization_plugin",
+        ]
+    },
+)

--- a/examples/ingest-and-anonymize-plugin/plugins/vdk-poc-anonymize/src/vdk/plugin/anonymize/anonymization_plugin.py
+++ b/examples/ingest-and-anonymize-plugin/plugins/vdk-poc-anonymize/src/vdk/plugin/anonymize/anonymization_plugin.py
@@ -1,0 +1,39 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import json
+import logging
+
+from vdk.api.plugin.hook_markers import hookimpl
+from vdk.api.plugin.plugin_input import IIngesterPlugin
+from vdk.internal.builtin_plugins.run.job_context import JobContext
+from vdk.internal.core.config import ConfigurationBuilder
+from vdk.plugin.anonymize.anonymizer import Anonymizer
+from vdk.plugin.anonymize.ingester_plugin import AnonymizationIngesterPlugin
+
+IngestionMetadata = IIngesterPlugin.IngestionMetadata
+
+log = logging.getLogger(__name__)
+
+
+@hookimpl(tryfirst=True)
+def vdk_configure(config_builder: ConfigurationBuilder) -> None:
+    # Declare needed configuration, it will be injected automatically fron file, env variables, etc.
+    config_builder.add(
+        key="anonymization_fields",
+        default_value='{"table_name": ["column_name"]}',
+        description="Map with entity/table name and list of attributes names that need to be anonymized."
+        "Checks are case sensitive.",
+    )
+
+
+@hookimpl
+def initialize_job(context: JobContext) -> None:
+    # Now let's get the correctly configured value
+    anonymization_fields = context.core_context.configuration.get_value(
+        "anonymization_fields"
+    )
+    anonymization_fields = json.loads(anonymization_fields)
+    context.ingester.add_ingester_factory_method(
+        "anonymize",
+        lambda: AnonymizationIngesterPlugin(anonymization_fields, Anonymizer()),
+    )

--- a/examples/ingest-and-anonymize-plugin/plugins/vdk-poc-anonymize/src/vdk/plugin/anonymize/anonymizer.py
+++ b/examples/ingest-and-anonymize-plugin/plugins/vdk-poc-anonymize/src/vdk/plugin/anonymize/anonymizer.py
@@ -1,0 +1,17 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import hashlib
+from typing import Any
+
+
+class Anonymizer:
+    """
+    Here the actual anonymizer algorithm is implemented.
+
+    Currently It is SHA256 but it could easily be change to anything that is necessary.
+
+    """
+
+    @staticmethod
+    def anonymize(value: Any):
+        return hashlib.sha256(f"{value}".encode()).hexdigest()

--- a/examples/ingest-and-anonymize-plugin/plugins/vdk-poc-anonymize/src/vdk/plugin/anonymize/ingester_plugin.py
+++ b/examples/ingest-and-anonymize-plugin/plugins/vdk-poc-anonymize/src/vdk/plugin/anonymize/ingester_plugin.py
@@ -1,0 +1,60 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+from vdk.api.plugin.plugin_input import IIngesterPlugin
+from vdk.plugin.anonymize.anonymizer import Anonymizer
+
+IngestionMetadata = IIngesterPlugin.IngestionMetadata
+
+log = logging.getLogger(__name__)
+
+
+"""
+Ingester Plugins are implemented by inheriting IIngesterPlugin and impelemented only the needed methods.
+See IIngesterPlugin docs for more info.
+"""
+
+
+class AnonymizationIngesterPlugin(IIngesterPlugin):
+    def __init__(
+        self, anonymization_fields: Dict[str, List[str]], anonymizer: Anonymizer
+    ) -> None:
+        self._anonymization_fields = anonymization_fields
+        self._anonymizer = anonymizer
+
+    def _anonymize_if_needed(self, destination_table: str, key: str, value: Any):
+        table = destination_table if destination_table else ""
+        if (
+            key
+            and table in self._anonymization_fields
+            and key in self._anonymization_fields[table]
+        ):
+            return self._anonymizer.anonymize(value)
+        else:
+            return value
+
+    # inherited
+    def pre_ingest_process(
+        self,
+        payload: List[dict],
+        destination_table: Optional[str] = None,
+        target: Optional[str] = None,
+        collection_id: Optional[str] = None,
+        metadata: IngestionMetadata = None,
+    ) -> Tuple[List[Dict], Optional[IngestionMetadata]]:
+
+        if self._anonymization_fields:
+            payload = [
+                {
+                    k: self._anonymize_if_needed(destination_table, k, v)
+                    for (k, v) in item.items()
+                }
+                for item in payload
+            ]
+        return payload, metadata

--- a/examples/ingest-and-anonymize-plugin/plugins/vdk-poc-anonymize/tests/jobs/ingest-job/10_step.py
+++ b/examples/ingest-and-anonymize-plugin/plugins/vdk-poc-anonymize/tests/jobs/ingest-job/10_step.py
@@ -1,0 +1,23 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from vdk.api.job_input import IJobInput
+
+
+def run(job_input: IJobInput):
+    obj = dict(
+        str_key="str",
+        sensitive_key="personal info!!",
+    )
+
+    job_input.send_object_for_ingestion(
+        payload=obj, destination_table="sample_entity", method="memory"
+    )
+
+    obj = dict(
+        str_key="str",
+        sensitive_key="personal info again!!",
+    )
+
+    job_input.send_object_for_ingestion(
+        payload=obj, destination_table="sample_entity", method="memory"
+    )

--- a/examples/ingest-and-anonymize-plugin/plugins/vdk-poc-anonymize/tests/test_anonymization.py
+++ b/examples/ingest-and-anonymize-plugin/plugins/vdk-poc-anonymize/tests/test_anonymization.py
@@ -1,0 +1,44 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import os
+from unittest import mock
+
+from click.testing import Result
+from vdk.plugin.anonymize import anonymization_plugin
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_funcs import jobs_path_from_caller_directory
+from vdk.plugin.test_utils.util_plugins import IngestIntoMemoryPlugin
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "VDK_INGEST_METHOD_DEFAULT": "memory",
+        "VDK_INGEST_PAYLOAD_PREPROCESS_SEQUENCE": "anonymize",
+        "VDK_ANONYMIZATION_FIELDS": '{"sample_entity": ["sensitive_key"]}',
+    },
+)
+def test_anonymization_ingestion():
+    # CliEntryBasedTestRunner (provided by vdk-test-utils) gives a way to simulate vdk command
+    # and mock large parts of it - e.g passed our own plugins
+    destination_plugin = IngestIntoMemoryPlugin()
+    runner = CliEntryBasedTestRunner(anonymization_plugin, destination_plugin)
+
+    result: Result = runner.invoke(
+        ["run", jobs_path_from_caller_directory("ingest-job")]
+    )
+    cli_assert_equal(0, result)
+
+    actual_payload = destination_plugin.payloads[0].payload
+    expected_payload = [
+        {
+            "str_key": "str",
+            "sensitive_key": "a46e1b9d0e3467d52e2dfc2e902f6c3f8c3529dde2df62652a25b4d4aebae5af",
+        },
+        {
+            "str_key": "str",
+            "sensitive_key": "d64e011391b12310cb932f47f9464d53367e5378e2d6900aa56495fba238d65c",
+        },
+    ]
+    assert actual_payload == expected_payload

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -24,6 +24,8 @@
 
 .control_service_base_build:
   image: docker:19.03.15
+  variables:
+    _JAVA_OPTIONS: "-Xms2048m -Xmx4096m"
   before_script:
     - apk --no-cache add git openjdk11-jdk curl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
     - curl -o aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator
@@ -84,6 +86,7 @@ control_service_integration_test:
     - mkdir -p ~/.kube
     - cp $KUBECONFIG ~/.kube/config
     - ./gradlew -v
+    - ./gradlew projects --info
     - ./gradlew -Djdk.tls.client.protocols=TLSv1.2 :pipelines_control_service:integrationTest --info --stacktrace
   retry: !reference [.control_service_retry, retry_options]
   artifacts:

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/BaseIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/BaseIT.java
@@ -98,6 +98,7 @@ public class BaseIT extends KerberosSecurityTestcaseJunit5 {
 
    @BeforeEach
    public void before() throws Exception {
+      log.info("Running test with: {} bytes of memory.", Runtime.getRuntime().totalMemory());
       mockMvc = MockMvcBuilders
               .webAppContextSetup(context)
               .apply(springSecurity())

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -14,6 +14,8 @@ import com.google.gson.reflect.TypeToken;
 import com.vmware.taurus.exception.JsonDissectException;
 import com.vmware.taurus.exception.KubernetesException;
 import com.vmware.taurus.exception.KubernetesJobDefinitionException;
+import com.vmware.taurus.exception.DataJobExecutionCannotBeCancelledException;
+import com.vmware.taurus.exception.ExecutionCancellationFailureReason;
 import com.vmware.taurus.service.deploy.DockerImageName;
 import com.vmware.taurus.service.deploy.JobCommandProvider;
 import com.vmware.taurus.service.model.JobAnnotation;
@@ -633,18 +635,24 @@ public abstract class KubernetesService implements InitializingBean {
     public void cancelRunningCronJob(String teamName, String jobName, String executionId) throws ApiException {
         log.info("K8S deleting job for team: {} data job name: {} execution: {}", teamName, jobName, executionId);
         try {
-            var operationResponse = new BatchV1Api(client).deleteNamespacedJob(executionId, namespace, null,
-                    null,
-                    null,
-                    null,
-                    "Foreground",
-                    null);
-            //Status of the operation. One of: "Success" or "Failure"
-            if (operationResponse.getStatus().equals("Failure")) {
-                log.warn("Failed to delete K8S job. Reason: {} Details: {}", operationResponse.getReason(), operationResponse.getDetails().toString());
-                throw new ApiException(operationResponse.getCode(), operationResponse.getMessage());
-            }
+            var operationResponse = initBatchV1Api().deleteNamespacedJob(
+                  executionId,
+                  namespace,
+                  null,
+                  null,
+                  null,
+                  null,
+                  "Foreground",
+                  null);
 
+            //Status of the operation. One of: "Success" or "Failure"
+            if (operationResponse == null || operationResponse.getStatus() == null) {
+                log.info("Execution: {} for data job: {} with team: {} not found! The data job has likely completed before it could be cancelled.", executionId, teamName, jobName);
+                throw new DataJobExecutionCannotBeCancelledException(executionId, ExecutionCancellationFailureReason.DataJobExecutionNotFound);
+            } else if (operationResponse.getStatus().equals("Failure")) {
+                log.warn("Failed to delete K8S job. Reason: {} Details: {}", operationResponse.getReason(), operationResponse.getDetails().toString());
+                throw new KubernetesException(operationResponse.getMessage(), new ApiException(operationResponse.getCode(), operationResponse.getMessage()));
+            }
         } catch (JsonSyntaxException e) {
             if (e.getCause() instanceof IllegalStateException) {
                 IllegalStateException ise = (IllegalStateException) e.getCause();

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service;
+
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.BatchV1Api;
+import io.kubernetes.client.openapi.models.V1Status;
+import io.kubernetes.client.openapi.models.V1StatusDetails;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.vmware.taurus.exception.DataJobExecutionCannotBeCancelledException;
+import com.vmware.taurus.exception.KubernetesException;
+
+public class KubernetesServiceCancelRunningCronJobTest {
+
+   @Test
+   public void testIsRunningJob_nullResponse_shouldThrowDataJobExecutionCannotBeCancelledException() throws ApiException {
+      KubernetesService kubernetesService = mockKubernetesService(null);
+
+      Assertions.assertThrows(DataJobExecutionCannotBeCancelledException.class, () ->
+            kubernetesService.cancelRunningCronJob("test-team", "test-job-name", "test-execution-id"));
+   }
+
+   @Test
+   public void testIsRunningJob_notNullResponseAndNullStatus_shouldThrowDataJobExecutionCannotBeCancelledException() throws ApiException {
+      KubernetesService kubernetesService = mockKubernetesService(new V1Status().status(null));
+
+      Assertions.assertThrows(DataJobExecutionCannotBeCancelledException.class, () ->
+            kubernetesService.cancelRunningCronJob("test-team", "test-job-name", "test-execution-id"));
+   }
+
+   @Test
+   public void testIsRunningJob_notNullResponseAndStatusSuccess_shouldNotThrowException() throws ApiException {
+      KubernetesService kubernetesService = mockKubernetesService(new V1Status().status("Success"));
+
+      Assertions.assertDoesNotThrow(() ->
+            kubernetesService.cancelRunningCronJob("test-team", "test-job-name", "test-execution-id"));
+   }
+
+   @Test
+   public void testIsRunningJob_notNullResponseAndStatusFailure_shouldThrowKubernetesException() throws ApiException {
+      V1Status v1Status = new V1Status()
+            .status("Failure")
+            .reason("test-reason")
+            .code(1)
+            .message("test-message")
+            .details(new V1StatusDetails());
+      KubernetesService kubernetesService = mockKubernetesService(v1Status);
+
+      Assertions.assertThrows(KubernetesException.class, () ->
+            kubernetesService.cancelRunningCronJob("test-team", "test-job-name", "test-execution-id"));
+   }
+
+   private KubernetesService mockKubernetesService(V1Status v1Status) throws ApiException {
+      KubernetesService kubernetesService = Mockito.mock(KubernetesService.class);
+      ReflectionTestUtils.setField(kubernetesService, // inject into this object
+            "log", // assign to this field
+            Mockito.mock(Logger.class)); // object to be injected
+      Mockito.doCallRealMethod().when(kubernetesService).cancelRunningCronJob(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+
+      BatchV1Api batchV1Api = Mockito.mock(BatchV1Api.class);
+      Mockito.when(batchV1Api.
+                  deleteNamespacedJob(
+                        Mockito.anyString(),
+                        Mockito.isNull(),
+                        Mockito.isNull(),
+                        Mockito.isNull(),
+                        Mockito.isNull(),
+                        Mockito.isNull(),
+                        Mockito.anyString(),
+                        Mockito.isNull()))
+            .thenReturn(v1Status);
+
+      Mockito.when(kubernetesService.initBatchV1Api()).thenReturn(batchV1Api);
+
+      return kubernetesService;
+   }
+}

--- a/projects/vdk-core/setup.cfg
+++ b/projects/vdk-core/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     # click 8 has some breaking changes that break vdk-control-cli
     # https://github.com/pallets/click/issues/1960
     click==8.*
-    pluggy==0.*
+    pluggy
     click_log
     click-plugins
     tenacity

--- a/projects/vdk-core/src/vdk/api/plugin/connection_hook_spec.py
+++ b/projects/vdk-core/src/vdk/api/plugin/connection_hook_spec.py
@@ -100,7 +100,7 @@ class ConnectionHookSpec:
                 # let's track duration of the query
                 start = time.time()
                 log.info(f"Starting query: {execution_cursor.get_managed_operation().get_operation()}")
-                outcome: pluggy.callers._Result
+                outcome: HookCallResult
                 outcome = yield # we yield the execution to other implementations (including default one)
                 is_success: bool = outcome.excinfo is None
                 log.info(f"Query finished. duration: {time.time() - start}. is_success: {is_success}")
@@ -112,7 +112,7 @@ class ConnectionHookSpec:
 
             @hookimpl(hookwrapper=True)
             db_connection_execute_operation(execution_cursor: ExecutionCursor) -> Optional[int]:
-                outcome: pluggy.callers._Result
+                outcome: HookCallResult
                 outcome = yield #
                 outcome.force_result(new_result)  # set new return result
 

--- a/projects/vdk-core/src/vdk/api/plugin/hook_markers.py
+++ b/projects/vdk-core/src/vdk/api/plugin/hook_markers.py
@@ -45,7 +45,7 @@ in the chain of N hook implementations.
 If ``hookwrapper`` is ``True`` the hook implementations needs to execute exactly
 one ``yield``.  The code before the ``yield`` is run early before any non-hookwrapper
 function is run.  The code after the ``yield`` is run after all non-hookwrapper
-function have run.  The ``yield`` receives a :py:class:`.callers._Result` object
+function have run.  The ``yield`` receives a :py:class:`HookCallResult` object
 representing the exception or result outcome of the inner calls (including other
 hookwrapper calls).
 Example:

--- a/projects/vdk-core/src/vdk/api/plugin/plugin_registry.py
+++ b/projects/vdk-core/src/vdk/api/plugin/plugin_registry.py
@@ -43,7 +43,9 @@ class PluginException(Exception):
 """
 Alias for the type of plugin hook call result returned in hookWrapper=True types of plugin hooks
 """
-HookCallResult = pluggy.callers._Result
+HookCallResult = (
+    pluggy.callers._Result if pluggy.__version__ < "1.0" else pluggy._callers._Result
+)
 
 
 class IPluginRegistry(metaclass=ABCMeta):

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_base.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_base.py
@@ -543,9 +543,9 @@ class IngesterBase(IIngester):
 
             log.info(
                 "Ingester statistics: \n\t\t"
-                f"Successful uploads:{self._success_count}\n\t\t"
-                f"Failed uploads:{self._fail_count}\n\t\t"
-                f"ingesting plugin errors:{self._plugin_errors}\n\t\t"
+                f"Successful uploads: {self._success_count}\n\t\t"
+                f"Failed uploads: {self._fail_count}\n\t\t"
+                f"Ingesting plugin errors: {'None' if not self._plugin_errors else dict(self._plugin_errors)}\n\t\t"
             )
 
     def _pre_process_payload(

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/job_properties/inmemproperties.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/job_properties/inmemproperties.py
@@ -22,5 +22,9 @@ class InMemPropertiesServiceClient(IPropertiesServiceClient):
         return res
 
     def write_properties(self, job_name: str, team_name: str, properties: Dict) -> Dict:
+        log.warning(
+            "You are using In Memory Properties client. "
+            "That means the properties will not be persisted past the Data Job run."
+        )
         self._props = deepcopy(properties)
         return self._props

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/job_properties/properties_api_plugin.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/job_properties/properties_api_plugin.py
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 from vdk.api.plugin.hook_markers import hookimpl
 from vdk.internal.builtin_plugins.job_properties import properties_config
+from vdk.internal.builtin_plugins.job_properties.inmemproperties import (
+    InMemPropertiesServiceClient,
+)
+from vdk.internal.builtin_plugins.run.job_context import JobContext
 from vdk.internal.core.config import ConfigurationBuilder
 
 
@@ -13,3 +17,9 @@ class PropertiesApiPlugin:
     @hookimpl(tryfirst=True)
     def vdk_configure(self, config_builder: ConfigurationBuilder) -> None:
         properties_config.add_definitions(config_builder)
+
+    @hookimpl
+    def initialize_job(self, context: JobContext) -> None:
+        context.properties.set_properties_factory_method(
+            "memory", lambda: InMemPropertiesServiceClient()
+        )

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/execution_tracking.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/execution_tracking.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import pluggy
 from vdk.api.plugin.hook_markers import hookimpl
+from vdk.api.plugin.plugin_registry import HookCallResult
 from vdk.internal.builtin_plugins.config import vdk_config
 from vdk.internal.builtin_plugins.run.execution_results import ExecutionResult
 from vdk.internal.builtin_plugins.run.execution_results import StepResult
@@ -38,7 +39,7 @@ class ExecutionTrackingPlugin:
         It executes the provided steps starting from context.step_tree_root in sequential order (using BFS)
         using
         """
-        out: pluggy.callers._Result
+        out: HookCallResult
         out = yield
 
         result: ExecutionResult = out.get_result()
@@ -50,7 +51,7 @@ class ExecutionTrackingPlugin:
         state = context.core_context.state
 
         state.get(ExecutionStateStoreKeys.STEPS_STARTED).append(step.name)
-        out: pluggy.callers._Result
+        out: HookCallResult
         out = yield
         if out.excinfo:
             state.get(ExecutionStateStoreKeys.STEPS_FAILED).append(step.name)

--- a/projects/vdk-core/tests/functional/run/test_run_errors.py
+++ b/projects/vdk-core/tests/functional/run/test_run_errors.py
@@ -84,7 +84,7 @@ def test_run_job_plugin_fails(tmp_termination_msg_file):
 
     class RunJobFailsPlugin:
         @staticmethod
-        @hookimpl(hookwrapper=True)
+        @hookimpl()
         def run_job(context: JobContext) -> None:
             raise OverflowError("Overflow")
 

--- a/projects/vdk-core/tests/functional/run/test_run_sql_queries.py
+++ b/projects/vdk-core/tests/functional/run/test_run_sql_queries.py
@@ -7,10 +7,10 @@ from typing import cast
 from typing import Optional
 from unittest import mock
 
-import pluggy
 from click.testing import Result
 from functional.run.util import job_path
 from vdk.api.plugin.hook_markers import hookimpl
+from vdk.api.plugin.plugin_registry import HookCallResult
 from vdk.internal.builtin_plugins.connection.execution_cursor import ExecutionCursor
 from vdk.internal.builtin_plugins.connection.pep249.interfaces import PEP249Connection
 from vdk.internal.builtin_plugins.connection.recovery_cursor import RecoveryCursor
@@ -257,7 +257,7 @@ class DbOperationTrackPlugin:
         self, execution_cursor: ExecutionCursor
     ) -> Optional[int]:
         self.log.append("start")
-        out: pluggy.callers._Result
+        out: HookCallResult
         out = yield
         self.log.append(("end", out.excinfo is None))
 

--- a/projects/vdk-plugins/airflow-provider-vdk/README.md
+++ b/projects/vdk-plugins/airflow-provider-vdk/README.md
@@ -1,3 +1,62 @@
-## Versatile Data Kit Airflow provider
+# Versatile Data Kit Airflow provider
 
 A set of Airflow operators, sensors and a connection hook intended to help schedule Versatile Data Kit jobs using Apache Airflow.
+
+# Usage
+
+To install it simply run:
+```
+pip install airflow-provider-vdk
+```
+
+Then you can create a workflow of data jobs (deployed by VDK Control Service) like this:
+
+```
+from datetime import datetime
+
+from airflow import DAG
+from vdk_provider.operators.vdk import VDKOperator
+
+with DAG(
+    "airflow_example_vdk",
+    schedule_interval=None,
+    start_date=datetime(2022, 1, 1),
+    catchup=False,
+    tags=["example", "vdk"],
+) as dag:
+    trino_job1 = VDKOperator(
+        conn_id="vdk-default",
+        job_name="airflow-trino-job1",
+        team_name="taurus",
+        task_id="trino-job1",
+    )
+
+    trino_job2 = VDKOperator(
+        conn_id="vdk-default",
+        job_name="airflow-trino-job2",
+        team_name="taurus",
+        task_id="trino-job2",
+    )
+
+    transform_job = VDKOperator(
+        conn_id="vdk-default",
+        job_name="airflow-transform-job",
+        team_name="taurus",
+        task_id="transform-job",
+    )
+
+    [trino_job1, trino_job2] >> transform_job
+
+```
+
+# Example
+
+See [full example here](https://github.com/vmware/versatile-data-kit/tree/main/examples/airflow-example)
+
+# Demo
+
+You can see demo during one of the community meetings here: https://www.youtube.com/watch?v=c3j1aOALjVU&t=690s
+
+# Architecture
+
+See the [vdk enhancement proposal spec here](https://github.com/vmware/versatile-data-kit/tree/main/specs/vep-554-apache-airflow-integration)

--- a/projects/vdk-plugins/vdk-csv/requirements.txt
+++ b/projects/vdk-plugins/vdk-csv/requirements.txt
@@ -1,7 +1,7 @@
 pandas
 vdk-core
 
+vdk-sqlite
+
 # testing
 vdk-test-utils
-
-vdk-sqlite

--- a/projects/vdk-plugins/vdk-csv/requirements.txt
+++ b/projects/vdk-plugins/vdk-csv/requirements.txt
@@ -4,4 +4,4 @@ vdk-core
 # testing
 vdk-test-utils
 
-
+vdk-sqlite

--- a/projects/vdk-plugins/vdk-csv/requirements.txt
+++ b/projects/vdk-plugins/vdk-csv/requirements.txt
@@ -3,3 +3,5 @@ vdk-core
 
 # testing
 vdk-test-utils
+
+

--- a/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_export_job/csv_export_step.py
+++ b/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_export_job/csv_export_step.py
@@ -1,7 +1,7 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
-import logging
 import csv
+import logging
 
 from vdk.api.job_input import IJobInput
 from vdk.internal.core import errors
@@ -28,9 +28,7 @@ class CsvExporter:
             writer = csv.writer(f, lineterminator="\n")
             for row in query_result:
                 writer.writerow(row)
-        log.info(
-            f"Exported data successfully.You can find the result here: {fullpath}"
-        )
+        log.info(f"Exported data successfully.You can find the result here: {fullpath}")
 
 
 def run(job_input: IJobInput) -> None:

--- a/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_export_job/csv_export_step.py
+++ b/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_export_job/csv_export_step.py
@@ -1,0 +1,40 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+import csv
+
+from vdk.api.job_input import IJobInput
+from vdk.internal.core import errors
+
+log = logging.getLogger(__name__)
+
+
+class CsvExporter:
+    def __init__(self, job_input: IJobInput):
+        self.__job_input = job_input
+
+    def export(self, query: str, fullpath: str):
+        query_result = self.__job_input.execute_query(query)
+        if not query_result:
+            errors.log_and_throw(
+                errors.ResolvableBy.USER_ERROR,
+                log,
+                "Cannot create the result csv file.",
+                f"""No data was found """,
+                "Will not proceed with exporting",
+                "Try with another query or check the database explicitly.",
+            )
+        with open(fullpath, "w", encoding="UTF8", newline="") as f:
+            writer = csv.writer(f, lineterminator="\n")
+            for row in query_result:
+                writer.writerow(row)
+        log.info(
+            f"Exported data successfully.You can find the result here: {fullpath}"
+        )
+
+
+def run(job_input: IJobInput) -> None:
+    query = job_input.get_arguments().get("query")
+    fullpath = job_input.get_arguments().get("fullpath")
+    exporter = CsvExporter(job_input)
+    exporter.export(query, fullpath)

--- a/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_export_job/csv_export_step.py
+++ b/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_export_job/csv_export_step.py
@@ -15,15 +15,6 @@ class CsvExporter:
 
     def export(self, query: str, fullpath: str):
         query_result = self.__job_input.execute_query(query)
-        if not query_result:
-            errors.log_and_throw(
-                errors.ResolvableBy.USER_ERROR,
-                log,
-                "Cannot create the result csv file.",
-                """No data was found """,
-                "Will not proceed with exporting",
-                "Try with another query or check the database explicitly.",
-            )
         with open(fullpath, "w", encoding="UTF8", newline="") as f:
             writer = csv.writer(f, lineterminator="\n")
             for row in query_result:

--- a/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_export_job/csv_export_step.py
+++ b/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_export_job/csv_export_step.py
@@ -20,7 +20,7 @@ class CsvExporter:
                 errors.ResolvableBy.USER_ERROR,
                 log,
                 "Cannot create the result csv file.",
-                f"""No data was found """,
+                """No data was found """,
                 "Will not proceed with exporting",
                 "Try with another query or check the database explicitly.",
             )

--- a/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_plugin.py
@@ -92,37 +92,43 @@ def ingest_csv(ctx: Context, file: str, table_name: str, options: str) -> None:
 Examples:
 
 \b
-# This will execute the given query and save the data 
-# in a CSV file with name result.csv in the current directory 
-# if there is no file with the same name there 
+# This will execute the given query and save the data
+# in a CSV file with name result.csv in the current directory
+# if there is no file with the same name there
 vdk export-csv -q  "SELECT * FROM test_table"
 
 \b
-# This will execute the given query and save the data 
+# This will execute the given query and save the data
 # in a CSV file with name result1.csv in User/Documents/csv
-# if there is no file with the same name there 
+# if there is no file with the same name there
 vdk export-csv -q  "SELECT * FROM test_table" -p User/Documents/csv -n result1.csv
 
     """,
     no_args_is_help=True,
 )
-@click.option("-q",
-              "--query",
-              type=click.STRING,
-              required=True,
-              help="The query that will be executed against the specified database.")
-@click.option("-n",
-              "--name",
-              type=click.STRING,
-              default="result.csv",
-              required=False,
-              help="The name of the CSV file that will be created.")
-@click.option("-p",
-              "--path",
-              type=click.STRING,
-              default="",
-              required=False,
-              help="Path to the directory where the CSV file will be saved.")
+@click.option(
+    "-q",
+    "--query",
+    type=click.STRING,
+    required=True,
+    help="The query that will be executed against the specified database.",
+)
+@click.option(
+    "-n",
+    "--name",
+    type=click.STRING,
+    default="result.csv",
+    required=False,
+    help="The name of the CSV file that will be created.",
+)
+@click.option(
+    "-p",
+    "--path",
+    type=click.STRING,
+    default="",
+    required=False,
+    help="Path to the directory where the CSV file will be saved.",
+)
 @click.pass_context
 def export_csv(ctx: click.Context, query, name: str, path: str):
     if not path:

--- a/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_plugin.py
@@ -11,9 +11,9 @@ import click
 from click import Context
 from vdk.api.plugin.hook_markers import hookimpl
 from vdk.internal.builtin_plugins.run.cli_run import run
-from vdk.plugin.csv.csv_ingest_job import csv_ingest_step
 from vdk.internal.core import errors
 from vdk.plugin.csv.csv_export_job import csv_export_step
+from vdk.plugin.csv.csv_ingest_job import csv_ingest_step
 
 log = logging.getLogger(__name__)
 
@@ -108,9 +108,9 @@ def export_csv(ctx: click.Context, query, name: str, path: str):
         )
     args = dict(query=query, fullpath=fullpath)
     ctx.invoke(
-                run,
-                data_job_directory=os.path.dirname(csv_export_step.__file__),
-                arguments=json.dumps(args),
+        run,
+        data_job_directory=os.path.dirname(csv_export_step.__file__),
+        arguments=json.dumps(args),
     )
 
 

--- a/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/src/vdk/plugin/csv/csv_plugin.py
@@ -87,11 +87,42 @@ def ingest_csv(ctx: Context, file: str, table_name: str, options: str) -> None:
 
 @click.command(
     name="export-csv",
-    help="Execute a SQL query against a configured database and export the result to a local CSV file.",
+    help="Execute a SQL query against a configured database and export the result to a local CSV file."
+    """
+Examples:
+
+\b
+# This will execute the given query and save the data 
+# in a CSV file with name result.csv in the current directory 
+# if there is no file with the same name there 
+vdk export-csv -q  "SELECT * FROM test_table"
+
+\b
+# This will execute the given query and save the data 
+# in a CSV file with name result1.csv in User/Documents/csv
+# if there is no file with the same name there 
+vdk export-csv -q  "SELECT * FROM test_table" -p User/Documents/csv -n result1.csv
+
+    """,
+    no_args_is_help=True,
 )
-@click.option("-q", "--query", type=click.STRING, required=True)
-@click.option("-n", "--name", type=click.STRING, default="result.csv", required=False)
-@click.option("-p", "--path", type=click.STRING, default="", required=False)
+@click.option("-q",
+              "--query",
+              type=click.STRING,
+              required=True,
+              help="The query that will be executed against the specified database.")
+@click.option("-n",
+              "--name",
+              type=click.STRING,
+              default="result.csv",
+              required=False,
+              help="The name of the CSV file that will be created.")
+@click.option("-p",
+              "--path",
+              type=click.STRING,
+              default="",
+              required=False,
+              help="Path to the directory where the CSV file will be saved.")
 @click.pass_context
 def export_csv(ctx: click.Context, query, name: str, path: str):
     if not path:

--- a/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
@@ -135,7 +135,9 @@ def test_export_csv_with_already_existing_file():
         f"{path}\n"
         "   CONSEQUENCES : Will not proceed with exporting\n"
         "COUNTERMEASURES : Use another name or choose another location for the file\n"
-    ) in runner.invoke(["export-csv", "--query", "SELECT * FROM test_table", "--name", "result2.csv"]).stdout
+    ) in runner.invoke(
+        ["export-csv", "--query", "SELECT * FROM test_table", "--name", "result2.csv"]
+    ).stdout
 
 
 def test_csv_export_with_no_data(tmpdir):
@@ -177,11 +179,12 @@ def test_csv_export_with_no_data(tmpdir):
             "WHY IT HAPPENED : No data was found\n"
             "   CONSEQUENCES : Will not proceed with exporting\n"
             "COUNTERMEASURES : Try with another query or check the database explicitly.\n"
-        ) in runner.invoke([
+        ) in runner.invoke(
+            [
                 "export-csv",
                 "--query",
                 "SELECT * FROM test_table",
                 "--name",
                 "result3.csv",
-            ]).stdout
-
+            ]
+        ).stdout

--- a/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
@@ -126,25 +126,34 @@ def test_csv_export(tmpdir):
 def test_export_csv_with_already_existing_file(tmpdir):
     db_dir = str(tmpdir) + "vdk-sqlite.db"
     with mock.patch.dict(
-            os.environ,
-            {
-                "VDK_DB_DEFAULT_TYPE": "SQLITE",
-                "VDK_SQLITE_FILE": db_dir,
-            },
+        os.environ,
+        {
+            "VDK_DB_DEFAULT_TYPE": "SQLITE",
+            "VDK_SQLITE_FILE": db_dir,
+        },
     ):
         path = os.path.abspath(os.getcwd())
         open(os.path.join(path, "result2.csv"), "w")
         runner = CliEntryBasedTestRunner(csv_plugin)
-        result = runner.invoke(["export-csv", "--query", "SELECT * FROM test_table", "--name", "result2.csv"])
+        result = runner.invoke(
+            [
+                "export-csv",
+                "--query",
+                "SELECT * FROM test_table",
+                "--name",
+                "result2.csv",
+            ]
+        )
         result_output = str(result.output)
         assert (
-                   'Error: An error in data job code  occurred. The error should be resolved by '
-                   'User Error. Here are the details:\n'
-                   '  WHAT HAPPENED : Cannot create the result csv file.\n'
-                   'WHY IT HAPPENED : File with name result2.csv already exists in '
-                   f'{path}\n'
-                   '   CONSEQUENCES : Will not proceed with exporting\n'
-                   'COUNTERMEASURES : Use another name or choose another location for the file\n') in result_output
+            "Error: An error in data job code  occurred. The error should be resolved by "
+            "User Error. Here are the details:\n"
+            "  WHAT HAPPENED : Cannot create the result csv file.\n"
+            "WHY IT HAPPENED : File with name result2.csv already exists in "
+            f"{path}\n"
+            "   CONSEQUENCES : Will not proceed with exporting\n"
+            "COUNTERMEASURES : Use another name or choose another location for the file\n"
+        ) in result_output
 
 
 def test_csv_export_with_no_data(tmpdir):
@@ -179,12 +188,21 @@ def test_csv_export_with_no_data(tmpdir):
             destination_table="test_table",
             target=db_dir,
         )
-        result = runner.invoke(["export-csv", "--query", "SELECT * FROM test_table", "--name", "result3.csv"])
+        result = runner.invoke(
+            [
+                "export-csv",
+                "--query",
+                "SELECT * FROM test_table",
+                "--name",
+                "result3.csv",
+            ]
+        )
         result_output = str(result.output)
         assert (
-                    'Error: An error in data job code  occurred. The error should be resolved by '
-                    'User Error. Here are the details:\n'
-                    '  WHAT HAPPENED : Cannot create the result csv file.\n'
-                    'WHY IT HAPPENED : No data was found\n'
-                    '   CONSEQUENCES : Will not proceed with exporting\n'
-                    'COUNTERMEASURES : Try with another query or check the database explicitly.\n') in result_output
+            "Error: An error in data job code  occurred. The error should be resolved by "
+            "User Error. Here are the details:\n"
+            "  WHAT HAPPENED : Cannot create the result csv file.\n"
+            "WHY IT HAPPENED : No data was found\n"
+            "   CONSEQUENCES : Will not proceed with exporting\n"
+            "COUNTERMEASURES : Try with another query or check the database explicitly.\n"
+        ) in result_output

--- a/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
@@ -127,7 +127,9 @@ def test_export_csv_with_already_existing_file():
     path = os.path.abspath(os.getcwd())
     open(os.path.join(path, "result2.csv"), "w")
     runner = CliEntryBasedTestRunner(csv_plugin)
-    result = runner.invoke(["export-csv", "--query", "SELECT * FROM test_table", "--name", "result2.csv"])
+    result = runner.invoke(
+        ["export-csv", "--query", "SELECT * FROM test_table", "--name", "result2.csv"]
+    )
     raise Exception(f"RESULT: {result.__dict__}")
     """
     assert runner.invoke(
@@ -176,13 +178,15 @@ def test_csv_export_with_no_data(tmpdir):
             destination_table="test_table",
             target=db_dir,
         )
-        result = runner.invoke([
-                    "export-csv",
-                    "--query",
-                    "SELECT * FROM test_table",
-                    "--name",
-                    "result3.csv",
-                ])
+        result = runner.invoke(
+            [
+                "export-csv",
+                "--query",
+                "SELECT * FROM test_table",
+                "--name",
+                "result3.csv",
+            ]
+        )
         raise Exception(f"RESULT: {result.__dict__}")
         """
         assert str(

--- a/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
@@ -5,6 +5,7 @@ import os
 from unittest import mock
 
 from click.testing import Result
+from vdk.internal.core.errors import UserCodeError
 from vdk.plugin.csv import csv_plugin
 from vdk.plugin.sqlite import sqlite_plugin
 from vdk.plugin.sqlite.ingest_to_sqlite import IngestToSQLite
@@ -144,6 +145,7 @@ def test_export_csv_with_already_existing_file(tmpdir):
                 "result2.csv",
             ]
         )
+        assert isinstance(result.exception, UserCodeError)
         cli_assert_equal(1, result)
 
 
@@ -188,4 +190,5 @@ def test_csv_export_with_no_data(tmpdir):
                 "result3.csv",
             ]
         )
+        assert isinstance(result.exception, UserCodeError)
         cli_assert_equal(1, result)

--- a/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
@@ -127,6 +127,9 @@ def test_export_csv_with_already_existing_file():
     path = os.path.abspath(os.getcwd())
     open(os.path.join(path, "result2.csv"), "w")
     runner = CliEntryBasedTestRunner(csv_plugin)
+    result = runner.invoke(["export-csv", "--query", "SELECT * FROM test_table", "--name", "result2.csv"])
+    raise Exception(f"RESULT: {result.__dict__}")
+    """
     assert runner.invoke(
         ["export-csv", "--query", "SELECT * FROM test_table", "--name", "result2.csv"]
     ).output == (
@@ -138,6 +141,7 @@ def test_export_csv_with_already_existing_file():
         "   CONSEQUENCES : Will not proceed with exporting\n"
         "COUNTERMEASURES : Use another name or choose another location for the file\n"
     )
+    """
 
 
 def test_csv_export_with_no_data(tmpdir):
@@ -172,6 +176,15 @@ def test_csv_export_with_no_data(tmpdir):
             destination_table="test_table",
             target=db_dir,
         )
+        result = runner.invoke([
+                    "export-csv",
+                    "--query",
+                    "SELECT * FROM test_table",
+                    "--name",
+                    "result3.csv",
+                ])
+        raise Exception(f"RESULT: {result.__dict__}")
+        """
         assert str(
             runner.invoke(
                 [
@@ -190,3 +203,4 @@ def test_csv_export_with_no_data(tmpdir):
             "   CONSEQUENCES : Will not proceed with exporting\n"
             "COUNTERMEASURES : Try with another query or check the database explicitly.\n"
         )
+        """

--- a/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
@@ -13,6 +13,7 @@ from vdk.plugin.test_utils.util_funcs import cli_assert_equal
 from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
 from vdk.plugin.test_utils.util_plugins import IngestIntoMemoryPlugin
 
+
 def _get_file(filename):
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), filename)
 
@@ -84,11 +85,11 @@ def test_ingestion_csv_with_options():
 def test_csv_export(tmpdir):
     db_dir = str(tmpdir) + "vdk-sqlite.db"
     with mock.patch.dict(
-            os.environ,
-            {
-                "VDK_DB_DEFAULT_TYPE": "SQLITE",
-                "VDK_SQLITE_FILE": db_dir,
-            },
+        os.environ,
+        {
+            "VDK_DB_DEFAULT_TYPE": "SQLITE",
+            "VDK_SQLITE_FILE": db_dir,
+        },
     ):
         runner = CliEntryBasedTestRunner(sqlite_plugin, csv_plugin)
         runner.invoke(
@@ -124,26 +125,29 @@ def test_csv_export(tmpdir):
 
 def test_export_csv_with_already_existing_file():
     path = os.path.abspath(os.getcwd())
-    open(os.path.join(path, 'result2.csv'), 'w')
+    open(os.path.join(path, "result2.csv"), "w")
     runner = CliEntryBasedTestRunner(csv_plugin)
-    assert runner.invoke(["export-csv", "--query", "SELECT * FROM test_table", "--name", "result2.csv"]).output == (
-            'Error: An error in data job code  occurred. The error should be resolved by '
-            'User Error. Here are the details:\n'
-            '  WHAT HAPPENED : Cannot create the result csv file.\n'
-            'WHY IT HAPPENED : File with name result2.csv already exists in '
-            f'{path}\n'
-            '   CONSEQUENCES : Will not proceed with exporting\n'
-            'COUNTERMEASURES : Use another name or choose another location for the file\n')
+    assert runner.invoke(
+        ["export-csv", "--query", "SELECT * FROM test_table", "--name", "result2.csv"]
+    ).output == (
+        "Error: An error in data job code  occurred. The error should be resolved by "
+        "User Error. Here are the details:\n"
+        "  WHAT HAPPENED : Cannot create the result csv file.\n"
+        "WHY IT HAPPENED : File with name result2.csv already exists in "
+        f"{path}\n"
+        "   CONSEQUENCES : Will not proceed with exporting\n"
+        "COUNTERMEASURES : Use another name or choose another location for the file\n"
+    )
 
 
 def test_csv_export_with_no_data(tmpdir):
     db_dir = str(tmpdir) + "vdk-sqlite.db"
     with mock.patch.dict(
-            os.environ,
-            {
-                "VDK_DB_DEFAULT_TYPE": "SQLITE",
-                "VDK_SQLITE_FILE": db_dir,
-            },
+        os.environ,
+        {
+            "VDK_DB_DEFAULT_TYPE": "SQLITE",
+            "VDK_SQLITE_FILE": db_dir,
+        },
     ):
         runner = CliEntryBasedTestRunner(sqlite_plugin, csv_plugin)
         runner.invoke(
@@ -168,10 +172,21 @@ def test_csv_export_with_no_data(tmpdir):
             destination_table="test_table",
             target=db_dir,
         )
-        assert str(runner.invoke(["export-csv", "--query", "SELECT * FROM test_table", "--name", "result3.csv"]).output).__contains__(
-                       'Error: An error in data job code  occurred. The error should be resolved by '
-                       'User Error. Here are the details:\n'
-                       '  WHAT HAPPENED : Cannot create the result csv file.\n'
-                       'WHY IT HAPPENED : No data was found\n'
-                       '   CONSEQUENCES : Will not proceed with exporting\n'
-                       'COUNTERMEASURES : Try with another query or check the database explicitly.\n')
+        assert str(
+            runner.invoke(
+                [
+                    "export-csv",
+                    "--query",
+                    "SELECT * FROM test_table",
+                    "--name",
+                    "result3.csv",
+                ]
+            ).output
+        ).__contains__(
+            "Error: An error in data job code  occurred. The error should be resolved by "
+            "User Error. Here are the details:\n"
+            "  WHAT HAPPENED : Cannot create the result csv file.\n"
+            "WHY IT HAPPENED : No data was found\n"
+            "   CONSEQUENCES : Will not proceed with exporting\n"
+            "COUNTERMEASURES : Try with another query or check the database explicitly.\n"
+        )

--- a/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
@@ -127,14 +127,7 @@ def test_export_csv_with_already_existing_file():
     path = os.path.abspath(os.getcwd())
     open(os.path.join(path, "result2.csv"), "w")
     runner = CliEntryBasedTestRunner(csv_plugin)
-    result = runner.invoke(
-        ["export-csv", "--query", "SELECT * FROM test_table", "--name", "result2.csv"]
-    )
-    raise Exception(f"RESULT: {result.__dict__}")
-    """
-    assert runner.invoke(
-        ["export-csv", "--query", "SELECT * FROM test_table", "--name", "result2.csv"]
-    ).output == (
+    assert (
         "Error: An error in data job code  occurred. The error should be resolved by "
         "User Error. Here are the details:\n"
         "  WHAT HAPPENED : Cannot create the result csv file.\n"
@@ -142,8 +135,7 @@ def test_export_csv_with_already_existing_file():
         f"{path}\n"
         "   CONSEQUENCES : Will not proceed with exporting\n"
         "COUNTERMEASURES : Use another name or choose another location for the file\n"
-    )
-    """
+    ) in runner.invoke(["export-csv", "--query", "SELECT * FROM test_table", "--name", "result2.csv"]).stdout
 
 
 def test_csv_export_with_no_data(tmpdir):
@@ -178,33 +170,18 @@ def test_csv_export_with_no_data(tmpdir):
             destination_table="test_table",
             target=db_dir,
         )
-        result = runner.invoke(
-            [
-                "export-csv",
-                "--query",
-                "SELECT * FROM test_table",
-                "--name",
-                "result3.csv",
-            ]
-        )
-        raise Exception(f"RESULT: {result.__dict__}")
-        """
-        assert str(
-            runner.invoke(
-                [
-                    "export-csv",
-                    "--query",
-                    "SELECT * FROM test_table",
-                    "--name",
-                    "result3.csv",
-                ]
-            ).output
-        ).__contains__(
+        assert (
             "Error: An error in data job code  occurred. The error should be resolved by "
             "User Error. Here are the details:\n"
             "  WHAT HAPPENED : Cannot create the result csv file.\n"
             "WHY IT HAPPENED : No data was found\n"
             "   CONSEQUENCES : Will not proceed with exporting\n"
             "COUNTERMEASURES : Try with another query or check the database explicitly.\n"
-        )
-        """
+        ) in runner.invoke([
+                "export-csv",
+                "--query",
+                "SELECT * FROM test_table",
+                "--name",
+                "result3.csv",
+            ]).stdout
+

--- a/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
@@ -1,14 +1,17 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import csv
 import os
 from unittest import mock
 
 from click.testing import Result
 from vdk.plugin.csv import csv_plugin
+from vdk.plugin.sqlite import sqlite_plugin
+from vdk.plugin.sqlite.ingest_to_sqlite import IngestToSQLite
+from vdk.plugin.sqlite.sqlite_configuration import SQLiteConfiguration
 from vdk.plugin.test_utils.util_funcs import cli_assert_equal
 from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
 from vdk.plugin.test_utils.util_plugins import IngestIntoMemoryPlugin
-
 
 def _get_file(filename):
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), filename)
@@ -76,3 +79,99 @@ def test_ingestion_csv_with_options():
 
     assert len(ingest_plugin.payloads) > 0
     assert ingest_plugin.payloads[0].payload[0]["US Zip"] == "08056"
+
+
+def test_csv_export(tmpdir):
+    db_dir = str(tmpdir) + "vdk-sqlite.db"
+    with mock.patch.dict(
+            os.environ,
+            {
+                "VDK_DB_DEFAULT_TYPE": "SQLITE",
+                "VDK_SQLITE_FILE": db_dir,
+            },
+    ):
+        runner = CliEntryBasedTestRunner(sqlite_plugin, csv_plugin)
+        runner.invoke(
+            [
+                "sqlite-query",
+                "--query",
+                "CREATE TABLE test_table (some_data TEXT, more_data TEXT)",
+            ]
+        )
+
+        mock_sqlite_conf = mock.MagicMock(SQLiteConfiguration)
+        sqlite_ingest = IngestToSQLite(mock_sqlite_conf)
+        payload = [
+            {"some_data": "some_test_data", "more_data": "more_test_data"},
+            {"some_data": "some_test_data_copy", "more_data": "more_test_data_copy"},
+        ]
+
+        sqlite_ingest.ingest_payload(
+            payload=payload,
+            destination_table="test_table",
+            target=db_dir,
+        )
+
+        runner.invoke(["export-csv", "--query", "SELECT * FROM test_table"])
+        output = []
+        with open(os.path.join(os.path.abspath(os.getcwd()), "result.csv")) as file:
+            reader = csv.reader(file, delimiter=",")
+            for row in reader:
+                output.append(row)
+        assert output[0] == ["some_test_data", "more_test_data"]
+        assert output[1] == ["some_test_data_copy", "more_test_data_copy"]
+
+
+def test_export_csv_with_already_existing_file():
+    path = os.path.abspath(os.getcwd())
+    open(os.path.join(path, 'result2.csv'), 'w')
+    runner = CliEntryBasedTestRunner(csv_plugin)
+    assert runner.invoke(["export-csv", "--query", "SELECT * FROM test_table", "--name", "result2.csv"]).output == (
+            'Error: An error in data job code  occurred. The error should be resolved by '
+            'User Error. Here are the details:\n'
+            '  WHAT HAPPENED : Cannot create the result csv file.\n'
+            'WHY IT HAPPENED : File with name result2.csv already exists in '
+            f'{path}\n'
+            '   CONSEQUENCES : Will not proceed with exporting\n'
+            'COUNTERMEASURES : Use another name or choose another location for the file\n')
+
+
+def test_csv_export_with_no_data(tmpdir):
+    db_dir = str(tmpdir) + "vdk-sqlite.db"
+    with mock.patch.dict(
+            os.environ,
+            {
+                "VDK_DB_DEFAULT_TYPE": "SQLITE",
+                "VDK_SQLITE_FILE": db_dir,
+            },
+    ):
+        runner = CliEntryBasedTestRunner(sqlite_plugin, csv_plugin)
+        runner.invoke(
+            [
+                "sqlite-query",
+                "--query",
+                "DROP TABLE IF EXISTS test_table",
+            ]
+        )
+        runner.invoke(
+            [
+                "sqlite-query",
+                "--query",
+                "CREATE TABLE test_table (some_data TEXT, more_data TEXT)",
+            ]
+        )
+        mock_sqlite_conf = mock.MagicMock(SQLiteConfiguration)
+        sqlite_ingest = IngestToSQLite(mock_sqlite_conf)
+        payload = []
+        sqlite_ingest.ingest_payload(
+            payload=payload,
+            destination_table="test_table",
+            target=db_dir,
+        )
+        assert str(runner.invoke(["export-csv", "--query", "SELECT * FROM test_table", "--name", "result3.csv"]).output).__contains__(
+                       'Error: An error in data job code  occurred. The error should be resolved by '
+                       'User Error. Here are the details:\n'
+                       '  WHAT HAPPENED : Cannot create the result csv file.\n'
+                       'WHY IT HAPPENED : No data was found\n'
+                       '   CONSEQUENCES : Will not proceed with exporting\n'
+                       'COUNTERMEASURES : Try with another query or check the database explicitly.\n')

--- a/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
@@ -144,16 +144,7 @@ def test_export_csv_with_already_existing_file(tmpdir):
                 "result2.csv",
             ]
         )
-        result_output = str(result.output)
-        assert (
-            "Error: An error in data job code  occurred. The error should be resolved by "
-            "User Error. Here are the details:\n"
-            "  WHAT HAPPENED : Cannot create the result csv file.\n"
-            "WHY IT HAPPENED : File with name result2.csv already exists in "
-            f"{path}\n"
-            "   CONSEQUENCES : Will not proceed with exporting\n"
-            "COUNTERMEASURES : Use another name or choose another location for the file\n"
-        ) in result_output
+        cli_assert_equal(1, result)
 
 
 def test_csv_export_with_no_data(tmpdir):
@@ -197,12 +188,4 @@ def test_csv_export_with_no_data(tmpdir):
                 "result3.csv",
             ]
         )
-        result_output = str(result.output)
-        assert (
-            "Error: An error in data job code  occurred. The error should be resolved by "
-            "User Error. Here are the details:\n"
-            "  WHAT HAPPENED : Cannot create the result csv file.\n"
-            "WHY IT HAPPENED : No data was found\n"
-            "   CONSEQUENCES : Will not proceed with exporting\n"
-            "COUNTERMEASURES : Try with another query or check the database explicitly.\n"
-        ) in result_output
+        cli_assert_equal(1, result)

--- a/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
@@ -123,21 +123,28 @@ def test_csv_export(tmpdir):
         assert output[1] == ["some_test_data_copy", "more_test_data_copy"]
 
 
-def test_export_csv_with_already_existing_file():
-    path = os.path.abspath(os.getcwd())
-    open(os.path.join(path, "result2.csv"), "w")
-    runner = CliEntryBasedTestRunner(csv_plugin)
-    assert (
-        "Error: An error in data job code  occurred. The error should be resolved by "
-        "User Error. Here are the details:\n"
-        "  WHAT HAPPENED : Cannot create the result csv file.\n"
-        "WHY IT HAPPENED : File with name result2.csv already exists in "
-        f"{path}\n"
-        "   CONSEQUENCES : Will not proceed with exporting\n"
-        "COUNTERMEASURES : Use another name or choose another location for the file\n"
-    ) in runner.invoke(
-        ["export-csv", "--query", "SELECT * FROM test_table", "--name", "result2.csv"]
-    ).stdout
+def test_export_csv_with_already_existing_file(tmpdir):
+    db_dir = str(tmpdir) + "vdk-sqlite.db"
+    with mock.patch.dict(
+            os.environ,
+            {
+                "VDK_DB_DEFAULT_TYPE": "SQLITE",
+                "VDK_SQLITE_FILE": db_dir,
+            },
+    ):
+        path = os.path.abspath(os.getcwd())
+        open(os.path.join(path, "result2.csv"), "w")
+        runner = CliEntryBasedTestRunner(csv_plugin)
+        result = runner.invoke(["export-csv", "--query", "SELECT * FROM test_table", "--name", "result2.csv"])
+        result_output = str(result.output)
+        assert (
+                   'Error: An error in data job code  occurred. The error should be resolved by '
+                   'User Error. Here are the details:\n'
+                   '  WHAT HAPPENED : Cannot create the result csv file.\n'
+                   'WHY IT HAPPENED : File with name result2.csv already exists in '
+                   f'{path}\n'
+                   '   CONSEQUENCES : Will not proceed with exporting\n'
+                   'COUNTERMEASURES : Use another name or choose another location for the file\n') in result_output
 
 
 def test_csv_export_with_no_data(tmpdir):
@@ -172,19 +179,12 @@ def test_csv_export_with_no_data(tmpdir):
             destination_table="test_table",
             target=db_dir,
         )
+        result = runner.invoke(["export-csv", "--query", "SELECT * FROM test_table", "--name", "result3.csv"])
+        result_output = str(result.output)
         assert (
-            "Error: An error in data job code  occurred. The error should be resolved by "
-            "User Error. Here are the details:\n"
-            "  WHAT HAPPENED : Cannot create the result csv file.\n"
-            "WHY IT HAPPENED : No data was found\n"
-            "   CONSEQUENCES : Will not proceed with exporting\n"
-            "COUNTERMEASURES : Try with another query or check the database explicitly.\n"
-        ) in runner.invoke(
-            [
-                "export-csv",
-                "--query",
-                "SELECT * FROM test_table",
-                "--name",
-                "result3.csv",
-            ]
-        ).stdout
+                    'Error: An error in data job code  occurred. The error should be resolved by '
+                    'User Error. Here are the details:\n'
+                    '  WHAT HAPPENED : Cannot create the result csv file.\n'
+                    'WHY IT HAPPENED : No data was found\n'
+                    '   CONSEQUENCES : Will not proceed with exporting\n'
+                    'COUNTERMEASURES : Try with another query or check the database explicitly.\n') in result_output

--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_plugin.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_plugin.py
@@ -6,9 +6,9 @@ import pathlib
 from typing import List
 
 import click
-import pluggy
 from tabulate import tabulate
 from vdk.api.plugin.hook_markers import hookimpl
+from vdk.api.plugin.plugin_registry import HookCallResult
 from vdk.api.plugin.plugin_registry import IPluginRegistry
 from vdk.internal.builtin_plugins.connection.decoration_cursor import DecorationCursor
 from vdk.internal.builtin_plugins.connection.recovery_cursor import RecoveryCursor
@@ -107,7 +107,7 @@ class ImpalaPlugin:
     @staticmethod
     @hookimpl(hookwrapper=True, tryfirst=True)
     def run_step(context: JobContext, step: Step) -> None:
-        out: pluggy.callers._Result
+        out: HookCallResult
         out = yield
 
         if out.result.exception:

--- a/projects/vdk-plugins/vdk-lineage/src/vdk/plugin/lineage/plugin_lineage.py
+++ b/projects/vdk-plugins/vdk-lineage/src/vdk/plugin/lineage/plugin_lineage.py
@@ -6,12 +6,12 @@ from abc import abstractmethod
 from typing import List
 from typing import Optional
 
-import pluggy
 from openlineage.client import OpenLineageClient
 from openlineage.client.facet import ParentRunFacet
 from openlineage.client.run import RunEvent
 from openlineage.client.run import RunState
 from vdk.api.plugin.hook_markers import hookimpl
+from vdk.api.plugin.plugin_registry import HookCallResult
 from vdk.internal.builtin_plugins.config.job_config import JobConfigKeys
 from vdk.internal.builtin_plugins.connection.decoration_cursor import DecorationCursor
 from vdk.internal.builtin_plugins.run.execution_results import ExecutionResult
@@ -94,7 +94,7 @@ class OpenLineagePlugin:
 
     @hookimpl(hookwrapper=True)
     def run_job(self, context: JobContext) -> Optional[ExecutionResult]:
-        out: pluggy.callers._Result
+        out: HookCallResult
         out = yield
         if self.__client:
             result: ExecutionResult = out.get_result()

--- a/projects/vdk-plugins/vdk-trino/src/vdk/plugin/trino/trino_plugin.py
+++ b/projects/vdk-plugins/vdk-trino/src/vdk/plugin/trino/trino_plugin.py
@@ -4,15 +4,14 @@ import logging
 import os
 import pathlib
 from typing import Callable
-from typing import Optional
 
 import click
-import pluggy
 import requests
 from tabulate import tabulate
 from trino.exceptions import TrinoUserError
 from vdk.api.lineage.model.logger.lineage_logger import ILineageLogger
 from vdk.api.plugin.hook_markers import hookimpl
+from vdk.api.plugin.plugin_registry import HookCallResult
 from vdk.internal.builtin_plugins.connection.pep249.interfaces import PEP249Connection
 from vdk.internal.builtin_plugins.run.execution_results import StepResult
 from vdk.internal.builtin_plugins.run.job_context import JobContext
@@ -94,7 +93,7 @@ def initialize_job(context: JobContext) -> None:
 
 @hookimpl(hookwrapper=True, tryfirst=True)
 def run_step(context: JobContext, step: Step) -> None:
-    out: pluggy.callers._Result
+    out: HookCallResult
     out = yield
     if out.excinfo:
         exc_type, exc_value, exc_traceback = out.excinfo

--- a/support/gitlab-runners/values.yaml
+++ b/support/gitlab-runners/values.yaml
@@ -73,7 +73,7 @@ runners:
   ## TODO: Have runners for big and small jobs.
   builds:
     cpuLimit: 1000m
-    memoryLimit: 4Gi
+    memoryLimit: 6Gi
     cpuRequests: 500m
     memoryRequests: 2Gi
 


### PR DESCRIPTION
vdk-csv: add export-csv command

What: Extended vdk-csv by adding a new command called vdk export-csv which can export from the default database to a local file.

Why: Often users would need to export result of some query to CSV file so they can send it to a colleague or to analyse it with other excel files they already have or to import it somewhere else.

Testing Done: added an unit test

Signed-off-by: Duygu Hasan [hduygu@vmware.com](mailto:hduygu@vmware.com)