### PR TITLE
Pinned minikerberos in vdk-kerberos-auth plugin

### DIFF
--- a/projects/vdk-plugins/vdk-kerberos-auth/requirements.txt
+++ b/projects/vdk-plugins/vdk-kerberos-auth/requirements.txt
@@ -1,5 +1,5 @@
 docker-compose
-minikerberos
+minikerberos==0.2.20
 pytest
 pytest-docker
 requests-kerberos


### PR DESCRIPTION
### Why
Currently vdk-kerberos-auth is not compatible with the minikerberos=0.3. 

```
An exception occurred, exception message was: ctx step failed: SpnegoError (7): Major (458752): No credentials were supplied, or the credentials were unavailable or inaccessible, Minor (2529639053): No Kerberos credentials available (default cache: FILE:/tmp/vdkkrb5cczsbdm8pd), Context: Processing security token
```
### What
The change aims to pin the latest compatible version of minikerberos.

### Testing done:
Local data job run.

