### PR TITLE
control-service: refactor db query to mitigate race condition

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobExecutionRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobExecutionRepository.java
@@ -8,6 +8,7 @@ package com.vmware.taurus.service;
 import com.vmware.taurus.service.model.*;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -49,6 +50,35 @@ public interface JobExecutionRepository
   @Transactional
   void deleteDataJobExecutionByIdAndDataJobAndStatusAndType(
       String id, DataJob dataJob, ExecutionStatus status, ExecutionType type);
+
+  /**
+   * Query method used to update execution status, end time and message of
+   * executions with specified id's and statuses.
+   * This method is necessary because we had a race condition between methods
+   * updating executions. The intention is to call this method only for executions
+   * in Running or Submitted state, therefore not updating executions that have a
+   * finalized state eliminating the possibility of race conditions.
+   *
+   * @param newStatus the new status to apply
+   * @param endTime the end time to set
+   * @param message the message to set
+   * @param statuses list of execution statuses permissible for update
+   * @param executionsToUpdate list of id's of executions to update.
+   */
+  @Modifying
+  @Transactional
+  @Query(
+      "UPDATE DataJobExecution dje SET dje.status = :newStatus,"
+          + " dje.endTime = :endTime,"
+          + " dje.message = :message"
+          + " WHERE dje.status in :statuses AND dje.id in :executionsToUpdate"
+  )
+  void updateExecutionStatusWhereOldStatusInAndExecutionIdIn(
+      @Param("newStatus") ExecutionStatus newStatus,
+      @Param("endTime") OffsetDateTime endTime,
+      @Param("message") String message,
+      @Param("statuses") List<ExecutionStatus> statuses,
+      @Param("executionsToUpdate") List<String> executionsToUpdate);
 
   @Query(
       "SELECT dje.status AS status, dje.dataJob.name AS jobName, count(dje.status) AS statusCount "

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobExecutionRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobExecutionRepository.java
@@ -52,12 +52,11 @@ public interface JobExecutionRepository
       String id, DataJob dataJob, ExecutionStatus status, ExecutionType type);
 
   /**
-   * Query method used to update execution status, end time and message of
-   * executions with specified id's and statuses.
-   * This method is necessary because we had a race condition between methods
-   * updating executions. The intention is to call this method only for executions
-   * in Running or Submitted state, therefore not updating executions that have a
-   * finalized state eliminating the possibility of race conditions.
+   * Query method used to update execution status, end time and message of executions with specified
+   * id's and statuses. This method is necessary because we had a race condition between methods
+   * updating executions. The intention is to call this method only for executions in Running or
+   * Submitted state, therefore not updating executions that have a finalized state eliminating the
+   * possibility of race conditions.
    *
    * @param newStatus the new status to apply
    * @param endTime the end time to set
@@ -71,8 +70,7 @@ public interface JobExecutionRepository
       "UPDATE DataJobExecution dje SET dje.status = :newStatus,"
           + " dje.endTime = :endTime,"
           + " dje.message = :message"
-          + " WHERE dje.status in :statuses AND dje.id in :executionsToUpdate"
-  )
+          + " WHERE dje.status in :statuses AND dje.id in :executionsToUpdate")
   void updateExecutionStatusWhereOldStatusInAndExecutionIdIn(
       @Param("newStatus") ExecutionStatus newStatus,
       @Param("endTime") OffsetDateTime endTime,

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
@@ -373,25 +373,25 @@ public class JobExecutionService {
     if (runningJobExecutionIds == null) {
       return;
     }
-
+    var runningJobStatus = List.of(ExecutionStatus.SUBMITTED, ExecutionStatus.RUNNING);
     List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsToBeUpdated =
         jobExecutionRepository
             .findDataJobExecutionsByStatusInAndStartTimeBefore(
-                List.of(ExecutionStatus.SUBMITTED, ExecutionStatus.RUNNING),
+                runningJobStatus,
                 OffsetDateTime.now().minusMinutes(3))
             .stream()
             .filter(dataJobExecution -> !runningJobExecutionIds.contains(dataJobExecution.getId()))
-            .map(
-                dataJobExecution -> {
-                  dataJobExecution.setStatus(ExecutionStatus.SUCCEEDED);
-                  dataJobExecution.setMessage("Status is set by VDK Control Service");
-                  dataJobExecution.setEndTime(OffsetDateTime.now());
-                  return dataJobExecution;
-                })
             .collect(Collectors.toList());
 
     if (!dataJobExecutionsToBeUpdated.isEmpty()) {
-      jobExecutionRepository.saveAll(dataJobExecutionsToBeUpdated);
+      var jobsToUpdate = dataJobExecutionsToBeUpdated.stream().map(e -> e.getId())
+          .collect(Collectors.toList());
+      jobExecutionRepository.updateExecutionStatusWhereOldStatusInAndExecutionIdIn(
+          ExecutionStatus.SUCCEEDED,
+          OffsetDateTime.now(),
+          "Status is set by VDK Control Service",
+          runningJobStatus,
+          jobsToUpdate);
       dataJobExecutionsToBeUpdated.forEach(
           dataJobExecution -> log.info("Sync Data Job Execution status: {}", dataJobExecution));
     }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
@@ -377,15 +377,14 @@ public class JobExecutionService {
     List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsToBeUpdated =
         jobExecutionRepository
             .findDataJobExecutionsByStatusInAndStartTimeBefore(
-                runningJobStatus,
-                OffsetDateTime.now().minusMinutes(3))
+                runningJobStatus, OffsetDateTime.now().minusMinutes(3))
             .stream()
             .filter(dataJobExecution -> !runningJobExecutionIds.contains(dataJobExecution.getId()))
             .collect(Collectors.toList());
 
     if (!dataJobExecutionsToBeUpdated.isEmpty()) {
-      var jobsToUpdate = dataJobExecutionsToBeUpdated.stream().map(e -> e.getId())
-          .collect(Collectors.toList());
+      var jobsToUpdate =
+          dataJobExecutionsToBeUpdated.stream().map(e -> e.getId()).collect(Collectors.toList());
       jobExecutionRepository.updateExecutionStatusWhereOldStatusInAndExecutionIdIn(
           ExecutionStatus.SUCCEEDED,
           OffsetDateTime.now(),

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobExecutionRepositoryIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobExecutionRepositoryIT.java
@@ -224,22 +224,24 @@ public class JobExecutionRepositoryIT {
   void testUpdateExecutionStatusWhereOldStatusInAndExecutionIdIn_withExecutions_shouldUpdateBoth() {
     DataJob dataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-    var execution1 = RepositoryUtil.createDataJobExecution(
-        jobExecutionRepository,
-        "execution1",
-        dataJob,
-        ExecutionStatus.SUCCEEDED,
-        "Success",
-        OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
-        OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC));
-    var execution2 = RepositoryUtil.createDataJobExecution(
-        jobExecutionRepository,
-        "execution2",
-        dataJob,
-        ExecutionStatus.RUNNING,
-        null,
-        OffsetDateTime.of(2000, 1, 1, 4, 0, 0, 0, ZoneOffset.UTC),
-        null);
+    var execution1 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "execution1",
+            dataJob,
+            ExecutionStatus.SUCCEEDED,
+            "Success",
+            OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
+            OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC));
+    var execution2 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "execution2",
+            dataJob,
+            ExecutionStatus.RUNNING,
+            null,
+            OffsetDateTime.of(2000, 1, 1, 4, 0, 0, 0, ZoneOffset.UTC),
+            null);
 
     jobExecutionRepository.save(execution1);
     jobExecutionRepository.save(execution2);
@@ -247,7 +249,9 @@ public class JobExecutionRepositoryIT {
     var executionEndTime = OffsetDateTime.now();
     var message = "Changed by test";
     jobExecutionRepository.updateExecutionStatusWhereOldStatusInAndExecutionIdIn(
-        ExecutionStatus.CANCELLED, executionEndTime, message,
+        ExecutionStatus.CANCELLED,
+        executionEndTime,
+        message,
         List.of(ExecutionStatus.SUCCEEDED, ExecutionStatus.RUNNING),
         List.of(execution1.getId(), execution2.getId()));
 
@@ -261,29 +265,30 @@ public class JobExecutionRepositoryIT {
     Assertions.assertEquals(expectedExecution2.getStatus(), ExecutionStatus.CANCELLED);
     Assertions.assertEquals(expectedExecution2.getMessage(), message);
     Assertions.assertEquals(expectedExecution2.getEndTime(), executionEndTime);
-
   }
 
   @Test
   void testUpdateExecutionStatusWhereOldStatusInAndExecutionIdIn_withExecutions_shouldUpdateOne() {
     DataJob dataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-    var execution1 = RepositoryUtil.createDataJobExecution(
-        jobExecutionRepository,
-        "execution1",
-        dataJob,
-        ExecutionStatus.SUCCEEDED,
-        "Success",
-        OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
-        OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC));
-    var execution2 = RepositoryUtil.createDataJobExecution(
-        jobExecutionRepository,
-        "execution2",
-        dataJob,
-        ExecutionStatus.SUCCEEDED,
-        null,
-        OffsetDateTime.of(2000, 1, 1, 4, 0, 0, 0, ZoneOffset.UTC),
-        null);
+    var execution1 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "execution1",
+            dataJob,
+            ExecutionStatus.SUCCEEDED,
+            "Success",
+            OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
+            OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC));
+    var execution2 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "execution2",
+            dataJob,
+            ExecutionStatus.SUCCEEDED,
+            null,
+            OffsetDateTime.of(2000, 1, 1, 4, 0, 0, 0, ZoneOffset.UTC),
+            null);
 
     jobExecutionRepository.save(execution1);
     jobExecutionRepository.save(execution2);
@@ -291,7 +296,9 @@ public class JobExecutionRepositoryIT {
     var executionEndTime = OffsetDateTime.now();
     var message = "Changed by test";
     jobExecutionRepository.updateExecutionStatusWhereOldStatusInAndExecutionIdIn(
-        ExecutionStatus.CANCELLED, executionEndTime, message,
+        ExecutionStatus.CANCELLED,
+        executionEndTime,
+        message,
         List.of(ExecutionStatus.SUCCEEDED, ExecutionStatus.RUNNING),
         List.of(execution1.getId(), execution2.getId()));
 
@@ -305,7 +312,5 @@ public class JobExecutionRepositoryIT {
     Assertions.assertEquals(expectedExecution2.getStatus(), execution2.getStatus());
     Assertions.assertEquals(expectedExecution2.getMessage(), execution2.getMessage());
     Assertions.assertEquals(expectedExecution2.getEndTime(), execution2.getEndTime());
-
   }
-
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobExecutionRepositoryIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobExecutionRepositoryIT.java
@@ -224,24 +224,22 @@ public class JobExecutionRepositoryIT {
   void testUpdateExecutionStatusWhereOldStatusInAndExecutionIdIn_withExecutions_shouldUpdateBoth() {
     DataJob dataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-    var execution1 =
-        RepositoryUtil.createDataJobExecution(
-            jobExecutionRepository,
-            "execution1",
-            dataJob,
-            ExecutionStatus.SUCCEEDED,
-            "Success",
-            OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
-            OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC));
-    var execution2 =
-        RepositoryUtil.createDataJobExecution(
-            jobExecutionRepository,
-            "execution2",
-            dataJob,
-            ExecutionStatus.RUNNING,
-            null,
-            OffsetDateTime.of(2000, 1, 1, 4, 0, 0, 0, ZoneOffset.UTC),
-            null);
+    var execution1 = RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "execution1",
+        dataJob,
+        ExecutionStatus.SUBMITTED,
+        "Success",
+        OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
+        OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC));
+    var execution2 = RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "execution2",
+        dataJob,
+        ExecutionStatus.RUNNING,
+        null,
+        OffsetDateTime.of(2000, 1, 1, 4, 0, 0, 0, ZoneOffset.UTC),
+        null);
 
     jobExecutionRepository.save(execution1);
     jobExecutionRepository.save(execution2);
@@ -249,10 +247,8 @@ public class JobExecutionRepositoryIT {
     var executionEndTime = OffsetDateTime.now();
     var message = "Changed by test";
     jobExecutionRepository.updateExecutionStatusWhereOldStatusInAndExecutionIdIn(
-        ExecutionStatus.CANCELLED,
-        executionEndTime,
-        message,
-        List.of(ExecutionStatus.SUCCEEDED, ExecutionStatus.RUNNING),
+        ExecutionStatus.CANCELLED, executionEndTime, message,
+        List.of(ExecutionStatus.SUBMITTED, ExecutionStatus.RUNNING),
         List.of(execution1.getId(), execution2.getId()));
 
     var expectedExecution1 = jobExecutionRepository.findById(execution1.getId()).get();
@@ -271,24 +267,22 @@ public class JobExecutionRepositoryIT {
   void testUpdateExecutionStatusWhereOldStatusInAndExecutionIdIn_withExecutions_shouldUpdateOne() {
     DataJob dataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-    var execution1 =
-        RepositoryUtil.createDataJobExecution(
-            jobExecutionRepository,
-            "execution1",
-            dataJob,
-            ExecutionStatus.SUCCEEDED,
-            "Success",
-            OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
-            OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC));
-    var execution2 =
-        RepositoryUtil.createDataJobExecution(
-            jobExecutionRepository,
-            "execution2",
-            dataJob,
-            ExecutionStatus.SUCCEEDED,
-            null,
-            OffsetDateTime.of(2000, 1, 1, 4, 0, 0, 0, ZoneOffset.UTC),
-            null);
+    var execution1 = RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "execution1",
+        dataJob,
+        ExecutionStatus.SUBMITTED,
+        "Success",
+        OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
+        OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC));
+    var execution2 = RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "execution2",
+        dataJob,
+        ExecutionStatus.SUCCEEDED,
+        null,
+        OffsetDateTime.of(2000, 1, 1, 4, 0, 0, 0, ZoneOffset.UTC),
+        null);
 
     jobExecutionRepository.save(execution1);
     jobExecutionRepository.save(execution2);
@@ -296,10 +290,8 @@ public class JobExecutionRepositoryIT {
     var executionEndTime = OffsetDateTime.now();
     var message = "Changed by test";
     jobExecutionRepository.updateExecutionStatusWhereOldStatusInAndExecutionIdIn(
-        ExecutionStatus.CANCELLED,
-        executionEndTime,
-        message,
-        List.of(ExecutionStatus.SUCCEEDED, ExecutionStatus.RUNNING),
+        ExecutionStatus.CANCELLED, executionEndTime, message,
+        List.of(ExecutionStatus.SUBMITTED, ExecutionStatus.RUNNING),
         List.of(execution1.getId(), execution2.getId()));
 
     var expectedExecution1 = jobExecutionRepository.findById(execution1.getId()).get();

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobExecutionRepositoryIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobExecutionRepositoryIT.java
@@ -224,22 +224,24 @@ public class JobExecutionRepositoryIT {
   void testUpdateExecutionStatusWhereOldStatusInAndExecutionIdIn_withExecutions_shouldUpdateBoth() {
     DataJob dataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-    var execution1 = RepositoryUtil.createDataJobExecution(
-        jobExecutionRepository,
-        "execution1",
-        dataJob,
-        ExecutionStatus.SUBMITTED,
-        "Success",
-        OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
-        OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC));
-    var execution2 = RepositoryUtil.createDataJobExecution(
-        jobExecutionRepository,
-        "execution2",
-        dataJob,
-        ExecutionStatus.RUNNING,
-        null,
-        OffsetDateTime.of(2000, 1, 1, 4, 0, 0, 0, ZoneOffset.UTC),
-        null);
+    var execution1 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "execution1",
+            dataJob,
+            ExecutionStatus.SUBMITTED,
+            "Success",
+            OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
+            OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC));
+    var execution2 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "execution2",
+            dataJob,
+            ExecutionStatus.RUNNING,
+            null,
+            OffsetDateTime.of(2000, 1, 1, 4, 0, 0, 0, ZoneOffset.UTC),
+            null);
 
     jobExecutionRepository.save(execution1);
     jobExecutionRepository.save(execution2);
@@ -247,7 +249,9 @@ public class JobExecutionRepositoryIT {
     var executionEndTime = OffsetDateTime.now();
     var message = "Changed by test";
     jobExecutionRepository.updateExecutionStatusWhereOldStatusInAndExecutionIdIn(
-        ExecutionStatus.CANCELLED, executionEndTime, message,
+        ExecutionStatus.CANCELLED,
+        executionEndTime,
+        message,
         List.of(ExecutionStatus.SUBMITTED, ExecutionStatus.RUNNING),
         List.of(execution1.getId(), execution2.getId()));
 
@@ -267,22 +271,24 @@ public class JobExecutionRepositoryIT {
   void testUpdateExecutionStatusWhereOldStatusInAndExecutionIdIn_withExecutions_shouldUpdateOne() {
     DataJob dataJob = RepositoryUtil.createDataJob(jobsRepository);
 
-    var execution1 = RepositoryUtil.createDataJobExecution(
-        jobExecutionRepository,
-        "execution1",
-        dataJob,
-        ExecutionStatus.SUBMITTED,
-        "Success",
-        OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
-        OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC));
-    var execution2 = RepositoryUtil.createDataJobExecution(
-        jobExecutionRepository,
-        "execution2",
-        dataJob,
-        ExecutionStatus.SUCCEEDED,
-        null,
-        OffsetDateTime.of(2000, 1, 1, 4, 0, 0, 0, ZoneOffset.UTC),
-        null);
+    var execution1 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "execution1",
+            dataJob,
+            ExecutionStatus.SUBMITTED,
+            "Success",
+            OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
+            OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC));
+    var execution2 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "execution2",
+            dataJob,
+            ExecutionStatus.SUCCEEDED,
+            null,
+            OffsetDateTime.of(2000, 1, 1, 4, 0, 0, 0, ZoneOffset.UTC),
+            null);
 
     jobExecutionRepository.save(execution1);
     jobExecutionRepository.save(execution2);
@@ -290,7 +296,9 @@ public class JobExecutionRepositoryIT {
     var executionEndTime = OffsetDateTime.now();
     var message = "Changed by test";
     jobExecutionRepository.updateExecutionStatusWhereOldStatusInAndExecutionIdIn(
-        ExecutionStatus.CANCELLED, executionEndTime, message,
+        ExecutionStatus.CANCELLED,
+        executionEndTime,
+        message,
         List.of(ExecutionStatus.SUBMITTED, ExecutionStatus.RUNNING),
         List.of(execution1.getId(), execution2.getId()));
 

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceSyncExecutionIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceSyncExecutionIT.java
@@ -41,7 +41,8 @@ public class JobExecutionServiceSyncExecutionIT {
   }
 
   @Test
-  public void testSyncJobExecutionStatuses_oneCancelledExecutionWithStartTimeBefore5min_shouldNotSyncAny() {
+  public void
+      testSyncJobExecutionStatuses_oneCancelledExecutionWithStartTimeBefore5min_shouldNotSyncAny() {
     DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
 
     com.vmware.taurus.service.model.DataJobExecution expectedJobExecution1 =
@@ -61,8 +62,7 @@ public class JobExecutionServiceSyncExecutionIT {
     expectedJobExecution1.setStatus(ExecutionStatus.CANCELLED);
     jobExecutionRepository.save(expectedJobExecution1);
     // Sync method is invoked with execution
-    jobExecutionService.syncJobExecutionStatuses(
-        List.of(expectedJobExecution1.getId()));
+    jobExecutionService.syncJobExecutionStatuses(List.of(expectedJobExecution1.getId()));
 
     List<com.vmware.taurus.service.model.DataJobExecution> dataJobExecutionsAfterSync =
         findRunningDataJobExecutions(actualDataJob.getName());
@@ -70,7 +70,6 @@ public class JobExecutionServiceSyncExecutionIT {
     Assert.assertEquals(0, dataJobExecutionsAfterSync.size());
     var execution = jobExecutionRepository.findById(expectedJobExecution1.getId()).get();
     Assert.assertEquals(ExecutionStatus.CANCELLED, execution.getStatus());
-
   }
 
   @Test


### PR DESCRIPTION
what: Refactored how the watch task updates missing kubernetes job executions. It should now update the statuses directly against the database, instead of loading entities in memory, updating them (in memory) and saving to the database.

why: Users reported that when cancelling executions, the cancelled execution's status is visible as Succeeded, even tough the API returned success and the status was set to Cancelled. This is caused by the watch task which updates executions in bulk and in memory before saving them to the database.

testing: Added unit tests that cover the new repository query. 

Signed-off-by: Momchil Zhivkov <mzhivkov@vmware.com>