### PR TITLE
vdk-jobs-troubleshooting: Run troubleshooting server as deamon thread

### DIFF
--- a/projects/vdk-plugins/vdk-jobs-troubleshooting/src/vdk/plugin/jobs_troubleshoot/jobs_troubleshoot_plugin.py
+++ b/projects/vdk-plugins/vdk-jobs-troubleshooting/src/vdk/plugin/jobs_troubleshoot/jobs_troubleshoot_plugin.py
@@ -49,7 +49,7 @@ class JobTroubleshootingPlugin:
         except Exception as e:
             log.info(
                 f"""
-                An exception occurred while processing a troubleshooting
+                An exception occurred while starting a troubleshooting
                 utility. The error was: {e}
                 """
             )
@@ -62,7 +62,7 @@ class JobTroubleshootingPlugin:
         except Exception as e:
             log.info(
                 f"""
-                An exception occurred while processing a troubleshooting
+                An exception occurred while stopping a troubleshooting
                 utility. The error was: {e}
                 """
             )

--- a/projects/vdk-plugins/vdk-jobs-troubleshooting/src/vdk/plugin/jobs_troubleshoot/troubleshoot_utilities/healthcheck_server.py
+++ b/projects/vdk-plugins/vdk-jobs-troubleshooting/src/vdk/plugin/jobs_troubleshoot/troubleshoot_utilities/healthcheck_server.py
@@ -26,7 +26,11 @@ class HealthCheckServer:
             if handler:
                 port = self.find_open_port(port)
                 self._server = HTTPServer(("", port), handler)
-                self._thread = Thread(target=self._server.serve_forever, daemon=True)
+                self._thread = Thread(
+                    target=self._server.serve_forever,
+                    name="troubleshooting_utility",
+                    daemon=True,
+                )
                 log.info(f"Troubleshooting utility server will start on port {port}.")
             else:
                 log.error(
@@ -54,7 +58,6 @@ class HealthCheckServer:
         try:
             self._server.shutdown()
             self._server.server_close()
-            self._thread.join()
             logging.info("Troubleshooting utility server stopped.")
         except Exception as e:
             logging.error("Unable to stop troubleshooting server", exc_info=e)

--- a/projects/vdk-plugins/vdk-jobs-troubleshooting/src/vdk/plugin/jobs_troubleshoot/troubleshoot_utilities/healthcheck_server.py
+++ b/projects/vdk-plugins/vdk-jobs-troubleshooting/src/vdk/plugin/jobs_troubleshoot/troubleshoot_utilities/healthcheck_server.py
@@ -26,8 +26,8 @@ class HealthCheckServer:
             if handler:
                 port = self.find_open_port(port)
                 self._server = HTTPServer(("", port), handler)
-                self._thread = Thread(target=self._server.serve_forever)
-                log.info(f"Troubleshooting utility server started on port {port}.")
+                self._thread = Thread(target=self._server.serve_forever, daemon=True)
+                log.info(f"Troubleshooting utility server will start on port {port}.")
             else:
                 log.error(
                     "Troubleshooting utility handler not specified. Will not start the server."
@@ -43,6 +43,7 @@ class HealthCheckServer:
         """
         try:
             self._thread.start()
+            logging.info("Troubleshooting utility server started.")
         except Exception as e:
             logging.error("Unable to start troubleshooting server", exc_info=e)
 
@@ -54,6 +55,7 @@ class HealthCheckServer:
             self._server.shutdown()
             self._server.server_close()
             self._thread.join()
+            logging.info("Troubleshooting utility server stopped.")
         except Exception as e:
             logging.error("Unable to stop troubleshooting server", exc_info=e)
 


### PR DESCRIPTION
Why?
Data jobs sometime don't finish/quite as expected when the troubleshooting server is started

What?
Change the HTTP server of the troubleshoot utilities to run as a deamon thread

Type of change
Bug fix

Signed-off-by: Dako Dakov <ddakov@vmware.com>