### PR TITLE
vdk-heartbeat: wait for execution to start

### DIFF
--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/hearbeat.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/hearbeat.py
@@ -57,7 +57,7 @@ class Heartbeat:
 
             self.clean(run_test, job_controller)
             log.info("Heartbeat has finished successfully.")
-        except Exception as e:
+        except:
             log.info("Heartbeat has failed.")
             job_controller.show_job_details()
             job_controller.show_last_job_execution_logs()

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/hearbeat.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/hearbeat.py
@@ -45,6 +45,7 @@ class Heartbeat:
             job_controller.enable_deployment()
             job_controller.wait_job_execution_started()
             job_controller.show_job_details()
+
             run_test.execute_test()
             job_controller.show_last_job_execution_logs()
 

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/hearbeat.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/hearbeat.py
@@ -43,8 +43,8 @@ class Heartbeat:
             run_test.setup()
 
             job_controller.enable_deployment()
+            job_controller.wait_job_execution_started()
             job_controller.show_job_details()
-
             run_test.execute_test()
             job_controller.show_last_job_execution_logs()
 
@@ -57,7 +57,7 @@ class Heartbeat:
 
             self.clean(run_test, job_controller)
             log.info("Heartbeat has finished successfully.")
-        except:
+        except Exception as e:
             log.info("Heartbeat has failed.")
             job_controller.show_job_details()
             job_controller.show_last_job_execution_logs()

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
@@ -359,7 +359,7 @@ class JobController:
             if execution_list:
                 return
             time.sleep(10)
-        raise Exception("Job never started")
+        raise Exception(f"Job {self.config.job_name} never started")
 
     @LogDecorator(log)
     def check_job_execution_finished(self) -> Optional[str]:

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
@@ -338,7 +338,7 @@ class JobController:
 
     @LogDecorator(log)
     def wait_job_execution_started(self):
-        log.info("Checking if data job execution is still running.")
+        log.debug("Waiting for job to create")
         start = time.time()
 
         while time.time() - start < self.config.RUN_TEST_TIMEOUT_SECONDS:

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
@@ -339,7 +339,6 @@ class JobController:
     @LogDecorator(log)
     def wait_job_execution_started(self):
         log.info("Checking if data job execution is still running.")
-        execution_list = []
         start = time.time()
 
         while time.time() - start < self.config.RUN_TEST_TIMEOUT_SECONDS:
@@ -360,7 +359,7 @@ class JobController:
             if execution_list:
                 return
             time.sleep(10)
-        raise "Job never started"
+        raise Exception("Job never started")
 
     @LogDecorator(log)
     def check_job_execution_finished(self) -> Optional[str]:

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
@@ -338,7 +338,7 @@ class JobController:
 
     @LogDecorator(log)
     def wait_job_execution_started(self):
-        log.debug("Waiting for job to create")
+        log.debug("Waiting for job {self.config.job_name} to start.")
         start = time.time()
 
         while time.time() - start < self.config.RUN_TEST_TIMEOUT_SECONDS:

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
@@ -337,6 +337,32 @@ class JobController:
         log.info("Execution started successfully.")
 
     @LogDecorator(log)
+    def wait_job_execution_started(self):
+        log.info("Checking if data job execution is still running.")
+        execution_list = []
+        start = time.time()
+
+        while time.time() - start < self.config.RUN_TEST_TIMEOUT_SECONDS:
+            response = self._execute(
+                [
+                    "execute",
+                    "--list",
+                    "-t",
+                    self.config.job_team,
+                    "-n",
+                    self.config.job_name,
+                    "-o" "json",
+                ]
+                + self.__get_rest_api_url_arg()
+            )
+            execution_list = json.loads(response)
+
+            if execution_list:
+                return
+            time.sleep(10)
+        raise "Job never started"
+
+    @LogDecorator(log)
     def check_job_execution_finished(self) -> Optional[str]:
         log.info("Checking if data job execution is still running.")
         job_execution_running = True


### PR DESCRIPTION
# Why?
In the heartbeat test we want to make sure a job is created automatically using the cron. However we often don't give k8s enough time to create it before disabling it again. This causes the test to fail with a cryptic message. 

# What?
Check that the job instance is created before disabling the creation of new ones. 

# How has this been tested?
I ran it many times locally and didn't see it fail again. 

# What type of change are you making?
Bug fix
