### PR TITLE
vdk-jupyter: create notebook-plugin

### DIFF
--- a/projects/vdk-plugins/vdk-notebook/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-notebook/.plugin-ci.yml
@@ -25,6 +25,10 @@ build-py310-vdk-notebook:
   extends: .build-vdk-notebook
   image: "python:3.10"
 
+build-py311-vdk-notebook:
+  extends: .build-vdk-notebook
+  image: "python:3.11"
+
 release-vdk-notebook:
   variables:
     PLUGIN_NAME: vdk-notebook

--- a/projects/vdk-plugins/vdk-notebook/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-notebook/.plugin-ci.yml
@@ -1,0 +1,31 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+image: "python:3.7"
+
+.build-vdk-notebook:
+  variables:
+    PLUGIN_NAME: vdk-notebook
+  extends: .build-plugin
+
+build-py37-vdk-notebook:
+  extends: .build-vdk-notebook
+  image: "python:3.7"
+
+
+build-py38-vdk-notebook:
+  extends: .build-vdk-notebook
+  image: "python:3.8"
+
+build-py39-vdk-notebook:
+  extends: .build-vdk-notebook
+  image: "python:3.9"
+
+build-py310-vdk-notebook:
+  extends: .build-vdk-notebook
+  image: "python:3.10"
+
+release-vdk-notebook:
+  variables:
+    PLUGIN_NAME: vdk-notebook
+  extends: .release-plugin

--- a/projects/vdk-plugins/vdk-notebook/README.md
+++ b/projects/vdk-plugins/vdk-notebook/README.md
@@ -1,0 +1,28 @@
+# notebook
+
+A VDK plugin for working with notebooks.
+
+TODO: what the project is about, what is its purpose
+
+## Usage
+To install the plugin you need to run:
+```
+pip install vdk-notebook
+```
+
+### Configuration
+No specific notebook configurations are needed currently.
+
+### Example
+
+TODO
+
+### Testing
+Testing this plugin locally requires installing the dependencies listed in vdk-plugins/vdk-notebook/requirements.txt
+
+Run
+```
+pip install -r requirements.txt
+```
+## Architecture
+See the [vdk enhancement proposal spec here](https://github.com/vmware/versatile-data-kit/blob/main/specs/vep-994-jupyter-notebook-integration/README.md)

--- a/projects/vdk-plugins/vdk-notebook/README.md
+++ b/projects/vdk-plugins/vdk-notebook/README.md
@@ -1,6 +1,7 @@
 # notebook
 
-A VDK plugin for working with notebooks.
+A new VDK plugin which will support running data jobs which consists of .ipynb files.
+You can see [VDK Jupyter Integration VEP](https://github.com/vmware/versatile-data-kit/blob/main/specs/vep-994-jupyter-notebook-integration/README.md)
 
 TODO: what the project is about, what is its purpose
 

--- a/projects/vdk-plugins/vdk-notebook/requirements.txt
+++ b/projects/vdk-plugins/vdk-notebook/requirements.txt
@@ -1,0 +1,7 @@
+# this file is used to provide testing requirements
+# for requirements (dependencies) needed during and after installation of the plugin see (and update) setup.py install_requires section
+
+vdk-core
+
+pytest
+vdk-test-utils

--- a/projects/vdk-plugins/vdk-notebook/requirements.txt
+++ b/projects/vdk-plugins/vdk-notebook/requirements.txt
@@ -1,7 +1,7 @@
 # this file is used to provide testing requirements
 # for requirements (dependencies) needed during and after installation of the plugin see (and update) setup.py install_requires section
 
-vdk-core
 
 pytest
+vdk-core
 vdk-test-utils

--- a/projects/vdk-plugins/vdk-notebook/setup.py
+++ b/projects/vdk-plugins/vdk-notebook/setup.py
@@ -1,0 +1,32 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import pathlib
+
+import setuptools
+
+
+__version__ = "0.1.0"
+
+setuptools.setup(
+    name="vdk-notebook",
+    version=__version__,
+    url="https://github.com/vmware/versatile-data-kit",
+    description="A VDK plugin for working with notebooks",
+    long_description=pathlib.Path("README.md").read_text(),
+    long_description_content_type="text/markdown",
+    install_requires=["vdk-core"],
+    package_dir={"": "src"},
+    packages=setuptools.find_namespace_packages(where="src"),
+    entry_points={"vdk.plugin.run": ["notebook = vdk.plugin.notebook.notebook_plugin"]},
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+    ],
+    python_requires="~=3.7",
+)
+

--- a/projects/vdk-plugins/vdk-notebook/setup.py
+++ b/projects/vdk-plugins/vdk-notebook/setup.py
@@ -1,6 +1,5 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
-
 import pathlib
 
 import setuptools
@@ -29,4 +28,3 @@ setuptools.setup(
     ],
     python_requires="~=3.7",
 )
-

