### PR TITLE
vdk-gitlab-runners: increase concurrent pipelines

### DIFF
--- a/support/gitlab-runners/README.md
+++ b/support/gitlab-runners/README.md
@@ -15,7 +15,7 @@ export AWS_DEFAULT_REGION=us-west-1
 export AWS_SECRET_ACCESS_KEY=<get-from-gitlab-ci-variables>
 export AWS_ACCESS_KEY_ID=<get-from-gitlab-ci-variables>
 
-export RUNNER_REGISTRATION_TOKEN= # Get the Gitlab token from
+export RUNNER_REGISTRATION_TOKEN= # Get the Gitlab token from https://gitlab.com/vmware-analytics/versatile-data-kit/-/settings/ci_cd
 ```
 The only prerequisite in order to run the scripts and deploy the runners is installed [helm 3](https://helm.sh/docs/).
 

--- a/support/gitlab-runners/values.yaml
+++ b/support/gitlab-runners/values.yaml
@@ -24,7 +24,7 @@ runnerRegistrationToken: ""
 ##
 # At the time of writing, we have 50 CPU core and 100 GiB RAM quota.
 #
-concurrent: 5
+concurrent: 15
 
 ## Defines in seconds how often to check GitLab for a new builds
 ## ref: https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-global-section


### PR DESCRIPTION
Currently our gitlab runenrs allowed max 5 concurrent runs, but we have resources for far more and the contribution has increased so 5 are not enough.

Testing Done: none, already deployed following README guidelines.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>