### PR TITLE
vdk-pipeline-control-service: improve docs and local runability of integration tests

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/README.md
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/README.md
@@ -3,13 +3,26 @@ This directory contains Integration tests for the Pipelines Control Service.
 The goal of the tests is to validate that the functionality of the service
 works in combination with other dependant components (KDC, Kubernetes, DB, Git repo, etc).
 
-# Prerequisites
+# Prerequisites to run locally
 * Kubernetes 1.15+ (E.g. minikube, kubernetes-in-docker, etc.)
 * Valid kubeconfig.yaml in ```${HOME}/.kube/config``` or set the ```datajobs.deployment.k8s.kubeconfig``` and ```datajobs.control.k8s.kubeconfig``` property
   in [integration-test/resources/application-test.properties](./resources/application-test.properties)
+* Git repo for storing the jobs
+  * Create an empty personal repo with a branch called `main`. e.g https://github.com/murphp15/test/tree/main
+* Docker registry for pushing and pulling the containers to
+  * It is recommended to use the private package manager provided Github located at https://ghcr.io.
+* Kubernetes needs to be configured with permissions to pull from the private github package manager
+```bash
+ kubectl create secret docker-registry regcred --docker-server=ghcr.io/<my_username> --docker-username=<my_username> --docker-password=<github_personal_access_token> --docker-email=<your-email>
+```
 * Fill required values section in [integration-test/resources/application-test.properties](./resources/application-test.properties)
-* example-integration-test need to exist in Data Jobs repository and correct git version for it
-  See DataJobDeploymentCrudIT#TEST_JOB_NAME and #TEST_JOB_VERSION
+```properties
+datajobs.docker.repositoryUrl=${DOCKER_REGISTRY_URL} # the URL of the docker registry created above. e.g ghcr.io/murphp15
+datajobs.git.url=${GIT_URL}  # the URL of the git repo created above. e.g github.com/murphp15/test
+datajobs.git.username=${GIT_USERNAME} # self explanatory
+datajobs.git.password=${GIT_PASSWORD} # a git personal access token
+```
+
 
 # Run
 ## IntelliJ

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-test.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-test.properties
@@ -12,20 +12,26 @@ datajobs.aws.secretAccessKey=
 datajobs.vdk_options_ini=
 datajobs.vdk.image=registry.hub.docker.com/versatiledatakit/quickstart-vdk:release
 
-datajobs.deployment.k8s.kubeconfig=${DEPLOYMENT_K8S_KUBECONFIG}
-datajobs.deployment.k8s.namespace=${DEPLOYMENT_K8S_NAMESPACE}
+datajobs.deployment.k8s.kubeconfig=${DEPLOYMENT_K8S_KUBECONFIG:}
+datajobs.deployment.k8s.namespace=${DEPLOYMENT_K8S_NAMESPACE:default}
 datajobs.control.k8s.k8sSupportsV1CronJob=false
 
-datajobs.control.k8s.kubeconfig=${CONTROL_K8S_KUBECONFIG}
-datajobs.control.k8s.namespace=${CONTROL_K8S_NAMESPACE}
+datajobs.control.k8s.kubeconfig=${CONTROL_K8S_KUBECONFIG:}
+datajobs.control.k8s.namespace=${CONTROL_K8S_NAMESPACE:default}
 
 datajobs.docker.repositoryUrl=${DOCKER_REGISTRY_URL}
 datajobs.docker.registryType=generic
 
+datajobs.git.url=${GIT_URL}
+datajobs.git.username=${GIT_USERNAME}
+datajobs.git.password=${GIT_PASSWORD}
+datajobs.git.branch=main
+
 # Credentials for generic registry type like Harbor or Dockerhub.
-datajobs.docker.registryUsername=${DOCKER_REGISTRY_USERNAME}
-datajobs.docker.registryPassword=${DOCKER_REGISTRY_PASSWORD}
-datajobs.docker.registrySecret=${DOCKER_REGISTRY_SECRET:}
+# If using git container registry then nothing needs to be set here
+datajobs.docker.registryUsername=${DOCKER_REGISTRY_USERNAME:${datajobs.git.username}}
+datajobs.docker.registryPassword=${DOCKER_REGISTRY_PASSWORD:${datajobs.git.password}}
+datajobs.docker.registrySecret=${DOCKER_REGISTRY_SECRET:regcred}
 
 #WebHook settings for the integration tests
 integrationTest.mockedWebHookServerHost=localhost
@@ -43,22 +49,19 @@ spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://test
 
 # By default test tries to create namespace dynamically - in this case leave them empty.
 # If in your kubernetes that is not possible, set a fixed namespace here
-integrationTest.dataJobsNamespace=${DEPLOYMENT_K8S_NAMESPACE}
-integrationTest.controlNamespace=${CONTROL_K8S_NAMESPACE}
+integrationTest.dataJobsNamespace=${DEPLOYMENT_K8S_NAMESPACE:default}
+integrationTest.controlNamespace=${CONTROL_K8S_NAMESPACE:default}
 
 datajobs.builder.image=registry.hub.docker.com/versatiledatakit/job-builder:1.2.3
-datajobs.proxy.repositoryUrl=${DOCKER_REGISTRY_URL}
+datajobs.proxy.repositoryUrl=${datajobs.docker.repositoryUrl}
 datajobs.deployment.dataJobBaseImage=versatiledatakit/data-job-base-python-3.7:latest
 
-datajobs.git.url=${GIT_URL}
-datajobs.git.username=${GIT_USERNAME}
-datajobs.git.password=${GIT_PASSWORD}
-datajobs.git.branch=main
+datajobs.deployment.builder.extraArgs=--force
 
 # For local run, create personal access token in github with read and write access (or use your user and password)
 # and export those environmental variables in the terminal or in your IDE depending on how you run the tests .
-datajobs.git.read.write.username=${GIT_USERNAME_READ_WRITE}
-datajobs.git.read.write.password=${GIT_PASSWORD_READ_WRITE}
+datajobs.git.read.write.username=${GIT_USERNAME_READ_WRITE:${datajobs.git.username}}
+datajobs.git.read.write.password=${GIT_PASSWORD_READ_WRITE:${datajobs.git.password}}
 
 datajobs.executions.logsUrl.template=https://log-insight-base-url/li/query/stream?query=%C2%A7%C2%A7%C2%A7AND%C\
 2%A7%C2%A7%C2%A7%C2%A7{{start_time}}%C2%A7{{end_time}}%C2%A7true%C2%A7COUNT%C2%A7*%C2%A7\


### PR DESCRIPTION
# Why?
When I tried to run the integration tests locally I experienced a number of issues. 
I have updated the docs and configuration to make it much quicker to get the tests running locally.

# What?
I added the property
```
datajobs.deployment.builder.extraArgs=--force
```
I also improved the docs and make more defaults in the test configuration file. 
# How has this been tested?
integration tests. No extra tests added
# What type of change are you making?
small changes to docs and also change to the configuration file for tests to give more sensible defaults 
Signed-off-by: murphp15 <murphp15@tcd.ie>