### PR TITLE
vdk-ingest-http: reduce verbosity of ingestion logs

### DIFF
--- a/projects/vdk-plugins/vdk-ingest-http/src/vdk/plugin/ingest_http/ingest_over_http.py
+++ b/projects/vdk-plugins/vdk-ingest-http/src/vdk/plugin/ingest_http/ingest_over_http.py
@@ -128,7 +128,7 @@ class IngestOverHttp(IIngesterPlugin):
     ) -> Optional[IngestionResult]:
         header = {"Content-Type": "application/octet-stream"}  # TODO: configurable
 
-        log.info(
+        log.debug(
             f"Ingesting payloads for target: {target}; "
             f"collection_id: {collection_id}"
         )


### PR DESCRIPTION
Logging each payload at INFO is extremely verbose, we can have thousands
and thousands of payloads being sent. So it also slows down teh
ingestion.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>