### PR TITLE
control-service: release helm chart with correct image tag

### DIFF
--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -301,7 +301,7 @@ control_service_release:
   stage: release
   script:
     - apk --no-cache add bash openssl curl git
-    - export IMAGE_TAG=$(git rev-parse --short HEAD)
+    - export IMAGE_TAG='$(git rev-parse --short HEAD)'
     - export DESIRED_VERSION=v3.6.3 # helm version 3.6.3
     - export CHART_NAME=pipelines-control-service
     - export CHART_VERSION="$(cat projects/control-service/projects/helm_charts/$CHART_NAME/version.txt | grep -o '^[0-9]\+\.[0-9]\+').$CI_PIPELINE_ID"

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -301,7 +301,7 @@ control_service_release:
   stage: release
   script:
     - apk --no-cache add bash openssl curl git
-    - export IMAGE_TAG='$(git rev-parse --short HEAD)'
+    - export IMAGE_TAG="$(git rev-parse --short HEAD)"
     - export DESIRED_VERSION=v3.6.3 # helm version 3.6.3
     - export CHART_NAME=pipelines-control-service
     - export CHART_VERSION="$(cat projects/control-service/projects/helm_charts/$CHART_NAME/version.txt | grep -o '^[0-9]\+\.[0-9]\+').$CI_PIPELINE_ID"

--- a/projects/control-service/cicd/release-pipelines-service.sh
+++ b/projects/control-service/cicd/release-pipelines-service.sh
@@ -2,7 +2,7 @@
 
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
-
+echo "image tag is $IMAGE_TAG"
 export HELM_REPO=versatile-data-kit-helm-registry
 # TODO: sign chart
 helm pack --version "$CHART_VERSION" --app-version "$CHART_VERSION" --dependency-update "$CHART_NAME" --set image.tag="$IMAGE_TAG"


### PR DESCRIPTION
### Why
I am seeing an issue where helm charts are being released and they point to a pipelines-control-service image that doesn't exist because they have dropped some numbers from the git hash id. 

The bug can be seen here: https://gitlab.com/vmware-analytics/versatile-data-kit/-/jobs/3408315682
the image it creates doesn’t have the full commit id.
if you search for `image.tag=`  in the logs you can see that it set the commit to something shorter than the commit id


I also think that adding the quotes when declaring the variable might fix this: https://github.com/vmware/versatile-data-kit/issues/1252

I did test locally but am not able to reproduce either issue locally and I think it is related to the shell version they are using on gitlab. 
### What
Add quotes around the commit id and log the commit id at the start of the called script to make sure it is passed in correctly. 

Signed-off-by: murphp15 <murphp15@tcd.ie>