### PR TITLE
vdk-control-cli: allow cli users to explicitly set the user agent tag

### DIFF
--- a/examples/ingest-and-anonymize-plugin/plugins/vdk-poc-anonymize/README.md
+++ b/examples/ingest-and-anonymize-plugin/plugins/vdk-poc-anonymize/README.md
@@ -1,6 +1,10 @@
 # POC Anonymization plugin
 
-(Created from https://github.com/vmware/versatile-data-kit/tree/main/projects/vdk-plugins/plugin-template/src/vdk/plugin/plugin_template)
+**This is a sample plugin used in an example/tutorial for creating plugins. It is not a real plugin.**
+
+**The below README is a sample README of what is usually expected of a real plugin README**
+
+
 
 
 POC Anonymization plugin automatically all data being ingested using Versatile Data Kit

--- a/projects/vdk-control-cli/src/vdk/internal/control/configuration/vdk_config.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/configuration/vdk_config.py
@@ -18,6 +18,8 @@ class VDKConfig:
 
     _op_id = os.environ.get("VDK_OP_ID_OVERRIDE", f"{uuid.uuid4().hex}"[:16])
 
+    _user_agent = os.environ.get("VDK_CONTROL_SERVICE_USER_AGENT", "VDK_CLI")
+
     @property
     def op_id(self) -> str:
         """
@@ -37,6 +39,16 @@ class VDKConfig:
 
         """
         return VDKConfig._op_id
+
+    @property
+    def user_agent(self) -> str:
+        """
+        user agent that is used to make easier troubleshooting.
+
+        This value won't appear in trace logs but will be included in events set to supercollider
+        """
+        return VDKConfig._user_agent
+
 
     @property
     def local_config_folder(self) -> str:

--- a/projects/vdk-control-cli/src/vdk/internal/control/configuration/vdk_config.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/configuration/vdk_config.py
@@ -19,8 +19,10 @@ class VDKConfig:
 
     _op_id = os.environ.get("VDK_OP_ID_OVERRIDE", f"{uuid.uuid4().hex}"[:16])
 
-    _user_agent = os.environ.get("VDK_CONTROL_SERVICE_USER_AGENT", f"vdk-control-cli/1.2 ({os.name}; {sys.platform})" +
-                                 sys.version.split(" ")[0])
+    _user_agent = os.environ.get(
+        "VDK_CONTROL_SERVICE_USER_AGENT",
+        f"vdk-control-cli/1.2 ({os.name}; {sys.platform})" + sys.version.split(" ")[0],
+    )
 
     @property
     def op_id(self) -> str:

--- a/projects/vdk-control-cli/src/vdk/internal/control/configuration/vdk_config.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/configuration/vdk_config.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import pathlib
+import sys
 from configparser import ConfigParser
 from pathlib import Path
 
@@ -18,7 +19,8 @@ class VDKConfig:
 
     _op_id = os.environ.get("VDK_OP_ID_OVERRIDE", f"{uuid.uuid4().hex}"[:16])
 
-    _user_agent = os.environ.get("VDK_CONTROL_SERVICE_USER_AGENT", "VDK_CLI")
+    _user_agent = os.environ.get("VDK_CONTROL_SERVICE_USER_AGENT", f"vdk-control-cli/1.2 ({os.name}; {sys.platform})" +
+                                 sys.version.split(" ")[0])
 
     @property
     def op_id(self) -> str:

--- a/projects/vdk-control-cli/src/vdk/internal/control/rest_lib/factory.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/rest_lib/factory.py
@@ -49,7 +49,7 @@ class ApiClientFactory:
         # We are setting X-OPID - this is send in telemetry and printed in logs on server side - make it easier
         # to troubleshoot and trace requests across different services
         api_client.set_default_header("X-OPID", self.vdk_config.op_id)
-        api_client.set_default_header("User-Agent", self.vdk_config.op_id)
+        api_client.set_default_header("User-Agent", self.vdk_config.user_agent)
         return api_client
 
     def get_jobs_api(self) -> DataJobsApi:

--- a/projects/vdk-control-cli/src/vdk/internal/control/rest_lib/factory.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/rest_lib/factory.py
@@ -20,7 +20,6 @@ class ApiClientFactory:
     def __init__(self, rest_api_url):
         log.debug(f"Rest API URL: {rest_api_url}")
         self.vdk_config = VDKConfig()
-        self.op_id = self.vdk_config.op_id
         self.timeouts = (
             self.vdk_config.http_connect_timeout_seconds,
             self.vdk_config.http_read_timeout_seconds,
@@ -49,7 +48,8 @@ class ApiClientFactory:
         api_client = ApiClient(self.config)
         # We are setting X-OPID - this is send in telemetry and printed in logs on server side - make it easier
         # to troubleshoot and trace requests across different services
-        api_client.set_default_header("X-OPID", self.op_id)
+        api_client.set_default_header("X-OPID", self.vdk_config.op_id)
+        api_client.set_default_header("User-Agent", self.vdk_config.op_id)
         return api_client
 
     def get_jobs_api(self) -> DataJobsApi:


### PR DESCRIPTION
### Why
Users are looking to be able to determine where requests originated from when browsing the data.
### How
We are going to let cli users explicitly set the user-agent header. 

### How has this been tested

sent requests to vdk aas and made sure they have the correct user agent in super collider. 
The results of this test can only be validated by VMware employees which isn't ideal for an open source project. https://sql.supercollider.vmware.com/stg/history/index.html?sql=select%20*%20from%20history_staging.taurus_httptrace%20where%20request_headers_user_agent%20like%20%27%25paul%25%27%20limit%2010&ddlOutputType=table&version=1#

Closes: https://github.com/vmware/versatile-data-kit/issues/1404


Signed-off-by: murphp15 <murphp15@tcd.ie>