### PR TITLE
vdk-quickstart-vdk: trigger a new release.

### DIFF
--- a/projects/vdk-plugins/quickstart-vdk/tests/test_dummy.py
+++ b/projects/vdk-plugins/quickstart-vdk/tests/test_dummy.py
@@ -1,6 +1,6 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-
+# test
 def test_dummy():
     assert True

--- a/projects/vdk-plugins/quickstart-vdk/tests/test_dummy.py
+++ b/projects/vdk-plugins/quickstart-vdk/tests/test_dummy.py
@@ -1,5 +1,6 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+
 # test
 def test_dummy():
     assert True

--- a/projects/vdk-plugins/quickstart-vdk/tests/test_dummy.py
+++ b/projects/vdk-plugins/quickstart-vdk/tests/test_dummy.py
@@ -1,6 +1,5 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
-
 # test
 def test_dummy():
     assert True


### PR DESCRIPTION
# Why?
The latest version of docker quickstart vdk for release tag is using python 3.9 instead of 3.7 https://hub.docker.com/r/versatiledatakit/quickstart-vdk/tags.
Which is not what master or the intgration tests expect. 
I am pushing this change to trigger a new release of the image so that the latest release tag is for a python 3.7 image.

# What?
This PR is a no-op. 
It is being used entirely to trigger a new release of main. 

# How has this been tested?
I will look at the image after it is generated to make sure that it is 3.7


# What type of change are you making?
Bug fix

Signed-off-by: murphp15 <murphp15@tcd.ie>