### PR TITLE
vdk-plugins: introduced vdk-audit-hook plugin

### DIFF
--- a/projects/vdk-plugins/__init__.py
+++ b/projects/vdk-plugins/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0

--- a/projects/vdk-plugins/vdk-audit-hook/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-audit-hook/.plugin-ci.yml
@@ -1,0 +1,24 @@
+# Copyright 2022 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+.build-vdk-audit-hook:
+  variables:
+    PLUGIN_NAME: vdk-audit-hook
+  extends: .build-plugin
+
+build-py38-vdk-audit-hook:
+  extends: .build-vdk-audit-hook
+  image: "python:3.8"
+
+build-py39-vdk-audit-hook:
+  extends: .build-vdk-audit-hook
+  image: "python:3.9"
+
+build-py310-vdk-audit-hook:
+  extends: .build-vdk-audit-hook
+  image: "python:3.10"
+
+release-vdk-audit-hook:
+  variables:
+    PLUGIN_NAME: vdk-audit-hook
+  extends: .release-plugin

--- a/projects/vdk-plugins/vdk-audit-hook/README.md
+++ b/projects/vdk-plugins/vdk-audit-hook/README.md
@@ -1,0 +1,16 @@
+## Versatile Data Kit Audit Hook Plugin
+
+Visibility into the actions provides opportunities for test frameworks, logging
+frameworks, and security tools to monitor and optionally limit actions taken by the
+runtime.
+This plugin provides an ability to audit and potentially limit user actions. In
+order to have a better understanding of what exactly the job does, we will log all
+job actions.
+
+### Usage
+
+To use the plugin, just install it using
+
+```bash
+pip install vdk-audit-hook
+```

--- a/projects/vdk-plugins/vdk-audit-hook/requirements.txt
+++ b/projects/vdk-plugins/vdk-audit-hook/requirements.txt
@@ -1,0 +1,5 @@
+pytest
+vdk-core
+
+# testing
+vdk-test-utils

--- a/projects/vdk-plugins/vdk-audit-hook/setup.py
+++ b/projects/vdk-plugins/vdk-audit-hook/setup.py
@@ -1,0 +1,32 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import pathlib
+
+import setuptools
+
+
+__version__ = "0.1.0"
+
+setuptools.setup(
+    name="vdk-audit-hook",
+    version=__version__,
+    url="https://github.com/vmware/versatile-data-kit",
+    description="Versatile Data Kit SDK Audit Hook plugin restricts not permitted actions.",
+    long_description=pathlib.Path("README.md").read_text(),
+    long_description_content_type="text/markdown",
+    install_requires=["vdk-core"],
+    package_dir={"": "src"},
+    packages=setuptools.find_namespace_packages(where="src"),
+    entry_points={
+        "vdk.plugin.run": ["vdk-audit-hook = vdk.plugin.audit_hook.audit_hook_plugin"]
+    },
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+    ],
+)

--- a/projects/vdk-plugins/vdk-audit-hook/src/vdk/plugin/audit_hook/audit_hook_config.py
+++ b/projects/vdk-plugins/vdk-audit-hook/src/vdk/plugin/audit_hook/audit_hook_config.py
@@ -31,9 +31,12 @@ class AuditHookConfiguration:
 
 
 def add_definitions(config_builder: ConfigurationBuilder) -> None:
+<<<<<<< HEAD
     """
     Here we define what configuration settings are needed for Impala with reasonable defaults
     """
