### PR TITLE
examples: clarify README sample anonymize plugin

### DIFF
--- a/examples/ingest-and-anonymize-plugin/plugins/vdk-poc-anonymize/README.md
+++ b/examples/ingest-and-anonymize-plugin/plugins/vdk-poc-anonymize/README.md
@@ -1,6 +1,10 @@
 # POC Anonymization plugin
 
-(Created from https://github.com/vmware/versatile-data-kit/tree/main/projects/vdk-plugins/plugin-template/src/vdk/plugin/plugin_template)
+**This is a sample plugin used in an example/tutorial for creating plugins. It is not a real plugin.**
+
+**The below README is a sample README of what is usually expected of a real plugin README**
+
+
 
 
 POC Anonymization plugin automatically all data being ingested using Versatile Data Kit


### PR DESCRIPTION
The sample README used in a tutorial may be misleading that it's a real plugin (since it looks like a README of a real plugin). This may confuse people and try to use it. So we are clarifying it here to avoid mistakes.

This was flagged by VMware security team as a potential dependecy confusion attack.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>