### PR TITLE
control-service: add docs on using different versions of k8s

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/README.md
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/README.md
@@ -2,7 +2,8 @@
 Versatile Data Kit is a platform that enables Data Engineers to implement automated pull ingestion (E in ELT) and batch data transformation into a database (T in ELT).
 
 ## Prerequisites
-- Kubernetes 1.15+
+- Kubernetes 1.19<=x>1.25 works with no config changes
+- for kubernetes 1.25+ the datajob template needs to be changed in the [values.yaml](./values.yaml). Specifically enabled needs to be set to true and apiVersion needs to be set to batch/v1
 - Helm 3.0
 - PV provisioner support in the underlying infrastructure if using the embedded database.
 - During helm install - CRUD on Kubernetes Deployment, Service, ServiceAccount, Role, Rolebindings. Control Service itself manages CronJob(Job and Pod as well), Secret resources. Statefulset and PVC if using the embedded database


### PR DESCRIPTION
# What
In this PR I include docs on using different versions of k8s
# Why
Make it easier for customers to configure a deployment successfully. 

Signed-off-by: murphp15 <murphp15@tcd.ie>