### PR TITLE
vdk-control-service: add empty dir storage

### DIFF
--- a/projects/control-service/CHANGELOG.md
+++ b/projects/control-service/CHANGELOG.md
@@ -14,6 +14,11 @@ MAJOR.MINOR - dd.MM.yyyy
 1.3 - 09.03.2022
 ----
 * **Improvement**
+  * Security improvement. Use empty dir storage for storing jobs during upload/deployment/etc instead of using the root file system
+
+1.3 - 09.03.2022
+----
+* **Improvement**
   * Adopted kubernetes-client 13.0
 
 * **Bug Fixes**

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -185,7 +185,7 @@ spec:
             - name: UPLOAD_VALIDATION_FILETYPES_ALLOWLIST
               value: "{{ .Values.uploadValidationFileTypesAllowList }}"
             - name: DATAJOBS_TEMP_STORAGE_FOLDER
-              value: /DATAJOBS_TEMP_STORAGE_FOLDER
+              value: /datajobs_temp_storage
             {{- if .Values.datajobTemplate.enabled }}
             - name: K8S_DATA_JOB_TEMPLATE_FILE
               value: "/etc/datajobs/k8s_data_job_template.yaml"
@@ -249,7 +249,7 @@ spec:
             - name: secrets
               mountPath: "/etc/secrets"
               readOnly: true
-            - mountPath: "/DATAJOBS_TEMP_STORAGE_FOLDER"
+            - mountPath: "/datajobs_temp_storage"
               name: DATAJOBS_TEMP_STORAGE_FOLDER_VOLUME
             {{- if .Values.datajobTemplate.enabled }}
             - name: datajob-template-volume

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -30,14 +30,6 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ template "pipelines-control-service.serviceAccountName" . }}
       {{- end }}
-      volumes:
-        - name: DATAJOBS_TEMP_STORAGE_FOLDER_VOLUME
-          ephemeral:
-            volumeClaimTemplate:
-              spec:
-                resources:
-                  requests:
-                    storage: 1Gi
       containers:
         - name: pipelines-control-service
           image: {{ template "pipelines-control-service.image" . }}
@@ -193,7 +185,7 @@ spec:
             - name: UPLOAD_VALIDATION_FILETYPES_ALLOWLIST
               value: "{{ .Values.uploadValidationFileTypesAllowList }}"
             - name: DATAJOBS_TEMP_STORAGE_FOLDER
-              value: DATAJOBS_TEMP_STORAGE_FOLDER
+              value: /DATAJOBS_TEMP_STORAGE_FOLDER
             {{- if .Values.datajobTemplate.enabled }}
             - name: K8S_DATA_JOB_TEMPLATE_FILE
               value: "/etc/datajobs/k8s_data_job_template.yaml"
@@ -310,6 +302,8 @@ spec:
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
       volumes:
+        - name: DATAJOBS_TEMP_STORAGE_FOLDER_VOLUME
+          emptyDir: {}
         - name: secrets
           secret:
             secretName: {{ template "pipelines-control-service.fullname" . }}-secrets

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -30,6 +30,14 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ template "pipelines-control-service.serviceAccountName" . }}
       {{- end }}
+      volumes:
+        - name: DATAJOBS_TEMP_STORAGE_FOLDER_VOLUME
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                resources:
+                  requests:
+                    storage: 1Gi
       containers:
         - name: pipelines-control-service
           image: {{ template "pipelines-control-service.image" . }}
@@ -184,6 +192,8 @@ spec:
               value: "{{ .Values.monitoringSync.initialDelayMillis }}"
             - name: UPLOAD_VALIDATION_FILETYPES_ALLOWLIST
               value: "{{ .Values.uploadValidationFileTypesAllowList }}"
+            - name: DATAJOBS_TEMP_STORAGE_FOLDER
+              value: DATAJOBS_TEMP_STORAGE_FOLDER
             {{- if .Values.datajobTemplate.enabled }}
             - name: K8S_DATA_JOB_TEMPLATE_FILE
               value: "/etc/datajobs/k8s_data_job_template.yaml"
@@ -242,10 +252,13 @@ spec:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
+
           volumeMounts:
             - name: secrets
               mountPath: "/etc/secrets"
               readOnly: true
+            - mountPath: "/DATAJOBS_TEMP_STORAGE_FOLDER"
+              name: DATAJOBS_TEMP_STORAGE_FOLDER_VOLUME
             {{- if .Values.datajobTemplate.enabled }}
             - name: datajob-template-volume
               mountPath: "/etc/datajobs"

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -254,7 +254,7 @@ spec:
               mountPath: "/etc/secrets"
               readOnly: true
             - mountPath: "/datajobs_temp_storage"
-              name: DATAJOBS_TEMP_STORAGE_FOLDER_VOLUME
+              name: datajobs-temp-storage-volume
             {{- if .Values.datajobTemplate.enabled }}
             - name: datajob-template-volume
               mountPath: "/etc/datajobs"
@@ -306,7 +306,7 @@ spec:
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
       volumes:
-        - name: DATAJOBS_TEMP_STORAGE_FOLDER_VOLUME
+        - name: datajobs-temp-storage-volume
           emptyDir: {}
         - name: secrets
           secret:

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -12,7 +12,7 @@ global: {}
 image:
    registry: registry.hub.docker.com/versatiledatakit
    repository: pipelines-control-service
-   tag: "d80d8b1"
+   tag: "1f57f0e"
 
    ## Specify a imagePullPolicy
    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -12,7 +12,7 @@ global: {}
 image:
    registry: registry.hub.docker.com/versatiledatakit
    repository: pipelines-control-service
-   tag: "1f57f0e"
+   tag: "d80d8b1"
 
    ## Specify a imagePullPolicy
    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
# Why?
Currently JobUpload uploads the file in the same file system as the container process so if too many requests with big data jobs are uploaded it may crash the process/the whole container

Beyond that it's recommended by https://cheatsheetseries.owasp.org/cheatsheets/File_Upload_Cheat_Sheet.html#file-storage-location to avoid using web root location for staring user supplied files.

# What?
add an empty directory volume mount to the pipelines-control-service pods. 
Use this to store the files in. 

# How has this been tested?
made a release of the helm chart under a different name and deployed to the vdk vdp cluster. 
Deployed a heartbeat job.

# What type of change are you making?
New feature (non-breaking change which adds functionality)


Signed-off-by: murphp15 <murphp15@tcd.ie>