### PR TITLE
Fluentd integration for data jobs

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/fluentdconfig_datajobs.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/fluentdconfig_datajobs.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.dataJob.fluentd.enabled }}
+apiVersion: logs.vdp.vmware.com/v1beta1
+kind: FluentdConfig
+metadata:
+  name: {{ include "pipelines-control-service.fullname" . }}-data-jobs-parser
+  namespace: {{ template "pipelines-control-service.deploymentK8sNamespace" . }}
+spec:
+  fluentconf: |
+    {{- if .Values.dataJob.fluentd.extra }}
+    {{ .Values.dataJob.fluentd.extra | indent 4 | trim }}
+    {{- end }}
+    {{- if .Values.dataJob.fluentd.filter }}
+    <filter **>
+      {{ .Values.dataJob.fluentd.filter | indent 6 | trim }}
+    </filter>
+    {{- end }}
+    {{- if .Values.dataJob.fluentd.match }}
+    <match **>
+      {{ .Values.dataJob.fluentd.match | indent 6 | trim }}
+    </match>
+    {{- end }}
+{{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -884,3 +884,18 @@ dataJob:
       # In case of negative number it will be subtracted from the {{end_time}}.
       # If left blank, defaults to 0.
       endTimeOffsetSeconds: 0
+  # configuration for the fluentd data collector (https://github.com/vmware/kube-fluentd-operator),
+  # which is currently used for collecting Data Job logs;
+  # filter and match refer to the fluentd config directives, see here https://docs.fluentd.org/configuration/config-file;
+  fluentd:
+    enabled: false
+    filter: |-
+      @type parser
+      key_name log
+      reserve_data true
+      remove_key_name_field true
+      <parse>
+        @type json
+      </parse>
+    match: |-
+      @type elastic


### PR DESCRIPTION
Currently, our helm chart supports Fluentd configuration only for the Control Service. 

This change aims to provide Fluentd configuration for Data Jobs.

Testing Done:
`helm template`:

```yaml
---
# Source: pipelines-control-service/templates/fluentdconfig_datajobs.yaml
apiVersion: logs.vdp.vmware.com/v1beta1
kind: FluentdConfig
metadata:
  name: pipelines-control-service-data-jobs-parser
  namespace: data-jobs-ns
spec:
  fluentconf: |
    <filter **>
      @type parser
      key_name log
      reserve_data true
      remove_key_name_field true
      <parse>
        @type json
      </parse>
    </filter>
    <match **>
      @type elastic
    </match>
---
```