### PR TITLE
vdk-core: Allow for modification of dynamic params

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_base.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_base.py
@@ -439,6 +439,28 @@ class IngesterBase(IIngester):
                     for payload_dict in payload_obj:
                         self.__verify_payload_format(payload_dict=payload_dict)
 
+                    if ingestion_metadata:
+                        updated_dynamic_params: Optional[dict] = ingestion_metadata.pop(
+                            IIngesterPlugin.UPDATED_DYNAMIC_PARAMS, None
+                        )
+                        if updated_dynamic_params:
+                            destination_table = (
+                                updated_dynamic_params.get(
+                                    IIngesterPlugin.DESTINATION_TABLE_KEY
+                                )
+                                or destination_table
+                            )
+                            target = (
+                                updated_dynamic_params.get(IIngesterPlugin.TARGET_KEY)
+                                or target
+                            )
+                            collection_id = (
+                                updated_dynamic_params.get(
+                                    IIngesterPlugin.COLLECTION_ID_KEY
+                                )
+                                or collection_id
+                            )
+
                     try:
                         ingestion_metadata = self._ingester.ingest_payload(
                             payload=payload_obj,


### PR DESCRIPTION
The ingestion functionality in vdk-core allows for the creation of pre-processor plugins that modify the passed payload. This works for most use-cases, but not when an operator of Versatile Data Kit needs to modify or otherwise ammend the dynamically set parameters like target, destination_table, etc., to comply with specific rules.

This change adds functionality to allow for the modification of dynamically set parameters like target by pre-processor plugins. Once modified, the parameters are to be placed in a dictionary, which is then to be added to the metadata using the `updated_dynamic_params` key.

Testing Done: Unit test

Signed-off-by: Andon Andonov <andonova@vmware.com>