--- a/projects/vdk-plugins/vdk-notebook/src/vdk/plugin/notebook/notebook_plugin.py
+++ b/projects/vdk-plugins/vdk-notebook/src/vdk/plugin/notebook/notebook_plugin.py
@@ -1,0 +1,34 @@
+from typing import List
+from vdk.api.plugin.hook_markers import hookimpl
+from vdk.api.plugin.plugin_registry import IPluginRegistry
+
+
+from vdk.internal.core.context import CoreContext
+from vdk.internal.core.config import ConfigurationBuilder
+
+"""
+Include the plugins implementation. For example:
+"""
+
+class DummyPlugin:
+
+    @hookimpl(tryfirst=True)
+    def vdk_configure(self, config_builder: ConfigurationBuilder):
+        config_builder.add(
+            key="dummy_config_key",
+            default_value="dummy",
+            description="""
+                Dummy configuration
+            """)
+
+
+    @hookimpl
+    def vdk_initialize(self, context: CoreContext):
+        print("initializing dummy")
+
+@hookimpl
+def vdk_start(plugin_registry: IPluginRegistry, command_line_args: List):
+    plugin_registry.load_plugin_with_hooks_impl(DummyPlugin(), "DummyPlugin")
+
+
+

--- a/projects/vdk-plugins/vdk-notebook/src/vdk/plugin/notebook/notebook_plugin.py
+++ b/projects/vdk-plugins/vdk-notebook/src/vdk/plugin/notebook/notebook_plugin.py
@@ -1,17 +1,19 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import List
+
 from vdk.api.plugin.hook_markers import hookimpl
 from vdk.api.plugin.plugin_registry import IPluginRegistry
-
-
-from vdk.internal.core.context import CoreContext
 from vdk.internal.core.config import ConfigurationBuilder
+from vdk.internal.core.context import CoreContext
 
 """
 Include the plugins implementation. For example:
 """
 
-class DummyPlugin:
 
+class DummyPlugin:
     @hookimpl(tryfirst=True)
     def vdk_configure(self, config_builder: ConfigurationBuilder):
         config_builder.add(
@@ -19,16 +21,14 @@ class DummyPlugin:
             default_value="dummy",
             description="""
                 Dummy configuration
-            """)
-
+            """,
+        )
 
     @hookimpl
     def vdk_initialize(self, context: CoreContext):
         print("initializing dummy")
 
+
 @hookimpl
 def vdk_start(plugin_registry: IPluginRegistry, command_line_args: List):
     plugin_registry.load_plugin_with_hooks_impl(DummyPlugin(), "DummyPlugin")
-
-
-

--- a/projects/vdk-plugins/vdk-notebook/src/vdk/plugin/notebook/notebook_plugin.py
+++ b/projects/vdk-plugins/vdk-notebook/src/vdk/plugin/notebook/notebook_plugin.py
@@ -1,6 +1,5 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
-
 from typing import List
 
 from vdk.api.plugin.hook_markers import hookimpl

--- a/projects/vdk-plugins/vdk-notebook/tests/test_plugin.py
+++ b/projects/vdk-plugins/vdk-notebook/tests/test_plugin.py
@@ -1,6 +1,5 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
-
 import os
 from unittest import mock
 

--- a/projects/vdk-plugins/vdk-notebook/tests/test_plugin.py
+++ b/projects/vdk-plugins/vdk-notebook/tests/test_plugin.py
@@ -1,3 +1,6 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 from unittest import mock
 

--- a/projects/vdk-plugins/vdk-notebook/tests/test_plugin.py
+++ b/projects/vdk-plugins/vdk-notebook/tests/test_plugin.py
@@ -1,0 +1,28 @@
+import os
+from unittest import mock
+
+from click.testing import Result
+from vdk.plugin.notebook import notebook_plugin
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_funcs import jobs_path_from_caller_directory
+
+"""
+This is a sample test file showing a recommended way to test new plugins.
+A good way to test a new plugin is how it would be used in the command that it extends.
+"""
+
+
+def test_dummy():
+    with mock.patch.dict(
+        os.environ,
+        {
+            # mock the vdk configuration needed for our test
+        },
+    ):
+        # CliEntryBasedTestRunner (provided by vdk-test-utils) gives a away to simulate vdk command
+        # and mock large parts of it - e.g passed our own plugins
+        runner = CliEntryBasedTestRunner(notebook_plugin)
+
+        # result: Result = runner.invoke(["run", jobs_path_from_caller_directory("job-using-a-plugin")])
+        # cli_assert_equal(0, result)


### PR DESCRIPTION
What:
Adding a new plugin which will support running data jobs which consists of .ipynb files. it is linked to https://github.com/vmware/versatile-data-kit/issues/1275
This is the default plugin created by the plugin template. 
Modifications and tests are yet to be done.

Why:
You can see [the Jupyter Integration VEP](https://github.com/vmware/versatile-data-kit/blob/main/specs/vep-994-jupyter-notebook-integration/README.md).

Signed-off-by: Duygu Hasan [hduygu@vmware.com](mailto:hduygu@vmware.com)