### PR TITLE
vdk-core: make db_default_type case insensitive

### DIFF
--- a/projects/vdk-core/src/vdk/api/plugin/plugin_input.py
+++ b/projects/vdk-core/src/vdk/api/plugin/plugin_input.py
@@ -151,10 +151,10 @@ class IManagedConnectionRegistry:
             @hookimpl
             def initialize_job(context: JobContext) -> None:
                 context.connections.add_open_connection_factory_method(
-                    "BIG_QUERY", lambda: dbapi.connect(host=cfg.get_value('host'), post=cfg.get_value('port')
+                    "BIG-QUERY", lambda: dbapi.connect(host=cfg.get_value('host'), post=cfg.get_value('port')
                 )
 
-        :param dbtype: the name of the database connection - e.g: redshift, impala, presto, big-query, postgres, etc.
+        :param dbtype: the name of the database connection (case-insensitive) - e.g: redshift, impala, presto, big-query, postgres, etc.
         :param open_connection_func:
             The function must implement the code necessary to open a new connection that includes getting all configuration necessary like url, user, etc.
             The function can return either original PEP 249 (DBAPI) Connection from the python library for the given database

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/impl/router.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/impl/router.py
@@ -52,7 +52,7 @@ class ManagedConnectionRouter(IManagedConnectionRegistry):
         """
         Add new connection factory method. See parent doc for more.
         """
-        self._connection_builders[dbtype] = open_connection_func
+        self._connection_builders[dbtype.lower()] = open_connection_func
 
     def open_default_connection(self) -> ManagedConnectionBase:
         """
@@ -74,6 +74,7 @@ class ManagedConnectionRouter(IManagedConnectionRegistry):
         or it will thrown an error
         :return: the new connection if succesfull or throws an expception
         """
+        dbtype = dbtype.lower() if dbtype else None
         if dbtype in self._connections:
             conn = self._connections[dbtype]
             if conn._is_connected():
@@ -94,7 +95,7 @@ class ManagedConnectionRouter(IManagedConnectionRegistry):
             f"Currently possible values are {list(self._connection_builders.keys())}",
         )
 
-    def __create_connection(self, dbtype):
+    def __create_connection(self, dbtype: str):
         conn = self._connection_builders[dbtype]()
         if isinstance(conn, ManagedConnectionBase):
             self._connections[dbtype] = conn

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_connection_router.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_connection_router.py
@@ -46,6 +46,13 @@ def test_router_open_connection():
     assert conn is conn.connect()
 
 
+def test_router_open_connection_case_insensitive_type():
+    router, mock_conn, _ = managed_connection_router()
+
+    conn = router.open_connection("test_db")
+    assert conn is conn.connect()
+
+
 def test_router_raw_connection():
     conf = MagicMock(spec=Configuration)
     router = ManagedConnectionRouter(conf, MagicMock(spec=ConnectionHookSpec))


### PR DESCRIPTION
It is a common error where you can set db_default_type=sqlite but
because it's declared in the plugin as "SQLITE" we get error that no
such db connection type exists which is not true.

This PR changes it so that the db type check is not case sensitive

Testing Done: unit tests

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>