### PR TITLE
vdk-core: Support for 3.11

### DIFF
--- a/projects/vdk-core/.gitlab-ci.yml
+++ b/projects/vdk-core/.gitlab-ci.yml
@@ -26,8 +26,11 @@ image: "python:3.9"
     changes: *vdk_core_locations
   artifacts:
     when: always
+    paths:
+      - ./projects/vdk-core/tests.xml
+    expire_in: 1 week
     reports:
-      junit: tests.xml
+      junit: ./projects/vdk-core/tests.xml
 
 vdk-core-build_with_py37:
   image: "python:3.7"
@@ -41,11 +44,14 @@ vdk-core-build_with_py39:
   image: "python:3.9"
   extends: .vdk-core-build
 
-# There seem to be an issue with python 3.10.6 ...
+# There seem to be an issue with python 3.10.6 ... TODO: add github issue
 vdk-core-build_with_py310:
   image: "python:3.10.5"
   extends: .vdk-core-build
 
+vdk-core-build_with_py311:
+    image: "python:3.11"
+    extends: .vdk-core-build
 
 .vdk-core-simple_func_test:
   services:
@@ -65,8 +71,11 @@ vdk-core-build_with_py310:
       - "projects/vdk-core/**/*"
   artifacts:
     when: always
+    paths:
+      - ./projects/vdk-core/tests.xml
+    expire_in: 1 week
     reports:
-      junit: tests.xml
+      junit: ./projects/vdk-core/tests.xml
 
 vdk-core-simple_func_test_with_py37:
   image: "python:3.7"
@@ -82,6 +91,10 @@ vdk-core-simple_func_test_with_py39:
 
 vdk-core-simple_func_test_with_py310:
   image: "python:3.10"
+  extends: .vdk-core-simple_func_test
+
+vdk-core-simple_func_test_with_py311:
+  image: "python:3.11"
   extends: .vdk-core-simple_func_test
 
 

--- a/projects/vdk-core/cicd/build.sh
+++ b/projects/vdk-core/cicd/build.sh
@@ -23,13 +23,8 @@ export PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL:-https://test.pypi.org/simple/}
 echo "Update pip to newest version"
 pip install -U pip
 
-# Below line uses --use-deprecated=legacy-resolver to temporary workaround a
-# dependency backtracking issue.
-# TODO: Remove the use of the legacy resolver once latest pip works as expected.
-echo "install dependencies from requirements.txt (used for development and testing)"
-pip install --use-deprecated="legacy-resolver" --extra-index-url $PIP_EXTRA_INDEX_URL -r requirements.txt
-
 echo "Setup git hook scripts with pre-commit install"
+pip install pre-commit
 pre-commit install --hook-type commit-msg --hook-type pre-commit
 
 # Below line uses --use-deprecated=legacy-resolver to temporary workaround a
@@ -41,8 +36,8 @@ pip install --use-deprecated="legacy-resolver" -e .
 # Below line uses --use-deprecated=legacy-resolver to temporary workaround a
 # dependency backtracking issue.
 # TODO: Remove the use of the legacy resolver once latest pip works as expected.
-echo "Install common vdk test utils library (in editable mode)"
-pip install --use-deprecated="legacy-resolver" -e ../vdk-plugins/vdk-test-utils
+echo "install dependencies from requirements.txt (used for development and testing)"
+pip install --use-deprecated="legacy-resolver" --extra-index-url $PIP_EXTRA_INDEX_URL -r requirements.txt
 
 # Print installed versions
 echo "Printing vdk version and python libraries"

--- a/projects/vdk-core/setup.cfg
+++ b/projects/vdk-core/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
     tenacity
 
 # Require a specific Python version
-python_requires = >=3.7, <3.11
+python_requires = >=3.7
 
 
 

--- a/projects/vdk-core/setup.cfg
+++ b/projects/vdk-core/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
 zip_safe = False
@@ -52,7 +53,7 @@ install_requires =
     tenacity
 
 # Require a specific Python version
-python_requires = >=3.7
+python_requires = >=3.7, <4
 
 
 

--- a/projects/vdk-plugins/vdk-test-utils/src/vdk/plugin/test_utils/util_plugins.py
+++ b/projects/vdk-plugins/vdk-test-utils/src/vdk/plugin/test_utils/util_plugins.py
@@ -57,7 +57,7 @@ class SqLite3MemoryDb:
         import sqlite3
 
         print(self.__db_name)
-        return sqlite3.connect(f"{self.__db_file}")
+        return sqlite3.connect(f"{self.__db_file}", isolation_level=None)
 
     def execute_query(self, query: str) -> List[List]:
         conn = self.new_connection()


### PR DESCRIPTION
With the GA release of Python 3.11 a month ago it's time to officially support it.
That means we need to start testing against Python 3.11. See release notes at https://docs.python.org/3/whatsnew/3.11.html

This change is adding tests (and changes related to make the tests run) for 3.11 for vdk-core.

Subsequent changes will add that for all other components that support multiple versions of python


While troubleshooting fixed the path to tests.xml so that it shows properly in the test tab - https://gitlab.com/vmware-analytics/versatile-data-kit/-/pipelines/712924440/test_report  and to be able to download the XML test report

Part 1 of https://github.com/vmware/versatile-data-kit/issues/1397

Testing Done: this PR pipeline.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>