### PR TITLE
vdk-core: added default values to write termination message method

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/termination_message/writer.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/termination_message/writer.py
@@ -36,7 +36,11 @@ class TerminationMessageWriterPlugin:
         )
 
     def write_termination_message(
-        self, error_overall, user_error, configuration, execution_skipped=False
+        self,
+        error_overall=None,
+        user_error=None,
+        configuration=None,
+        execution_skipped=False,
     ):
         termination_message_writer_cfg = WriterConfiguration(configuration)
 

--- a/projects/vdk-plugins/vdk-plugin-control-cli/src/vdk/plugin/control_cli_plugin/execution_skip.py
+++ b/projects/vdk-plugins/vdk-plugin-control-cli/src/vdk/plugin/control_cli_plugin/execution_skip.py
@@ -121,8 +121,7 @@ def _skip_job_if_necessary(
             log.info(f"Skipping job {job_name}")
             writer_plugin = TerminationMessageWriterPlugin()
             writer_plugin.write_termination_message(
-                configuration=configuration,
-                execution_skipped=True,
+                configuration=configuration, execution_skipped=True
             )
             _skip_job_run(job_name)  # calls os._exit(0)
             return 1  # All other branches return None

--- a/projects/vdk-plugins/vdk-plugin-control-cli/src/vdk/plugin/control_cli_plugin/execution_skip.py
+++ b/projects/vdk-plugins/vdk-plugin-control-cli/src/vdk/plugin/control_cli_plugin/execution_skip.py
@@ -121,8 +121,6 @@ def _skip_job_if_necessary(
             log.info(f"Skipping job {job_name}")
             writer_plugin = TerminationMessageWriterPlugin()
             writer_plugin.write_termination_message(
-                error_overall=None,
-                user_error=None,
                 configuration=configuration,
                 execution_skipped=True,
             )

--- a/projects/vdk-plugins/vdk-plugin-control-cli/src/vdk/plugin/control_cli_plugin/execution_skip.py
+++ b/projects/vdk-plugins/vdk-plugin-control-cli/src/vdk/plugin/control_cli_plugin/execution_skip.py
@@ -121,7 +121,10 @@ def _skip_job_if_necessary(
             log.info(f"Skipping job {job_name}")
             writer_plugin = TerminationMessageWriterPlugin()
             writer_plugin.write_termination_message(
-                configuration=configuration, execution_skipped=True
+                error_overall=None,
+                user_error=None,
+                configuration=configuration,
+                execution_skipped=True,
             )
             _skip_job_run(job_name)  # calls os._exit(0)
             return 1  # All other branches return None


### PR DESCRIPTION
Currently, we have an internal customer experiencing concurrent executions of the same data job. The issue is in the execution logic because of missing default values of the write_termination_message method.

Exception:
```
execution_skip.py:130  _skip_job_if_nec[id:moonshine-stage-cost-optimization-strategies-1663579200-qfxw2]- Error while checking for another data job excecution: write_termination_message() missing 2 required positional arguments: 'error_overall' and 'user_error' 
```

This change aims to fix the issue ASAP since the customer may have duplicate data because of it.