### PR TITLE
vdk-control-cli: update doc for deployment of multiple jobs w/single command

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli.py
@@ -50,13 +50,11 @@ vdk deploy --disable -n example-job -t job-team
 # Deploy job and wait until deployed
 new_version=`vdk deploy -p /home/user/data-jobs/example-job -o json | jq '.job_version'`
 while ! vdk deploy --show -o json -n example-job -t job-team | grep $new_version ; do echo "waiting ..."; sleep 10; done
-
 \b
-# Deploy multiple Data Jobs in a single command
-echo "Job1
-job2
-job3" | xargs -I {JOB} vdk deploy  -t job-team  -n {JOB} –p <PARENT_DIR_TO_JOBS>/{JOB}
-
+# Deploy multiple Data Jobs in a single command. Data jobs must be created and
+reside in their own folders with the same name as the data-job's names e.g. job1
+these folders should be within a <PARENT_DIR_TO_JOBS> folder:
+echo "job1\n job2\n job3" | xargs -I "#" vdk deploy -t job-team -n "#" -p "<PARENT_DIR_TO_JOBS>/#" -r "Deploy reason."
 \b
 # Experimental. Update job version (for example rollback quickly to latest stable version)
 vdk deploy --update --job-version <job-version-here> -n example-job -t job-team

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli.py
@@ -54,7 +54,7 @@ while ! vdk deploy --show -o json -n example-job -t job-team | grep $new_version
 # Deploy multiple Data Jobs in a single command. Data jobs must be created and
 reside in their own folders with the same name as the data-job's names e.g. job1
 these folders should be within a <PARENT_DIR_TO_JOBS> folder:
-echo "job1\n job2\n job3" | xargs -I "#" vdk deploy -t job-team -n "#" -p "<PARENT_DIR_TO_JOBS>/#" -r "Deploy reason."
+echo "job1\n job2\n job3" | xargs -I "#" vdk deploy -t job-team -n "#" -p "<PARENT_DIR_TO_JOBS>/#" -r "<deployment-reason>"
 \b
 # Experimental. Update job version (for example rollback quickly to latest stable version)
 vdk deploy --update --job-version <job-version-here> -n example-job -t job-team


### PR DESCRIPTION

what: Updated existing user facing documentation with a command that doesn't fail when
copy/pasted directly in a terminal.

why: Documentation of deploy command says that deploying multiple jobs in a single command is done by:
```
echo "Job1
job2
job3" | xargs -I {JOB} vdk deploy -t job-team -n {JOB} –p <PARENT_DIR_TO_JOBS>/{JOB}
```

But this command fails with:
`Error: Got unexpected extra arguments (–p <PARENT_DIR_TO_JOBS>/{JOB})`

testing: Tested locally to copy/paste the newly produced output and verified command now
works as intended.

Signed-off-by: Momchil Zhivkov <mzhivkov@vmware.com>