### PR TITLE
vdk-cicd: during a scheduled run publish_artifacts and release shouldn't run

### DIFF
--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -151,6 +151,8 @@ control_service_publish_job_base_image-secure:
     - bash -ex ./publish-job-base.sh
   retry: !reference [.control_service_retry, retry_options]
   rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
     - if: '$CI_COMMIT_BRANCH == "main"'
       changes:
         - projects/control-service/projects/job-base-image-secure/**/*
@@ -165,6 +167,8 @@ control_service_publish_job_builder_image:
     - bash -ex ./publish-vdk-job-builder.sh
   retry: !reference [.control_service_retry, retry_options]
   rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
     - if: '$CI_COMMIT_BRANCH == "main"'
       changes:
         - projects/control-service/projects/job-builder/version.txt

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -212,13 +212,13 @@ control_service_publish_image:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
       when: never
-#    - if: '$CI_COMMIT_BRANCH == "main"'
-#      changes: [ projects/control-service/projects/helm_charts/pipelines-control-service/version.txt ]
-#      when: never
-#    - if: '$CI_COMMIT_BRANCH == "main"'
-#      changes: *control_service_code_change_locations
-#    - if: '$CI_COMMIT_BRANCH == "main"'
-#      changes: *control_service_helm_change_locations
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes: [ projects/control-service/projects/helm_charts/pipelines-control-service/version.txt ]
+      when: never
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes: *control_service_code_change_locations
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes: *control_service_helm_change_locations
 
 control_service_publish_api_client:
   image: docker:20.10.22
@@ -303,10 +303,10 @@ control_service_release:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
       when: never
-#    - if: '$CI_COMMIT_BRANCH == "main"'
-#      changes: *control_service_code_change_locations
-#    - if: '$CI_COMMIT_BRANCH == "main"'
-#      changes: *control_service_helm_change_locations
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes: *control_service_code_change_locations
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes: *control_service_helm_change_locations
 
 # TODO: automatically rebuild image on vdk-heartbeat change
 # We are using an old version of docker here because we get error on the newest version which at the time was tag=20.10.22
@@ -332,7 +332,7 @@ control_service_vdk_heartbeat_release:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
       when: never
-#    - if: '$CI_COMMIT_BRANCH == "main"'
-#      changes: *control_service_code_change_locations
-#    - if: '$CI_COMMIT_BRANCH == "main"'
-#      changes: *control_service_helm_change_locations
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes: *control_service_code_change_locations
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes: *control_service_helm_change_locations

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -299,6 +299,8 @@ control_service_release:
     - bash -ex ../../cicd/release-pipelines-service.sh
   retry: !reference [.control_service_retry, retry_options]
   rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
     - if: '$CI_COMMIT_BRANCH == "main"'
       changes: *control_service_code_change_locations
     - if: '$CI_COMMIT_BRANCH == "main"'
@@ -326,6 +328,8 @@ control_service_vdk_heartbeat_release:
     - docker push $VDK_HEARTBEAT_IMAGE_NAME
   retry: !reference [.control_service_retry, retry_options]
   rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
     - if: '$CI_COMMIT_BRANCH == "main"'
       changes: *control_service_code_change_locations
     - if: '$CI_COMMIT_BRANCH == "main"'

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -180,8 +180,12 @@ control_service_publish_job_builder_secure_image:
     - docker login --username "${VDK_DOCKER_REGISTRY_USERNAME}" --password "${VDK_DOCKER_REGISTRY_PASSWORD}" "${VDK_DOCKER_REGISTRY_URL}"
     - cd projects/control-service/projects/job-builder-secure
     - bash -ex ./publish-vdk-job-builder-secure.sh
-  only:
-    changes:
+  retry: !reference [.control_service_retry, retry_options]
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes:
       - projects/control-service/projects/job-builder-secure/version.txt
 
 

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -212,13 +212,13 @@ control_service_publish_image:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
       when: never
