### PR TITLE
control-service: latest graphql version

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/ExecutionDataFetcher.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/ExecutionDataFetcher.java
@@ -80,8 +80,8 @@ public class ExecutionDataFetcher {
     final Map<String, Object> arguments =
         dataFetchingEnvironment
             .getSelectionSet()
-            .getField(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath())
-            .getArguments();
+            .getFields(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath())
+            .get(0).getArguments();
     final DataJobExecutionQueryVariables dataJobExecutionQueryVariables =
         fetchDataJobExecutionQueryVariables(arguments);
     allDataJob.forEach(

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/ExecutionDataFetcher.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/ExecutionDataFetcher.java
@@ -81,7 +81,8 @@ public class ExecutionDataFetcher {
         dataFetchingEnvironment
             .getSelectionSet()
             .getFields(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath())
-            .get(0).getArguments();
+            .get(0)
+            .getArguments();
     final DataJobExecutionQueryVariables dataJobExecutionQueryVariables =
         fetchDataJobExecutionQueryVariables(arguments);
     allDataJob.forEach(

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/ExecutionDataFetcherTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/ExecutionDataFetcherTest.java
@@ -67,7 +67,8 @@ class ExecutionDataFetcherTest {
   @Test
   void testDataFetcherOfJobs_whenInvalidExecutionPageNumberIsProvided_shouldThrowException() {
     when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-    when(dataFetchingFieldSelectionSet.getFields(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
+    when(dataFetchingFieldSelectionSet.getFields(
+            JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
         .thenReturn(Lists.newArrayList(selectedField));
     Map<String, Object> executionArgs = new HashMap<>();
     executionArgs.put("pageNumber", 0);
@@ -83,7 +84,8 @@ class ExecutionDataFetcherTest {
   @Test
   void testDataFetcherOfJobs_whenInvalidExecutionPageSizeIsProvided_shouldThrowException() {
     when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-    when(dataFetchingFieldSelectionSet.getFields(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
+    when(dataFetchingFieldSelectionSet.getFields(
+            JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
         .thenReturn(Lists.newArrayList(selectedField));
     Map<String, Object> executionArgs = new HashMap<>();
     executionArgs.put("pageNumber", 1);
@@ -99,7 +101,8 @@ class ExecutionDataFetcherTest {
   @Test
   void testDataFetcherOfJobs_whenRequestIncludesExecutions_shouldInvokeExecutions() {
     when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-    when(dataFetchingFieldSelectionSet.getFields(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
+    when(dataFetchingFieldSelectionSet.getFields(
+            JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
         .thenReturn(Lists.newArrayList(selectedField));
     Map<String, Object> executionArgs = new HashMap<>();
     executionArgs.put("pageNumber", 1);
@@ -119,7 +122,8 @@ class ExecutionDataFetcherTest {
   @Test
   void testDataFetcherOfJobs_whenUnsupportedOrderInExecutionOperation_shouldThrowException() {
     when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-    when(dataFetchingFieldSelectionSet.getFields(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
+    when(dataFetchingFieldSelectionSet.getFields(
+            JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
         .thenReturn(Lists.newArrayList(selectedField));
     Map<String, Object> executionArgs = new HashMap<>();
     executionArgs.put("pageNumber", 1);
@@ -143,7 +147,8 @@ class ExecutionDataFetcherTest {
   @Test
   void testDataFetcherOfJobs_whenJobNameInIsSpecified_shouldThrowException() {
     when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-    when(dataFetchingFieldSelectionSet.getFields(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
+    when(dataFetchingFieldSelectionSet.getFields(
+            JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
         .thenReturn(Lists.newArrayList(selectedField));
     Map<String, Object> executionArgs = new HashMap<>();
     executionArgs.put("pageNumber", 1);

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/ExecutionDataFetcherTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/ExecutionDataFetcherTest.java
@@ -5,6 +5,7 @@
 
 package com.vmware.taurus.service.graphql;
 
+import com.google.common.collect.Lists;
 import com.vmware.taurus.controlplane.model.data.DataJobMode;
 import com.vmware.taurus.service.JobExecutionRepository;
 import com.vmware.taurus.service.execution.JobExecutionLogsUrlBuilder;
@@ -66,8 +67,8 @@ class ExecutionDataFetcherTest {
   @Test
   void testDataFetcherOfJobs_whenInvalidExecutionPageNumberIsProvided_shouldThrowException() {
     when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-    when(dataFetchingFieldSelectionSet.getField(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
-        .thenReturn(selectedField);
+    when(dataFetchingFieldSelectionSet.getFields(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
+        .thenReturn(Lists.newArrayList(selectedField));
     Map<String, Object> executionArgs = new HashMap<>();
     executionArgs.put("pageNumber", 0);
     executionArgs.put("pageSize", 25);
@@ -82,8 +83,8 @@ class ExecutionDataFetcherTest {
   @Test
   void testDataFetcherOfJobs_whenInvalidExecutionPageSizeIsProvided_shouldThrowException() {
     when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-    when(dataFetchingFieldSelectionSet.getField(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
-        .thenReturn(selectedField);
+    when(dataFetchingFieldSelectionSet.getFields(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
+        .thenReturn(Lists.newArrayList(selectedField));
     Map<String, Object> executionArgs = new HashMap<>();
     executionArgs.put("pageNumber", 1);
     executionArgs.put("pageSize", 0);
@@ -98,8 +99,8 @@ class ExecutionDataFetcherTest {
   @Test
   void testDataFetcherOfJobs_whenRequestIncludesExecutions_shouldInvokeExecutions() {
     when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-    when(dataFetchingFieldSelectionSet.getField(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
-        .thenReturn(selectedField);
+    when(dataFetchingFieldSelectionSet.getFields(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
+        .thenReturn(Lists.newArrayList(selectedField));
     Map<String, Object> executionArgs = new HashMap<>();
     executionArgs.put("pageNumber", 1);
     executionArgs.put("pageSize", 25);
@@ -118,8 +119,8 @@ class ExecutionDataFetcherTest {
   @Test
   void testDataFetcherOfJobs_whenUnsupportedOrderInExecutionOperation_shouldThrowException() {
     when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-    when(dataFetchingFieldSelectionSet.getField(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
-        .thenReturn(selectedField);
+    when(dataFetchingFieldSelectionSet.getFields(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
+        .thenReturn(Lists.newArrayList(selectedField));
     Map<String, Object> executionArgs = new HashMap<>();
     executionArgs.put("pageNumber", 1);
     executionArgs.put("pageSize", 25);
@@ -142,8 +143,8 @@ class ExecutionDataFetcherTest {
   @Test
   void testDataFetcherOfJobs_whenJobNameInIsSpecified_shouldThrowException() {
     when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
-    when(dataFetchingFieldSelectionSet.getField(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
-        .thenReturn(selectedField);
+    when(dataFetchingFieldSelectionSet.getFields(JobFieldStrategyBy.DEPLOYMENT_EXECUTIONS.getPath()))
+        .thenReturn(Lists.newArrayList(selectedField));
     Map<String, Object> executionArgs = new HashMap<>();
     executionArgs.put("pageNumber", 1);
     executionArgs.put("pageSize", 25);

--- a/projects/control-service/projects/versions-of-external-dependencies.gradle
+++ b/projects/control-service/projects/versions-of-external-dependencies.gradle
@@ -31,7 +31,7 @@ project.ext {
             'org.ini4j:ini4j'                                                    : 'org.ini4j:ini4j:0.5.4',
             'io.kubernetes:client-java'                                          : 'io.kubernetes:client-java:16.0.0',
             'io.kubernetes:client-java-api-fluent'                               : 'io.kubernetes:client-java-api-fluent:16.0.2',
-            'com.graphql-java:graphql-java-spring-boot-starter-webmvc'           : 'com.graphql-java:graphql-java-spring-boot-starter-webmvc:2.0',
+            'com.graphql-java:graphql-java-spring-boot-starter-webmvc'           : 'com.graphql-java:graphql-java-spring-boot-starter-webmvc:2021-10-25T04-50-54-fbc162f',
             'com.cronutils:cron-utils'                                           : 'com.cronutils:cron-utils:9.1.5',
             'net.lingala.zip4j:zip4j'                                            : 'net.lingala.zip4j:zip4j:2.11.2',
             'net.javacrumbs.shedlock:shedlock-spring'                            : 'net.javacrumbs.shedlock:shedlock-spring:4.25.0',
@@ -44,7 +44,7 @@ project.ext {
             'org.apache.commons:commons-lang3'                                   : 'org.apache.commons:commons-lang3:3.12.0',
             'org.apache.commons:commons-text'                                    : 'org.apache.commons:commons-text:1.10.0',
             'com.github.tomakehurst:wiremock'                                    : 'com.github.tomakehurst:wiremock:2.27.2',
-            'com.graphql-java:graphql-java-extended-scalars'                     : 'com.graphql-java:graphql-java-extended-scalars:15.0.0',
+            'com.graphql-java:graphql-java-extended-scalars'                     : 'com.graphql-java:graphql-java-extended-scalars:19.1',
             'org.springframework.retry:spring-retry'                             : 'org.springframework.retry:spring-retry:2.0.0',
             'org.apache.tika:tika-core'                                          : 'org.apache.tika:tika-core:2.5.0',
 


### PR DESCRIPTION
### Why
Dependabot is trying to upgrade to the latest version of spring (https://github.com/vmware/versatile-data-kit/pull/1305) but it is running in to compile issues.
These compile issues are related to us using very old graphql libraries.  

### What
In this PR I upgrade the very old graphql libraries so that the spring upgrade can happen in the other PR.  
There is one method declaration change in the newer functions so I had to make that change in the codebase too. 
### How has this been tested

Unit and integration tests.