### PR TITLE
control-service: namespace can be null

### DIFF
--- a/projects/control-service/cicd/deploy-testing-pipelines-service.sh
+++ b/projects/control-service/cicd/deploy-testing-pipelines-service.sh
@@ -73,7 +73,7 @@ helm dependency update --kubeconfig=$KUBECONFIG
 #
 # image.tag is fixed during release. It is set here to deploy using latest change in source code.
 # We are using here embedded database, and we need to set the storageclass since in our test k8s no default storage class is not set.
-helm upgrade --install --wait --timeout 10m0s $RELEASE_NAME . \
+helm upgrade --install --debug --wait --timeout 10m0s $RELEASE_NAME . \
       --set image.tag="$TAG" \
       --set resources.limits.memory=2G \
       --set credentials.repository="EMPTY" \

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -60,7 +60,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import static graphql.Assert.assertTrue;
 import static java.util.function.Predicate.not;
 
 /**

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -199,7 +199,6 @@ public abstract class KubernetesService implements InitializingBean {
    */
   protected KubernetesService(
       String namespace, String kubeconfig, boolean k8sSupportsV1CronJob, Logger log) {
-    assertTrue(StringUtils.isNotBlank(namespace), () -> "Namespace must be set to an actual value");
     this.namespace = namespace;
     this.kubeconfig = kubeconfig;
     this.k8sSupportsV1CronJob = k8sSupportsV1CronJob;


### PR DESCRIPTION
### Why 
Within my previous commit I wanted to cleanup the tests where we create namespaces on the fly if namespace is null or empty. 
That code still did need to be removed and more of my PR was correct however when namespace is empty or null then we should take the default namespace from the kubeconfig file instead of throwing an error.
### What
remove the assertion and add in debug logging to helm chart deployment to make this easier to debug. 
### How has this been tested
all pipelines. 
 