### PR TITLE
vdk-plugins: run tests on release of vdk-core

### DIFF
--- a/projects/vdk-plugins/.plugin-common.yml
+++ b/projects/vdk-plugins/.plugin-common.yml
@@ -13,6 +13,7 @@
     - cd projects/vdk-plugins/
     - pip install -U pip
     - pip install ./vdk-test-utils # TODO: REMOVE THIS AT SOME POINT
+    - if [ -n "${USE_VDKCORE_DEV_VERSION}" ] ; then pip install -e ../vdk-core; fi
   script:
     - echo "Build plugin $PLUGIN_NAME"
     - cd ./$PLUGIN_NAME || exit 1
@@ -27,6 +28,17 @@
     when: always
     reports:
       junit: tests.xml
+
+.build-plugin-on-vdk-core-release:
+  stage: pre_release_test
+  variables:
+    USE_VDKCORE_DEV_VERSION: "yes"
+  extends: .build-plugin
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes:
+       - "projects/vdk-core/*"
+       - "projects/vdk-core/src/**/*"
 
 .build-plugin-dind:
   image: docker:19.03.8

--- a/projects/vdk-plugins/vdk-control-api-auth/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-control-api-auth/.plugin-ci.yml
@@ -26,6 +26,13 @@ build-py310-vdk-control-api-auth:
   extends: .build-vdk-control-api-auth
   image: "python:3.10"
 
+
+build-vdk-control-api-auth-on-vdk-core-release:
+  variables:
+    PLUGIN_NAME: vdk-control-api-auth
+  extends: .build-plugin-on-vdk-core-release
+  image: "python:3.9"
+
 release-vdk-control-api-auth:
   variables:
     PLUGIN_NAME: vdk-control-api-auth

--- a/projects/vdk-plugins/vdk-csv/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-csv/.plugin-ci.yml
@@ -26,6 +26,11 @@ build-py310-vdk-csv:
   extends: .build-vdk-csv
   image: "python:3.10"
 
+build-vdk-csv-on-vdk-core-release:
+  variables:
+    PLUGIN_NAME: vdk-csv
+  extends: .build-plugin-on-vdk-core-release
+  image: "python:3.9"
 
 release-vdk-csv:
   variables:

--- a/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
+++ b/projects/vdk-plugins/vdk-csv/tests/functional/test_csv_plugin.py
@@ -6,6 +6,7 @@ from sqlite3 import OperationalError
 from unittest import mock
 
 from click.testing import Result
+from vdk.internal.core.errors import PlatformServiceError
 from vdk.internal.core.errors import UserCodeError
 from vdk.plugin.csv import csv_plugin
 from vdk.plugin.sqlite import sqlite_plugin
@@ -170,7 +171,7 @@ def test_csv_export_with_nonexistent_table(tmpdir):
                 "result3.csv",
             ]
         )
-        assert isinstance(result.exception, OperationalError)
+        assert isinstance(result.exception, PlatformServiceError)
 
 
 def test_csv_export_with_no_data(tmpdir):

--- a/projects/vdk-plugins/vdk-impala/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-impala/.plugin-ci.yml
@@ -4,15 +4,9 @@
 image: "python:3.7"
 
 .build-vdk-impala:
-  image: docker:19.03.8
-  services:
-    - docker:19.03.8-dind
   variables:
-    DOCKER_HOST: tcp://localhost:2375
-    DOCKER_DRIVER: overlay2
-    DOCKER_TLS_CERTDIR: ""
     PLUGIN_NAME: vdk-impala
-  extends: .build-plugin
+  extends: .build-plugin-dind
 
 build-py37-vdk-impala:
   extends: .build-vdk-impala
@@ -31,6 +25,13 @@ build-py39-vdk-impala:
 build-py310-vdk-impala:
   extends: .build-vdk-impala
   image: "python:3.10"
+
+
+build-vdk-impala-on-vdk-core-release:
+  variables:
+    PLUGIN_NAME: vdk-impala
+  extends: .build-plugin-on-vdk-core-release
+  image: "python:3.9"
 
 
 release-vdk-impala:

--- a/projects/vdk-plugins/vdk-ingest-http/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-ingest-http/.plugin-ci.yml
@@ -26,6 +26,12 @@ build-py310-vdk-ingest-http:
   extends: .build-vdk-ingest-http
   image: "python:3.10"
 
+build-vdk-ingest-http-on-vdk-core-release:
+  variables:
+    PLUGIN_NAME: vdk-ingest-http
+  extends: .build-plugin-on-vdk-core-release
+  image: "python:3.9"
+
 release-vdk-ingest-http:
   variables:
     PLUGIN_NAME: vdk-ingest-http

--- a/projects/vdk-plugins/vdk-kerberos-auth/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-kerberos-auth/.plugin-ci.yml
@@ -30,6 +30,12 @@ build-py310-vdk-kerberos-auth:
   extends: .build-vdk-kerberos-auth
   image: "python:3.10"
 
+build-vdk-kerberos-auth-on-vdk-core-release:
+  variables:
+    PLUGIN_NAME: vdk-kerberos-auth
+  extends: .build-plugin-on-vdk-core-release
+  image: "python:3.9"
+
 release-vdk-kerberos-auth:
   variables:
     PLUGIN_NAME: vdk-kerberos-auth

--- a/projects/vdk-plugins/vdk-plugin-control-cli/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-plugin-control-cli/.plugin-ci.yml
@@ -27,6 +27,12 @@ build-py310-vdk-plugin-control-cli:
   image: "python:3.10"
 
 
+build-vdk-plugin-control-cli-on-vdk-core-release:
+  variables:
+    PLUGIN_NAME: vdk-plugin-control-cli
+  extends: .build-plugin-on-vdk-core-release
+  image: "python:3.9"
+
 release-vdk-plugin-control-cli:
   variables:
     PLUGIN_NAME: vdk-plugin-control-cli

--- a/projects/vdk-plugins/vdk-trino/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-trino/.plugin-ci.yml
@@ -32,6 +32,12 @@ build-py310-vdk-trino:
   extends: .build-vdk-trino
   image: "python:3.10"
 
+build-vdk-trino-on-vdk-core-release:
+  variables:
+    PLUGIN_NAME: vdk-trino
+  extends: .build-plugin-on-vdk-core-release
+  image: "python:3.9"
+
 release-vdk-trino:
   variables:
     PLUGIN_NAME: vdk-trino


### PR DESCRIPTION
Changes in vdk-core can break some plugins. We need some functionality that enables us to catch such regression quicker.

The proposoed change is to introduce in .plugin-common.yml new generic "job" template `.build-plugin-on-vdk-core-release` which can be used by plugins CI.

As it should not be necessary to run all plugin tests, we can select some more important

Testing Done: CI

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>