### PR TITLE
vdk-control-cli and some plugins:  Support for 3.11

### DIFF
--- a/projects/vdk-control-cli/.gitlab-ci.yml
+++ b/projects/vdk-control-cli/.gitlab-ci.yml
@@ -41,6 +41,10 @@ vdk-control-cli-build-with-py310:
   image: "python:3.10"
   extends: .vdk-control-cli-build
 
+vdk-control-cli-build-with-py311:
+    image: "python:3.11"
+    extends: .vdk-control-cli-build
+
 vdk-control-cli-release-acceptance-test:
   stage: pre_release
   before_script:

--- a/projects/vdk-control-cli/setup.cfg
+++ b/projects/vdk-control-cli/setup.cfg
@@ -27,6 +27,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
 zip_safe = False
@@ -57,7 +58,7 @@ install_requires =
     vdk-control-api-auth
 
 # Require a specific Python version
-python_requires = >=3.7, <3.11
+python_requires = >=3.7, <4
 
 [options.packages.find]
 where = src

--- a/projects/vdk-heartbeat/setup.cfg
+++ b/projects/vdk-heartbeat/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
 zip_safe = False
@@ -49,7 +50,7 @@ install_requires =
     junit-xml
 
 # Require a specific Python version
-python_requires = >=3.7, <3.11
+python_requires = >=3.7, <4
 
 
 

--- a/projects/vdk-plugins/airflow-provider-vdk/setup.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/setup.py
@@ -35,5 +35,5 @@ setup(
     author="Versatile Data Kit Development Team",
     author_email="versatile-data-kit@vmware.com",
     url="https://github.com/vmware/versatile-data-kit",
-    python_requires="~=3.7",
+    python_requires=">=3.7",
 )

--- a/projects/vdk-plugins/quickstart-vdk/.plugin-ci.yml
+++ b/projects/vdk-plugins/quickstart-vdk/.plugin-ci.yml
@@ -50,6 +50,9 @@ build-py310-quickstart-vdk:
   extends: .build-quickstart-vdk
   image: "python:3.10"
 
+build-py311-quickstart-vdk:
+  extends: .build-quickstart-vdk
+  image: "python:3.11"
 
 quickstart-vdk-release-candidate:
   stage: pre_release

--- a/projects/vdk-plugins/quickstart-vdk/setup.py
+++ b/projects/vdk-plugins/quickstart-vdk/setup.py
@@ -32,5 +32,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/projects/vdk-plugins/vdk-audit/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-audit/.plugin-ci.yml
@@ -18,6 +18,10 @@ build-py310-vdk-audit:
   extends: .build-vdk-audit
   image: "python:3.10"
 
+build-py311-vdk-audit:
+  extends: .build-vdk-audit
+  image: "python:3.11"
+
 release-vdk-audit:
   variables:
     PLUGIN_NAME: vdk-audit

--- a/projects/vdk-plugins/vdk-audit/setup.py
+++ b/projects/vdk-plugins/vdk-audit/setup.py
@@ -27,5 +27,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/projects/vdk-plugins/vdk-control-api-auth/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-control-api-auth/.plugin-ci.yml
@@ -26,6 +26,9 @@ build-py310-vdk-control-api-auth:
   extends: .build-vdk-control-api-auth
   image: "python:3.10"
 
+build-py311-vdk-control-api-auth:
+  extends: .build-vdk-control-api-auth
+  image: "python:3.11"
 
 build-vdk-control-api-auth-on-vdk-core-release:
   variables:

--- a/projects/vdk-plugins/vdk-control-api-auth/setup.py
+++ b/projects/vdk-plugins/vdk-control-api-auth/setup.py
@@ -35,5 +35,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/projects/vdk-plugins/vdk-csv/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-csv/.plugin-ci.yml
@@ -26,6 +26,10 @@ build-py310-vdk-csv:
   extends: .build-vdk-csv
   image: "python:3.10"
 
+build-py311-vdk-csv:
+  extends: .build-vdk-csv
+  image: "python:3.11"
+
 build-vdk-csv-on-vdk-core-release:
   variables:
     PLUGIN_NAME: vdk-csv

--- a/projects/vdk-plugins/vdk-csv/setup.py
+++ b/projects/vdk-plugins/vdk-csv/setup.py
@@ -25,5 +25,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/projects/vdk-plugins/vdk-greenplum/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-greenplum/.plugin-ci.yml
@@ -32,6 +32,9 @@ build-py310-vdk-greenplum:
   extends: .build-vdk-greenplum
   image: "python:3.10"
 
+build-py311-vdk-greenplum:
+  extends: .build-vdk-greenplum
+  image: "python:3.11"
 
 release-vdk-greenplum:
   variables:

--- a/projects/vdk-plugins/vdk-greenplum/setup.py
+++ b/projects/vdk-plugins/vdk-greenplum/setup.py
@@ -28,5 +28,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/projects/vdk-plugins/vdk-impala/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-impala/.plugin-ci.yml
@@ -26,6 +26,9 @@ build-py310-vdk-impala:
   extends: .build-vdk-impala
   image: "python:3.10"
 
+build-py311-vdk-impala:
+  extends: .build-vdk-impala
+  image: "python:3.11"
 
 build-vdk-impala-on-vdk-core-release:
   variables:

--- a/projects/vdk-plugins/vdk-impala/setup.py
+++ b/projects/vdk-plugins/vdk-impala/setup.py
@@ -34,5 +34,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/projects/vdk-plugins/vdk-ingest-file/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-ingest-file/.plugin-ci.yml
@@ -26,6 +26,10 @@ build-py310-vdk-ingest-file:
   extends: .build-vdk-ingest-file
   image: "python:3.10"
 
