### PR TITLE
vdk-control-service: fix ingress template

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/ingress.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
   annotations: {{- toYaml .Values.ingress.annotations | nindent 4 }}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 apiVersion: networking.k8s.io/v1
 spec:
   rules:


### PR DESCRIPTION
# Why?
The current check always returns false

# What?
Change to the property we should actually be checking for 

# How has this been tested?
I created a helm chart locally which looked like this

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: test
data:
  apiVersions.txt: |
    {{ .Capabilities.APIVersions.Has "networking.k8s.io/v1"  }}
{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/ingress" }}
  blah: hasC
{{- else }}
  blah: noC
{{- end }}
{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
  blah2: hasC
{{- else }}
  blah2: noC
{{- end }}
```

I rendered it with helm by running `helm template myhelmchart `. The underlying kubectl version was 1.23.x.


the rendered template was: 
```
# Source: apiversiontest/templates/serviceaccount.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: test
data:
  apiVersions.txt: |
    true
  blah: noC
  blah2: hasC

```
This shows that it finds networking v1 but not the ingress version we were using before. 


# What type of change are you making?
Bug fix

Signed-off-by: murphp15 <murphp15@tcd.ie>