### PR TITLE
vdk-core: fix flakey test in test checking logs output

### DIFF
--- a/projects/vdk-core/tests/functional/run/test_run_sql_queries.py
+++ b/projects/vdk-core/tests/functional/run/test_run_sql_queries.py
@@ -75,6 +75,8 @@ class SyntaxErrorRecoverySqLite3MemoryDbPlugin:
 
 @mock.patch.dict(os.environ, {})
 def test_run_dbapi_connection_no_such_db_type():
+    logging.getLogger().setLevel(logging.INFO)
+    logging.getLogger("vdk").setLevel(logging.INFO)
     runner = CliEntryBasedTestRunner()
 
     with mock.patch.dict(os.environ, {VDK_DB_DEFAULT_TYPE: DB_TYPE_SQLITE_MEMORY}):

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_log_config.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_log_config.py
@@ -37,40 +37,46 @@ from vdk.internal.core.statestore import StateStore
     ),
 )
 def test_log_plugin(log_type, vdk_level, expected_vdk_level):
-    with mock.patch("socket.socket.connect"):
-        logging.getLogger().setLevel(logging.DEBUG)  # root level
-        logging.getLogger("vdk").setLevel(logging.NOTSET)  # reset vdk log level
+    try:
+        with mock.patch("socket.socket.connect"):
+            logging.getLogger().setLevel(logging.DEBUG)  # root level
+            logging.getLogger("vdk").setLevel(logging.NOTSET)  # reset vdk log level
 
-        log_plugin = LoggingPlugin()
+            log_plugin = LoggingPlugin()
 
-        store = StateStore()
-        store.set(CommonStoreKeys.ATTEMPT_ID, "attempt_id")
+            store = StateStore()
+            store.set(CommonStoreKeys.ATTEMPT_ID, "attempt_id")
 
-        conf = (
-            ConfigurationBuilder()
-            .add(vdk_config.LOG_CONFIG, log_type)
-            .add(vdk_config.LOG_LEVEL_VDK, vdk_level)
-            .add(SYSLOG_URL, "localhost")
-            .add(SYSLOG_PORT, 514)
-            .add(SYSLOG_ENABLED, True)
-            .add(SYSLOG_SOCK_TYPE, "UDP")
-            .build()
-        )
-        core_context = CoreContext(mock.MagicMock(spec=IPluginRegistry), conf, store)
+            conf = (
+                ConfigurationBuilder()
+                .add(vdk_config.LOG_CONFIG, log_type)
+                .add(vdk_config.LOG_LEVEL_VDK, vdk_level)
+                .add(SYSLOG_URL, "localhost")
+                .add(SYSLOG_PORT, 514)
+                .add(SYSLOG_ENABLED, True)
+                .add(SYSLOG_SOCK_TYPE, "UDP")
+                .build()
+            )
+            core_context = CoreContext(
+                mock.MagicMock(spec=IPluginRegistry), conf, store
+            )
 
-        job_context = JobContext(
-            "foo",
-            pathlib.Path("foo"),
-            core_context,
-            JobArguments([]),
-            TemplatesImpl("foo", core_context),
-        )
+            job_context = JobContext(
+                "foo",
+                pathlib.Path("foo"),
+                core_context,
+                JobArguments([]),
+                TemplatesImpl("foo", core_context),
+            )
 
-        log_plugin.initialize_job(job_context)
+            log_plugin.initialize_job(job_context)
 
-        assert (
-            logging.getLogger("vdk").getEffectiveLevel() == expected_vdk_level
-        ), "internal vdk logs must be set according to configuration option LOG_LEVEL_VDK but are not"
+            assert (
+                logging.getLogger("vdk").getEffectiveLevel() == expected_vdk_level
+            ), "internal vdk logs must be set according to configuration option LOG_LEVEL_VDK but are not"
+    finally:
+        logging.getLogger().setLevel(logging.INFO)
+        logging.getLogger("vdk").setLevel(logging.INFO)
 
 
 def test_parse_log_level_module():


### PR DESCRIPTION
# Why?
We want to fix intermittent failures in tests. Specifically the described in https://github.com/vmware/versatile-data-kit/issues/1177.

# What?
The underlying issue was that `test_log_plugin` was modifying the log level to warning. 
the test `test_run_dbapi_connection_no_such_db_type` relies on it being INFO to pass. 
There are two fixes to prevent this in the future

1. the log level is explicitly set at the start of the test `test_run_dbapi_connection_no_such_db_type`. 
2. in the test `test_log_plugin` we revert the start back to info at the end of it. 

# How has this been tested?
Before my fix I was getting an error reasonably frequently during runs. 
After I added my fix in I ran the pipeline many more times and never encountered the error again. 

# What type of change are you making?
Bug fix (non-breaking change which fixes an issue) or a cosmetic change/minor improvement



Signed-off-by: murphp15 murphp15@tcd.ie