### PR TITLE
versatile-data-kit: update contact instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,13 @@ If you are interested in contributing as a developer, visit [CONTRIBUTING.md](CO
 # Contacts
 Feedback is very welcome via the [GitHub site as issues](https://github.com/vmware/versatile-data-kit/issues) or [pull requests](https://github.com/vmware/versatile-data-kit/pulls)
 
+* Join our dedicated Slack channel on the CNCF Slack workspace: 
+    * First [Join CNCF Slack workspace](https://communityinviter.com/apps/cloud-native/cncf) 
+    * Then search for #versatile-data-kit or [click here to join the channel](https://cloud-native.slack.com/archives/C033PSLKCPR)
+
 - [Follow us on twitter](https://twitter.com/intent/follow?screen_name=VDKProject).
 - Subscribe to the [Versatile Data Kit YouTube Channel](https://www.youtube.com/channel/UCasf2Q7X8nF7S4VEmcTHJ0Q).
-- [Join our dedicated Slack channel on the CNCF Slack workspace](https://communityinviter.com/apps/cloud-native/cncf)  - simply search for #versatile-data-kit or [click here to join the channel](https://cloud-native.slack.com/archives/C033PSLKCPR)
+
 - [Join our mailing list](mailto:join-versatiledatakit@groups.vmware.com?subject=Invite%20me%20to%20the%20VDK%20mailing%20list)
 
 # How to use Versatile Data Kit?

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ If you are interested in contributing as a developer, visit [CONTRIBUTING.md](CO
 # Contacts
 Feedback is very welcome via the [GitHub site as issues](https://github.com/vmware/versatile-data-kit/issues) or [pull requests](https://github.com/vmware/versatile-data-kit/pulls)
 
-* Join our dedicated Slack channel on the CNCF Slack workspace: 
-    * First [Join CNCF Slack workspace](https://communityinviter.com/apps/cloud-native/cncf) 
+* Join our dedicated Slack channel on the CNCF Slack workspace:
+    * First [Join CNCF Slack workspace](https://communityinviter.com/apps/cloud-native/cncf)
     * Then search for #versatile-data-kit or [click here to join the channel](https://cloud-native.slack.com/archives/C033PSLKCPR)
 
 - [Follow us on twitter](https://twitter.com/intent/follow?screen_name=VDKProject).


### PR DESCRIPTION
People miss that they need first to join CNCF slack space. So I am making the instructions clears. 

Signed-off-by: Antoni Ivanov (aivanov@vmware.com)