-    - if: '$CI_COMMIT_BRANCH == "main"'
-      changes: [ projects/control-service/projects/helm_charts/pipelines-control-service/version.txt ]
-      when: never
-    - if: '$CI_COMMIT_BRANCH == "main"'
-      changes: *control_service_code_change_locations
-    - if: '$CI_COMMIT_BRANCH == "main"'
-      changes: *control_service_helm_change_locations
+#    - if: '$CI_COMMIT_BRANCH == "main"'
+#      changes: [ projects/control-service/projects/helm_charts/pipelines-control-service/version.txt ]
+#      when: never
+#    - if: '$CI_COMMIT_BRANCH == "main"'
+#      changes: *control_service_code_change_locations
+#    - if: '$CI_COMMIT_BRANCH == "main"'
+#      changes: *control_service_helm_change_locations
 
 control_service_publish_api_client:
   image: docker:20.10.22
@@ -303,10 +303,10 @@ control_service_release:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
       when: never
-    - if: '$CI_COMMIT_BRANCH == "main"'
-      changes: *control_service_code_change_locations
-    - if: '$CI_COMMIT_BRANCH == "main"'
-      changes: *control_service_helm_change_locations
+#    - if: '$CI_COMMIT_BRANCH == "main"'
+#      changes: *control_service_code_change_locations
+#    - if: '$CI_COMMIT_BRANCH == "main"'
+#      changes: *control_service_helm_change_locations
 
 # TODO: automatically rebuild image on vdk-heartbeat change
 # We are using an old version of docker here because we get error on the newest version which at the time was tag=20.10.22
@@ -332,7 +332,7 @@ control_service_vdk_heartbeat_release:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
       when: never
-    - if: '$CI_COMMIT_BRANCH == "main"'
-      changes: *control_service_code_change_locations
-    - if: '$CI_COMMIT_BRANCH == "main"'
-      changes: *control_service_helm_change_locations
+#    - if: '$CI_COMMIT_BRANCH == "main"'
+#      changes: *control_service_code_change_locations
+#    - if: '$CI_COMMIT_BRANCH == "main"'
+#      changes: *control_service_helm_change_locations

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -107,7 +107,7 @@ control_service_integration_test:
 control_service_test_helm_chart:
   stage: build
   script:
-    - export DESIRED_VERSION=v3.6.3 # helm version 3.6.3
+    - export DESIRED_VERSION=v3.11.0 # helm version 3.11.0
     - curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
     - cd projects/control-service/projects/helm_charts/pipelines-control-service
     - helm dependency update
@@ -289,7 +289,7 @@ control_service_release:
   script:
     - apk --no-cache add bash openssl curl git
     - export IMAGE_TAG="$(git rev-parse --short HEAD)"
-    - export DESIRED_VERSION=v3.6.3 # helm version 3.6.3
+    - export DESIRED_VERSION=v3.11.0 # helm version 3.11.0
     - export CHART_NAME=pipelines-control-service
     - export CHART_VERSION="$(cat projects/control-service/projects/helm_charts/$CHART_NAME/version.txt | grep -o '^[0-9]\+\.[0-9]\+').$CI_PIPELINE_ID"
     - curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -186,7 +186,7 @@ control_service_publish_job_builder_secure_image:
       when: never
     - if: '$CI_COMMIT_BRANCH == "main"'
       changes:
-      - projects/control-service/projects/job-builder-secure/version.txt
+        - projects/control-service/projects/job-builder-secure/version.txt
 
 
 control_service_publish_image:
@@ -233,7 +233,7 @@ control_service_publish_api_client:
       when: never
     - if: '$CI_COMMIT_BRANCH == "main"'
       changes:
-      - projects/control-service/projects/model/apidefs/datajob-api/config-python.json
+        - projects/control-service/projects/model/apidefs/datajob-api/config-python.json
 
 # (there are docker KDC servers that can be used for demo? but it will not work with Impala ?)
 # The cockroach storage class is taken from DECC https://devhub.eng.vmware.com/console/resources/namespaces

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -150,15 +150,10 @@ control_service_publish_job_base_image-secure:
     - export VERSION_TAG="1.$CI_PIPELINE_ID"
     - bash -ex ./publish-job-base.sh
   retry: !reference [.control_service_retry, retry_options]
