### PR TITLE
versatile-data-kit: simplify release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,7 @@ To make a new public release, follow these steps:
 - Review which components have received changes since the previous release - this should be apparent from the changelog;
 - Record the latest versions of the components included in the release (from the auto generated notes) and list them in the Release description;
     - You can see the current version (as of time of release) of a Python package in https://pypi.org/search/?q=
-    - You can see the current version (as of time of release) of control service in [helm repo here](https://gitlab.com/vmware-analytics/versatile-data-kit-helm-registry/-/packages)
+    - You can see the current version (as of time of release) of the Control Service in [the helm repo here](https://gitlab.com/vmware-analytics/versatile-data-kit-helm-registry/-/packages)
 - Make sure you have clicked the "Create a discussion for this release" button before publishing the new release
 - Post a tweet on the official VDK Twitter account, and on slack, announcing the new release and linking to it.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ To make a new public release, follow these steps:
   - Backwards incompatible changes
   - Removal of features
 - Review which components have received changes since the previous release - this should be apparent from the changelog;
-- Record the latest versions of the components included in teh release (from the auto generated notes) and list them in the Release description;
+- Record the latest versions of the components included in the release (from the auto generated notes) and list them in the Release description;
     - You can see the current version (as of time of release) of python distribution in https://pypi.org/search/?q=
     - You can see the current version (as of time of release) of control service in [helm repo here](https://gitlab.com/vmware-analytics/versatile-data-kit-helm-registry/-/packages)
 - Make sure you have clicked the "Create a discussion for this release" button before publishing the new release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ To make a new public release, follow these steps:
   - Removal of features
 - Review which components have received changes since the previous release - this should be apparent from the changelog;
 - Record the latest versions of the components included in teh release (from the auto generated notes) and list them in the Release description;
-    - You can see the current version (as of time of release) of python distribution in https://pypi.org/search/?q= 
+    - You can see the current version (as of time of release) of python distribution in https://pypi.org/search/?q=
     - You can see the current version (as of time of release) of control service in [helm repo here](https://gitlab.com/vmware-analytics/versatile-data-kit-helm-registry/-/packages)
 - Make sure you have clicked the "Create a discussion for this release" button before publishing the new release
 - Post a tweet on the official VDK Twitter account, and on slack, announcing the new release and linking to it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ To make a new public release, follow these steps:
   - Removal of features
 - Review which components have received changes since the previous release - this should be apparent from the changelog;
 - Record the latest versions of the components included in the release (from the auto generated notes) and list them in the Release description;
-    - You can see the current version (as of time of release) of python distribution in https://pypi.org/search/?q=
+    - You can see the current version (as of time of release) of a Python package in https://pypi.org/search/?q=
     - You can see the current version (as of time of release) of control service in [helm repo here](https://gitlab.com/vmware-analytics/versatile-data-kit-helm-registry/-/packages)
 - Make sure you have clicked the "Create a discussion for this release" button before publishing the new release
 - Post a tweet on the official VDK Twitter account, and on slack, announcing the new release and linking to it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,18 +145,14 @@ We aim to make a new public release every few weeks.
 To make a new public release, follow these steps:
 - Create a new release from the Releases menu - this will require a new tag;
 - Autogenerate the changelog (https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes), then sort the changes alphabetically; if all change names are prefixed with the component name, this will ensure changes are grouped by component. Sorting can be done using the `sort` utility available in MacOS and Linux distros; Clean up unnecessary commits (e.g automated commits like pre-commit.ci)
-- Review which components have received changes since the previous release - this should be apparent from the changelog;
 - Write a summary at the top of the release page. It should include sections:
   - Major features include
   - Backwards incompatible changes
   - Removal of features
-- Create a new PR which bumps the minor versions of all newly changed components:
-  - plugins' version source of truth is located inside their respective `setup.py` files;
-  - vdk-core's version source of truth is located [here](projects/vdk-core/version.txt);
-  - vdk-heartbeat's version source of truth is located [here](projects/vdk-heartbeat/version.txt);
-  - vdk-control-cli's version source of truth is located [here](projects/vdk-control-cl/version.txt);
-  - control-service's version source of truth is located [here](projects/control-service/projects/helm_charts/pipelines-control-service/version.txt);
-- Record the new versions as they are released and list them in the Release description;
+- Review which components have received changes since the previous release - this should be apparent from the changelog;
+- Record the latest versions of the components included in teh release (from the auto generated notes) and list them in the Release description;
+    - You can see the current version (as of time of release) of python distribution in https://pypi.org/search/?q= 
+    - You can see the current version (as of time of release) of control service in [helm repo here](https://gitlab.com/vmware-analytics/versatile-data-kit-helm-registry/-/packages)
 - Make sure you have clicked the "Create a discussion for this release" button before publishing the new release
 - Post a tweet on the official VDK Twitter account, and on slack, announcing the new release and linking to it.
 


### PR DESCRIPTION
Remove the step that requires making extra bump of a version. It's unnecessary as we can record the version at the time of release as the one corresponding to the release.

It would have made some sense if we tagged the commit with the release but we do not do that for now , so it's just extra step

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>