+build-py311-vdk-ingest-file:
+  extends: .build-vdk-ingest-file
+  image: "python:3.11"
+
 release-vdk-ingest-file:
   variables:
     PLUGIN_NAME: vdk-ingest-file

--- a/projects/vdk-plugins/vdk-ingest-file/setup.py
+++ b/projects/vdk-plugins/vdk-ingest-file/setup.py
@@ -29,5 +29,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/projects/vdk-plugins/vdk-ingest-http/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-ingest-http/.plugin-ci.yml
@@ -26,6 +26,10 @@ build-py310-vdk-ingest-http:
   extends: .build-vdk-ingest-http
   image: "python:3.10"
 
+build-py311-vdk-ingest-http:
+  extends: .build-vdk-ingest-http
+  image: "python:3.11"
+
 build-vdk-ingest-http-on-vdk-core-release:
   variables:
     PLUGIN_NAME: vdk-ingest-http

--- a/projects/vdk-plugins/vdk-ingest-http/setup.py
+++ b/projects/vdk-plugins/vdk-ingest-http/setup.py
@@ -29,5 +29,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/projects/vdk-plugins/vdk-logging-format/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-logging-format/.plugin-ci.yml
@@ -26,6 +26,10 @@ build-py310-vdk-logging-format:
   extends: .build-vdk-logging-format
   image: "python:3.10"
 
+build-py311-vdk-logging-format:
+  extends: .build-vdk-logging-format
+  image: "python:3.11"
+
 release-vdk-logging-format:
   variables:
     PLUGIN_NAME: vdk-logging-format

--- a/projects/vdk-plugins/vdk-logging-format/setup.py
+++ b/projects/vdk-plugins/vdk-logging-format/setup.py
@@ -29,5 +29,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/projects/vdk-plugins/vdk-plugin-control-cli/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-plugin-control-cli/.plugin-ci.yml
@@ -26,6 +26,9 @@ build-py310-vdk-plugin-control-cli:
   extends: .build-vdk-plugin-control-cli
   image: "python:3.10"
 
+build-py311-vdk-plugin-control-cli:
+  extends: .build-vdk-plugin-control-cli
+  image: "python:3.11"
 
 build-vdk-plugin-control-cli-on-vdk-core-release:
   variables:

--- a/projects/vdk-plugins/vdk-plugin-control-cli/setup.py
+++ b/projects/vdk-plugins/vdk-plugin-control-cli/setup.py
@@ -34,5 +34,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/projects/vdk-plugins/vdk-postgres/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-postgres/.plugin-ci.yml
@@ -32,6 +32,10 @@ build-py310-vdk-postgres:
   extends: .build-vdk-postgres
   image: "python:3.10"
 
+build-py311-vdk-postgres:
+  extends: .build-vdk-postgres
+  image: "python:3.11"
+
 release-vdk-postgres:
   variables:
     PLUGIN_NAME: vdk-postgres

--- a/projects/vdk-plugins/vdk-postgres/setup.py
+++ b/projects/vdk-plugins/vdk-postgres/setup.py
@@ -28,5 +28,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/projects/vdk-plugins/vdk-properties-fs/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-properties-fs/.plugin-ci.yml
@@ -32,6 +32,9 @@ build-py310-vdk-properties-fs:
   extends: .build-vdk-properties-fs
   image: "python:3.10"
 
+build-py311-vdk-properties-fs:
+  extends: .build-vdk-properties-fs
+  image: "python:3.11"
 
 release-vdk-properties-fs:
   variables:

--- a/projects/vdk-plugins/vdk-properties-fs/setup.py
+++ b/projects/vdk-plugins/vdk-properties-fs/setup.py
@@ -30,5 +30,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/projects/vdk-plugins/vdk-server/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-server/.plugin-ci.yml
@@ -26,6 +26,10 @@ build-py310-vdk-server:
   extends: .build-vdk-server
   image: "python:3.10"
 
+build-py311-vdk-server:
+  extends: .build-vdk-server
+  image: "python:3.11"
+
 release-vdk-server:
   variables:
     PLUGIN_NAME: vdk-server

--- a/projects/vdk-plugins/vdk-server/setup.py
+++ b/projects/vdk-plugins/vdk-server/setup.py
@@ -26,5 +26,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/projects/vdk-plugins/vdk-test-utils/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-test-utils/.plugin-ci.yml
@@ -26,6 +26,10 @@ build-py310-vdk-test-utils:
   extends: .build-vdk-test-utils
   image: "python:3.10"
 
+build-py311-vdk-test-utils:
+  extends: .build-vdk-test-utils
+  image: "python:3.11"
+
 release-vdk-test-utils:
   variables:
     PLUGIN_NAME: vdk-test-utils

--- a/projects/vdk-plugins/vdk-test-utils/setup.py
+++ b/projects/vdk-plugins/vdk-test-utils/setup.py
@@ -24,5 +24,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )


### PR DESCRIPTION
With the GA release of Python 3.11 a month ago it's time to officially support it.
That means we need to start testing against Python 3.11. See release notes at https://docs.python.org/3/whatsnew/3.11.html

Part of #1397

This PR contains multiple commits - they will be submitted without squash so that each plugin is changed in a separate commit. Each commit updates 2 files - .plugin-ci yaml file and setup.py (or cfg). 
For vdk-heartbeat and airflow-provider-vdk only the setup.py/cfg file is updated because they test with a single version of python. 

Testing Done: this PR pipeline.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>