### PR TITLE
vdk-core: fix error classification of vdk code

### DIFF
--- a/projects/vdk-core/.gitlab-ci.yml
+++ b/projects/vdk-core/.gitlab-ci.yml
@@ -41,8 +41,9 @@ vdk-core-build_with_py39:
   image: "python:3.9"
   extends: .vdk-core-build
 
+# There seem to be an issue with python 3.10.6 ...
 vdk-core-build_with_py310:
-  image: "python:3.10"
+  image: "python:3.10.5"
   extends: .vdk-core-build
 
 

--- a/projects/vdk-core/cicd/build.sh
+++ b/projects/vdk-core/cicd/build.sh
@@ -44,6 +44,11 @@ pip install --use-deprecated="legacy-resolver" -e .
 echo "Install common vdk test utils library (in editable mode)"
 pip install --use-deprecated="legacy-resolver" -e ../vdk-plugins/vdk-test-utils
 
+# Print installed versions
+echo "Printing vdk version and python libraries"
+vdk version
+pip list
+
 # Below line uses --use-deprecated=legacy-resolver to temporary workaround a
 # dependency backtracking issue.
 # TODO: Remove the use of the legacy resolver once latest pip works as expected.

--- a/projects/vdk-core/tests/functional/run/jobs/fail-job-indirect-library/1_step.py
+++ b/projects/vdk-core/tests/functional/run/jobs/fail-job-indirect-library/1_step.py
@@ -1,0 +1,10 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import collections
+import json
+
+from vdk.api.job_input import IJobInput
+
+
+def run(job_input: IJobInput):
+    json.loads('{"key": kj}')

--- a/projects/vdk-core/tests/functional/run/jobs/fail-job-ingest-iterator/1_step.py
+++ b/projects/vdk-core/tests/functional/run/jobs/fail-job-ingest-iterator/1_step.py
@@ -1,0 +1,32 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from vdk.api.job_input import IJobInput
+
+
+class BrokenIterator:
+    """Class to implement an iterator
+    of powers of two"""
+
+    def __init__(self, break_at_index=3):
+        self._break_at_index = break_at_index
+
+    def __iter__(self):
+        self.n = 0
+        return self
+
+    def __next__(self):
+        if self.n <= self._break_at_index:
+            self.n += 1
+            return [1, 2]
+        else:
+            raise FloatingPointError("foo")
+
+
+def run(job_input: IJobInput):
+    ingest_some_data(job_input)
+
+
+def ingest_some_data(job_input):
+    job_input.send_tabular_data_for_ingestion(
+        rows=BrokenIterator(), column_names=["a", "b"]
+    )

--- a/projects/vdk-core/tests/functional/run/test_run_errors.py
+++ b/projects/vdk-core/tests/functional/run/test_run_errors.py
@@ -46,6 +46,24 @@ def test_run_user_error(tmp_termination_msg_file):
     assert (json.loads(tmp_termination_msg_file.read_text())["status"]) == "User error"
 
 
+def test_run_user_error_fail_job_library(tmp_termination_msg_file):
+    errors.clear_intermediate_errors()
+    runner = CliEntryBasedTestRunner()
+
+    result: Result = runner.invoke(["run", util.job_path("fail-job-indirect-library")])
+    cli_assert_equal(1, result)
+    assert (json.loads(tmp_termination_msg_file.read_text())["status"]) == "User error"
+
+
+def test_run_user_error_fail_job_ingest_iterator(tmp_termination_msg_file):
+    errors.clear_intermediate_errors()
+    runner = CliEntryBasedTestRunner()
+
+    result: Result = runner.invoke(["run", util.job_path("fail-job-ingest-iterator")])
+    cli_assert_equal(1, result)
+    assert (json.loads(tmp_termination_msg_file.read_text())["status"]) == "User error"
+
+
 def test_run_init_fails(tmp_termination_msg_file: pathlib.Path):
     errors.clear_intermediate_errors()
 


### PR DESCRIPTION
In case the User code is indirectly responsible (yet closest to the
error in the stack trace), for example using a dependency incorrectly,
the error cause (vdk, or user code) is not recognized correctly.

See more details in https://github.com/vmware/versatile-data-kit/issues/1118 and https://github.com/vmware/versatile-data-kit/issues/580

Testing Done: added functional test covering the scenario

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>