+=======
+>>>>>>> 239d7165 (vdk-plugins: introduced vdk-audit-hook plugin)
     config_builder.add(
         key=AUDIT_HOOK_ENABLED,
         default_value=True,

--- a/projects/vdk-plugins/vdk-audit-hook/src/vdk/plugin/audit_hook/audit_hook_config.py
+++ b/projects/vdk-plugins/vdk-audit-hook/src/vdk/plugin/audit_hook/audit_hook_config.py
@@ -1,0 +1,51 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from vdk.internal.core.config import ConfigurationBuilder
+
+AUDIT_HOOK_ENABLED = "AUDIT_HOOK_ENABLED"
+NOT_PERMITTED_EVENTS_LIST = "NOT_PERMITTED_EVENTS_LIST"
+EXIT_ON_NOT_PERMITTED_EVENT = "EXIT_ON_NOT_PERMITTED_EVENT"
+NOT_PERMITTED_EVENTS_LIST_DEFAULT = (
+    "os.system;os.chdir;os.chflags;os.chmod;os.chown;os.fork;"
+    "os.forkpty;os.getxattr;os.kill;os.killpg;os.link;os.listxattr;"
+    "os.lockf;os.posix_spawn;os.putenv;os.removexattr;os.rmdir;"
+    "os.scandir;os.setxattr;os.spawn;os.startfile;os.symlink;"
+    "os.truncate;os.unsetenv;os.utime;pty.spawn"
+)
+
+
+class AuditHookConfiguration:
+    def __init__(self, config):
+        self.__config = config
+
+    def enabled(self):
+        return self.__config.get_value(AUDIT_HOOK_ENABLED)
+
+    def not_permitted_events_list(self):
+        return self.__config.get_value(NOT_PERMITTED_EVENTS_LIST)
+
+    def exit_on_not_permitted_event(self):
+        return self.__config.get_value(EXIT_ON_NOT_PERMITTED_EVENT)
+
+
+def add_definitions(config_builder: ConfigurationBuilder) -> None:
+    """
+    Here we define what configuration settings are needed for Impala with reasonable defaults
+    """
+    config_builder.add(
+        key=AUDIT_HOOK_ENABLED,
+        default_value=True,
+        description="Set to false if you want to disable audit hook plugin entirely.",
+    )
+    config_builder.add(
+        key=NOT_PERMITTED_EVENTS_LIST,
+        default_value=NOT_PERMITTED_EVENTS_LIST_DEFAULT,
+        description="List of NOT permitted actions.",
+    )
+    config_builder.add(
+        key=EXIT_ON_NOT_PERMITTED_EVENT,
+        default_value=True,
+        description="Set to false if you want to disable termination of data job on not permitted action.",
+    )

--- a/projects/vdk-plugins/vdk-audit-hook/src/vdk/plugin/audit_hook/audit_hook_plugin.py
+++ b/projects/vdk-plugins/vdk-audit-hook/src/vdk/plugin/audit_hook/audit_hook_plugin.py
@@ -41,7 +41,11 @@ class AuditHookPlugin:
 
                 if self._config.exit_on_not_permitted_event():
                     logging.getLogger(__name__).error(
+<<<<<<< HEAD
                         f'[Audit Hook] Exiting the data job due to the NOT permitted operation "{event}" with arguments "{args}"'
+=======
+                        f'[Audit Hook] Terminating the data job due to the NOT permitted operation "{event}" with arguments "{args}"'
+>>>>>>> 239d7165 (vdk-plugins: introduced vdk-audit-hook plugin)
                     )
                     os._exit(0)
 

--- a/projects/vdk-plugins/vdk-audit-hook/src/vdk/plugin/audit_hook/audit_hook_plugin.py
+++ b/projects/vdk-plugins/vdk-audit-hook/src/vdk/plugin/audit_hook/audit_hook_plugin.py
@@ -1,0 +1,53 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+import os
+import sys
+from typing import List
+
+from vdk.api.plugin.hook_markers import hookimpl
+from vdk.api.plugin.plugin_registry import IPluginRegistry
+from vdk.internal.builtin_plugins.run.job_context import JobContext
+from vdk.internal.core.config import ConfigurationBuilder
+from vdk.plugin.audit_hook.audit_hook_config import add_definitions
+from vdk.plugin.audit_hook.audit_hook_config import AuditHookConfiguration
+
+
+class AuditHookPlugin:
+    @staticmethod
+    @hookimpl
+    def vdk_configure(config_builder: ConfigurationBuilder) -> None:
+        add_definitions(config_builder)
+
+    @hookimpl
+    def initialize_job(self, context: JobContext) -> None:
+        self._config = AuditHookConfiguration(context.core_context.configuration)
+
+        if not self._config.enabled():
+            return
+
+        not_permitted_events_list = self._config.not_permitted_events_list().split(";")
+
+        def _audit(event, args):
+            if any(
+                event in not_permitted_event
+                for not_permitted_event in not_permitted_events_list
+            ):
+                logging.getLogger(__name__).warning(
+                    f'[Audit Hook] Detected NOT permitted operation "{event}" with arguments "{args}"'
+                )
+
+                if self._config.exit_on_not_permitted_event():
+                    logging.getLogger(__name__).error(
+                        f'[Audit Hook] Exiting the data job due to the NOT permitted operation "{event}" with arguments "{args}"'
+                    )
+                    os._exit(0)
+
+        sys.addaudithook(_audit)
+
+
+@hookimpl
+def vdk_start(plugin_registry: IPluginRegistry, command_line_args: List):
+    plugin_registry.load_plugin_with_hooks_impl(AuditHookPlugin(), "audit-hook-plugin")

--- a/projects/vdk-plugins/vdk-audit-hook/tests/functional/jobs/os-listdir-command-job/10_os_listdir_command_job.py
+++ b/projects/vdk-plugins/vdk-audit-hook/tests/functional/jobs/os-listdir-command-job/10_os_listdir_command_job.py
@@ -1,0 +1,9 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import os
+
+from vdk.api.job_input import IJobInput
+
+
+def run(job_input: IJobInput):
+    os.listdir(".")

--- a/projects/vdk-plugins/vdk-audit-hook/tests/functional/jobs/os-system-command-job/10_os_system_command_job.py
+++ b/projects/vdk-plugins/vdk-audit-hook/tests/functional/jobs/os-system-command-job/10_os_system_command_job.py
@@ -1,0 +1,9 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import os
+
+from vdk.api.job_input import IJobInput
+
+
+def run(job_input: IJobInput):
+    os.system("ls")

--- a/projects/vdk-plugins/vdk-audit-hook/tests/functional/test_audit_hook_plugin.py
+++ b/projects/vdk-plugins/vdk-audit-hook/tests/functional/test_audit_hook_plugin.py
@@ -1,0 +1,76 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import os
+from unittest import mock
+
+from click.testing import Result
+from vdk.plugin.audit_hook import audit_hook_plugin
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_funcs import jobs_path_from_caller_directory
+
+
+def test_audit_hook_enabled_and_not_permitted_action():
+    with mock.patch.dict(
+        os.environ,
+        {
+            "VDK_AUDIT_HOOK_ENABLED": "True",
+            "NOT_PERMITTED_EVENTS_LIST": "exec;os.system",
+        },
+    ):
+        os._exit = mock.MagicMock()
+        runner = CliEntryBasedTestRunner(audit_hook_plugin)
+
+        runner.invoke(["run", jobs_path_from_caller_directory("os-system-command-job")])
+
+        assert os._exit.called
+
+
+def test_audit_hook_enabled_and_permitted_action():
+    with mock.patch.dict(
+        os.environ,
+        {"VDK_AUDIT_HOOK_ENABLED": "True", "NOT_PERMITTED_EVENTS_LIST": "os.system"},
+    ):
+        os._exit = mock.MagicMock()
+        runner = CliEntryBasedTestRunner(audit_hook_plugin)
+
+        result: Result = runner.invoke(
+            ["run", jobs_path_from_caller_directory("os-listdir-command-job")]
+        )
+
+        cli_assert_equal(0, result)
+        assert not os._exit.called
+
+
+def test_audit_hook_disabled_and_not_permitted_action():
+    with mock.patch.dict(
+        os.environ,
+        {"VDK_AUDIT_HOOK_ENABLED": "False", "NOT_PERMITTED_EVENTS_LIST": "os.system"},
+    ):
+        os._exit = mock.MagicMock()
+        runner = CliEntryBasedTestRunner(audit_hook_plugin)
+
+        result: Result = runner.invoke(
+            ["run", jobs_path_from_caller_directory("os-system-command-job")]
+        )
+
+        cli_assert_equal(0, result)
+        assert not os._exit.called
+
+
+def test_audit_hook_disabled_and_permitted_action():
+    with mock.patch.dict(
+        os.environ,
+        {"VDK_AUDIT_HOOK_ENABLED": "False", "NOT_PERMITTED_EVENTS_LIST": "os.system"},
+    ):
+        os._exit = mock.MagicMock()
+        runner = CliEntryBasedTestRunner(audit_hook_plugin)
+
+        result: Result = runner.invoke(
+            ["run", jobs_path_from_caller_directory("os-listdir-command-job")]
+        )
+
+        cli_assert_equal(0, result)
+        assert not os._exit.called


### PR DESCRIPTION
Currently, the VDK users have the ability to execute any kind of system commands through the data job. This increases the risk to the system as data jobs contain arbitrary user code.

Visibility into the actions provides opportunities for test frameworks, logging frameworks, and security tools to monitor and optionally limit actions taken by the runtime.
This plugin provides the ability to audit and potentially limit user actions. In order to reduce the attack surface, we will limit the user actions related to the interaction with the system like os commands (e.g. `os.system("ls")`). Also, to have a better understanding of what precisely the job does, we will log not permitted job actions. The plugin is based on the Python Audit Hook and you can find more information here - https://peps.python.org/pep-0578/.

Testing Done: local job execution and unit tests

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com