### PR TITLE
vdk-control-cli: fix cicd

### DIFF
--- a/projects/vdk-control-cli/requirements.txt
+++ b/projects/vdk-control-cli/requirements.txt
@@ -6,6 +6,7 @@ click-spinner
 # Dependencies license report:
 pip-licenses
 pluggy~=0.13
+py
 
 # TESTING dependencies:
 


### PR DESCRIPTION
what: Added py dependency in requirements.txt

why: Pipeline was failing with missing module. E.g. https://gitlab.com/vmware-analytics/versatile-data-kit/-/jobs/3323662821

testing: cicd pipeline

Signed-off-by: Momchil Zhivkov <mzhivkov@vmware.com>