### PR TITLE
vdk-jobs-trobleshooting: Introduce plugin API and configuration

### DIFF
--- a/projects/vdk-plugins/vdk-jobs-troubleshooting/src/vdk/plugin/jobs_troubleshoot/api/troubleshoot_utility.py
+++ b/projects/vdk-plugins/vdk-jobs-troubleshooting/src/vdk/plugin/jobs_troubleshoot/api/troubleshoot_utility.py
@@ -1,0 +1,42 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from abc import abstractmethod
+
+
+class ITroubleshootUtility:
+    """
+    Allows for troubleshoot utilities to be implemented. It provides a unified
+    API to be used by all utilities.
+
+    A troubleshooting utility is a utility class, containing logic which is to
+    be used for troubleshooting of deployed data jobs.
+    """
+
+    @abstractmethod
+    def start(self):
+        """
+        Starts the execution of the utility when the job is initialized.
+        The method is called at the `initialize_job` step of the Job lifecycle,
+        https://github.com/vmware/versatile-data-kit/tree/main/projects/vdk-plugins#data-job-run-execution-cycle
+
+        NOTE: Any troubleshooting utility needs to be self-contained and when
+        used should not interfere with the normal operation of the data job.
+        The framework will ignore any exception coming from the troubleshooting
+        utility and will only log the error message.
+        """
+        pass
+
+    @abstractmethod
+    def stop(self):
+        """
+        Terminates the troubleshooting utility at the end of the data job
+        execution. This method should implement everything needed to clean up
+        after the utility is used.
+
+        The method is called at the `finalize_job` step of the Job lifecycle,
+        https://github.com/vmware/versatile-data-kit/tree/main/projects/vdk-plugins#data-job-run-execution-cycle
+
+        NOTE: The framework will ignore any exception coming from the
+        troubleshooting utility and will only log the error message.
+        """
+        pass

--- a/projects/vdk-plugins/vdk-jobs-troubleshooting/src/vdk/plugin/jobs_troubleshoot/jobs_troubleshoot_plugin.py
+++ b/projects/vdk-plugins/vdk-jobs-troubleshooting/src/vdk/plugin/jobs_troubleshoot/jobs_troubleshoot_plugin.py
@@ -4,32 +4,25 @@
 VDK-JOBS-TROUBLESHOOTING plugin script.
 """
 import logging
+from typing import List
 
 from vdk.api.plugin.hook_markers import hookimpl
-from vdk.internal.builtin_plugins.run.job_context import JobContext
+from vdk.api.plugin.plugin_registry import IPluginRegistry
 from vdk.internal.core.config import ConfigurationBuilder
+from vdk.plugin.jobs_troubleshoot.troubleshoot_configuration import add_definitions
 
 log = logging.getLogger(__name__)
 
-TROUBLESHOOT_UTILITIES_TO_USE = "TROUBLESHOOT_UTILITIES_TO_USE"
+
+class JobTroubleshootingPlugin:
+    @staticmethod
+    @hookimpl
+    def vdk_configure(config_builder: ConfigurationBuilder) -> None:
+        add_definitions(config_builder=config_builder)
 
 
 @hookimpl
-def vdk_configure(config_builder: ConfigurationBuilder) -> None:
-    """
-    Here we define what configuration settings are needed for the
-    Jobs Troubleshooting plugin with reasonable defaults.
-    """
-    config_builder.add(
-        key=TROUBLESHOOT_UTILITIES_TO_USE,
-        default_value=None,
-        description="""
-        An unordered comma-separated list of strings, indicating what
-        troubleshooting utilities are to be used.
-        """,
+def vdk_start(plugin_registry: IPluginRegistry, command_line_args: List) -> None:
+    plugin_registry.load_plugin_with_hooks_impl(
+        JobTroubleshootingPlugin(), "job-troubleshooting-plugin"
     )
-
-
-@hookimpl
-def initialize_job(context: JobContext) -> None:
-    pass

--- a/projects/vdk-plugins/vdk-jobs-troubleshooting/src/vdk/plugin/jobs_troubleshoot/troubleshoot_configuration.py
+++ b/projects/vdk-plugins/vdk-jobs-troubleshooting/src/vdk/plugin/jobs_troubleshoot/troubleshoot_configuration.py
@@ -1,0 +1,31 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from vdk.internal.core.config import ConfigurationBuilder
+
+TROUBLESHOOT_UTILITIES_TO_USE = "TROUBLESHOOT_UTILITIES_TO_USE"
+TROUBLESHOOT_PORT_TO_USE = "TROUBLESHOOT_PORT_TO_USE"
+
+
+def add_definitions(config_builder: ConfigurationBuilder):
+    """
+    Here we define what configuration settings are needed for the
+    Jobs Troubleshooting plugin with reasonable defaults.
+    """
+    config_builder.add(
+        key=TROUBLESHOOT_UTILITIES_TO_USE,
+        default_value=None,
+        description="""
+            An unordered comma-separated list of strings, indicating what
+            troubleshooting utilities are to be used. E.g., "utility1,utility2".
+            For full list of available utilities, check the plugin's README at:
+            https://github.com/vmware/versatile-data-kit/blob/main/projects/vdk-plugins/vdk-jobs-troubleshooting/README.md
+            """,
+    )
+    config_builder.add(
+        key=TROUBLESHOOT_PORT_TO_USE,
+        default_value=8783,
+        description="""
+        Specify an http port to be used by troubleshooting utilities (e.g.,
+        utilities that rely on local http server).
+        """,
+    )


### PR DESCRIPTION
This change introduces the base utility class which is to be used by all troubleshooting utilities.

Additionally, the plugin configuration is moved to a separate method to be easier to extend.

Testing Done: Documentation change.

Signed-off-by: Andon Andonov <andonova@vmware.com>