### PR TITLE
vdk: update changelog instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,21 +111,13 @@ Familiarize with [recommendations written here](https://github.com/vmware/versat
 We prefer maintaining a straight branch history by rebasing before merging. Fast-forward merges should not create merge commits.
 
 ## Changelog
-It's important to update CHANGELOG.md with any adjustments to the project.
 Versioning of all components follows https://semver.org
 
-Changelog has the following sections:
-- New feature: significant additions to the project. This usually requires bumping at least a minor version;
-- Improvements - an enhancement to existing functionality and minor additions;
-- Bug Fixes - Fixes of bugs/regressions;
-- Breaking Changes: any changes that break Versatile Data Kit's backward-compatibility.
+For generating release notes (changelog) we rely on good commit titles and commit descriptions (see above section). 
 
-Each component project maintains its own CHANGELOG.
-Go to projects/component-name/CHANGELOG.md to see the changelog of the component
-
+## Pull Request Checklist
 
 Before submitting your pull request, we advise you to use the following:
-## Pull Request Checklist
 
 1. Check if your code changes will pass both code linting checks and unit tests.
 2. Ensure your commit messages are descriptive. Be sure to include any related GitHub issue references in the commit message. See [GFM syntax](https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown) for referencing issues and commits.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ We prefer maintaining a straight branch history by rebasing before merging. Fast
 ## Changelog
 Versioning of all components follows https://semver.org
 
-For generating release notes (changelog) we rely on good commit titles and commit descriptions (see above section). 
+For generating release notes (changelog) we rely on good commit titles and commit descriptions (see above section).
 
 ## Pull Request Checklist
 


### PR DESCRIPTION
In time it has proven that maintaining a separate Changelog file is not an efficient way of documenting changes. It's very rarely updated. And often the quality is not high as most users I have shown it to do not understand it. We also have a lot of components and it's hard to track changes across all component's distinct changelog files. Unofficially we had not really be using/udpating changelogs for some time. 

This PR is abolishing this practice officially by removing it from contributing guide. 

Nowaday once a month we make a [release](https://github.com/vmware/versatile-data-kit/releases) instead and [document the changes there as release notes](https://github.com/vmware/versatile-data-kit/blob/main/CONTRIBUTING.md#how-to-make-a-new-vdk-release).

After merging this, I will review changelog files if there's any point in keeping some for information purposes and remove ones that are unnecessary.