-  only:
-    refs:
-      - main
-    changes:
-      - projects/control-service/projects/job-base-image-secure/**/*
-  except:
-    changes:
-      - projects/control-service/projects/helm_charts/pipelines-control-service/version.txt
-
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes:
+        - projects/control-service/projects/job-base-image-secure/**/*
 
 control_service_publish_job_builder_image:
   extends: .images:dind
@@ -169,14 +164,10 @@ control_service_publish_job_builder_image:
     - cd projects/control-service/projects/job-builder
     - bash -ex ./publish-vdk-job-builder.sh
   retry: !reference [.control_service_retry, retry_options]
-  only:
-    refs:
-      - main
-    changes:
-      - projects/control-service/projects/job-builder/version.txt
-  except:
-    changes:
-      - projects/control-service/projects/helm_charts/pipelines-control-service/version.txt
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes:
+        - projects/control-service/projects/job-builder/version.txt
 
 
 control_service_publish_job_builder_secure_image:
@@ -232,14 +223,10 @@ control_service_publish_api_client:
     - python setup.py sdist --formats=gztar
     - twine upload --repository-url $PIP_REPO_UPLOAD_URL -u "$PIP_REPO_UPLOAD_USER_NAME" -p "$PIP_REPO_UPLOAD_USER_PASSWORD" dist/*tar.gz --verbose
   retry: !reference [.control_service_retry, retry_options]
-  only:
-    refs:
-      - main
-    changes:
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes:
       - projects/control-service/projects/model/apidefs/datajob-api/config-python.json
-  except:
-    changes:
-      - projects/control-service/projects/helm_charts/pipelines-control-service/version.txt
 
 # (there are docker KDC servers that can be used for demo? but it will not work with Impala ?)
 # The cockroach storage class is taken from DECC https://devhub.eng.vmware.com/console/resources/namespaces

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -224,6 +224,8 @@ control_service_publish_api_client:
     - twine upload --repository-url $PIP_REPO_UPLOAD_URL -u "$PIP_REPO_UPLOAD_USER_NAME" -p "$PIP_REPO_UPLOAD_USER_PASSWORD" dist/*tar.gz --verbose
   retry: !reference [.control_service_retry, retry_options]
   rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
     - if: '$CI_COMMIT_BRANCH == "main"'
       changes:
       - projects/control-service/projects/model/apidefs/datajob-api/config-python.json

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -130,15 +130,12 @@ control_service_publish_job_base_image:
     - export VERSION_TAG="1.$CI_PIPELINE_ID"
     - bash -ex ./publish-job-base.sh
   retry: !reference [.control_service_retry, retry_options]
-  only:
-    refs:
-      - main
-      - external_pull_requests
-    changes:
-      - projects/control-service/projects/job-base-image/**/*
-  except:
-    changes:
-      - projects/control-service/projects/helm_charts/pipelines-control-service/version.txt
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes:
+        - projects/control-service/projects/job-base-image/**/*
 
 control_service_publish_job_base_image-secure:
   extends: .images:dind

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -210,6 +210,8 @@ control_service_publish_image:
     reports:
       junit: ./projects/control-serviceprojects/**/build/test-results/test/TEST-*.xml
   rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
     - if: '$CI_COMMIT_BRANCH == "main"'
       changes: [ projects/control-service/projects/helm_charts/pipelines-control-service/version.txt ]
       when: never

