### PR TITLE
vdk-trino: Fix typo in the documentation

### DIFF
--- a/projects/vdk-plugins/vdk-trino/README.md
+++ b/projects/vdk-plugins/vdk-trino/README.md
@@ -5,7 +5,7 @@ This plugin allows vdk-core to interface with and execute queries against a Trin
 
 Run
 ```bash
-pip install vdk-tino
+pip install vdk-trino
 ```
 
 After this data jobs will have access to Trino database connection managed by Versatile Data Kit SDK.


### PR DESCRIPTION
There was a typo in the documentation. That's fixed now.