### PR TITLE
vdk-impala: fix error classification in impala

### DIFF
--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_plugin.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_plugin.py
@@ -111,17 +111,23 @@ class ImpalaPlugin:
         out: HookCallResult
         out = yield
 
-        if out.get_result().exception:
-            if is_impala_user_error(out.get_result().exception):
+        exception = out.get_result().exception
+        if exception:
+            exception = (
+                exception.__cause__
+                if hasattr(exception, "__cause__") and exception.__cause__
+                else exception
+            )
+            if is_impala_user_error(exception):
                 raise UserCodeError(
                     ErrorMessage(
                         summary="Error occurred.",
-                        what=f"Error occurred. Exception message: {out.get_result().exception}",
+                        what=f"Error occurred. Exception message: {exception}",
                         why="Review exception for details.",
                         consequences="Data Job execution will not continue.",
                         countermeasures="Review exception for details.",
                     )
-                ) from out.get_result().exception
+                ) from exception
 
     @staticmethod
     @hookimpl

--- a/projects/vdk-plugins/vdk-impala/tests/conftest.py
+++ b/projects/vdk-plugins/vdk-impala/tests/conftest.py
@@ -51,6 +51,6 @@ def impala_service(docker_ip, docker_services):
     time.sleep(3)
 
     docker_services.wait_until_responsive(
-        timeout=120.0, pause=0.3, check=lambda: _is_responsive(runner)
+        timeout=120.0, pause=1, check=lambda: _is_responsive(runner)
     )
     time.sleep(10)

--- a/projects/vdk-plugins/vdk-impala/tests/functional/template_regression_test.py
+++ b/projects/vdk-plugins/vdk-impala/tests/functional/template_regression_test.py
@@ -30,7 +30,7 @@ VDK_IMPALA_PORT = "VDK_IMPALA_PORT"
     },
 )
 @pytest.mark.usefixtures("impala_service")
-class TemplateRegressionTests(unittest.TestCase):
+class TestTemplateRegression(unittest.TestCase):
     def setUp(self) -> None:
         self.__runner = CliEntryBasedTestRunner(impala_plugin)
         time.sleep(10)  # wait for impala instance to come online
@@ -527,22 +527,16 @@ class TemplateRegressionTests(unittest.TestCase):
         with patch.object(errors, "log_and_rethrow") as patched_log_and_rethrow:
             patched_log_and_rethrow.side_effect = just_rethrow
             result = self._run_job(template_name, template_args)
-            assert expected_error_regex in result.output
+            assert expected_error_regex in result.output, result.output
+            assert errors.log_and_rethrow.call_args[1]["what_happened"], result.output
             assert (
-                errors.log_and_rethrow.call_args[1]["what_happened"]
-                == "Template execution in Data Job finished with error"
-            )
-            assert errors.log_and_rethrow.call_args[1]["why_it_happened"].startswith(
-                f"An exception occurred, exception message was: {num_exp_errors} validation error"
-            )
-            assert (
-                errors.log_and_rethrow.call_args[1]["consequences"]
-                == errors.MSG_CONSEQUENCE_TERMINATING_APP
-            )
-            assert (
-                errors.MSG_COUNTERMEASURE_FIX_PARENT_EXCEPTION
-                == errors.log_and_rethrow.call_args[1]["countermeasures"]
-            )
+                f"{num_exp_errors} validation error"
+                in errors.log_and_rethrow.call_args[1]["why_it_happened"]
+                or f"{num_exp_errors}\\ validation\\ error"
+                in errors.log_and_rethrow.call_args[1]["why_it_happened"]
+            ), result.output
+            assert errors.log_and_rethrow.call_args[1]["consequences"], result.output
+            assert errors.log_and_rethrow.call_args[1]["countermeasures"], result.output
 
     def _run_template_with_bad_target_schema(
         self, template_name: str, template_args: dict


### PR DESCRIPTION
With the change in
https://github.com/vmware/versatile-data-kit/pull/1173 this caused the classification not to work properly.

Tests did not catch this because vdk-impala tests are not run on vdk-core release. 

I am thinking of how we can rework the classification logic to be more first class citizen. But that's a large effort than this story.

Testing Done: unit tests

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>