--- a/projects/vdk-control-cli/.gitlab-ci.yml
+++ b/projects/vdk-control-cli/.gitlab-ci.yml
@@ -84,7 +84,8 @@ vdk-control-cli-release:
     - pip install -U pip setuptools wheel twine
     - python setup.py sdist --formats=gztar
     - twine upload --repository-url "$PIP_REPO_UPLOAD_URL" -u "$PIP_REPO_UPLOAD_USER_NAME" -p "$PIP_REPO_UPLOAD_USER_PASSWORD" dist/*tar.gz --verbose
-  only:
-    refs:
-      - main
-    changes: *vdk_control_cli_changes_locations
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes: *vdk_control_cli_changes_locations

--- a/projects/vdk-core/.gitlab-ci.yml
+++ b/projects/vdk-core/.gitlab-ci.yml
@@ -108,7 +108,8 @@ vdk-core-release:
     - ./cicd/set-patch-version.sh "$VDK_RELEASE_OVERRIDE_PATCH_VERSION"
     - ./cicd/release-vdk-core.sh
   retry: !reference [.retry, retry_options]
-  only:
-    refs:
-      - main
-    changes: *vdk_core_locations
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes: *vdk_core_locations

--- a/projects/vdk-heartbeat/.gitlab-ci.yml
+++ b/projects/vdk-heartbeat/.gitlab-ci.yml
@@ -35,7 +35,8 @@ vdk-heartbeat-release:
     - pip install -U pip setuptools wheel twine
     - python setup.py sdist --formats=gztar
     - twine upload --repository-url $PIP_REPO_UPLOAD_URL -u "$PIP_REPO_UPLOAD_USER_NAME" -p "$PIP_REPO_UPLOAD_USER_PASSWORD" dist/*tar.gz --verbose
-  only:
-    refs:
-      - main
-    changes: *vdk_heartbeat_changes_locations
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes: *vdk_heartbeat_changes_locations

--- a/projects/vdk-heartbeat/.gitlab-ci.yml
+++ b/projects/vdk-heartbeat/.gitlab-ci.yml
@@ -38,5 +38,5 @@ vdk-heartbeat-release:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
       when: never
-#    - if: '$CI_COMMIT_BRANCH == "main"'
-#      changes: *vdk_heartbeat_changes_locations
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes: *vdk_heartbeat_changes_locations

--- a/projects/vdk-heartbeat/.gitlab-ci.yml
+++ b/projects/vdk-heartbeat/.gitlab-ci.yml
@@ -38,5 +38,5 @@ vdk-heartbeat-release:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
       when: never
-    - if: '$CI_COMMIT_BRANCH == "main"'
-      changes: *vdk_heartbeat_changes_locations
+#    - if: '$CI_COMMIT_BRANCH == "main"'
+#      changes: *vdk_heartbeat_changes_locations

--- a/projects/vdk-plugins/.plugin-common.yml
+++ b/projects/vdk-plugins/.plugin-common.yml
@@ -65,6 +65,8 @@
     - twine upload --repository-url $PIP_REPO_UPLOAD_URL -u "$PIP_REPO_UPLOAD_USER_NAME" -p "$PIP_REPO_UPLOAD_USER_PASSWORD" dist/*tar.gz --verbose
   retry: !reference [.retry, retry_options]
   rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
     - if: '$CI_COMMIT_BRANCH == "main"'
       changes:
        - "projects/vdk-plugins/$PLUGIN_NAME/**/*"
@@ -95,6 +97,8 @@
     - bash -x ../../vdk-core/cicd/deploy-base-vdk-image.sh
   retry: !reference [.retry, retry_options]
   rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
     - if: '$CI_COMMIT_BRANCH == "main"'
       changes:
         - "projects/vdk-plugins/$PLUGIN_NAME/**/*"

--- a/projects/vdk-plugins/.plugin-common.yml
+++ b/projects/vdk-plugins/.plugin-common.yml
@@ -67,9 +67,9 @@
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
       when: never
-    - if: '$CI_COMMIT_BRANCH == "main"'
-      changes:
-       - "projects/vdk-plugins/$PLUGIN_NAME/**/*"
+#    - if: '$CI_COMMIT_BRANCH == "main"'
+#      changes:
+#       - "projects/vdk-plugins/$PLUGIN_NAME/**/*"
 
 
 .release-vdk-image:
@@ -99,6 +99,6 @@
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
       when: never
