### PR TITLE
vdk-audit: set python requires >= 3.8

### DIFF
--- a/projects/vdk-plugins/vdk-audit/setup.py
+++ b/projects/vdk-plugins/vdk-audit/setup.py
@@ -17,6 +17,7 @@ setuptools.setup(
     long_description=pathlib.Path("README.md").read_text(),
     long_description_content_type="text/markdown",
     install_requires=["vdk-core"],
+    python_requires=">=3.8",
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),
     entry_points={"vdk.plugin.run": ["vdk-audit = vdk.plugin.audit.audit_plugin"]},


### PR DESCRIPTION
vdk-audit hook works only with 3.8 python or newer. We want to prevent the vdk-audit from being installed on older python version.

Setting the python_requires argument to the appropriate PEP 440 version specifier string will prevent pip from installing the project on other Python versions

Testing Done: `pip install -e ./vdk-audit` failed correctly with "ERROR: Package 'vdk-audit' requires a different Python: 3.7.9 not in '>=3.8'"

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>