### PR TITLE
Revert "build(deps): bump mockito-core from 3.11.2 to 4.9.0 

### DIFF
--- a/projects/control-service/projects/versions-of-external-dependencies.gradle
+++ b/projects/control-service/projects/versions-of-external-dependencies.gradle
@@ -18,7 +18,7 @@ project.ext {
             'org.junit.jupiter:junit-jupiter-engine'                             : 'org.junit.jupiter:junit-jupiter-engine:5.7.2',
             'org.junit.platform:junit-platform-suite-api'                        : 'org.junit.platform:junit-platform-suite-api:1.8.1',
             'com.mmnaseri.utils:spring-data-mock'                                : 'com.mmnaseri.utils:spring-data-mock:2.2.0',
-            'org.mockito:mockito-core'                                           : 'org.mockito:mockito-core:4.9.0',
+            'org.mockito:mockito-core'                                           : 'org.mockito:mockito-core:3.11.2',
             'com.fasterxml.jackson.core:jackson-databind'                        : 'com.fasterxml.jackson.core:jackson-databind:2.12.4',
             'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'             : 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.4',
             'org.json:json'                                                      : 'org.json:json:20210307',


### PR DESCRIPTION
Reverts vmware/versatile-data-kit#1350 as the mockito upgrade seems to be unsuccessful - it failed with https://gitlab.com/vmware-analytics/versatile-data-kit/-/jobs/3383814328  Specidic error was "java.lang.IllegalStateException: Could not initialize plugin: interface org.mockito.plugins.MockMaker (alternate: null)
" - [see details here](https://vmware-analytics.gitlab.io/-/versatile-data-kit/-/jobs/3383814328/artifacts/projects/control-service/projects/pipelines_control_service/build/reports/tests/test/classes/com.vmware.taurus.service.upload.JobUploadTest.html#initializationError)
 I am not sure how the same test passed in the pre-merge testing but it's better to be save