### PR TITLE
Revert "build(deps): bump io.freefair.lombok from 6.1.0-m3 to 6.5.1 in /projects/control-service/projects"

### DIFF
--- a/projects/control-service/projects/settings.gradle
+++ b/projects/control-service/projects/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
       id 'io.spring.dependency-management' version '1.0.11.RELEASE'
       id 'com.palantir.docker' version '0.34.0'
       // https://projectlombok.org/setup/gradle
-      id 'io.freefair.lombok' version '6.5.1'
+      id 'io.freefair.lombok' version '6.1.0-m3'
       id 'com.palantir.git-version' version '0.15.0'
       id 'org.unbroken-dome.test-sets' version '4.0.0'
       // https://gitlab.com/barfuin/gradle-jacoco-log/-/blob/master/README.md


### PR DESCRIPTION
Reverts vmware/versatile-data-kit#1306 

The pipeline is consistently failing after merging this - https://gitlab.com/vmware-analytics/versatile-data-kit/-/pipelines/690278941 