### PR TITLE
vdk-pipeline-core: upgrade java client k8s version

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -422,7 +422,7 @@ public abstract class KubernetesService implements InitializingBean {
             .withMetadata(new V1ObjectMetaBuilder().withName(namespaceName).build())
             .build();
 
-    new CoreV1Api(client).createNamespace(namespaceBody, null, null, null,null);
+    new CoreV1Api(client).createNamespace(namespaceBody, null, null, null, null);
   }
 
   public void deleteNamespace(String namespaceName) throws ApiException {
@@ -923,7 +923,8 @@ public abstract class KubernetesService implements InitializingBean {
             jobLabels,
             imagePullSecrets);
     V1beta1CronJob nsJob =
-        new BatchV1beta1Api(client).createNamespacedCronJob(namespace, cronJob, null, null, null,null);
+        new BatchV1beta1Api(client)
+            .createNamespacedCronJob(namespace, cronJob, null, null, null, null);
     log.debug("Created k8s cron job: {}", nsJob);
     log.debug(
         "Created k8s cron job name: {}, uid:{}, link:{}",
@@ -967,7 +968,7 @@ public abstract class KubernetesService implements InitializingBean {
             jobLabels,
             imagePullSecrets);
     V1CronJob nsJob =
-        new BatchV1Api(client).createNamespacedCronJob(namespace, cronJob, null, null, null,null);
+        new BatchV1Api(client).createNamespacedCronJob(namespace, cronJob, null, null, null, null);
     log.debug("Created k8s cron job: {}", nsJob);
     log.debug(
         "Created k8s cron job name: {}, uid:{}, link:{}",
@@ -1119,7 +1120,7 @@ public abstract class KubernetesService implements InitializingBean {
             imagePullSecrets);
     V1beta1CronJob nsJob =
         new BatchV1beta1Api(client)
-            .replaceNamespacedCronJob(name, namespace, cronJob, null, null, null,null);
+            .replaceNamespacedCronJob(name, namespace, cronJob, null, null, null, null);
     log.debug(
         "Updated k8s cron job status for name:{}, image:{}, uid:{}, link:{}",
         name,
@@ -1160,7 +1161,8 @@ public abstract class KubernetesService implements InitializingBean {
             jobLabels,
             imagePullSecrets);
     V1CronJob nsJob =
-        new BatchV1Api(client).replaceNamespacedCronJob(name, namespace, cronJob, null, null, null,null);
+        new BatchV1Api(client)
+            .replaceNamespacedCronJob(name, namespace, cronJob, null, null, null, null);
     log.debug(
         "Updated k8s cron job status for name:{}, image:{}, uid:{}, link:{}",
         name,
@@ -1258,7 +1260,8 @@ public abstract class KubernetesService implements InitializingBean {
             .withSpec(spec)
             .build();
 
-    V1Job nsJob = new BatchV1Api(client).createNamespacedJob(namespace, job, null, null, null,null);
+    V1Job nsJob =
+        new BatchV1Api(client).createNamespacedJob(namespace, job, null, null, null, null);
     log.debug("Created k8s job: {}", nsJob);
     log.debug(
         "Created k8s job name: {}, uid:{}, link:{}",
@@ -2314,12 +2317,12 @@ public abstract class KubernetesService implements InitializingBean {
 
     V1Secret nsSecret;
     try {
-      nsSecret = api.replaceNamespacedSecret(name, this.namespace, secret, null, null, null,null);
+      nsSecret = api.replaceNamespacedSecret(name, this.namespace, secret, null, null, null, null);
     } catch (ApiException e) {
       log.warn("Error while trying to save K8S secret", e);
       if (e.getCode() == 404) {
         log.debug("Secret {} does not exist. Creating ...", name);
-        nsSecret = api.createNamespacedSecret(this.namespace, secret, null, null, null,null);
+        nsSecret = api.createNamespacedSecret(this.namespace, secret, null, null, null, null);
       } else {
         log.error("Failed to save k8s secret: {}", name);
         throw e;

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -422,7 +422,7 @@ public abstract class KubernetesService implements InitializingBean {
             .withMetadata(new V1ObjectMetaBuilder().withName(namespaceName).build())
             .build();
 
-    new CoreV1Api(client).createNamespace(namespaceBody, null, null, null);
+    new CoreV1Api(client).createNamespace(namespaceBody, null, null, null,null);
   }
 
   public void deleteNamespace(String namespaceName) throws ApiException {
@@ -923,7 +923,7 @@ public abstract class KubernetesService implements InitializingBean {
             jobLabels,
             imagePullSecrets);
     V1beta1CronJob nsJob =
-        new BatchV1beta1Api(client).createNamespacedCronJob(namespace, cronJob, null, null, null);
+        new BatchV1beta1Api(client).createNamespacedCronJob(namespace, cronJob, null, null, null,null);
     log.debug("Created k8s cron job: {}", nsJob);
     log.debug(
         "Created k8s cron job name: {}, uid:{}, link:{}",
@@ -967,7 +967,7 @@ public abstract class KubernetesService implements InitializingBean {
             jobLabels,
             imagePullSecrets);
     V1CronJob nsJob =
-        new BatchV1Api(client).createNamespacedCronJob(namespace, cronJob, null, null, null);
+        new BatchV1Api(client).createNamespacedCronJob(namespace, cronJob, null, null, null,null);
     log.debug("Created k8s cron job: {}", nsJob);
     log.debug(
         "Created k8s cron job name: {}, uid:{}, link:{}",
@@ -1119,7 +1119,7 @@ public abstract class KubernetesService implements InitializingBean {
             imagePullSecrets);
     V1beta1CronJob nsJob =
         new BatchV1beta1Api(client)
-            .replaceNamespacedCronJob(name, namespace, cronJob, null, null, null);
+            .replaceNamespacedCronJob(name, namespace, cronJob, null, null, null,null);
     log.debug(
         "Updated k8s cron job status for name:{}, image:{}, uid:{}, link:{}",
         name,
@@ -1160,7 +1160,7 @@ public abstract class KubernetesService implements InitializingBean {
             jobLabels,
             imagePullSecrets);
     V1CronJob nsJob =
-        new BatchV1Api(client).replaceNamespacedCronJob(name, namespace, cronJob, null, null, null);
+        new BatchV1Api(client).replaceNamespacedCronJob(name, namespace, cronJob, null, null, null,null);
     log.debug(
         "Updated k8s cron job status for name:{}, image:{}, uid:{}, link:{}",
         name,
@@ -1258,7 +1258,7 @@ public abstract class KubernetesService implements InitializingBean {
             .withSpec(spec)
             .build();
 
-    V1Job nsJob = new BatchV1Api(client).createNamespacedJob(namespace, job, null, null, null);
+    V1Job nsJob = new BatchV1Api(client).createNamespacedJob(namespace, job, null, null, null,null);
     log.debug("Created k8s job: {}", nsJob);
     log.debug(
         "Created k8s job name: {}, uid:{}, link:{}",
@@ -2314,12 +2314,12 @@ public abstract class KubernetesService implements InitializingBean {
 
     V1Secret nsSecret;
     try {
-      nsSecret = api.replaceNamespacedSecret(name, this.namespace, secret, null, null, null);
+      nsSecret = api.replaceNamespacedSecret(name, this.namespace, secret, null, null, null,null);
     } catch (ApiException e) {
       log.warn("Error while trying to save K8S secret", e);
       if (e.getCode() == 404) {
         log.debug("Secret {} does not exist. Creating ...", name);
-        nsSecret = api.createNamespacedSecret(this.namespace, secret, null, null, null);
+        nsSecret = api.createNamespacedSecret(this.namespace, secret, null, null, null,null);
       } else {
         log.error("Failed to save k8s secret: {}", name);
         throw e;


### PR DESCRIPTION
# Why?
I upgraded java client k8s version when trying to fix an issue related to connecting to the k8s cluster. 
This was ultimately not the fix that was needed. But considering the work is done I think it make sense to merge it regardless. 

# What?
Upgrade the version in gradle and make a few small code changes to support the new apis. 

# How has this been tested?
Unit tests, integration tests but no new tests have been added

# What type of change are you making?
Upgrade the version in gradle and make a few small code changes to support the new apis. 


Signed-off-by: murphp15 <murphp15@tcd.ie>