### PR TITLE
control-service: minor db query optimisation refactor

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobExecutionRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobExecutionRepository.java
@@ -44,7 +44,7 @@ public interface JobExecutionRepository
   List<DataJobExecutionIdAndEndTime> findByDataJobNameAndStatusNotInOrderByEndTime(
       String jobName, List<ExecutionStatus> statuses);
 
-  List<DataJobExecution> findDataJobExecutionsByStatusInAndStartTimeBefore(
+  List<DataJobExecutionId> findDataJobExecutionsByStatusInAndStartTimeBefore(
       List<ExecutionStatus> statuses, OffsetDateTime startTime);
 
   @Transactional

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DataJobExecutionId.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DataJobExecutionId.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.model;
+
+public interface DataJobExecutionId {
+
+  String getId();
+}

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobExecutionRepositoryIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobExecutionRepositoryIT.java
@@ -313,4 +313,92 @@ public class JobExecutionRepositoryIT {
     Assertions.assertEquals(expectedExecution2.getMessage(), execution2.getMessage());
     Assertions.assertEquals(expectedExecution2.getEndTime(), execution2.getEndTime());
   }
+
+  @Test
+  void testFindDataJobExecutionsByStatusInAndStartTimeBefore_shouldReturnOne(){
+    DataJob dataJob = RepositoryUtil.createDataJob(jobsRepository);
+
+    var execution =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "execution1",
+            dataJob,
+            ExecutionStatus.SUBMITTED,
+            null,
+            OffsetDateTime.now().minusMinutes(30),
+            OffsetDateTime.now().minusMinutes(15));
+
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "execution2",
+            dataJob,
+            ExecutionStatus.SUCCEEDED,
+            null,
+            OffsetDateTime.now().minusMinutes(20),
+            OffsetDateTime.now().minusMinutes(15));
+
+    var returnedExecutions = jobExecutionRepository.findDataJobExecutionsByStatusInAndStartTimeBefore(
+        List.of(ExecutionStatus.SUBMITTED, ExecutionStatus.SUCCEEDED),
+        OffsetDateTime.now().minusMinutes(25));
+
+    Assertions.assertTrue(returnedExecutions.size() == 1);
+    Assertions.assertEquals(execution.getId(), returnedExecutions.get(0).getId());
+
+  }
+
+  @Test
+  void testFindDataJobExecutionsByStatusInAndStartTimeBefore_shouldReturnTwo(){
+    DataJob dataJob = RepositoryUtil.createDataJob(jobsRepository);
+
+    var execution =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "execution",
+            dataJob,
+            ExecutionStatus.SUBMITTED,
+            null,
+            OffsetDateTime.now().minusMinutes(30),
+            OffsetDateTime.now().minusMinutes(15));
+
+    var execution2 =
+        RepositoryUtil.createDataJobExecution(
+            jobExecutionRepository,
+            "execution1",
+            dataJob,
+            ExecutionStatus.RUNNING,
+            null,
+            OffsetDateTime.now().minusMinutes(35),
+            OffsetDateTime.now().minusMinutes(15));
+
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "execution2",
+        dataJob,
+        ExecutionStatus.SUCCEEDED,
+        null,
+        OffsetDateTime.now().minusMinutes(35),
+        OffsetDateTime.now().minusMinutes(15));
+
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "execution3",
+        dataJob,
+        ExecutionStatus.RUNNING,
+        null,
+        OffsetDateTime.now().minusMinutes(20),
+        OffsetDateTime.now().minusMinutes(15));
+
+    var returnedExecutions = jobExecutionRepository.findDataJobExecutionsByStatusInAndStartTimeBefore(
+        List.of(ExecutionStatus.SUBMITTED, ExecutionStatus.RUNNING),
+        OffsetDateTime.now().minusMinutes(25));
+
+    Assertions.assertTrue(returnedExecutions.size() == 2);
+    Assertions.assertEquals(2,
+        returnedExecutions.stream()
+            .filter(
+                e -> e.getId().equals(execution.getId()) || e.getId().equals(execution2.getId()))
+            .count());
+
+  }
+
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobExecutionRepositoryIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobExecutionRepositoryIT.java
@@ -315,7 +315,7 @@ public class JobExecutionRepositoryIT {
   }
 
   @Test
