### PR TITLE
control-service: Dynamic python site-packages directory detection

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobCommandProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobCommandProvider.java
@@ -26,8 +26,8 @@ public class JobCommandProvider {
         List.of(
             "/bin/bash",
             "-c",
-            "export PYTHONPATH=$(python -c \"from distutils.sysconfig import get_python_lib; print(get_python_lib())\"):/vdk/site-packages/ &&"
-                  + " /vdk/vdk run");
+            "export PYTHONPATH=$(python -c \"from distutils.sysconfig import get_python_lib;"
+                + " print(get_python_lib())\"):/vdk/site-packages/ && /vdk/vdk run");
   }
 
   private String getJobNameArgument(String jobName) {

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobCommandProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobCommandProvider.java
@@ -26,8 +26,8 @@ public class JobCommandProvider {
         List.of(
             "/bin/bash",
             "-c",
-            "export PYTHONPATH=/usr/local/lib/python3.7/site-packages:/vdk/site-packages/ &&"
-                + " /vdk/vdk run");
+            "export PYTHONPATH=$(python -c \"from distutils.sysconfig import get_python_lib; print(get_python_lib())\"):/vdk/site-packages/ &&"
+                  + " /vdk/vdk run");
   }
 
   private String getJobNameArgument(String jobName) {

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
@@ -234,7 +234,8 @@ public class JobImageDeployer {
         List.of(
             "/bin/bash",
             "-c",
-            "cp -r $(python -c \"from distutils.sysconfig import get_python_lib; print(get_python_lib())\") /vdk/. && cp /usr/local/bin/vdk /vdk/.");
+            "cp -r $(python -c \"from distutils.sysconfig import get_python_lib;"
+                + " print(get_python_lib())\") /vdk/. && cp /usr/local/bin/vdk /vdk/.");
     var jobVdkImage = getJobVdkImage(jobDeployment);
     var jobInitContainer =
         KubernetesService.container(

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
@@ -234,7 +234,7 @@ public class JobImageDeployer {
         List.of(
             "/bin/bash",
             "-c",
-            "cp -r /usr/local/lib/python3.7/site-packages /vdk/. && cp /usr/local/bin/vdk /vdk/.");
+            "cp -r $(python -c \"from distutils.sysconfig import get_python_lib; print(get_python_lib())\") /vdk/. && cp /usr/local/bin/vdk /vdk/.");
     var jobVdkImage = getJobVdkImage(jobDeployment);
     var jobInitContainer =
         KubernetesService.container(

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartJobWithArgumentsIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartJobWithArgumentsIT.java
@@ -66,8 +66,9 @@ public class KubernetesServiceStartJobWithArgumentsIT {
           capturedSpec.getTemplate().getSpec().getContainers().get(0).getCommand().get(2);
       // check if command arg starts correctly
       Assertions.assertEquals(
-          "export PYTHONPATH=$(python -c \"from distutils.sysconfig import get_python_lib; print(get_python_lib())\"):/vdk/site-packages/ && /vdk/vdk"
-              + " run ./test-job --arguments '{\"argument1\":\"value1\"}'",
+          "export PYTHONPATH=$(python -c \"from distutils.sysconfig import get_python_lib;"
+              + " print(get_python_lib())\"):/vdk/site-packages/ && /vdk/vdk run ./test-job"
+              + " --arguments '{\"argument1\":\"value1\"}'",
           capturedCommand);
 
     } catch (Exception e) {
@@ -92,7 +93,9 @@ public class KubernetesServiceStartJobWithArgumentsIT {
       // check if command arg starts correctly
       Assertions.assertTrue(
           capturedCommand.startsWith(
-              "export PYTHONPATH=$(python -c \"from distutils.sysconfig import get_python_lib; print(get_python_lib())\"):/vdk/site-packages/ && /vdk/vdk run ./test-job --arguments '{"),
+              "export PYTHONPATH=$(python -c \"from distutils.sysconfig import get_python_lib;"
+                  + " print(get_python_lib())\"):/vdk/site-packages/ && /vdk/vdk run ./test-job"
+                  + " --arguments '{"),
           "Vdk run command string invalid.");
       // extra arguments passed as a map, print order might be different.
       Assertions.assertTrue(

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartJobWithArgumentsIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartJobWithArgumentsIT.java
@@ -66,7 +66,7 @@ public class KubernetesServiceStartJobWithArgumentsIT {
           capturedSpec.getTemplate().getSpec().getContainers().get(0).getCommand().get(2);
       // check if command arg starts correctly
       Assertions.assertEquals(
-          "export PYTHONPATH=/usr/local/lib/python3.7/site-packages:/vdk/site-packages/ && /vdk/vdk"
+          "export PYTHONPATH=$(python -c \"from distutils.sysconfig import get_python_lib; print(get_python_lib())\"):/vdk/site-packages/ && /vdk/vdk"
               + " run ./test-job --arguments '{\"argument1\":\"value1\"}'",
           capturedCommand);
 
@@ -92,8 +92,7 @@ public class KubernetesServiceStartJobWithArgumentsIT {
       // check if command arg starts correctly
       Assertions.assertTrue(
           capturedCommand.startsWith(
-              "export PYTHONPATH=/usr/local/lib/python3.7/si"
-                  + "te-packages:/vdk/site-packages/ && /vdk/vdk run ./test-job --arguments '{"),
+              "export PYTHONPATH=$(python -c \"from distutils.sysconfig import get_python_lib; print(get_python_lib())\"):/vdk/site-packages/ && /vdk/vdk run ./test-job --arguments '{"),
           "Vdk run command string invalid.");
       // extra arguments passed as a map, print order might be different.
       Assertions.assertTrue(


### PR DESCRIPTION
The python site-packages directory is currently hardcoded in the data job container command. However,
this works only for data jobs based on Python 3.7.

This change aims to make the data job cronjob template agnostic for the python version by replacing the hardcoded python site-packages directory with a python command that returns it.

Tested locally against kind cluster.

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com