### PR TITLE
vdk-spec: cleanup template

### DIFF
--- a/specs/NNNN-template/README.md
+++ b/specs/NNNN-template/README.md
@@ -4,11 +4,6 @@
 * **Author(s):** Name (mail), ...
 * **Status:** draft | implementable | implemented | rejected | withdrawn | replaced
 
-<!--
-**Note:** Any PRs to move a VEP to `implementable`, or significant changes once
-it is marked `implementable`, must be approved by at least 2 maintainers .
-
--->
 
 To get started with this template:
 


### PR DESCRIPTION
# Why
The documentation here is redundant because all PRs now require 2 approvals.

# What
 Remove needless docs.

Signed-off-by: murphp15 <murphp15@tcd.ie>