-  void testFindDataJobExecutionsByStatusInAndStartTimeBefore_shouldReturnOne(){
+  void testFindDataJobExecutionsByStatusInAndStartTimeBefore_shouldReturnOne() {
     DataJob dataJob = RepositoryUtil.createDataJob(jobsRepository);
 
     var execution =
@@ -328,26 +328,26 @@ public class JobExecutionRepositoryIT {
             OffsetDateTime.now().minusMinutes(30),
             OffsetDateTime.now().minusMinutes(15));
 
-        RepositoryUtil.createDataJobExecution(
-            jobExecutionRepository,
-            "execution2",
-            dataJob,
-            ExecutionStatus.SUCCEEDED,
-            null,
-            OffsetDateTime.now().minusMinutes(20),
-            OffsetDateTime.now().minusMinutes(15));
+    RepositoryUtil.createDataJobExecution(
+        jobExecutionRepository,
+        "execution2",
+        dataJob,
+        ExecutionStatus.SUCCEEDED,
+        null,
+        OffsetDateTime.now().minusMinutes(20),
+        OffsetDateTime.now().minusMinutes(15));
 
-    var returnedExecutions = jobExecutionRepository.findDataJobExecutionsByStatusInAndStartTimeBefore(
-        List.of(ExecutionStatus.SUBMITTED, ExecutionStatus.SUCCEEDED),
-        OffsetDateTime.now().minusMinutes(25));
+    var returnedExecutions =
+        jobExecutionRepository.findDataJobExecutionsByStatusInAndStartTimeBefore(
+            List.of(ExecutionStatus.SUBMITTED, ExecutionStatus.SUCCEEDED),
+            OffsetDateTime.now().minusMinutes(25));
 
     Assertions.assertTrue(returnedExecutions.size() == 1);
     Assertions.assertEquals(execution.getId(), returnedExecutions.get(0).getId());
-
   }
 
   @Test
-  void testFindDataJobExecutionsByStatusInAndStartTimeBefore_shouldReturnTwo(){
+  void testFindDataJobExecutionsByStatusInAndStartTimeBefore_shouldReturnTwo() {
     DataJob dataJob = RepositoryUtil.createDataJob(jobsRepository);
 
     var execution =
@@ -388,17 +388,17 @@ public class JobExecutionRepositoryIT {
         OffsetDateTime.now().minusMinutes(20),
         OffsetDateTime.now().minusMinutes(15));
 
-    var returnedExecutions = jobExecutionRepository.findDataJobExecutionsByStatusInAndStartTimeBefore(
-        List.of(ExecutionStatus.SUBMITTED, ExecutionStatus.RUNNING),
-        OffsetDateTime.now().minusMinutes(25));
+    var returnedExecutions =
+        jobExecutionRepository.findDataJobExecutionsByStatusInAndStartTimeBefore(
+            List.of(ExecutionStatus.SUBMITTED, ExecutionStatus.RUNNING),
+            OffsetDateTime.now().minusMinutes(25));
 
     Assertions.assertTrue(returnedExecutions.size() == 2);
-    Assertions.assertEquals(2,
+    Assertions.assertEquals(
+        2,
         returnedExecutions.stream()
             .filter(
                 e -> e.getId().equals(execution.getId()) || e.getId().equals(execution2.getId()))
             .count());
-
   }
-
 }


### PR DESCRIPTION
what: Refactored a query in the JobExecutionRepository to only return the execution id, instead of the whole entity.

why: The query is used by the watch task which after recent changes only needs the id of executions. 

testing: added unit tests that cover the changed repository method.

Signed-off-by: Momchil Zhivkov <mzhivkov@vmware.com>