### PR TITLE
vdk-logging-format: Fix path to readme in setup.py

### DIFF
--- a/projects/vdk-plugins/vdk-logging-format/setup.py
+++ b/projects/vdk-plugins/vdk-logging-format/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     version=__version__,
     url="https://github.com/vmware/versatile-data-kit",
     description="Versatile Data Kit SDK plugin that configures logging output format.",
-    long_description=pathlib.Path("../vdk-logging-format/README.md").read_text(),
+    long_description=pathlib.Path("README.md").read_text(),
     long_description_content_type="text/markdown",
     install_requires=["vdk-core", "ecs-logging"],
     package_dir={"": "src"},


### PR DESCRIPTION
Amended path to readme file in setup.py to be consisten with
other plugins.

Signed-off-by: Gabriel Georgiev <gageorgiev@vmware.com>