### PR TITLE
control-service: only delete file in test path

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/MiniKdcCredentialsRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/MiniKdcCredentialsRepository.java
@@ -40,10 +40,10 @@ public class MiniKdcCredentialsRepository extends KerberosCredentialsRepository 
   public void createPrincipal(String principal, Optional<File> keytabLocation) {
     try {
       /* delete the file if it is present at the location.
-       Different KDC implementations expect different inputs for the create principal function.
-       the SimpleKDCServer expects no file at the location of the provided filename.
-       whereas the production kdc server impl expects an empty file.
-       To make the production code as clear as possible we create a file in the production code and the onus falls on the test code to delete the file. */
+      Different KDC implementations expect different inputs for the create principal function.
+      the SimpleKDCServer expects no file at the location of the provided filename.
+      whereas the production kdc server impl expects an empty file.
+      To make the production code as clear as possible we create a file in the production code and the onus falls on the test code to delete the file. */
       keytabLocation.get().delete();
       miniKdc.createAndExportPrincipals(keytabLocation.get(), principal);
     } catch (Exception e) {

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/MiniKdcCredentialsRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/MiniKdcCredentialsRepository.java
@@ -39,6 +39,12 @@ public class MiniKdcCredentialsRepository extends KerberosCredentialsRepository 
   @Override
   public void createPrincipal(String principal, Optional<File> keytabLocation) {
     try {
+      /* delete the file if it is present at the location.
+       Different KDC implementations expect different inputs for the create principal function.
+       the SimpleKDCServer expects no file at the location of the provided filename.
+       whereas the production kdc server impl expects an empty file.
+       To make the production code as clear as possible we create a file in the production code and the onus falls on the test code to delete the file. */
+      keytabLocation.get().delete();
       miniKdc.createAndExportPrincipals(keytabLocation.get(), principal);
     } catch (Exception e) {
       log.error("Failed to create principal", e);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/credentials/JobCredentialsService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/credentials/JobCredentialsService.java
@@ -54,9 +54,7 @@ public class JobCredentialsService {
     String principal = getJobPrincipalName(jobName);
     File keytabFile;
     try {
-      // create a temp file name by creating a temp file and then deleteing the actual file.
       keytabFile = File.createTempFile(principal, ".keytab");
-      keytabFile.delete();
     } catch (IOException e) {
       throw new ExternalSystemError(MainExternalSystem.HOST_CONTAINER, e);
     }


### PR DESCRIPTION
# Why
In my previous PR I merged code which deletes an empty keytab file, so that we keep only the filename. 
This is the desired behaviour for the test kdc server as it expects no file to be at the file location. 
However the production path expects there to be an empty file there. 

# What 
Push the delete logic into the test impl so that we aren't modifying the production code path. 

# How has this been tested
entire deployment pipeline


# Open questions
Should more of the pipeline run on branches as it would have caught this issue?



Signed-off-by: murphp15 <murphp15@tcd.ie>