### PR TITLE
vdk-gitlab: upgrade the gitlab runner to latest version

### DIFF
--- a/support/gitlab-runners/install-runners.sh
+++ b/support/gitlab-runners/install-runners.sh
@@ -55,4 +55,4 @@ helm repo add gitlab https://charts.gitlab.io
 helm upgrade --install \
   --set runnerRegistrationToken=$RUNNER_REGISTRATION_TOKEN \
   --set runners.namespace=$NAMESPACE \
-  --kubeconfig $KUBECONFIG --namespace $NAMESPACE --version "0.22.0" $RUNNER_NAME -f $VALUES gitlab/gitlab-runner
+  --kubeconfig $KUBECONFIG --namespace $NAMESPACE --version "0.45.0" $RUNNER_NAME -f $VALUES gitlab/gitlab-runner


### PR DESCRIPTION
I noticed that sometimes gitlab jobs would stuck in pending despite not seeing any pods running (each Gitlab job starts 1 pod, upto 15 (our current limit) of concurrent Gitlab jobs running)

After I restarted the gitlab runner deployment they'd start (kubectl rollout restart deployment).

I am not sure why. But as a first step I am upgrading the gitlab runner to latest version. 0.22 is pretty old anyway

Testing Done: deployed it directly (as per readme) and start gitlab job and saw it works

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>