-    - if: '$CI_COMMIT_BRANCH == "main"'
-      changes:
-        - "projects/vdk-plugins/$PLUGIN_NAME/**/*"
+#    - if: '$CI_COMMIT_BRANCH == "main"'
+#      changes:
+#        - "projects/vdk-plugins/$PLUGIN_NAME/**/*"

--- a/projects/vdk-plugins/.plugin-common.yml
+++ b/projects/vdk-plugins/.plugin-common.yml
@@ -67,9 +67,9 @@
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
       when: never
-#    - if: '$CI_COMMIT_BRANCH == "main"'
-#      changes:
-#       - "projects/vdk-plugins/$PLUGIN_NAME/**/*"
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes:
+       - "projects/vdk-plugins/$PLUGIN_NAME/**/*"
 
 
 .release-vdk-image:
@@ -99,6 +99,6 @@
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
       when: never
-#    - if: '$CI_COMMIT_BRANCH == "main"'
-#      changes:
-#        - "projects/vdk-plugins/$PLUGIN_NAME/**/*"
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes:
+        - "projects/vdk-plugins/$PLUGIN_NAME/**/*"

--- a/projects/vdk-plugins/airflow-provider-vdk/.airflow-ci.yml
+++ b/projects/vdk-plugins/airflow-provider-vdk/.airflow-ci.yml
@@ -47,6 +47,8 @@ release-airflow-provider-vdk:
     - twine upload --repository-url $PIP_REPO_UPLOAD_URL -u "$PIP_REPO_UPLOAD_USER_NAME" -p "$PIP_REPO_UPLOAD_USER_PASSWORD" dist/*tar.gz --verbose
   retry: !reference [.retry, retry_options]
   rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
     - if: '$CI_COMMIT_BRANCH == "main"'
       changes:
         - "projects/vdk-plugins/airflow-provider-vdk/**/*"

--- a/projects/vdk-plugins/airflow-provider-vdk/.airflow-ci.yml
+++ b/projects/vdk-plugins/airflow-provider-vdk/.airflow-ci.yml
@@ -49,6 +49,6 @@ release-airflow-provider-vdk:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
       when: never
-#    - if: '$CI_COMMIT_BRANCH == "main"'
-#      changes:
-#        - "projects/vdk-plugins/airflow-provider-vdk/**/*"
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes:
+        - "projects/vdk-plugins/airflow-provider-vdk/**/*"

--- a/projects/vdk-plugins/airflow-provider-vdk/.airflow-ci.yml
+++ b/projects/vdk-plugins/airflow-provider-vdk/.airflow-ci.yml
@@ -49,6 +49,6 @@ release-airflow-provider-vdk:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
       when: never
-    - if: '$CI_COMMIT_BRANCH == "main"'
-      changes:
-        - "projects/vdk-plugins/airflow-provider-vdk/**/*"
+#    - if: '$CI_COMMIT_BRANCH == "main"'
+#      changes:
+#        - "projects/vdk-plugins/airflow-provider-vdk/**/*"

--- a/projects/vdk-plugins/quickstart-vdk/.plugin-ci.yml
+++ b/projects/vdk-plugins/quickstart-vdk/.plugin-ci.yml
@@ -110,3 +110,6 @@ release-vdk-image-quickstart-vdk:
   variables:
     PLUGIN_NAME: quickstart-vdk
   extends: .release-vdk-image
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never


### PR DESCRIPTION
# Why
We want to be able to run scheduled jobs. 
But as part of the scheduled jobs we want to skip `publish_artifact` jobs and also `release` jobs.

This change should not have any impact on the pipeline and I will start running the scheduled jobs once we see the pipeline is still green for merge triggered builds. 

In the future I might extract the rule into a shared abstract job. But that will be a later PR
# What
Add a guard on all `publish_artifact` jobs and also `release` jobs so that they won't run if it is triggered by a scheduled operation. 
I also upgraded helm if we are testing everything we should try upgrade that too. The hope here is that it fixes https://github.com/vmware/versatile-data-kit/issues/1252. 

# How has this been tested
Not much, mostly visual inspection. 

closes https://github.com/vmware/versatile-data-kit/issues/1254