### PR TITLE
[vdk-plugins] vdk-ingest-http: Move data conversion above size calc

### DIFF
--- a/projects/vdk-plugins/vdk-ingest-http/src/vdk/plugin/ingest_http/ingest_over_http.py
+++ b/projects/vdk-plugins/vdk-ingest-http/src/vdk/plugin/ingest_http/ingest_over_http.py
@@ -172,9 +172,9 @@ class IngestOverHttp(IIngesterPlugin):
                     obj["@table"] = destination_table
 
     def __send_data(self, data, http_url, headers) -> IngestionResult:
+        data = json.dumps(data, allow_nan=self._allow_nan)
         uncompressed_size_in_bytes = sys.getsizeof(data)
         compressed_size_in_bytes = None
-        data = json.dumps(data, allow_nan=self._allow_nan)
 
         if (
             self._compression_threshold_bytes

--- a/projects/vdk-plugins/vdk-ingest-http/tests/test_ingest_over_http.py
+++ b/projects/vdk-plugins/vdk-ingest-http/tests/test_ingest_over_http.py
@@ -119,7 +119,9 @@ def test_ingest_over_http_result(mock_post):
         target="http://example.com/data-source",
     )
 
-    assert ingestion_result["uncompressed_size_in_bytes"] == sys.getsizeof([payload])
+    assert ingestion_result["uncompressed_size_in_bytes"] == sys.getsizeof(
+        json.dumps([payload])
+    )
     assert ingestion_result["compressed_size_in_bytes"] == sys.getsizeof(
         gzip.compress(json.dumps([payload], allow_nan=False).encode(encoding))
     )


### PR DESCRIPTION
Currently, the memory size of the payload to be ingested is calculated before it is converted to string. This is fine for most cases, however, it gets a bit tricky for more complex objects, due to how memory size is calculated (see https://stackoverflow.com/questions/63204377/memory-size-of-list-python for reference).

This change moves the conversion of the payload to string before the memory size is calculated, so we avoid posibility to return misleading IngestionResult data.

Testing Done: Cosmetic change, all tests pass.

Signed-off-by: Andon Andonov <andonova@vmware.com>