### PR TITLE
vdk-core: errors occurred and the state (handled or not) context missing

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/file_based_step.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/file_based_step.py
@@ -11,6 +11,7 @@ from typing import List
 from vdk.api.job_input import IJobInput
 from vdk.internal.builtin_plugins.run.step import Step
 from vdk.internal.core import errors
+from vdk.internal.core.errors import ResolvableByActual
 
 log = logging.getLogger(__name__)
 
@@ -105,6 +106,15 @@ class StepFuncFactory:
                     finally:
                         if success:
                             log.info("Exiting  %s#run(...) SUCCESS" % filename)
+                            user_errors_in_step_handled = [
+                                i
+                                for i in errors.resolvable_context().resolvables.get(
+                                    ResolvableByActual.USER, []
+                                )
+                                if str(step.file_path) == i.caused_by_step_file
+                            ]
+                            for e in user_errors_in_step_handled:
+                                e.resolved = True
                         else:
                             log.error("Exiting  %s#run(...) FAILURE" % filename)
             log.warn(

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/termination_message/writer.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/termination_message/writer.py
@@ -29,9 +29,10 @@ class TerminationMessageWriterPlugin:
 
     @hookimpl
     def vdk_exit(self, context: CoreContext, exit_code: int):
+        not_resolved_predicate = lambda e: not e.resolved
         self.write_termination_message(
-            errors.get_blamee_overall(),  # TODO: get this from context
-            errors.get_blamee_overall_user_error(),  # TODO: get this from context
+            errors.get_blamee_overall(not_resolved_predicate),
+            errors.get_blamee_overall_user_error(not_resolved_predicate),
             context.configuration,
         )
 

--- a/projects/vdk-core/src/vdk/internal/core/errors.py
+++ b/projects/vdk-core/src/vdk/internal/core/errors.py
@@ -10,6 +10,7 @@ It defines classes and methods for handling exceptions, and ensuring that there 
 """
 from __future__ import annotations
 
+import enum
 import logging
 import re
 import sys
@@ -18,19 +19,32 @@ from collections import defaultdict
 from enum import Enum
 from logging import Logger
 from types import TracebackType
-from typing import Any
+from typing import Callable
 from typing import cast
 
+log = logging.getLogger(__name__)
+MSG_CONSEQUENCE_DELEGATING_TO_CALLER__LIKELY_EXECUTION_FAILURE = (
+    "I'm rethrowing this exception to my caller to process."
+    "Most likely this will result in failure of current Data Job."
+)
+MSG_CONSEQUENCE_TERMINATING_APP = (
+    "The provided Data Job will not be executed. Terminating application."
+)
+MSG_COUNTERMEASURE_FIX_PARENT_EXCEPTION = (
+    "See contents of the exception and fix the problem that causes it."
+)
 
+
+@enum.unique
 class ResolvableBy(str, Enum):
     """
-    Type of errors being thrown by VDK during execution of some command based on who is responsible for resolving/fixing them
+    Type of errors being thrown by VDK during execution of some command.
 
     Those are:
 
-    * PLATFORM_ERROR - for infrastructure errors that can and should be fixed by SRE Team, Platform team, operating the infrastructure and services.
-    * USER_ERROR - Errors in user code/configuration, that should be fixed by the end user (or job owner) for example: supplied bad arguments, bug in user code.
-    * CONFIG_ERROR - Errors in the configuration provided to VDK. Should be fixed by Platform if run in Platfrom infrastructure, or by end user, when run locally.
+    * PLATFORM_ERROR - infrastructure errors
+    * USER_ERROR - errors in user code/configuration
+    * CONFIG_ERROR - errors in the configuration provided to VDK
     """
 
     PLATFORM_ERROR = "Platform error"
@@ -38,15 +52,93 @@ class ResolvableBy(str, Enum):
     CONFIG_ERROR = "Configuration error"
 
 
-# TODO: instead of global variable set this in JobContext
-#  (one benefit this way we can run even multiple jobs/templates in the same process)
-# The key is 'blamee' (i.e. responsible for the error fixing) and the value is a list of corresponding ErrorMessages
-BLAMEES: dict[str, list[Any]] = defaultdict(list)
+@enum.unique
+class ResolvableByActual(str, Enum):
+    """
+    Who is responsible for resolving/fixing the error.
 
-# overide when running in kubernetes
-CONFIGURATION_ERRORS_ARE_TO_BE_RESOLVED_BY = ResolvableBy.PLATFORM_ERROR
+    Each Resolvable error type, along with the corresponding accountable:
 
-log = logging.getLogger(__name__)
+    * PLATFORM_ERROR - should be fixed by the PLATFORM (SRE Team, Platform team, operating the infrastructure and services).
+    * USER_ERROR - should be fixed by the end USER (or data job owner), for example: supplied bad arguments, bug in user code.
+    * CONFIG_ERROR that occurred during:
+      - platform run (in case the data job runs on platfrom infrastructure), is handled by the PLATFORM;
+      - local run (in case the data job runs on local end user infrastructure), is handled by the USER.
+
+    Returns:
+    * PLATFORM - accountable for infrastructure errors, or configuration errors occurred during a platform run;
+    * USER - accountable for errors in user code/configuration, or configuration errors occurred during a local run.
+    """
+
+    PLATFORM = "Platform"
+    USER = "User"
+
+
+# overwrite when running in kubernetes
+CONFIGURATION_ERRORS_ARE_TO_BE_RESOLVED_BY = ResolvableByActual.PLATFORM
+
+
+class Resolvable:
+    def __init__(
+        self,
+        resolvable_by: ResolvableBy,
+        resolvable_by_actual: ResolvableByActual,
+        error_message: ErrorMessage,
+        exception: BaseException,
+        resolved: bool = False,
+    ):
+        self.resolvable_by = resolvable_by
+        self.resolvable_by_actual = resolvable_by_actual
+        self.error_message = error_message
+        self.exception = exception
+        self.caused_by_step_file = _parse_caused_by_step_file_from_stacktrace(exception)
+        self.resolved = resolved
+
+
+class ResolvableContext:
+    """
+    A global registry for resolvable entries lookup, available immediately upon class loading.
+    Purposed for keeping track of any errors that may occur before, during or after CoreContext/JobContext initialization.
+    """
+
+    # The key is 'blamee' (i.e. responsible for the error fixing) and the value is a list of corresponding Resolvables
+    resolvables: dict[ResolvableByActual, list[Resolvable]]
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance.__init__()
+        return cls._instance
+
+    @classmethod
+    def instance(cls):
+        return cls.__new__(cls)
+
+    def __init__(self):
+        self.resolvables = defaultdict(list)
+
+    def add(self, resolvable: Resolvable) -> None:
+        """
+        Register a resolvable entry in the context.
+        :param resolvable:
+        :return:
+        """
+        resolvable_by_actual = resolvable.resolvable_by_actual
+        if resolvable_by_actual not in self.resolvables.keys():
+            self.resolvables[resolvable_by_actual] = []
+        self.resolvables[resolvable_by_actual].append(resolvable)
+
+    def clear(self) -> None:
+        """
+        Clear so far recorded records - those are considered intermediate and resolved.
+        For example after successful completion of a step.
+        """
+        self.resolvables.clear()
+
+
+def resolvable_context():
+    return ResolvableContext.instance()
 
 
 class BaseVdkError(Exception):
@@ -146,149 +238,59 @@ class ErrorMessage:
         return self._to_string(self._get_template("<br />"))
 
 
-def get_blamee_overall() -> str | None:
+def get_blamee_overall(
+    predicate: Callable[[Resolvable], bool] = lambda x: True
+) -> ResolvableByActual | None:
     """
     Finds who is responsible for fixing the error/s.
 
     Returns:
 
     None - if there were no errors
-    ResolvableBy.PLATFORM_ERROR - if during the run there were only Platfrom exception
-    ResolvableBy.USER_ERROR - if during the run there was at least one job owner exceptions
+    ResolvableByActual.PLATFORM - if during the run there were only Platfrom exceptions
+    ResolvableByActual.USER - if during the run there was at least one job owner exceptions
 
-    The reason it is set to ResolvableBy.USER_ERROR if there is at least one job owner is:
+    The reason it is set to ResolvableByActual.USER if there is at least one job owner is:
     VDK defaults the error to be resolved by Platform team  until it can determine for certain that it's an issue in the job code.
     There might be multiple components logging error (for example in exception propagation), and if at least one component says error is in the job code,
     then we set to be resolved by data job owner.
 
     """
-    if len(BLAMEES) == 0:
+    if len(resolvable_context().resolvables) == 0:
         return None
-    else:
-        return (
-            ResolvableBy.USER_ERROR
-            if ResolvableBy.USER_ERROR in BLAMEES
-            else ResolvableBy.PLATFORM_ERROR
-        )
+
+    def filter(resolvable_by_actual):
+        filtered = [
+            i
+            for i in resolvable_context().resolvables.get(resolvable_by_actual)
+            if predicate(i)
+        ]
+        return resolvable_by_actual if filtered else None
+
+    if ResolvableByActual.USER in resolvable_context().resolvables:
+        return filter(ResolvableByActual.USER)
+
+    if ResolvableByActual.PLATFORM in resolvable_context().resolvables:
+        return filter(ResolvableByActual.PLATFORM)
 
 
-def get_blamee_overall_user_error() -> str:
+def get_blamee_overall_user_error(
+    predicate: Callable[[Resolvable], bool] = lambda x: True
+) -> str:
     """
     Finds the first encountered error where the blamee overall is the owner.
 
     :return:
        Empty string if the owner is not the overall blamee
-       An ErrorMessage instance
+       An ErrorMessage instance to string
     """
-    blamee = get_blamee_overall()
-    if blamee is None or blamee == ResolvableBy.PLATFORM_ERROR:
+    blamee = get_blamee_overall(predicate)
+    if blamee is None or blamee != ResolvableByActual.USER:
         return ""
-    blamee_errors = BLAMEES.get(blamee, [])
-    return str(blamee_errors[0])
-
-
-def get_error_type() -> str | None:
-    """
-    :return: "User" or "Platform"
-    """
-    blamee = get_blamee_overall()
-    return (
-        "User" if blamee == ResolvableBy.USER_ERROR else "Platform" if blamee else None
+    blamee_user_errors = resolvable_context().resolvables.get(
+        ResolvableByActual.USER, []
     )
-
-
-def _build_message_for_end_user(
-    to_be_fixed_by: ResolvableBy,
-    what_happened: str,
-    why_it_happened: str,
-    consequences: str,
-    countermeasures: str,
-) -> ErrorMessage:
-    error = ""
-    if ResolvableBy.PLATFORM_ERROR == to_be_fixed_by:
-        error = " Platform service error "
-    elif ResolvableBy.USER_ERROR == to_be_fixed_by:
-        error = "n error in data job code "
-    elif ResolvableBy.CONFIG_ERROR == to_be_fixed_by:
-        error = " configuration error "
-
-    current_error_responsible_for_resolution = _error_type_to_actual_resolver(
-        to_be_fixed_by
-    )
-    # statement to add the key in the dictionary (if not already there),
-    # for get_blamee_overall()' to be calculated correctly
-    BLAMEES[current_error_responsible_for_resolution]
-    responsible_for_resolution = get_blamee_overall()
-
-    msg = ErrorMessage(
-        "A{} occurred. The error should be resolved by {}. Here are the details:".format(
-            error, responsible_for_resolution
-        ),
-        what_happened.strip(),
-        why_it_happened.strip(),
-        consequences.strip(),
-        countermeasures.strip(),
-    )
-
-    BLAMEES[current_error_responsible_for_resolution].append(msg)
-    return msg
-
-
-def get_caller_stacktrace() -> str:
-    """
-    :return: stacktrace excluding this method (hence caller stacktrace)
-    """
-    info = sys.exc_info()
-    tb = cast(TracebackType, info[2])
-    f = tb.tb_frame.f_back
-    lst = ["Traceback (most recent call first):\n"]
-    fstack = traceback.extract_stack(f)
-    fstack.reverse()
-    lst = lst + traceback.format_list(fstack)
-    lines = ""
-    for line in lst:
-        lines = lines + line
-    return lines
-
-
-def _error_type_to_actual_resolver(to_be_fixed_by: ResolvableBy) -> str:
-    if ResolvableBy.CONFIG_ERROR == to_be_fixed_by:
-        return CONFIGURATION_ERRORS_ARE_TO_BE_RESOLVED_BY
-    else:
-        return to_be_fixed_by
-
-
-def log_and_throw(
-    to_be_fixed_by: ResolvableBy,
-    log: Logger,
-    what_happened: str,
-    why_it_happened: str,
-    consequences: str,
-    countermeasures: str,
-) -> None:
-    """
-    Log error message and then throw it to be handled up the stack.
-    """
-    msg = _build_message_for_end_user(
-        to_be_fixed_by, what_happened, why_it_happened, consequences, countermeasures
-    )
-
-    try:
-        if ResolvableBy.PLATFORM_ERROR == to_be_fixed_by:
-            raise PlatformServiceError(msg)
-        elif ResolvableBy.USER_ERROR == to_be_fixed_by:
-            raise UserCodeError(msg)
-        elif ResolvableBy.CONFIG_ERROR == to_be_fixed_by:
-            raise VdkConfigurationError(msg)
-        else:
-            raise Exception(
-                "BUG! Fix me!"
-            )  # What type is the error that caused this and whom to blame Platform or Data Jobs Developer?
-    except BaseVdkError as e:
-        lines = get_caller_stacktrace()
-        log.error(str(msg) + "\n" + lines)
-        __set_error_is_logged(e)
-        raise
+    return str(blamee_user_errors[0].error_message) if blamee_user_errors else None
 
 
 def log_exception(
@@ -306,33 +308,68 @@ def log_exception(
     """
     if __error_is_logged(exception):
         return
-    msg = _build_message_for_end_user(
-        to_be_fixed_by, what_happened, why_it_happened, consequences, countermeasures
+
+    resolvable_by_actual = _error_type_to_actual_resolver(to_be_fixed_by)
+    error_message = _build_message_for_end_user(
+        to_be_fixed_by,
+        resolvable_by_actual,
+        what_happened,
+        why_it_happened,
+        consequences,
+        countermeasures,
     )
+    resolvable_context().add(
+        Resolvable(to_be_fixed_by, resolvable_by_actual, error_message, exception)
+    )
+
     __set_error_is_logged(exception)
-    log.exception(msg)
+    log.exception(error_message)
 
 
-def wrap_exception_if_not_already(
-    to_be_fixed_by: ResolvableBy, msg: ErrorMessage, exception: BaseException
-):
-    if isinstance(exception, BaseVdkError):
-        # already wrapped
-        return exception
+def log_and_throw(
+    to_be_fixed_by: ResolvableBy,
+    log: Logger,
+    what_happened: str,
+    why_it_happened: str,
+    consequences: str,
+    countermeasures: str,
+) -> None:
+    """
+    Log error message and then throw it to be handled up the stack.
+    """
 
-    # TODO: how to assign cause (new_ex from old_ex) ?
+    resolvable_by_actual = _error_type_to_actual_resolver(to_be_fixed_by)
+    error_message = _build_message_for_end_user(
+        to_be_fixed_by,
+        resolvable_by_actual,
+        what_happened,
+        why_it_happened,
+        consequences,
+        countermeasures,
+    )
+
+    exception: BaseVdkError
     if ResolvableBy.PLATFORM_ERROR == to_be_fixed_by:
-        return PlatformServiceError(msg)
+        exception = PlatformServiceError(error_message)
     elif ResolvableBy.USER_ERROR == to_be_fixed_by:
-        return UserCodeError(msg)
+        exception = UserCodeError(error_message)
     elif ResolvableBy.CONFIG_ERROR == to_be_fixed_by:
-        return VdkConfigurationError(msg)
+        exception = VdkConfigurationError(error_message)
     else:
-        log.warning(
-            "Unknown to_be_fixed_by type. "
-            "This seems like a bug. We cannot wrap exception and return original one "
+        raise Exception(
+            "BUG! Fix me!"
+        )  # What type is the error that caused this and whom to blame Platform or Data Jobs Developer?
+
+    try:
+        raise exception
+    except BaseVdkError as e:
+        resolvable_context().add(
+            Resolvable(to_be_fixed_by, resolvable_by_actual, error_message, e)
         )
-        return exception
+        lines = _get_caller_stacktrace()
+        log.error(str(error_message) + "\n" + lines)
+        __set_error_is_logged(e)
+        raise
 
 
 def log_and_rethrow(
@@ -358,39 +395,39 @@ def log_and_rethrow(
             it will wrap it in corresponding BaseVdkError exception based on to_be_fixed_by parameter
     """
 
-    msg = _build_message_for_end_user(
-        to_be_fixed_by, what_happened, why_it_happened, consequences, countermeasures
+    resolvable_by_actual = _error_type_to_actual_resolver(to_be_fixed_by)
+    error_message = _build_message_for_end_user(
+        to_be_fixed_by,
+        resolvable_by_actual,
+        what_happened,
+        why_it_happened,
+        consequences,
+        countermeasures,
     )
+
     to_be_raised_exception = exception
     if wrap_in_vdk_error:
-        to_be_raised_exception = wrap_exception_if_not_already(
-            to_be_fixed_by, msg, exception
+        to_be_raised_exception = _wrap_exception_if_not_already(
+            to_be_fixed_by, error_message, exception
         )
 
     if not __error_is_logged(exception):
-        log.exception(msg)
+        log.exception(error_message)
         __set_error_is_logged(exception)
 
-    if wrap_in_vdk_error:
-        raise to_be_raised_exception from exception
-    else:
-        raise exception
-
-
-def __error_is_logged(exception: BaseException) -> bool:
-    """Check if exception has custom added attribute is_logged"""
-    return hasattr(exception, "is_logged")
-
-
-def __set_error_is_logged(exception: BaseException):
-    setattr(exception, "is_logged", True)
+    try:
+        raise to_be_raised_exception from exception if wrap_in_vdk_error else exception
+    except Exception as e:
+        resolvable_context().add(
+            Resolvable(to_be_fixed_by, resolvable_by_actual, error_message, e)
+        )
+        raise
 
 
 def find_whom_to_blame_from_exception(exception: Exception) -> ResolvableBy:
     """
     Tries to determine if it's user or platform error
     """
-
     if issubclass(type(exception), UserCodeError):
         return ResolvableBy.USER_ERROR
     if issubclass(type(exception), VdkConfigurationError):
@@ -399,28 +436,15 @@ def find_whom_to_blame_from_exception(exception: Exception) -> ResolvableBy:
         )  # TODO find out if this is a local or platform deployment and fix this line.
     if issubclass(type(exception), PlatformServiceError):
         return ResolvableBy.PLATFORM_ERROR
-
     return ResolvableBy.PLATFORM_ERROR
 
 
-MSG_CONSEQUENCE_DELEGATING_TO_CALLER__LIKELY_EXECUTION_FAILURE = (
-    "I'm rethrowing this exception to my caller to process."
-    "Most likely this will result in failure of current Data Job."
-)
-MSG_CONSEQUENCE_TERMINATING_APP = (
-    "The provided Data Job will not be executed. Terminating application."
-)
-MSG_COUNTERMEASURE_FIX_PARENT_EXCEPTION = (
-    "See contents of the exception and fix the problem that causes it."
-)
-
-
-def get_exception_message(exception: Exception) -> str:
+def _get_exception_message(exception: Exception) -> str:
     """Returns the message part of an exception as string"""
     return str(exception).strip()
 
 
-class CustomMessageExceptionDecorator:
+class _CustomMessageExceptionDecorator:
     """
     Provides custom message for an exception.
 
@@ -462,13 +486,14 @@ def MSG_WHY_FROM_EXCEPTION(exception: Exception) -> str:
     """
     Try to figure what is the reason for the failure (why) from the exception and return as a reason.
     """
-    custom_message = CustomMessageExceptionDecorator(exception).get_custom_message()
-    if custom_message:
-        return custom_message
-    else:
-        return "An exception occurred, exception message was: {}".format(
-            get_exception_message(exception)
+    custom_message = _CustomMessageExceptionDecorator(exception).get_custom_message()
+    return (
+        custom_message
+        if custom_message
+        else "An exception occurred, exception message was: {}".format(
+            _get_exception_message(exception)
         )
+    )
 
 
 def exception_matches(
@@ -492,7 +517,7 @@ def exception_matches(
     if not (grp == classname):
         return False
 
-    msg = get_exception_message(e)
+    msg = _get_exception_message(e)
     match = msgMatcher.match(msg)
     if None is match:
         return False
@@ -500,11 +525,112 @@ def exception_matches(
     return grp == msg
 
 
-def clear_intermediate_errors() -> None:
-    """
-    Clear so far recorded records - those are considered intermediate and resolved.
+def _build_message_for_end_user(
+    to_be_fixed_by: ResolvableBy,
+    to_be_fixed_by_actual: ResolvableByActual,
+    what_happened: str,
+    why_it_happened: str,
+    consequences: str,
+    countermeasures: str,
+) -> ErrorMessage:
+    error = ""
+    if ResolvableBy.PLATFORM_ERROR == to_be_fixed_by:
+        error = " Platform service error "
+    elif ResolvableBy.USER_ERROR == to_be_fixed_by:
+        error = "n error in data job code "
+    elif ResolvableBy.CONFIG_ERROR == to_be_fixed_by:
+        error = " configuration error "
 
-    For example after successful completion of a step.
-    # TODO: better keep errors in context and not globally!
+    return ErrorMessage(
+        "A{} occurred. The error should be resolved by {}. Here are the details:".format(
+            error, to_be_fixed_by_actual
+        ),
+        what_happened.strip(),
+        why_it_happened.strip(),
+        consequences.strip(),
+        countermeasures.strip(),
+    )
+
+
+def _get_caller_stacktrace(exception: BaseException = None) -> str:
     """
-    BLAMEES.clear()
+    :return: stacktrace excluding this method (hence caller stacktrace)
+    """
+    tb = (
+        exception.__traceback__
+        if exception and exception.__traceback__
+        else cast(TracebackType, sys.exc_info()[2])
+    )
+    f = tb.tb_frame.f_back
+    lst = ["Traceback (most recent call first):\n"]
+    fstack = traceback.extract_stack(f)
+    fstack.reverse()
+    lst = lst + traceback.format_list(fstack)
+    lines = ""
+    for line in lst:
+        lines = lines + line
+    return lines
+
+
+def _parse_caused_by_step_file_from_stacktrace(exception: BaseException):
+    from vdk.internal.builtin_plugins.run import file_based_step
+
+    stack_trace_lines = _get_caller_stacktrace(exception).split("\n  File ")
+    file_based_step_line = [
+        i
+        for i in stack_trace_lines
+        if f'"{file_based_step.__file__}"' in i
+        and f"in {file_based_step.StepFuncFactory.invoke_run_function.__name__}" in i
+    ]
+    if file_based_step_line:
+        # assert len(file_based_step_line) == 1
+        step_file_invoked_by_step_factory = re.findall(
+            r'"([^"]*)"',
+            stack_trace_lines[stack_trace_lines.index(file_based_step_line[0]) - 1],
+        )
+        if step_file_invoked_by_step_factory:
+            return step_file_invoked_by_step_factory[0]
+        return None
+
+
+def _error_type_to_actual_resolver(to_be_fixed_by: ResolvableBy) -> ResolvableByActual:
+    if ResolvableBy.PLATFORM_ERROR == to_be_fixed_by:
+        return ResolvableByActual.PLATFORM
+    if ResolvableBy.USER_ERROR == to_be_fixed_by:
+        return ResolvableByActual.USER
+    if ResolvableBy.CONFIG_ERROR == to_be_fixed_by:
+        return CONFIGURATION_ERRORS_ARE_TO_BE_RESOLVED_BY
+    raise Exception(
+        "BUG! Fix me!"
+    )  # What type is the error that caused this and whom to blame, Platform or Data Jobs Developer?
+
+
+def _wrap_exception_if_not_already(
+    to_be_fixed_by: ResolvableBy, msg: ErrorMessage, exception: BaseException
+):
+    if isinstance(exception, BaseVdkError):
+        # already wrapped
+        return exception
+
+    # TODO: how to assign cause (new_ex from old_ex) ?
+    if ResolvableBy.PLATFORM_ERROR == to_be_fixed_by:
+        return PlatformServiceError(msg)
+    elif ResolvableBy.USER_ERROR == to_be_fixed_by:
+        return UserCodeError(msg)
+    elif ResolvableBy.CONFIG_ERROR == to_be_fixed_by:
+        return VdkConfigurationError(msg)
+    else:
+        log.warning(
+            "Unknown to_be_fixed_by type. "
+            "This seems like a bug. We cannot wrap exception and return original one "
+        )
+        return exception
+
+
+def __error_is_logged(exception: BaseException) -> bool:
+    """Check if exception has custom added attribute is_logged"""
+    return hasattr(exception, "is_logged")
+
+
+def __set_error_is_logged(exception: BaseException):
+    setattr(exception, "is_logged", True)

--- a/projects/vdk-core/tests/functional/run/jobs/simple-query-failed-handled/10_query_then_handle_exceptions.py
+++ b/projects/vdk-core/tests/functional/run/jobs/simple-query-failed-handled/10_query_then_handle_exceptions.py
@@ -1,0 +1,10 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from vdk.api.job_input import IJobInput
+
+
+def run(job_input: IJobInput):
+    try:
+        job_input.execute_query("SELECT Syntax error")
+    except:
+        pass  # exception handled by user

--- a/projects/vdk-core/tests/functional/run/test_run_notifications.py
+++ b/projects/vdk-core/tests/functional/run/test_run_notifications.py
@@ -34,7 +34,7 @@ def __get_smtp_env(smtpd: SMTPDFix):
 
 
 def test_run_successfull(smtpd: SMTPDFix):
-    errors.clear_intermediate_errors()
+    errors.resolvable_context().clear()
     with mock.patch.dict(
         os.environ,
         {
@@ -54,7 +54,7 @@ def test_run_successfull(smtpd: SMTPDFix):
 
 
 def test_run_successfull_notify_multiple_users(smtpd: SMTPDFix):
-    errors.clear_intermediate_errors()
+    errors.resolvable_context().clear()
     with mock.patch.dict(
         os.environ,
         {
@@ -77,7 +77,7 @@ def test_run_successfull_notify_multiple_users(smtpd: SMTPDFix):
 
 @mock.patch.dict(os.environ, {"VDK_DB_DEFAULT_TYPE": DB_TYPE_SQLITE_MEMORY})
 def test_run_query_failed_user_error_notification_sent(smtpd: SMTPDFix):
-    errors.clear_intermediate_errors()
+    errors.resolvable_context().clear()
     db_plugin = DecoratedSqLite3MemoryDbPlugin()
     runner = CliEntryBasedTestRunner(db_plugin)
 
@@ -98,7 +98,7 @@ def test_run_query_failed_user_error_notification_sent(smtpd: SMTPDFix):
 
 @mock.patch.dict(os.environ, {"VDK_DB_DEFAULT_TYPE": DB_TYPE_SQLITE_MEMORY})
 def test_run_query_failed_user_error_no_notification_configured(smtpd: SMTPDFix):
-    errors.clear_intermediate_errors()
+    errors.resolvable_context().clear()
     db_plugin = DecoratedSqLite3MemoryDbPlugin()
     runner = CliEntryBasedTestRunner(db_plugin)
 


### PR DESCRIPTION
User code may trigger a SDK feature in a way that raises a user error. In such a use case, the error could be handled by the cautious user, in runtime. The VDK platform should be aware if user errors are handled in runtime or not, so that affects the data job termination status.

The old errors.BLAMEES (experimental data structure for keeping track of responsibles for errors priorly logged) should be refactored:
* a resolvable context abstraction introduced
* it is memory-managed (singleton, reasoning documented)
* populated by the 3 user-facing `errors.log_*()` methods - in favour of a method designed to populate ErrorMessage entries
* keeps track if the actual exception, along with all properties like who is the actual respobsible persona (user or platform, that was free-form str before), resolved by a data job step or not, etc.

Testing Done: added a functional test covering the
 `simple-query-failed-handled` scenario, added singleton verification
 for the resolvable context; ci/cd

Signed-off-by: ivakoleva <iva.koleva@clearcode.bg>