### PR TITLE
vdk-impala: Add performance logs

### DIFF
--- a/projects/vdk-plugins/vdk-impala/tests/impala_lineage_plugin_test.py
+++ b/projects/vdk-plugins/vdk-impala/tests/impala_lineage_plugin_test.py
@@ -1,0 +1,20 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import unittest
+
+from vdk.api.lineage.model.sql.model import LineageTable
+from vdk.plugin.impala.impala_lineage_plugin import ImpalaLineagePlugin
+
+
+class ImpalaLineagePluginTest(unittest.TestCase):
+    def test_get_lineage_table_from_table_name_valid_name(self):
+        actual = ImpalaLineagePlugin._get_lineage_table_from_table_name("schema.table")
+        expected = LineageTable(schema="schema", table="table", catalog=None)
+        self.assertEqual(expected, actual)
+
+    def test_get_lineage_table_from_table_name_none(self):
+        self.assertIsNone(ImpalaLineagePlugin._get_lineage_table_from_table_name(None))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add performance measurement logs that show how much time it takes to fetch the
query plan. This can be used to estimate potential impact on Impala for
calculating lineage. Also fixed a bug where lineage for select queries was not
generated.

Add debug logs for time taken to fetch query profile and the size of the query
profile itself.
Add support for None output table which enable lineage for select statements.

Add unit tests to to validate table name parsing behaviour.

Bug fix (non-breaking change which fixes an issue) and minor improvement.

Signed-off-by: Vladimir Petkov <petkovv@vmware.com>