### PR TITLE
vdk-pipelines-control-service: use newer version of ingress template

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/ingress.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/ingress.yaml
@@ -19,7 +19,7 @@ spec:
             port:
               number: {{ .Values.service.internalPort }}
 {{- else }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 spec:
   rules:
   - host: {{ .Values.ingress.host | quote }}


### PR DESCRIPTION
### Why
This functionality was deprecated in 1.22 (https://kubernetes.io/docs/reference/using-api/deprecation-guide/).
I am looking to deploy to a cluster on a version newer than this. 
122 was released more than a year ago so it seems incredibly unlikely that anyone would want the v1beta version. 
###  What
Use the offical v1 instead of v1Beta1. 
# How has this been tested?
In the process of doing this now. 




Signed-off-by: murphp15 <murphp15@tcd.ie>