### PR TITLE
control-service: fix secret in helm chart

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_base_img.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_base_img.yaml
@@ -9,5 +9,5 @@ type: Opaque
 stringData:
 {{/* Within this section any set of properties can be set and then used in a job builder image
 at the moment the only one set is extra_auth: Within this property docker config should be included to connect to the registry used to pull the image from. */}}
-  extra_auth: {{- printf ", \"%s\": {\"auth\": \"%s\"}" .Values.deploymentDataJobBaseImage.registry (printf "%s:%s" .Values.deploymentDataJobBaseImage.username .Values.deploymentDataJobBaseImage.password | b64enc) }}
+  extra_auth: {{- printf " ', \"%s\": {\"auth\": \"%s\"}'" .Values.deploymentDataJobBaseImage.registry (printf "%s:%s" .Values.deploymentDataJobBaseImage.username .Values.deploymentDataJobBaseImage.password | b64enc) }}
 {{- end }}


### PR DESCRIPTION
### Why
The secret was invalid and wasn't saving into k8s
### Why
it needed a space before the start of the secret and also needed single quotes around it

### How has this been tested
I created the secret in my local cluster and everything works fine. 
Also it passes basic linting.

Signed-off-by: murphp15 <murphp15@tcd.ie>