### PR TITLE
vdk-plugins: set dind tempalte job for default build of plugins

### DIFF
--- a/projects/vdk-core/requirements.txt
+++ b/projects/vdk-core/requirements.txt
@@ -1,4 +1,4 @@
-# Python dependencies used during build and tests
+# Python dependencies used during build and tests.
 # For dependencies used during installation make sure to set them in setup.cfg (install_requires section)
 
 -e ../vdk-plugins/vdk-test-utils

--- a/projects/vdk-plugins/.plugin-common.yml
+++ b/projects/vdk-plugins/.plugin-common.yml
@@ -33,9 +33,9 @@
   stage: pre_release_test
   variables:
     USE_VDKCORE_DEV_VERSION: "yes"
-  extends: .build-plugin
+  extends: .build-plugin-dind
   rules:
-    - if: '$CI_COMMIT_BRANCH == "main"'
+    - if: '$CI_COMMIT_BRANCH == "main" || $CI_PIPELINE_SOURCE == "external_pull_request_event"'
       changes:
        - "projects/vdk-core/*"
        - "projects/vdk-core/src/**/*"

--- a/projects/vdk-plugins/vdk-kerberos-auth/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-kerberos-auth/.plugin-ci.yml
@@ -30,11 +30,11 @@ build-py310-vdk-kerberos-auth:
   extends: .build-vdk-kerberos-auth
   image: "python:3.10"
 
-build-vdk-kerberos-auth-on-vdk-core-release:
-  variables:
-    PLUGIN_NAME: vdk-kerberos-auth
-  extends: .build-plugin-on-vdk-core-release
-  image: "python:3.9"
+#build-vdk-kerberos-auth-on-vdk-core-release:
+#  variables:
+#    PLUGIN_NAME: vdk-kerberos-auth
+#  extends: .build-plugin-on-vdk-core-release
+#  image: "python:3.9"
 
 release-vdk-kerberos-auth:
   variables:


### PR DESCRIPTION
Some builds required Docker in docker (dind) so it's better to assume it's always found. 

This also changes the build-xxx-on-vdk-release to run before merge. For now.  It's better to block the PR than the CICD to be red. If it turns out they slow down things , we can reconsider . 

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>