### PR TITLE
control-service: graphql wildcard matching filter for team and job names

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLJobTeamAndNameFilterMatcherIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLJobTeamAndNameFilterMatcherIT.java
@@ -5,7 +5,6 @@ package com.vmware.taurus.graphql.it;
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import com.vmware.taurus.ControlplaneApplication;
 import com.vmware.taurus.datajobs.it.common.BaseIT;
 import com.vmware.taurus.service.JobsRepository;
@@ -29,11 +28,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc(addFilters = false)
 public class GraphQLJobTeamAndNameFilterMatcherIT extends BaseIT {
 
-  @Autowired
-  JobsRepository jobsRepository;
+  @Autowired JobsRepository jobsRepository;
 
-  @Autowired
-  private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
   @AfterEach
   public void cleanup() {
@@ -50,7 +47,9 @@ public class GraphQLJobTeamAndNameFilterMatcherIT extends BaseIT {
         + "    pageNumber: 1\n"
         + "    pageSize: 100\n"
         + "    filter: [\n"
-        + "      { property: " + searchProperty + ", pattern: \""
+        + "      { property: "
+        + searchProperty
+        + ", pattern: \""
         + searchPattern
         + "\", sort: ASC }\n"
         + "      { property: \"jobName\", sort: ASC }\n"
@@ -77,81 +76,77 @@ public class GraphQLJobTeamAndNameFilterMatcherIT extends BaseIT {
   @Test
   public void testFilterByJobTeamExactMatch_shouldRetrieve() throws Exception {
     createJobWithTeam("test-team", "test-job");
-    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected("test-team", "test-team",
-        "\"config.team\"");
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(
+        "test-team", "test-team", "\"config.team\"");
   }
 
   @Test
   public void testFilterByJobNameExactMatch_shouldRetrieve() throws Exception {
     createJobWithTeam("test-team", "test-job");
-    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected("test-team", "test-job",
-        "\"jobName\"");
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(
+        "test-team", "test-job", "\"jobName\"");
   }
 
   @Test
   public void testFilterByJobTeamExactMatch_shouldNotRetrieve() throws Exception {
     createJobWithTeam("test-team", "test-job");
-    testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected("test-team", "test-team1",
-        "\"config.team\"");
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected(
+        "test-team", "test-team1", "\"config.team\"");
   }
 
   @Test
   public void testFilterByJobNameExactMatch_shouldNotRetrieve() throws Exception {
     createJobWithTeam("test-team", "test-job");
-    testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected("test-team", "test-job1",
-        "\"jobName\"");
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected(
+        "test-team", "test-job1", "\"jobName\"");
   }
 
   @Test
   public void testFilterByJobNameExactMatch_multipleJobs_shouldRetrieve() throws Exception {
     createJobWithTeam("test-team", "test-job");
     createJobWithTeam("another-team", "another-job");
-    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected("test-team", "test-job",
-        "\"jobName\"");
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(
+        "test-team", "test-job", "\"jobName\"");
   }
 
   @Test
   public void testFilterByJobNameExactMatch_multipleJobs_shouldNotRetrieve() throws Exception {
     createJobWithTeam("test-team", "test-job");
     createJobWithTeam("another-team", "another-job");
-    testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected("test-team", "test-job1",
-        "\"jobName\"");
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected(
+        "test-team", "test-job1", "\"jobName\"");
   }
 
   @Test
   public void testFilterByJobNameWildcardMatch_multipleJobs_shouldRetrieve() throws Exception {
     createJobWithTeam("test-team", "test-job");
     createJobWithTeam("another-team", "another-job");
-    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected("test-team", "test-*",
-        "\"jobName\"");
-
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(
+        "test-team", "test-*", "\"jobName\"");
   }
 
   @Test
   public void testFilterByJobNameWildcardMatch_multipleJobs_shouldNotRetrieve() throws Exception {
     createJobWithTeam("test-team", "test-job");
     createJobWithTeam("another-team", "another-job");
-    testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected("test-team", "unrelated-*",
-        "\"jobName\"");
-
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected(
+        "test-team", "unrelated-*", "\"jobName\"");
   }
 
   @Test
   public void testFilterByTeamNameWildcardMatch_multipleJobs_shouldRetrieve() throws Exception {
     createJobWithTeam("test-team", "test-job");
     createJobWithTeam("another-team", "another-job");
-    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected("test-team", "test-*",
-        "\"config.team\"");
-
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(
+        "test-team", "test-*", "\"config.team\"");
   }
 
   @Test
   public void testFilterByTeamNameWildcardMatch_multipleJobs_shouldNotRetrieve() throws Exception {
     createJobWithTeam("test-team", "test-job");
     createJobWithTeam("another-team", "another-job");
-    testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected("test-team", "unrelated-*",
-        "\"config.team\"");
-
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected(
+        "test-team", "unrelated-*", "\"config.team\"");
   }
 
   private void testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLJobTeamAndNameFilterMatcherIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLJobTeamAndNameFilterMatcherIT.java
@@ -1,0 +1,188 @@
+package com.vmware.taurus.graphql.it;
+
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+import com.vmware.taurus.ControlplaneApplication;
+import com.vmware.taurus.datajobs.it.common.BaseIT;
+import com.vmware.taurus.service.JobsRepository;
+import com.vmware.taurus.service.model.DataJob;
+import com.vmware.taurus.service.model.JobConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = ControlplaneApplication.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class GraphQLJobTeamAndNameFilterMatcherIT extends BaseIT {
+
+  @Autowired
+  JobsRepository jobsRepository;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @AfterEach
+  public void cleanup() {
+    jobsRepository.deleteAll();
+  }
+
+  private static String getJobsUri(String teamName) {
+    return "/data-jobs/for-team/" + teamName + "/jobs";
+  }
+
+  private static String getQuery(String searchPattern, String searchProperty) {
+    return "{\n"
+        + "  jobs(\n"
+        + "    pageNumber: 1\n"
+        + "    pageSize: 100\n"
+        + "    filter: [\n"
+        + "      { property: " + searchProperty + ", pattern: \""
+        + searchPattern
+        + "\", sort: ASC }\n"
+        + "      { property: \"jobName\", sort: ASC }\n"
+        + "    ]\n"
+        + "  ) {\n"
+        + "    content {\n"
+        + "      jobName\n"
+        + "      config {\n"
+        + "        team\n"
+        + "        description\n"
+        + "        schedule {\n"
+        + "          scheduleCron\n"
+        + "        }\n"
+        + "      }\n"
+        + "      deployments {\n"
+        + "        enabled\n"
+        + "        status\n"
+        + "      }\n"
+        + "    }\n"
+        + "  }\n"
+        + "}";
+  }
+
+  @Test
+  public void testFilterByJobTeamExactMatch_shouldRetrieve() throws Exception {
+    createJobWithTeam("test-team", "test-job");
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected("test-team", "test-team",
+        "\"config.team\"");
+  }
+
+  @Test
+  public void testFilterByJobNameExactMatch_shouldRetrieve() throws Exception {
+    createJobWithTeam("test-team", "test-job");
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected("test-team", "test-job",
+        "\"jobName\"");
+  }
+
+  @Test
+  public void testFilterByJobTeamExactMatch_shouldNotRetrieve() throws Exception {
+    createJobWithTeam("test-team", "test-job");
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected("test-team", "test-team1",
+        "\"config.team\"");
+  }
+
+  @Test
+  public void testFilterByJobNameExactMatch_shouldNotRetrieve() throws Exception {
+    createJobWithTeam("test-team", "test-job");
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected("test-team", "test-job1",
+        "\"jobName\"");
+  }
+
+  @Test
+  public void testFilterByJobNameExactMatch_multipleJobs_shouldRetrieve() throws Exception {
+    createJobWithTeam("test-team", "test-job");
+    createJobWithTeam("another-team", "another-job");
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected("test-team", "test-job",
+        "\"jobName\"");
+  }
+
+  @Test
+  public void testFilterByJobNameExactMatch_multipleJobs_shouldNotRetrieve() throws Exception {
+    createJobWithTeam("test-team", "test-job");
+    createJobWithTeam("another-team", "another-job");
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected("test-team", "test-job1",
+        "\"jobName\"");
+  }
+
+  @Test
+  public void testFilterByJobNameWildcardMatch_multipleJobs_shouldRetrieve() throws Exception {
+    createJobWithTeam("test-team", "test-job");
+    createJobWithTeam("another-team", "another-job");
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected("test-team", "test-*",
+        "\"jobName\"");
+
+  }
+
+  @Test
+  public void testFilterByJobNameWildcardMatch_multipleJobs_shouldNotRetrieve() throws Exception {
+    createJobWithTeam("test-team", "test-job");
+    createJobWithTeam("another-team", "another-job");
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected("test-team", "unrelated-*",
+        "\"jobName\"");
+
+  }
+
+  @Test
+  public void testFilterByTeamNameWildcardMatch_multipleJobs_shouldRetrieve() throws Exception {
+    createJobWithTeam("test-team", "test-job");
+    createJobWithTeam("another-team", "another-job");
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected("test-team", "test-*",
+        "\"config.team\"");
+
+  }
+
+  @Test
+  public void testFilterByTeamNameWildcardMatch_multipleJobs_shouldNotRetrieve() throws Exception {
+    createJobWithTeam("test-team", "test-job");
+    createJobWithTeam("another-team", "another-job");
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected("test-team", "unrelated-*",
+        "\"config.team\"");
+
+  }
+
+  private void testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(
+      String jobTeam, String searchString, String searchProperty) throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(getJobsUri(jobTeam))
+                .queryParam("query", getQuery(searchString, searchProperty))
+                .with(user("test")))
+        .andExpect(status().is(200))
+        .andExpect(jsonPath("$.data.content[0].jobName").value("test-job"))
+        .andExpect(jsonPath("$.data.content[0].config.team").value(jobTeam));
+  }
+
+  private void testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected(
+      String jobTeam, String searchString, String searchProperty) throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(getJobsUri(jobTeam))
+                .queryParam("query", getQuery(searchString, searchProperty))
+                .with(user("test")))
+        .andExpect(status().is(200))
+        .andExpect(jsonPath("$.data.content").isEmpty());
+  }
+
+  private void createJobWithTeam(String jobTeam, String jobName) {
+    DataJob dataJob = new DataJob();
+    JobConfig jobConfig = new JobConfig();
+    jobConfig.setTeam(jobTeam);
+    dataJob.setName(jobName);
+    dataJob.setJobConfig(jobConfig);
+    jobsRepository.save(dataJob);
+  }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/FieldStrategy.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/FieldStrategy.java
@@ -133,12 +133,14 @@ public abstract class FieldStrategy<T> {
    * @return
    */
   protected boolean checkMatch(String searchString, String matcherString) {
-    if(matcherString.contains("*")) {
+    if (searchString == null || matcherString == null) {
+      return false;
+    } else if (matcherString.contains("*")) {
       // Matching strings that contain * as wildcards.
       return FilenameUtils.wildcardMatch(searchString.toLowerCase(), matcherString.toLowerCase());
     } else {
-     // exact matches
-     return searchString.equalsIgnoreCase(matcherString);
+      // exact matches
+      return searchString.equalsIgnoreCase(matcherString);
     }
   }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/FieldStrategy.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/FieldStrategy.java
@@ -10,6 +10,7 @@ import com.vmware.taurus.service.graphql.strategy.datajob.JobFieldStrategyBy;
 import com.vmware.taurus.service.graphql.model.Filter;
 import org.springframework.data.domain.Sort;
 import org.springframework.lang.NonNull;
+import org.apache.commons.io.FilenameUtils;
 
 import java.util.Comparator;
 import java.util.function.Predicate;
@@ -119,4 +120,26 @@ public abstract class FieldStrategy<T> {
     }
     return criteria.getComparator();
   }
+
+  /**
+   *
+   * Helper method which checks if the provided search string matches with a given matcher string.
+   * String capitalization is ignored.
+   * Supported operations are wildcard matching of '*' characters in the matcher string, or
+   * exact matches. If the matcher string contains '*' we will attempt to match wildcards,
+   * otherwise both strings are compared for equality.
+   * @param searchString
+   * @param matcherString
+   * @return
+   */
+  protected boolean checkMatch(String searchString, String matcherString) {
+    if(matcherString.contains("*")) {
+      // Matching strings that contain * as wildcards.
+      return FilenameUtils.wildcardMatch(searchString.toLowerCase(), matcherString.toLowerCase());
+    } else {
+     // exact matches
+     return searchString.equalsIgnoreCase(matcherString);
+    }
+  }
+
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/FieldStrategy.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/FieldStrategy.java
@@ -122,12 +122,11 @@ public abstract class FieldStrategy<T> {
   }
 
   /**
-   *
    * Helper method which checks if the provided search string matches with a given matcher string.
-   * String capitalization is ignored.
-   * Supported operations are wildcard matching of '*' characters in the matcher string, or
-   * exact matches. If the matcher string contains '*' we will attempt to match wildcards,
-   * otherwise both strings are compared for equality.
+   * String capitalization is ignored. Supported operations are wildcard matching of '*' characters
+   * in the matcher string, or exact matches. If the matcher string contains '*' we will attempt to
+   * match wildcards, otherwise both strings are compared for equality.
+   *
    * @param searchString
    * @param matcherString
    * @return
@@ -143,5 +142,4 @@ public abstract class FieldStrategy<T> {
       return searchString.equalsIgnoreCase(matcherString);
     }
   }
-
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByName.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByName.java
@@ -30,9 +30,7 @@ public class JobFieldStrategyByName extends FieldStrategy<V2DataJob> {
       @NonNull Criteria<V2DataJob> criteria, @NonNull Filter filter) {
     Predicate<V2DataJob> predicate = criteria.getPredicate();
     if (filterProvided(filter)) {
-      predicate =
-          predicate.and(
-              dataJob -> checkMatch(dataJob.getJobName(), filter.getPattern()));
+      predicate = predicate.and(dataJob -> checkMatch(dataJob.getJobName(), filter.getPattern()));
     }
     return new Criteria<>(predicate, detectSortingComparator(filter, COMPARATOR_DEFAULT, criteria));
   }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByName.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByName.java
@@ -6,15 +6,13 @@
 package com.vmware.taurus.service.graphql.strategy.datajob;
 
 import com.vmware.taurus.service.graphql.model.Criteria;
+import com.vmware.taurus.service.graphql.model.Filter;
 import com.vmware.taurus.service.graphql.model.V2DataJob;
 import com.vmware.taurus.service.graphql.strategy.FieldStrategy;
-import com.vmware.taurus.service.graphql.model.Filter;
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.lang.NonNull;
-import org.springframework.stereotype.Component;
-
 import java.util.Comparator;
 import java.util.function.Predicate;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
 
 @Component
 public class JobFieldStrategyByName extends FieldStrategy<V2DataJob> {
@@ -34,14 +32,13 @@ public class JobFieldStrategyByName extends FieldStrategy<V2DataJob> {
     if (filterProvided(filter)) {
       predicate =
           predicate.and(
-              dataJob -> StringUtils.containsIgnoreCase(dataJob.getJobName(), filter.getPattern()));
+              dataJob -> checkMatch(dataJob.getJobName(), filter.getPattern()));
     }
-
     return new Criteria<>(predicate, detectSortingComparator(filter, COMPARATOR_DEFAULT, criteria));
   }
 
   @Override
   public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
-    return dataJob -> StringUtils.containsIgnoreCase(dataJob.getJobName(), searchStr);
+    return dataJob -> dataJob.getJobName() != null && checkMatch(dataJob.getJobName(), searchStr);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByName.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByName.java
@@ -37,6 +37,6 @@ public class JobFieldStrategyByName extends FieldStrategy<V2DataJob> {
 
   @Override
   public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
-    return dataJob -> dataJob.getJobName() != null && checkMatch(dataJob.getJobName(), searchStr);
+    return dataJob -> checkMatch(dataJob.getJobName(), searchStr);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByTeam.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByTeam.java
@@ -51,8 +51,7 @@ public class JobFieldStrategyByTeam extends FieldStrategy<V2DataJob> {
   @Override
   public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
     return dataJob ->
-        dataJob.getConfig() != null
-            && checkMatch(dataJob.getConfig().getTeam(), searchStr);
+        dataJob.getConfig() != null && checkMatch(dataJob.getConfig().getTeam(), searchStr);
   }
 
   @Override

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByTeam.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByTeam.java
@@ -6,16 +6,14 @@
 package com.vmware.taurus.service.graphql.strategy.datajob;
 
 import com.vmware.taurus.service.graphql.model.Criteria;
+import com.vmware.taurus.service.graphql.model.Filter;
 import com.vmware.taurus.service.graphql.model.V2DataJob;
 import com.vmware.taurus.service.graphql.model.V2DataJobConfig;
 import com.vmware.taurus.service.graphql.strategy.FieldStrategy;
-import com.vmware.taurus.service.graphql.model.Filter;
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.lang.NonNull;
-import org.springframework.stereotype.Component;
-
 import java.util.Comparator;
 import java.util.function.Predicate;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
 
 @Component
 public class JobFieldStrategyByTeam extends FieldStrategy<V2DataJob> {
@@ -43,9 +41,7 @@ public class JobFieldStrategyByTeam extends FieldStrategy<V2DataJob> {
                 part = part.replace("%", ".*").trim();
                 var configTeamLower = config.getTeam().toLowerCase();
                 var partLower = part.toLowerCase();
-
-                return configTeamLower.matches(partLower)
-                    || configTeamLower.trim().equals(partLower.trim());
+                return checkMatch(configTeamLower, partLower);
               });
     }
 
@@ -56,7 +52,7 @@ public class JobFieldStrategyByTeam extends FieldStrategy<V2DataJob> {
   public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
     return dataJob ->
         dataJob.getConfig() != null
-            && StringUtils.containsIgnoreCase(dataJob.getConfig().getTeam(), searchStr);
+            && checkMatch(dataJob.getConfig().getTeam(), searchStr);
   }
 
   @Override

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLDataFetchersTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLDataFetchersTest.java
@@ -125,7 +125,7 @@ class GraphQLDataFetchersTest {
     when(jobsRepository.findAll()).thenReturn(mockListOfDataJobs());
     when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
     when(dataFetchingEnvironment.getArgument("filter"))
-        .thenReturn(constructFilter(Filter.of("jobName", "sample-job", Sort.Direction.DESC)));
+        .thenReturn(constructFilter(Filter.of("jobName", "sample-job*", Sort.Direction.DESC)));
 
     DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
 

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLJobTeamFetcherIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLJobTeamFetcherIT.java
@@ -10,7 +10,6 @@ import com.vmware.taurus.service.JobsRepository;
 import com.vmware.taurus.service.model.DataJob;
 import com.vmware.taurus.service.model.JobConfig;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -28,11 +27,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc(addFilters = false)
 public class GraphQLJobTeamFetcherIT {
 
-  @Autowired
-  JobsRepository jobsRepository;
+  @Autowired JobsRepository jobsRepository;
 
-  @Autowired
-  private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
   @AfterEach
   public void cleanup() {
@@ -85,46 +82,45 @@ public class GraphQLJobTeamFetcherIT {
 
   @Test
   public void testRetrieveJobNameWithTrailingWildcard() throws Exception {
-    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected("some-long-data-job-name",
-        "some-*");
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(
+        "some-long-data-job-name", "some-*");
   }
 
   @Test
   public void testRetrieveJobNameWithTrailingAndLeadingWildcard() throws Exception {
-    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected("some-long-data-job-name",
-        "*-long-*");
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(
+        "some-long-data-job-name", "*-long-*");
   }
 
   @Test
   public void testRetrieveJobNameWithLeadingWildcard() throws Exception {
-    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected("some-long-data-job-name",
-        "*-name");
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(
+        "some-long-data-job-name", "*-name");
   }
 
   @Test
   public void testRetrieveJobNameWithComplicatedWildcard() throws Exception {
-    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected("some-long-data-job-name",
-        "*-long-*-name");
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(
+        "some-long-data-job-name", "*-long-*-name");
   }
 
   @Test
   public void testRetrieveJobNameWithWildcard_shouldNotRetrieve() throws Exception {
 
-    testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected("some-long-data-job-name",
-        "*-other-*");
-
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected(
+        "some-long-data-job-name", "*-other-*");
   }
 
   /**
    * Re-usable test that creates a data job with a given team name and attempts to retrieve it via
    * the graphQL API, expecting to find it.
    *
-   * @param jobTeam      - the team name.
+   * @param jobTeam - the team name.
    * @param searchString - the graphQl search string.
    * @throws Exception
    */
-  private void testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(String jobTeam,
-      String searchString) throws Exception {
+  private void testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(
+      String jobTeam, String searchString) throws Exception {
     createJobWithTeam(jobTeam);
     mockMvc
         .perform(
@@ -140,12 +136,12 @@ public class GraphQLJobTeamFetcherIT {
    * Re-usable test that creates a data job with a given team name and attempts to retrieve it via
    * the graphQL API, expecting to not find it, due to the provided search string.
    *
-   * @param jobTeam      - the team name.
+   * @param jobTeam - the team name.
    * @param searchString - the graphQl search string.
    * @throws Exception
    */
-  private void testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected(String jobTeam,
-      String searchString) throws Exception {
+  private void testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected(
+      String jobTeam, String searchString) throws Exception {
     createJobWithTeam(jobTeam);
     mockMvc
         .perform(
@@ -156,8 +152,7 @@ public class GraphQLJobTeamFetcherIT {
         .andExpect(jsonPath("$.data.content").isEmpty());
   }
 
-  private void testJobApiRetrievalWithTeamName_retrieveExpected(String jobTeam)
-      throws Exception {
+  private void testJobApiRetrievalWithTeamName_retrieveExpected(String jobTeam) throws Exception {
     testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(jobTeam, jobTeam);
   }
 

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLJobTeamFetcherIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLJobTeamFetcherIT.java
@@ -10,6 +10,7 @@ import com.vmware.taurus.service.JobsRepository;
 import com.vmware.taurus.service.model.DataJob;
 import com.vmware.taurus.service.model.JobConfig;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -27,9 +28,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc(addFilters = false)
 public class GraphQLJobTeamFetcherIT {
 
-  @Autowired JobsRepository jobsRepository;
+  @Autowired
+  JobsRepository jobsRepository;
 
-  @Autowired private MockMvc mockMvc;
+  @Autowired
+  private MockMvc mockMvc;
 
   @AfterEach
   public void cleanup() {
@@ -72,31 +75,90 @@ public class GraphQLJobTeamFetcherIT {
 
   @Test
   public void testRetrieveJobNameWithParentheses() throws Exception {
-    testJobApiRetrievalWithTeamName("VIDA (Eco-system)");
+    testJobApiRetrievalWithTeamName_retrieveExpected("VIDA (Eco-system)");
   }
 
   @Test
   public void testRetrieveJobNameWithoutParentheses() throws Exception {
-    testJobApiRetrievalWithTeamName("VIDA");
+    testJobApiRetrievalWithTeamName_retrieveExpected("VIDA");
+  }
+
+  @Test
+  public void testRetrieveJobNameWithTrailingWildcard() throws Exception {
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected("some-long-data-job-name",
+        "some-*");
+  }
+
+  @Test
+  public void testRetrieveJobNameWithTrailingAndLeadingWildcard() throws Exception {
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected("some-long-data-job-name",
+        "*-long-*");
+  }
+
+  @Test
+  public void testRetrieveJobNameWithLeadingWildcard() throws Exception {
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected("some-long-data-job-name",
+        "*-name");
+  }
+
+  @Test
+  public void testRetrieveJobNameWithComplicatedWildcard() throws Exception {
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected("some-long-data-job-name",
+        "*-long-*-name");
+  }
+
+  @Test
+  public void testRetrieveJobNameWithWildcard_shouldNotRetrieve() throws Exception {
+
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected("some-long-data-job-name",
+        "*-other-*");
+
   }
 
   /**
    * Re-usable test that creates a data job with a given team name and attempts to retrieve it via
-   * the graphQL API
+   * the graphQL API, expecting to find it.
    *
-   * @param jobTeam - the team name.
+   * @param jobTeam      - the team name.
+   * @param searchString - the graphQl search string.
    * @throws Exception
    */
-  private void testJobApiRetrievalWithTeamName(String jobTeam) throws Exception {
+  private void testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(String jobTeam,
+      String searchString) throws Exception {
     createJobWithTeam(jobTeam);
     mockMvc
         .perform(
             MockMvcRequestBuilders.get(getJobsUri(jobTeam))
-                .queryParam("query", getQuery(jobTeam))
+                .queryParam("query", getQuery(searchString))
                 .with(user("test")))
         .andExpect(status().is(200))
         .andExpect(jsonPath("$.data.content[0].jobName").value("test-job"))
         .andExpect(jsonPath("$.data.content[0].config.team").value(jobTeam));
+  }
+
+  /**
+   * Re-usable test that creates a data job with a given team name and attempts to retrieve it via
+   * the graphQL API, expecting to not find it, due to the provided search string.
+   *
+   * @param jobTeam      - the team name.
+   * @param searchString - the graphQl search string.
+   * @throws Exception
+   */
+  private void testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected(String jobTeam,
+      String searchString) throws Exception {
+    createJobWithTeam(jobTeam);
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(getJobsUri(jobTeam))
+                .queryParam("query", getQuery(searchString))
+                .with(user("test")))
+        .andExpect(status().is(200))
+        .andExpect(jsonPath("$.data.content").isEmpty());
+  }
+
+  private void testJobApiRetrievalWithTeamName_retrieveExpected(String jobTeam)
+      throws Exception {
+    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(jobTeam, jobTeam);
   }
 
   private void createJobWithTeam(String jobTeam) {


### PR DESCRIPTION
what: Added wildcard matching e.g *-search-* in graphQl filters for job name and team name and exact matching of search strings.

why: Current implementation uses Java String's .contains() method which doesn't have the ability to return exact matches. Users of the control-service API ran into usability issues when multiple results were returned, without the ability to filter for exact matches.

testing: added tests.

Signed-off-by: Momchil Zhivkov <mzhivkov@vmware.com>