### PR TITLE
vdk-core: Add log before query result fetch

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
@@ -127,6 +127,7 @@ class ManagedConnectionBase(PEP249Connection, IManagedConnection):
                 and swallow the exception in very narrow set of cases.
                 """
                 # TODO support for fetchmany
+                self._log.info("Fetching query result...")
                 res = cur.fetchall()
             except Exception as e:
                 res = None


### PR DESCRIPTION
Occasionally, vdk may indicate that a query execution took 10 or 20 minutes, even though the DB back shows that the query was actually executes in seconds. This results in the DB backend issuing a timeout error and a job failure. Because it happens sporadically, it is hard to reproduce and debug locally.

This change adds a log message just before the result of a query is fetched, and should help better understand at which step the query execution hanged.

Testing done: Documentation change.

Signed-off-by: Andon Andonov <andonova@vmware.com>