### PR TITLE
control-service: builder images load secrets from k8s

### DIFF
--- a/projects/control-service/projects/job-builder/build_image.sh
+++ b/projects/control-service/projects/job-builder/build_image.sh
@@ -52,6 +52,7 @@ cat > /kaniko/.docker/config.json <<- EOM
       "password":"$registry_password",
       "auth": "$auth"
     }
+  $extra_auth
   }
 }
 EOM

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-private-builder.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-private-builder.properties
@@ -1,3 +1,4 @@
 datajobs.builder.registrySecret=integration-test-docker-pull-secret
 datajobs.builder.registrySecret.content.testOnly=${BUILDER_TEST_REGISTRY_SECRET}
 datajobs.builder.image=${DOCKER_REGISTRY_URL}/versatiledatakit/job-builder:1.2.3
+datajobs.deployment.dataJobBaseImage=ghcr.io/versatile-data-kit-dev/dp/versatiledatakit/data-job-base-python-3.7:latest

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -2202,6 +2202,7 @@ public abstract class KubernetesService implements InitializingBean {
                     .withRequests(resources(request))
                     .withLimits(resources(limit))
                     .build())
+                .withEnvFrom(new V1EnvFromSource().secretRef(new V1SecretEnvSource().name("builder-secrets").optional(true)))
             .withEnv(
                 envs.entrySet().stream()
                     .map(KubernetesService::envVar)

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -2202,7 +2202,9 @@ public abstract class KubernetesService implements InitializingBean {
                     .withRequests(resources(request))
                     .withLimits(resources(limit))
                     .build())
-                .withEnvFrom(new V1EnvFromSource().secretRef(new V1SecretEnvSource().name("builder-secrets").optional(true)))
+            .withEnvFrom(
+                new V1EnvFromSource()
+                    .secretRef(new V1SecretEnvSource().name("builder-secrets").optional(true)))
             .withEnv(
                 envs.entrySet().stream()
                     .map(KubernetesService::envVar)


### PR DESCRIPTION
###  Why
I wrote this PR with the intent of being able to pass extra docker creds to to the image builder so that we would be able to pull a private base image from a docker repo. 
The builder now contains login details for 2 registries. The registry it pushes to and the registry it pulls base image from.

However this PR also introduces the concept of builder secrets being sourced from k8s which leads to much cleaner separation between the control plane and the builder image. I think this will lead to much better support for custom build images in the future.

I added new functionality and didn't document it but have created this ticket to follow up on it. 

https://github.com/vmware/versatile-data-kit/issues/1357

### How was this been tested
tested extensively locally. 
I added a test to check that the base image can be pulled from a private repo but in fact it is pulling from the same repo as it is pushing to and so it is could let bugs through related to the auth not working for the base image repo. 