### PR TITLE
control-service: fix integration tests

### DIFF
--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -27,11 +27,8 @@
   variables:
     _JAVA_OPTIONS: "-Xms2048m -Xmx4096m"
   before_script:
-    - apk --no-cache add git openjdk11-jdk curl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
-    - curl -o aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator
-    - chmod +x ./aws-iam-authenticator
-    - mkdir -p $HOME/bin && cp ./aws-iam-authenticator $HOME/bin/aws-iam-authenticator && export PATH=$PATH:$HOME/bin
-    - echo 'export PATH=$PATH:$HOME/bin' >> ~/.bashrc
+    - apk --no-cache add git zip openjdk11-jdk curl zip python3 py3-pip  --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
+    - pip3 install --upgrade pip && pip3 install awscli
 
 control_service_build_image:
   extends: .control_service_base_build


### PR DESCRIPTION

Latest changes in Kubernetes have broken our KUBECONFIG which uses older version of API resource and we get errors like "invalid apiVersion "client.authentication.k8s.io/v1alpha1" (similar to https://github.com/aws/aws-cli/issues/6920)

I am upgrading things around to fix it.

Amazon EKS uses the `aws eks get-token` command, available in version 1.16.156 or later. Until now we used aws-iam-authenticator but it seems latest changes in Kubernetes do not work there. 

I have also regenerated the KUBECONFIG and updated in Gitlab CI Variables (using https://aws.amazon.com/premiumsupport/knowledge-center /eks-generate-kubeconfig-file-for-cluster/)

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>