### PR TITLE
vdk-postgres: add ingest plugin

### DIFF
--- a/projects/vdk-plugins/vdk-postgres/src/vdk/plugin/postgres/ingest_to_postgres.py
+++ b/projects/vdk-plugins/vdk-postgres/src/vdk/plugin/postgres/ingest_to_postgres.py
@@ -1,0 +1,92 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+from vdk.internal.builtin_plugins.connection.pep249.interfaces import PEP249Cursor
+from vdk.internal.builtin_plugins.ingestion.ingester_base import IIngesterPlugin
+from vdk.internal.builtin_plugins.run.job_context import JobContext
+from vdk.internal.core import errors
+
+_log = logging.getLogger(__name__)
+
+
+class IngestToPostgres(IIngesterPlugin):
+    """
+    Create a new ingestion mechanism for ingesting to a database
+    """
+
+    def __init__(self, context: JobContext):
+        self._context = context
+
+    def ingest_payload(
+        self,
+        payload: List[dict],
+        destination_table: Optional[str],
+        target: Optional[str] = None,
+        collection_id: Optional[str] = None,
+        metadata: Optional[IIngesterPlugin.IngestionMetadata] = None,
+    ) -> None:
+        """
+        See parent class doc for details
+        """
+
+        _log.info(
+            f"Ingesting payloads to table: {destination_table} in database; "
+            f"collection_id: {collection_id}"
+        )
+
+        with self._context.connections.open_connection(
+            "POSTGRES"
+        ).connect() as connection:
+            cursor = connection.cursor()
+            query, parameters = self._populate_query_parameters_tuple(
+                destination_table, cursor, payload
+            )
+
+            try:
+                cursor.execute(query, parameters)
+                connection.commit()
+                _log.debug("Payload was ingested.")
+            except Exception as e:
+                errors.log_and_rethrow(
+                    errors.find_whom_to_blame_from_exception(e),
+                    _log,
+                    "Failed to send payload",
+                    "Unknown error. Error message was : " + str(e),
+                    "Will not be able to send the payload for ingestion",
+                    "See error message for help ",
+                    e,
+                    wrap_in_vdk_error=True,
+                )
+
+    @staticmethod
+    def _populate_query_parameters_tuple(
+        destination_table: str, cursor: PEP249Cursor, payload: List[dict]
+    ) -> (str, Tuple[str]):
+        """
+        Returns insert into destination table tuple of query and parameters;
+        E.g. for a table dest_table with columns val1, val2 and payload size 3, this method will return:
+        'INSERT INTO dest_table (val1, val2) VALUES (%s, %s), (%s, %s), (%s, %s)', ['val1', 'val2']
+
+        :param destination_table: str
+            the name of the destination table
+        :param cursor: PEP249Cursor
+            the database cursor
+        :param payload: List[dict]
+            the payloads to be ingested
+        :return: Tuple[str, Tuple[str]]
+            tuple containing the query and parameters
+        """
+        cursor.execute(f"SELECT * FROM {destination_table} WHERE false")
+        columns = [c.name for c in cursor.description]
+
+        row_placeholder = f"({', '.join('%s' for column in columns)})"
+
+        return (
+            f"INSERT INTO {destination_table} ({', '.join(columns)}) "
+            f"VALUES {', '.join([row_placeholder for i in range(len(payload))])}",
+            tuple(obj[column] for obj in payload for column in columns),
+        )

--- a/projects/vdk-plugins/vdk-postgres/src/vdk/plugin/postgres/postgres_plugin.py
+++ b/projects/vdk-plugins/vdk-postgres/src/vdk/plugin/postgres/postgres_plugin.py
@@ -6,6 +6,7 @@ from vdk.api.plugin.hook_markers import hookimpl
 from vdk.internal.builtin_plugins.run.job_context import JobContext
 from vdk.internal.core.config import Configuration
 from vdk.internal.core.config import ConfigurationBuilder
+from vdk.plugin.postgres.ingest_to_postgres import IngestToPostgres
 from vdk.plugin.postgres.postgres_connection import PostgresConnection
 
 
@@ -56,6 +57,9 @@ def initialize_job(context: JobContext) -> None:
     context.connections.add_open_connection_factory_method(
         "POSTGRES",
         lambda: _connection_by_configuration(context.core_context.configuration),
+    )
+    context.ingester.add_ingester_factory_method(
+        "POSTGRES", lambda: IngestToPostgres(context)
     )
 
 

