### PR TITLE
versatile-data-kit: Adding support to read SQM statement as DataFrame

### DIFF
--- a/projects/vdk-core/src/vdk/api/job_input.py
+++ b/projects/vdk-core/src/vdk/api/job_input.py
@@ -7,6 +7,8 @@ from typing import Any
 from typing import List
 from typing import Optional
 
+from pandas import DataFrame
+
 
 class IProperties:
     """
@@ -61,6 +63,29 @@ class IManagedConnection:
         """
         Executes the provided query and returns results from PEP 249 Cursor.fetchall() method, see:
             https://www.python.org/dev/peps/pep-0249/#fetchall
+
+        Query can contain parameters in format -> {query_parameter}. Parameters in the query will
+        be automatically substituted if they exist in Data Job properties and arguments as keys.
+        If parameter with same key is used both as arguments and properties,
+        arguments (get_arguments()) will take precedence over properties (get_property()).
+
+        Note:
+            Parameters are case sensitive.
+            If a query parameter is not present in Data Job properties or arguments it will not be replaced in the query
+            and most likely result in query failure.
+
+        Example usage:
+            job_input.set_all_properties({'target_table': 'history.people','etl_run_date_column': 'pa__arrival_ts'})
+            query_result = job_input.execute_query("SELECT * FROM {target_table} WHERE {etl_run_date_column} > now() - interval 2 hours")
+
+        """
+        pass
+
+    @abstractmethod
+    def read_sql_as_dataframe(self, query_as_utf8_string) -> DataFrame:
+        """
+        Executes the provided query and returns results from PEP 249 pandas.read_sql() method, see:
+            https://pandas.pydata.org/docs/reference/api/pandas.read_sql.html
 
         Query can contain parameters in format -> {query_parameter}. Parameters in the query will
         be automatically substituted if they exist in Data Job properties and arguments as keys.

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/job_input.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/job_input.py
@@ -112,6 +112,15 @@ class JobInput(IJobInput):
         connection = self.get_managed_connection()
         return connection.execute_query(query)
 
+    def read_sql_as_dataframe(self, sql: str):
+        if not sql or not sql.strip():
+            raise UserCodeError("Trying to execute an empty SQL query.")
+
+        query = self._substitute_query_params(sql)
+
+        connection = self.get_managed_connection()
+        return connection.read_sql_as_dataframe(query)
+
     def send_object_for_ingestion(
         self,
         payload: dict,

--- a/projects/vdk-plugins/vdk-greenplum/src/vdk/plugin/greenplum/greenplum_connection.py
+++ b/projects/vdk-plugins/vdk-greenplum/src/vdk/plugin/greenplum/greenplum_connection.py
@@ -5,6 +5,7 @@ from typing import Any
 from typing import List
 from typing import Optional
 
+from pandas import DataFrame
 from vdk.internal.builtin_plugins.connection.managed_connection_base import (
     ManagedConnectionBase,
 )
@@ -110,5 +111,11 @@ class GreenplumConnection(ManagedConnectionBase):
     def execute_query(self, query: str) -> List[List[Any]]:
         try:
             return super().execute_query(query)
+        finally:
+            self.commit()
+
+    def read_sql_as_dataframe(self, query: str) -> DataFrame:
+        try:
+            return super().read_sql_as_dataframe(query)
         finally:
             self.commit()

--- a/projects/vdk-plugins/vdk-impala/tests/functional/test_impala_lineage.py
+++ b/projects/vdk-plugins/vdk-impala/tests/functional/test_impala_lineage.py
@@ -41,6 +41,11 @@ def execute_query(runner, query: str):
     cli_assert_equal(0, result)
 
 
+def read_sql_as_dataframe(runner, query: str):
+    result: Result = runner.invoke(["impala-query", "--query", query])
+    cli_assert_equal(0, result)
+
+
 @pytest.mark.skipif(
     sys.version_info >= (3, 10),
     reason="Lineage collection is not supported in python 3.10."

--- a/projects/vdk-plugins/vdk-postgres/requirements.txt
+++ b/projects/vdk-plugins/vdk-postgres/requirements.txt
@@ -2,6 +2,7 @@
 # testing requirements
 click
 docker-compose
+pandas
 psycopg2-binary
 pytest-docker
 tabulate

--- a/projects/vdk-plugins/vdk-postgres/src/vdk/plugin/postgres/postgres_connection.py
+++ b/projects/vdk-plugins/vdk-postgres/src/vdk/plugin/postgres/postgres_connection.py
@@ -5,6 +5,7 @@ from typing import Any
 from typing import List
 from typing import Optional
 
+from pandas import DataFrame
 from vdk.internal.builtin_plugins.connection.managed_connection_base import (
     ManagedConnectionBase,
 )
@@ -110,5 +111,11 @@ class PostgresConnection(ManagedConnectionBase):
     def execute_query(self, query: str) -> List[List[Any]]:
         try:
             return super().execute_query(query)
+        finally:
+            self.commit()
+
+    def read_sql_as_dataframe(self, query: str) -> List[List[Any]]:
+        try:
+            return super().read_sql_as_dataframe(query)
         finally:
             self.commit()


### PR DESCRIPTION
#Why
execute_query does not return column name, DataFrames are move useful

#What
Adding new method to job_input

#How has this been tested?
None, could not make build.sh run

#Type
New feature (non-breaking change which adds functionality)

Signed-off-by: Victor Mishovski <vmishovski@vmware.com>