### PR TITLE
vdk-core: avoid circular references in print results

### DIFF
--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/run/test_execution_results.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/run/test_execution_results.py
@@ -116,3 +116,31 @@ def test_serialization_non_serializable():
 
     result_as_string = result.__repr__()
     assert json.loads(result_as_string) is not None
+
+
+def test_serialization_circular_referecen():
+    exception = ArithmeticError("foo")
+    exception.__cause__ = exception
+    step_result = StepResult(
+        "step",
+        "type",
+        datetime.fromisoformat("2012-10-12 00:00:00"),
+        datetime.fromisoformat("2012-10-12 01:00:00"),
+        ExecutionStatus.ERROR,
+        "details",
+        exception,
+        ResolvableBy.USER_ERROR,
+    )
+    result = ExecutionResult(
+        "job-name",
+        "exec-id",
+        datetime.fromisoformat("2012-10-12 00:00:00"),
+        datetime.fromisoformat("2012-10-12 01:00:00"),
+        ExecutionStatus.ERROR,
+        [step_result],
+        exception,
+        ResolvableBy.USER_ERROR,
+    )
+
+    result_as_string = result.__repr__()
+    assert result_as_string is not None


### PR DESCRIPTION
If there's a circular reference in the data printed by execution_results, json.dumps will fail.
So we are failing back to pprint which can handle them.

pprint would sort the keys for us which leads to more confusing message (e.g the name of the stpe is not first for each step, etc.) That's why we are not using it by default.

Sorting can be disabled but only from 3.8+

Testing Done: extended unit tests

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>