--- a/projects/vdk-plugins/vdk-postgres/tests/jobs/test-ingest/10_ingest.py
+++ b/projects/vdk-plugins/vdk-postgres/tests/jobs/test-ingest/10_ingest.py
@@ -1,0 +1,17 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+
+def run(job_input):
+    payload = {
+        "some_data": "some_test_data",
+        "more_data": "more_test_data",
+        "int_data": 11,
+        "float_data": 3.14,
+        "bool_data": True,
+    }
+
+    for _ in range(5):
+        job_input.send_object_for_ingestion(
+            payload=payload, destination_table="test_table"
+        )

--- a/projects/vdk-plugins/vdk-postgres/tests/test_ingest.py
+++ b/projects/vdk-plugins/vdk-postgres/tests/test_ingest.py
@@ -1,0 +1,94 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import os
+import pathlib
+from unittest import mock
+from unittest import TestCase
+
+import pytest
+from vdk.plugin.postgres import postgres_plugin
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_funcs import get_test_job_path
+
+VDK_DB_DEFAULT_TYPE = "VDK_DB_DEFAULT_TYPE"
+VDK_POSTGRES_DBNAME = "VDK_POSTGRES_DBNAME"
+VDK_POSTGRES_USER = "VDK_POSTGRES_USER"
+VDK_POSTGRES_PASSWORD = "VDK_POSTGRES_PASSWORD"
+VDK_POSTGRES_HOST = "VDK_POSTGRES_HOST"
+VDK_POSTGRES_PORT = "VDK_POSTGRES_PORT"
+VDK_INGEST_METHOD_DEFAULT = "VDK_INGEST_METHOD_DEFAULT"
+
+
+@pytest.mark.usefixtures("postgres_service")
+@mock.patch.dict(
+    os.environ,
+    {
+        VDK_DB_DEFAULT_TYPE: "POSTGRES",
+        VDK_POSTGRES_DBNAME: "postgres",
+        VDK_POSTGRES_USER: "postgres",
+        VDK_POSTGRES_PASSWORD: "postgres",
+        VDK_POSTGRES_HOST: "localhost",
+        VDK_POSTGRES_PORT: "5432",
+        VDK_INGEST_METHOD_DEFAULT: "POSTGRES",
+    },
+)
+class IngestToPostgresTests(TestCase):
+    def test_ingest_to_postgres(self):
+        runner = CliEntryBasedTestRunner(postgres_plugin)
+
+        query_result = runner.invoke(
+            [
+                "postgres-query",
+                "--query",
+                "CREATE TABLE test_table "
+                "(some_data varchar, more_data varchar, int_data bigint, float_data real, bool_data boolean)",
+            ]
+        )
+        cli_assert_equal(0, query_result)
+
+        ingest_job_result = runner.invoke(
+            [
+                "run",
+                get_test_job_path(
+                    pathlib.Path(os.path.dirname(os.path.abspath(__file__))),
+                    "test-ingest",
+                ),
+            ]
+        )
+
+        cli_assert_equal(0, ingest_job_result)
+
+        check_result = runner.invoke(
+            ["postgres-query", "--query", "SELECT * FROM test_table"]
+        )
+
+        assert check_result.stdout == (
+            "--------------  --------------  --  ----  ----\n"
+            "some_test_data  more_test_data  11  3.14  True\n"
+            "some_test_data  more_test_data  11  3.14  True\n"
+            "some_test_data  more_test_data  11  3.14  True\n"
+            "some_test_data  more_test_data  11  3.14  True\n"
+            "some_test_data  more_test_data  11  3.14  True\n"
+            "--------------  --------------  --  ----  ----\n"
+        )
+
+    def test_ingest_no_dest_table(self):
+        runner = CliEntryBasedTestRunner(postgres_plugin)
+
+        query_result = runner.invoke(
+            ["postgres-query", "--query", "DROP TABLE IF EXISTS test_table"]
+        )
+        cli_assert_equal(0, query_result)
+
+        ingest_job_result = runner.invoke(
+            [
+                "run",
+                get_test_job_path(
+                    pathlib.Path(os.path.dirname(os.path.abspath(__file__))),
+                    "test-ingest",
+                ),
+            ]
+        )
+
+        assert "UndefinedTable" in ingest_job_result.output


### PR DESCRIPTION
When we were preparing for DSC conference we realized that we are missing simple ingest plugin.

This is really copy pasting the greenplum ingestion. where I changed "greenplum" to "postgres"

I will add this now since we need it . But I think it's time to refactor the db plugins - https://refactoring.guru/refactoring/when

A lot of the code is basically the same with names changed. ... So I will open a PR for that.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>