### PR TITLE
vdk-core: platform error no longer logged when skipping execution steps

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/file_based_step.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/file_based_step.py
@@ -137,7 +137,11 @@ class StepFuncFactory:
             try:
                 func(**actual_arguments)
             except SkipRemainingStepsException as e:
-                log.info(e)
+                # Catch and rethrow exception here since it is handled at
+                # the run_step() hook level. We also don't want to use the
+                # errors.log_and_rethrow() method since it will log a
+                # confusing message to the users.
+                log.debug(e)
                 raise e
             except BaseException as e:
                 from vdk.internal.builtin_plugins.run.job_input_error_classifier import (

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/file_based_step.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/file_based_step.py
@@ -11,6 +11,7 @@ from typing import List
 from vdk.api.job_input import IJobInput
 from vdk.internal.builtin_plugins.run.step import Step
 from vdk.internal.core import errors
+from vdk.internal.core.errors import SkipRemainingStepsException
 
 log = logging.getLogger(__name__)
 
@@ -135,6 +136,9 @@ class StepFuncFactory:
         if actual_arguments:
             try:
                 func(**actual_arguments)
+            except SkipRemainingStepsException as e:
+                log.info(e)
+                raise e
             except BaseException as e:
                 from vdk.internal.builtin_plugins.run.job_input_error_classifier import (
                     whom_to_blame,
@@ -146,7 +150,7 @@ class StepFuncFactory:
                     what_happened=f"Data Job step {step_name} completed with error.",
                     why_it_happened=errors.MSG_WHY_FROM_EXCEPTION(e),
                     consequences="I will not process the remaining steps (if any), "
-                    "and this Data Job execution will likely be marked as failed.",
+                    "and this Data Job execution will be marked as failed.",
                     countermeasures="See exception and fix the root cause, so that the exception does "
                     "not appear anymore.",
                     exception=e,

--- a/projects/vdk-core/tests/functional/run/test_run_job_cancel.py
+++ b/projects/vdk-core/tests/functional/run/test_run_job_cancel.py
@@ -1,6 +1,5 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
-import logging
 import unittest.mock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -10,7 +9,6 @@ from functional.run import util
 from vdk.internal.core import errors
 from vdk.plugin.test_utils.util_funcs import cli_assert_equal
 from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
-from vdk.plugin.test_utils.util_funcs import TestingCliEntryPlugin
 
 
 class TestCancellation(unittest.TestCase):

--- a/projects/vdk-core/tests/functional/run/test_run_job_cancel.py
+++ b/projects/vdk-core/tests/functional/run/test_run_job_cancel.py
@@ -1,12 +1,20 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import unittest.mock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import vdk.internal.core.errors
 from click.testing import Result
 from functional.run import util
 from vdk.plugin.test_utils.util_funcs import cli_assert_equal
 from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
 
 
-def test_run():
+@patch(
+    "vdk.internal.builtin_plugins.termination_message.writer.TerminationMessageWriterPlugin.write_termination_message"
+)
+def test_run(patched_writer: MagicMock):
     """
     Test that runs a sample data job consisting of 3 steps.
     Each step logs <Step 1,2> etc. However after the second step's log call
@@ -21,6 +29,11 @@ def test_run():
 
     result: Result = test_runner.invoke(["run", util.job_path("cancel-job")])
 
+    # Check the writer plugin wasn't called with user or platform errors.
+    # 1st param is overall blamee, should be None.
+    # 2nd parm is overall user error in this case it's empty string which is a falsy value.
+    # 3rd param is context.configuration and can be ignored for this test.
+    patched_writer.assert_called_once_with(None, "", unittest.mock.ANY)
     assert "Step Cancel 1." in result.output
     assert "Step Cancel 2." in result.output
     assert "Step Cancel 3." not in result.output

--- a/projects/vdk-core/tests/functional/run/test_run_job_cancel.py
+++ b/projects/vdk-core/tests/functional/run/test_run_job_cancel.py
@@ -4,7 +4,6 @@ import unittest.mock
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
-import vdk.internal.core.errors
 from click.testing import Result
 from functional.run import util
 from vdk.plugin.test_utils.util_funcs import cli_assert_equal

--- a/projects/vdk-core/tests/functional/run/test_run_job_cancel.py
+++ b/projects/vdk-core/tests/functional/run/test_run_job_cancel.py
@@ -1,43 +1,51 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import logging
 import unittest.mock
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from click.testing import Result
 from functional.run import util
+from vdk.internal.core import errors
 from vdk.plugin.test_utils.util_funcs import cli_assert_equal
 from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_funcs import TestingCliEntryPlugin
 
 
-@patch(
-    "vdk.internal.builtin_plugins.termination_message.writer.TerminationMessageWriterPlugin.write_termination_message"
-)
-def test_run(patched_writer: MagicMock):
-    """
-    Test that runs a sample data job consisting of 3 steps.
-    Each step logs <Step 1,2> etc. However after the second step's log call
-    the cancel_job_execution method is invoked which should cancel
-    the job execution. Test checks:
-    execution is canceled and final step isn't executed.
-    proper exit code is set.
-    proper message is logged confirming job was cancelled from cancel_job_execution() method.
-    :return:
-    """
-    test_runner = CliEntryBasedTestRunner()
-
-    result: Result = test_runner.invoke(["run", util.job_path("cancel-job")])
-
-    # Check the writer plugin wasn't called with user or platform errors.
-    # 1st param is overall blamee, should be None.
-    # 2nd parm is overall user error in this case it's empty string which is a falsy value.
-    # 3rd param is context.configuration and can be ignored for this test.
-    patched_writer.assert_called_once_with(None, "", unittest.mock.ANY)
-    assert "Step Cancel 1." in result.output
-    assert "Step Cancel 2." in result.output
-    assert "Step Cancel 3." not in result.output
-    assert (
-        "Job/template execution was skipped from job/template step code."
-        in result.output
+class TestCancellation(unittest.TestCase):
+    @patch(
+        "vdk.internal.builtin_plugins.termination_message.writer.TerminationMessageWriterPlugin"
+        + ".write_termination_message"
     )
-    cli_assert_equal(0, result)
+    def test_run(self, patched_writer: MagicMock):
+        """
+        Test that runs a sample data job consisting of 3 steps.
+        Each step logs <Step 1,2> etc. However after the second step's log call
+        the cancel_job_execution method is invoked which should cancel
+        the job execution. Test checks:
+        execution is canceled and final step isn't executed.
+        proper exit code is set.
+        proper message is logged confirming job was cancelled from cancel_job_execution() method.
+        :return:
+        """
+        test_runner = CliEntryBasedTestRunner()
+
+        # clear recorded errors before invoking run since other tests might leave a dirty state
+        errors.clear_intermediate_errors()
+
+        result: Result = test_runner.invoke(["run", util.job_path("cancel-job")])
+
+        # Check the writer plugin wasn't called with user or platform errors.
+        # 1st param is overall blamee, should be None.
+        # 2nd parm is overall user error in this case it's empty string which is a falsy value.
+        # 3rd param is context.configuration and can be ignored for this test.
+        patched_writer.assert_called_once_with(None, "", unittest.mock.ANY)
+        assert "Step Cancel 1." in result.output
+        assert "Step Cancel 2." in result.output
+        assert "Step Cancel 3." not in result.output
+        assert (
+            "Job/template execution was skipped from job/template step code."
+            in result.output
+        )
+        cli_assert_equal(0, result)

--- a/projects/vdk-core/tests/functional/run/test_run_templates.py
+++ b/projects/vdk-core/tests/functional/run/test_run_templates.py
@@ -86,9 +86,5 @@ def test_run_job_with_cancelled_template():
     assert "Step Cancel 1." in result.output
     assert "Step Cancel 2." in result.output
     assert "Step Cancel 3." not in result.output
-    assert (
-        "Job/template execution was skipped from job/template step code."
-        in result.output
-    )
 
     cli_assert_equal(0, result)


### PR DESCRIPTION
what: Changed the call to the errors.log_and_rethrow method for
a simple log statement and re-raising the exception when the
CancelRemainingSteps exception is raised.

why: Users reading the logs might be confused by the statement,
which assumes a platform error occurred. Recently reverted changes
to the error handling also made jobs using this feature fail with
platform errors since the log_and_rethrow method tripped the
internal logic and made the writer plugin write a platform error
termination message.

testing: Expanded unit test to cover the termination plugin when using
the skip_remaining_steps() functionality.