### PR TITLE
Add a comment to the README.md

### DIFF
--- a/examples/incremental-ingest-from-db-example/README.md
+++ b/examples/incremental-ingest-from-db-example/README.md
@@ -80,6 +80,8 @@ export VDK_CONTROL_SERVICE_REST_API_URL=http://localhost:8092/
 
 To see all possible configuration options, use the command `vdk config-help.`
 
+**Instead of using environment variables, the alternative option is to set these configuration parameters in the config.ini file of the data job under the [vdk] section.**
+
 Data Job
 --------
 


### PR DESCRIPTION
In the configuration settings section, include explanation that they can be added to the config.ini file of the job instead of using environment variables.