### PR TITLE
vdk-control-cli: Drop requirement pluggy to be 0.*

### DIFF
--- a/projects/vdk-control-cli/setup.cfg
+++ b/projects/vdk-control-cli/setup.cfg
@@ -49,7 +49,7 @@ install_requires =
     click-spinner==0.*
     requests>=2.25
     setuptools>=47.0
-    pluggy==0.*
+    pluggy
     vdk-control-service-api==1.0.6
     tabulate
     requests_oauthlib>=1.0


### PR DESCRIPTION
VDK supports pluggy 1.0 as well as older versions.

Testing done: cicd

Signed-off-by: Gabriel Georgiev <gageorgiev@vmware.com>