### PR TITLE
vdk-core: get_managed_connection should return opened connection

### DIFF
--- a/projects/vdk-core/requirements.txt
+++ b/projects/vdk-core/requirements.txt
@@ -4,6 +4,7 @@
 -e ../vdk-plugins/vdk-test-utils
 black
 mypy
+pandas
 
 # Dependencies license report:
 pip-licenses

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
@@ -96,8 +96,11 @@ class ManagedConnectionBase(PEP249Connection, IManagedConnection):
     )
     def connect(self) -> PEP249Connection:
         """
+        Checks if we are still properly connected to the database (including by issuing validation query)
+        and re-connect if not.
         :return: PEP249 Connection object (managed)
         """
+
         if not self._is_db_con_open:
             db_con = self._connect()
             self._log.debug(f"Established {str(db_con)}")

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
@@ -213,6 +213,12 @@ class ManagedConnectionBase(PEP249Connection, IManagedConnection):
         if False is self._is_db_con_open:
             return False
         try:
+            """
+            The remote end (the database server) may have disconnected or the session may have timed out (on the remote one)
+            but in the client (here in vdk - we are the client) we do not know.
+            We try to check with "select 1". It is statement that both is something that works on each db (we think)
+            and it's usually optimized by most db since it's frequently used by validation
+            """
             self._cursor().execute(" select 1 -- Testing if connection is alive.")
             return True
         except Exception as e:

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/job_input.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/job_input.py
@@ -9,7 +9,6 @@ from typing import Optional
 from vdk.api.job_input import IJobArguments
 from vdk.api.job_input import IJobInput
 from vdk.api.job_input import ITemplate
-from vdk.api.plugin.plugin_input import PEP249Connection
 from vdk.internal.builtin_plugins.connection.impl.router import ManagedConnectionRouter
 from vdk.internal.builtin_plugins.connection.managed_connection_base import (
     ManagedConnectionBase,
@@ -61,8 +60,8 @@ class JobInput(IJobInput):
 
     # Connections
 
-    def get_managed_connection(self) -> PEP249Connection:
-        return self.__managed_connection_builder.open_default_connection().connect()
+    def get_managed_connection(self) -> ManagedConnectionBase:
+        return self.__managed_connection_builder.open_default_connection()
 
     def get_arguments(self) -> dict:
         return self.__job_arguments.get_arguments()

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/job_input.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/job_input.py
@@ -9,6 +9,7 @@ from typing import Optional
 from vdk.api.job_input import IJobArguments
 from vdk.api.job_input import IJobInput
 from vdk.api.job_input import ITemplate
+from vdk.api.plugin.plugin_input import PEP249Connection
 from vdk.internal.builtin_plugins.connection.impl.router import ManagedConnectionRouter
 from vdk.internal.builtin_plugins.connection.managed_connection_base import (
     ManagedConnectionBase,
@@ -60,8 +61,8 @@ class JobInput(IJobInput):
 
     # Connections
 
-    def get_managed_connection(self) -> ManagedConnectionBase:
-        return self.__managed_connection_builder.open_default_connection()
+    def get_managed_connection(self) -> PEP249Connection:
+        return self.__managed_connection_builder.open_default_connection().connect()
 
     def get_arguments(self) -> dict:
         return self.__job_arguments.get_arguments()

--- a/projects/vdk-core/tests/functional/run/jobs/pandas-job/10_pandas_step.py
+++ b/projects/vdk-core/tests/functional/run/jobs/pandas-job/10_pandas_step.py
@@ -1,0 +1,21 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import pandas as pd
+from vdk.api.job_input import IJobInput
+
+
+def run(job_input: IJobInput):
+    # The job only uses job_input.get_managed_connection to check it is initialized properly
+    # Should not use job_input.execute_query
+
+    data = {"product_name": ["Computer", "Tablet"], "price": [900, 300]}
+    df = pd.DataFrame(data, columns=["product_name", "price"])
+    df.to_sql(
+        "test_table",
+        job_input.get_managed_connection(),
+        if_exists="replace",
+        index=False,
+    )
+
+    df = pd.read_sql("select * from test_table", con=job_input.get_managed_connection())
+    assert len(df) > 0

--- a/projects/vdk-core/tests/functional/run/test_run_sql_queries.py
+++ b/projects/vdk-core/tests/functional/run/test_run_sql_queries.py
@@ -320,3 +320,22 @@ def test_run_dbapi_connection_with_execute_hook_proxies(tmpdir):
     result: Result = runner.invoke(["run", job_path("simple-create-insert")])
 
     cli_assert_equal(0, result)
+
+
+@mock.patch.dict(os.environ, {VDK_DB_DEFAULT_TYPE: DB_TYPE_SQLITE_MEMORY})
+def test_run_job_with_get_managed_connection():
+    db_plugin = SqLite3MemoryDbPlugin()
+    runner = CliEntryBasedTestRunner(db_plugin)
+
+    result: Result = runner.invoke(
+        [
+            "run",
+            job_path("pandas-job"),
+        ]
+    )
+
+    cli_assert_equal(0, result)
+    assert db_plugin.db.execute_query("select * from test_table") == [
+        ("Computer", 900),
+        ("Tablet", 300),
+    ]

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_connection_router.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_connection_router.py
@@ -75,6 +75,17 @@ def test_router_open_connection_closed():
     assert conn is conn.connect()
 
 
+def test_router_open_connection_validation_check_reconnect():
+    router, mock_conn, _ = managed_connection_router()
+
+    conn = router.open_connection("TEST_DB")
+    # we are purposefully using the raw connection (_db_con) and closing it
+    # in order to see if the validation check works
+    conn._db_con.close()
+    conn = router.open_connection("TEST_DB")
+    assert conn is conn.connect()
+
+
 def test_router_no_such_connection():
     router, mock_conn, _ = managed_connection_router()
 


### PR DESCRIPTION
Currently job_input.get_managed_connection() return the current managed connection which may not be opened if it's called for a first time. THis may lead to subtle bugs e.g

```
pandas.to_sql(sql, con = job_input.get_managed_connection())
```

will return error if job_input.execute_query has not be run before. But will succeed if it's not . That's clearly error prone and also it's unnecessary to force users to called
job_input.get_managed_connection().connect() explicitly).

Testing Done: functional test

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>