### PR TITLE
vdk-pipeline-control-plane: better error logging for transient error in tests

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobTerminationStatusIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobTerminationStatusIT.java
@@ -150,7 +150,9 @@ public class DataJobTerminationStatusIT extends BaseDataJobDeploymentIT {
     System.out.println(match.get().trim());
     assertTrue(
         match.get().trim().endsWith("0.0"),
-        "The value of the taurus_datajob_termination_status metrics does not match. It was actually "+ match.get());
+        "The value of the taurus_datajob_termination_status metrics does not match. It was actually"
+            + " "
+            + match.get());
 
     // Check the data job execution status
     checkDataJobExecutionStatus(

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobTerminationStatusIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobTerminationStatusIT.java
@@ -150,7 +150,7 @@ public class DataJobTerminationStatusIT extends BaseDataJobDeploymentIT {
     System.out.println(match.get().trim());
     assertTrue(
         match.get().trim().endsWith("0.0"),
-        "The value of the taurus_datajob_termination_status metrics does not match");
+        "The value of the taurus_datajob_termination_status metrics does not match. It was actually "+ match.get());
 
     // Check the data job execution status
     checkDataJobExecutionStatus(


### PR DESCRIPTION
# Why

When the tests fails it would be nice to know what the actual value is and not just that it doesn't match.
Here we can see the error is not nearly descriptive enough
https://vmware-analytics.gitlab.io/-/versatile-data-kit/-/jobs/3130654022/artifacts/projects/control-service/projects/pipelines_control_service/build/reports/tests/integrationTest/classes/com.vmware.taurus.datajobs.it.DataJobTerminationStatusIT.html#testDataJobTerminationStatus(String,%20String,%20String)

# What
Added extra details to the error message. 

Signed-off-by: murphp15 <murphp15@tcd.ie>