### PR TITLE
job-builder:

### DIFF
--- a/projects/control-service/projects/job-base-image-secure/Dockerfile-data-job-base
+++ b/projects/control-service/projects/job-base-image-secure/Dockerfile-data-job-base
@@ -4,8 +4,10 @@ FROM photon:latest
 # Set the working directory
 WORKDIR /job
 
+# Uninstall native dependencies
+RUN yum erase toybox -y
+
 # Install python
-RUN yum update -y
 RUN yum install python3-3.10.0-9.ph4 python3-pip-3.10.0-9.ph4 shadow -y
 RUN ln -fs /usr/bin/python3 /usr/local/bin/python
 

--- a/projects/control-service/projects/job-builder-secure/Dockerfile.python.vdk
+++ b/projects/control-service/projects/job-builder-secure/Dockerfile.python.vdk
@@ -1,6 +1,6 @@
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices
 
-ARG base_image=python:3.9-slim
+ARG base_image=versatiledatakit/data-job-base-python-3.10-secure:latest
 
 FROM $base_image
 
@@ -33,8 +33,9 @@ ENV JOB_NAME $job_name
 ENV VDK_JOB_GITHASH $job_githash
 
 # Delete system executables
-RUN rm /bin/chown
-RUN rm /bin/uname
+RUN rm /usr/bin/chmod
+RUN rm /usr/bin/chown
+RUN rm /usr/bin/uname
 RUN python -m pip uninstall pip -y
 
 USER $UID


### PR DESCRIPTION
# Why
We want to secure our base image by deleting the `[toybox](http://landley.net/toybox/about.html)` because of its rich capabilities:

```
acpi base64 basename blkid blockdev bunzip2 bzcat cal cat catv chattr chgrp chmod chown chroot chvt cksum
cmp comm count cp cpio cut date devmem df dirname dmesg dos2unix du echo egrep eject env expand factor fallocate
false fgrep file find flock free freeramdisk fsfreeze fstype fsync ftpget ftpput grep groups gunzip gzip head
help hexedit hostname hwclock id ifconfig inotifyd insmod install ionice iorenice iotop kill killall killall5
link ln login logname losetup ls lsattr lsmod lspci lsusb makedevs md5sum microcom mix mkdir mkfifo mknod mkpasswd
mkswap mktemp modinfo mount mountpoint mv nbd-client nc netcat netstat nice nl nohup nproc nsenter od oneit
partprobe passwd paste patch pgrep pidof ping ping6 pivot_root pkill pmap printenv printf ps pwd pwdx readahead
readlink realpath renice rev rfkill rm rmdir rmmod sed seq setsid sha1sum sha224sum sha256sum sha384sum sha512sum
shred sleep sort split stat stty su swapoff swapon switch_root sync sysctl tac tail tar taskset tee test time
timeout top touch true truncate tty tunctl umount uname uniq unix2dos unlink uptime uudecode uuencode vconfig
vmstat w wc which who whoami xargs xxd yes zcat
```

# What
Deleted `toybox` from base job image.

# Testing done
Locally against Kind cluster.

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com