### PR TITLE
control-service: Reset termination status when job is disabled

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
@@ -33,7 +33,7 @@ public class DeploymentModelConverter {
   }
 
   /**
-   * Merge to deployments with preference of fields from newDeployment over oldDeployment.
+   * Merge two deployments with preference of fields from newDeployment over oldDeployment.
    *
    * @param oldDeployment the old deployment
    * @param newDeployment the new deployment if a field is not null it is set other oldDeployment

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentService.java
@@ -81,7 +81,7 @@ public class DeploymentService {
       saveDeployment(dataJob, mergedDeployment);
 
       if (!mergedDeployment.getEnabled()) {
-        dataJobMetrics.clearGaugesAtJobDisable(mergedDeployment.getDataJobName());
+        dataJobMetrics.clearTerminationStatusAndDelayNotifGauges(mergedDeployment.getDataJobName());
       }
 
       deploymentProgress.configuration_updated(dataJob.getJobConfig(), jobDeployment);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentService.java
@@ -15,6 +15,7 @@ import com.vmware.taurus.service.diag.OperationContext;
 import com.vmware.taurus.service.diag.methodintercept.Measurable;
 import com.vmware.taurus.service.model.*;
 import com.vmware.taurus.service.notification.NotificationContent;
+import com.vmware.taurus.service.monitoring.DataJobMetrics;
 import io.kubernetes.client.openapi.ApiException;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -44,6 +45,7 @@ public class DeploymentService {
   private final JobImageDeployer jobImageDeployer;
   private final OperationContext operationContext;
   private final JobsRepository jobsRepository;
+  private final DataJobMetrics dataJobMetrics;
 
   public Optional<JobDeploymentStatus> readDeployment(String jobName) {
     return jobImageDeployer.readScheduledJob(jobName);
@@ -77,6 +79,11 @@ public class DeploymentService {
       jobImageDeployer.scheduleJob(dataJob, mergedDeployment, false, operationContext.getUser());
 
       saveDeployment(dataJob, mergedDeployment);
+
+      if (!mergedDeployment.getEnabled()) {
+        dataJobMetrics.clearGaugesAtJobDisable(mergedDeployment.getDataJobName());
+      }
+
       deploymentProgress.configuration_updated(dataJob.getJobConfig(), jobDeployment);
     } else {
       throw new DataJobDeploymentNotFoundException(dataJob.getName());

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMetrics.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMetrics.java
@@ -207,6 +207,18 @@ public class DataJobMetrics {
   }
 
   /**
+   * Removes the delay notification and termination status gauges
+   * associated with the specific data job. This is done when a data job is
+   * being disabled.
+   *
+   * @param dataJobName The name of the data job for which to clear the gauges.
+   * */
+  public void clearGaugesAtJobDisable(final String dataJobName) {
+    removeNotificationDelayGauge(dataJobName);
+    removeTerminationStatusGauge(dataJobName);
+  }
+
+  /**
    * Removes all gauges associated with data jobs that are not present in the specified iterable.
    *
    * @param dataJobNames The names of the data jobs which will still have gauges.

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMetrics.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMetrics.java
@@ -207,13 +207,12 @@ public class DataJobMetrics {
   }
 
   /**
-   * Removes the delay notification and termination status gauges
-   * associated with the specific data job. This is done when a data job is
-   * being disabled.
+   * Removes the delay notification and termination status gauges associated with the specific data
+   * job. This is done when a data job is being disabled.
    *
    * @param dataJobName The name of the data job for which to clear the gauges.
-   * */
-  public void clearGaugesAtJobDisable(final String dataJobName) {
+   */
+  public void clearTerminationStatusAndDelayNotifGauges(final String dataJobName) {
     removeNotificationDelayGauge(dataJobName);
     removeTerminationStatusGauge(dataJobName);
   }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
@@ -13,6 +13,7 @@ import com.vmware.taurus.service.diag.OperationContext;
 import com.vmware.taurus.service.kubernetes.DataJobsKubernetesService;
 import com.vmware.taurus.service.model.*;
 import com.vmware.taurus.service.monitoring.DeploymentMonitor;
+import com.vmware.taurus.service.monitoring.DataJobMetrics;
 import com.vmware.taurus.service.notification.DataJobNotification;
 import io.kubernetes.client.openapi.ApiException;
 import org.junit.jupiter.api.BeforeEach;
@@ -53,6 +54,8 @@ public class DeploymentServiceTest {
   @Mock private DataJobsKubernetesService kubernetesService;
 
   @Mock private DockerRegistryService dockerRegistryService;
+
+  @Mock private DataJobMetrics dataJobMetrics;
 
   @Mock private DataJobNotification dataJobNotification;
 
@@ -110,7 +113,8 @@ public class DeploymentServiceTest {
             jobImageBuilder,
             jobImageDeployer,
             operationContext,
-            jobsRepository);
+            jobsRepository,
+                dataJobMetrics);
 
     Mockito.when(vdkOptionsReader.readVdkOptions(TEST_JOB_NAME)).thenReturn(TEST_VDK_OPTS);
     Mockito.when(jobCredentialsService.getJobPrincipalName(TEST_JOB_NAME))

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
@@ -359,7 +359,8 @@ public class DeploymentServiceTest {
   }
 
   @Test
-  public void patchDeployment_deploymentEnabled_shouldNotClearTerminationStatus() throws ApiException {
+  public void patchDeployment_deploymentEnabled_shouldNotClearTerminationStatus()
+      throws ApiException {
     JobDeployment jobDeployment = new JobDeployment();
     jobDeployment.setDataJobTeam(testDataJob.getJobConfig().getTeam());
     jobDeployment.setDataJobName(testDataJob.getName());
@@ -372,7 +373,8 @@ public class DeploymentServiceTest {
   }
 
   @Test
-  public void patchDeployment_deploymentDisabled_shouldClearTerminationStatus() throws ApiException {
+  public void patchDeployment_deploymentDisabled_shouldClearTerminationStatus()
+      throws ApiException {
     JobDeployment jobDeployment = new JobDeployment();
     jobDeployment.setDataJobTeam(testDataJob.getJobConfig().getTeam());
     jobDeployment.setDataJobName(testDataJob.getName());

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
@@ -114,7 +114,7 @@ public class DeploymentServiceTest {
             jobImageDeployer,
             operationContext,
             jobsRepository,
-                dataJobMetrics);
+            dataJobMetrics);
 
     Mockito.when(vdkOptionsReader.readVdkOptions(TEST_JOB_NAME)).thenReturn(TEST_VDK_OPTS);
     Mockito.when(jobCredentialsService.getJobPrincipalName(TEST_JOB_NAME))
@@ -356,6 +356,30 @@ public class DeploymentServiceTest {
     var dataJobCaptor = ArgumentCaptor.forClass(DataJob.class);
     verify(jobsRepository).save(dataJobCaptor.capture());
     assertEquals(true, dataJobCaptor.getValue().getEnabled());
+  }
+
+  @Test
+  public void patchDeployment_enabled() throws ApiException {
+    JobDeployment jobDeployment = new JobDeployment();
+    jobDeployment.setDataJobTeam(testDataJob.getJobConfig().getTeam());
+    jobDeployment.setDataJobName(testDataJob.getName());
+    jobDeployment.setEnabled(true);
+
+    deploymentService.patchDeployment(testDataJob, jobDeployment);
+
+    verify(dataJobMetrics, times(0)).clearTerminationStatusAndDelayNotifGauges(testDataJob.getName());
+  }
+
+  @Test
+  public void patchDeployment_disabled() throws ApiException {
+    JobDeployment jobDeployment = new JobDeployment();
+    jobDeployment.setDataJobTeam(testDataJob.getJobConfig().getTeam());
+    jobDeployment.setDataJobName(testDataJob.getName());
+    jobDeployment.setEnabled(false);
+
+    deploymentService.patchDeployment(testDataJob, jobDeployment);
+
+    verify(dataJobMetrics, times(1)).clearTerminationStatusAndDelayNotifGauges(testDataJob.getName());
   }
 
   @Test

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
@@ -359,7 +359,7 @@ public class DeploymentServiceTest {
   }
 
   @Test
-  public void patchDeployment_enabled() throws ApiException {
+  public void patchDeployment_deploymentEnabled_shouldNotClearTerminationStatus() throws ApiException {
     JobDeployment jobDeployment = new JobDeployment();
     jobDeployment.setDataJobTeam(testDataJob.getJobConfig().getTeam());
     jobDeployment.setDataJobName(testDataJob.getName());
@@ -367,11 +367,12 @@ public class DeploymentServiceTest {
 
     deploymentService.patchDeployment(testDataJob, jobDeployment);
 
-    verify(dataJobMetrics, times(0)).clearTerminationStatusAndDelayNotifGauges(testDataJob.getName());
+    verify(dataJobMetrics, times(0))
+        .clearTerminationStatusAndDelayNotifGauges(testDataJob.getName());
   }
 
   @Test
-  public void patchDeployment_disabled() throws ApiException {
+  public void patchDeployment_deploymentDisabled_shouldClearTerminationStatus() throws ApiException {
     JobDeployment jobDeployment = new JobDeployment();
     jobDeployment.setDataJobTeam(testDataJob.getJobConfig().getTeam());
     jobDeployment.setDataJobName(testDataJob.getName());
@@ -379,7 +380,8 @@ public class DeploymentServiceTest {
 
     deploymentService.patchDeployment(testDataJob, jobDeployment);
 
-    verify(dataJobMetrics, times(1)).clearTerminationStatusAndDelayNotifGauges(testDataJob.getName());
+    verify(dataJobMetrics, times(1))
+        .clearTerminationStatusAndDelayNotifGauges(testDataJob.getName());
   }
 
   @Test

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DataJobMetricsTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DataJobMetricsTest.java
@@ -276,7 +276,7 @@ public class DataJobMetricsTest {
 
   @Test
   @Order(14)
-  void testClearGaugesAtJobDisable(){
+  void testClearGaugesAtJobDisable() {
     var config = new JobConfig();
     config.setNotificationDelayPeriodMinutes(60);
 
@@ -290,21 +290,23 @@ public class DataJobMetricsTest {
 
     // Assert that the termination status gauge has been set.
     var gauges =
-            meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
     Assertions.assertEquals(1, gauges.size());
 
     // Assert that the data job notification delay gauge has been set.
-    gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
+    gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
     Assertions.assertEquals(1, gauges.size());
 
     // Clear the gauges
-    dataJobMetrics.clearGaugesAtJobDisable("test-data-job");
+    dataJobMetrics.clearTerminationStatusAndDelayNotifGauges("test-data-job");
 
     // Assert that the gauges have been cleared.
-    gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
+    gauges =
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
     Assertions.assertEquals(0, gauges.size());
     gauges =
-            meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+        meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
     Assertions.assertEquals(0, gauges.size());
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DataJobMetricsTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DataJobMetricsTest.java
@@ -273,4 +273,38 @@ public class DataJobMetricsTest {
         meterRegistry.counter(DataJobMetrics.TAURUS_DATAJOB_WATCH_TASK_INVOCATIONS_COUNTER_NAME);
     Assertions.assertEquals(5.0, counter.count(), 0.001);
   }
+
+  @Test
+  @Order(14)
+  void testClearGaugesAtJobDisable(){
+    var config = new JobConfig();
+    config.setNotificationDelayPeriodMinutes(60);
+
+    var dataJob = new DataJob("test-data-job", config);
+    dataJob.setLatestJobTerminationStatus(ExecutionStatus.SUCCEEDED);
+    dataJob.setLatestJobExecutionId("execution-id-new");
+
+    // Update metrics
+    dataJobMetrics.updateInfoGauges(jobsRepository.save(dataJob));
+    dataJobMetrics.updateTerminationStatusGauge(jobsRepository.save(dataJob));
+
+    // Assert that the termination status gauge has been set.
+    var gauges =
+            meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
+
+    // Assert that the data job notification delay gauge has been set.
+    gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
+    Assertions.assertEquals(1, gauges.size());
+
+    // Clear the gauges
+    dataJobMetrics.clearGaugesAtJobDisable("test-data-job");
+
+    // Assert that the gauges have been cleared.
+    gauges = meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_NOTIFICATION_DELAY_METRIC_NAME).gauges();
+    Assertions.assertEquals(0, gauges.size());
+    gauges =
+            meterRegistry.find(DataJobMetrics.TAURUS_DATAJOB_TERMINATION_STATUS_METRIC_NAME).gauges();
+    Assertions.assertEquals(0, gauges.size());
+  }
 }


### PR DESCRIPTION
Currently, when a data job is deleted, we reset its termination status, so as to avoid issues with monitoring services reporting incorrect status. This, however, is not done in case a data job is disabled, even though the job is no longer active and its termination status should not matter.

This change modifies the DeplymentService, so that if a data job is disabled, the termination status is reset.

Testing Done: Added test.

Signed-off-by: Andon Andonov <andonova@vmware.com>