### PR TITLE
control-service: builder base image in helm

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/_helpers.tpl
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/_helpers.tpl
@@ -247,3 +247,7 @@ Image Pull Secret in json format
 {{- define "builderPullSecretJson" }}
     {{ include "buildImagePullSecretJson" (list .Values.deploymentBuilderImage.registry .Values.deploymentBuilderImage.username .Values.deploymentBuilderImage.password) }}
 {{- end }}
+
+{{- define "basePullSecretJson" }}
+    {{ include "buildImagePullSecretJson" (list .Values.deploymentDataJobBaseImage.registry .Values.deploymentDataJobBaseImage.username .Values.deploymentDataJobBaseImage.password) }}
+{{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_base_img.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_base_img.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.deploymentDataJobBaseImage.password }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: builder-secrets
+  namespace: {{ .Values.controlK8sNamespace }}
+  labels: {{- include "pipelines-control-service.labels" . | nindent 4 }}
+type: kubernetes.io/dockerconfigjson
+data:
+{{/* Within this section any set of properties can be set and then used in a job builder image
+at the moment the only one set is extra_auth: Within this property docker config should be included to connect to the registry used to pull the image from. */}}
+  extra_auth: {{- printf ", \"%s\": {\"auth\": \"%s\"}" .Values.deploymentDataJobBaseImage.registry (printf "%s:%s" .Values.deploymentDataJobBaseImage.username .Values.deploymentDataJobBaseImage.password | b64enc) | b64enc }}
+{{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -236,6 +236,8 @@ deploymentDataJobBaseImage:
   registry: registry.hub.docker.com/versatiledatakit
   repository: data-job-base-python-3.7
   tag: "latest"
+  username:
+  password:
 
 ## ini formatted options that provides default and per-job VDK options.
 ## Allows to provide VDK configuration via environment variables.


### PR DESCRIPTION
### Why
Within this PR we add support in a builder image for using extra info from k8s through secrets in the namespace. 
In this PR we create the actual secret in the namespace if the info required to create it is present.

### How was this tested. 
Basic linting and looking at a printed out chart. 
closes https://github.com/vmware/versatile-data-kit/issues/1333 
Signed-off-by: murphp15 <murphp15@tcd.ie>