### PR TITLE
vdk-cicd: cleanup cicd rules

### DIFF
--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -107,7 +107,7 @@ control_service_integration_test:
 control_service_test_helm_chart:
   stage: build
   script:
-    - export DESIRED_VERSION=v3.6.3 # helm version 3.6.3
+    - export DESIRED_VERSION=v3.11.0 # helm version 3.11.0
     - curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
     - cd projects/control-service/projects/helm_charts/pipelines-control-service
     - helm dependency update
@@ -289,7 +289,7 @@ control_service_release:
   script:
     - apk --no-cache add bash openssl curl git
     - export IMAGE_TAG="$(git rev-parse --short HEAD)"
-    - export DESIRED_VERSION=v3.6.3 # helm version 3.6.3
+    - export DESIRED_VERSION=v3.11.0 # helm version 3.11.0
     - export CHART_NAME=pipelines-control-service
     - export CHART_VERSION="$(cat projects/control-service/projects/helm_charts/$CHART_NAME/version.txt | grep -o '^[0-9]\+\.[0-9]\+').$CI_PIPELINE_ID"
     - curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -163,7 +163,7 @@ control_service_publish_job_builder_image:
   rules:
     - if: '$CI_COMMIT_BRANCH == "main"'
       changes:
-        - projects/control-service/projects/job-builder-secure/version.txt
+        - projects/control-service/projects/job-builder/version.txt
 
 
 control_service_publish_job_builder_secure_image:

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -175,9 +175,10 @@ control_service_publish_job_builder_secure_image:
     - docker login --username "${VDK_DOCKER_REGISTRY_USERNAME}" --password "${VDK_DOCKER_REGISTRY_PASSWORD}" "${VDK_DOCKER_REGISTRY_URL}"
     - cd projects/control-service/projects/job-builder-secure
     - bash -ex ./publish-vdk-job-builder-secure.sh
-  only:
-    changes:
-      - projects/control-service/projects/job-builder-secure/version.txt
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes:
+        - projects/control-service/projects/job-builder-secure/version.txt
 
 
 control_service_publish_image:

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -130,15 +130,10 @@ control_service_publish_job_base_image:
     - export VERSION_TAG="1.$CI_PIPELINE_ID"
     - bash -ex ./publish-job-base.sh
   retry: !reference [.control_service_retry, retry_options]
-  only:
-    refs:
-      - main
-      - external_pull_requests
-    changes:
-      - projects/control-service/projects/job-base-image/**/*
-  except:
-    changes:
-      - projects/control-service/projects/helm_charts/pipelines-control-service/version.txt
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes:
+        - projects/control-service/projects/job-base-image/**/*
 
 control_service_publish_job_base_image-secure:
   extends: .images:dind
@@ -150,14 +145,10 @@ control_service_publish_job_base_image-secure:
     - export VERSION_TAG="1.$CI_PIPELINE_ID"
     - bash -ex ./publish-job-base.sh
   retry: !reference [.control_service_retry, retry_options]
-  only:
-    refs:
-      - main
-    changes:
-      - projects/control-service/projects/job-base-image-secure/**/*
-  except:
-    changes:
-      - projects/control-service/projects/helm_charts/pipelines-control-service/version.txt
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes:
+        - projects/control-service/projects/job-base-image-secure/**/*
 
 
 control_service_publish_job_builder_image:
@@ -169,14 +160,10 @@ control_service_publish_job_builder_image:
     - cd projects/control-service/projects/job-builder
     - bash -ex ./publish-vdk-job-builder.sh
   retry: !reference [.control_service_retry, retry_options]
-  only:
-    refs:
-      - main
-    changes:
-      - projects/control-service/projects/job-builder/version.txt
-  except:
-    changes:
-      - projects/control-service/projects/helm_charts/pipelines-control-service/version.txt
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes:
+        - projects/control-service/projects/job-builder-secure/version.txt
 
 
 control_service_publish_job_builder_secure_image:
@@ -230,14 +217,10 @@ control_service_publish_api_client:
     - python setup.py sdist --formats=gztar
     - twine upload --repository-url $PIP_REPO_UPLOAD_URL -u "$PIP_REPO_UPLOAD_USER_NAME" -p "$PIP_REPO_UPLOAD_USER_PASSWORD" dist/*tar.gz --verbose
   retry: !reference [.control_service_retry, retry_options]
-  only:
-    refs:
-      - main
-    changes:
-      - projects/control-service/projects/model/apidefs/datajob-api/config-python.json
-  except:
-    changes:
-      - projects/control-service/projects/helm_charts/pipelines-control-service/version.txt
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes:
+        - projects/control-service/projects/model/apidefs/datajob-api/config-python.json
 
 # (there are docker KDC servers that can be used for demo? but it will not work with Impala ?)
 # The cockroach storage class is taken from DECC https://devhub.eng.vmware.com/console/resources/namespaces

--- a/projects/vdk-control-cli/.gitlab-ci.yml
+++ b/projects/vdk-control-cli/.gitlab-ci.yml
@@ -84,7 +84,6 @@ vdk-control-cli-release:
     - pip install -U pip setuptools wheel twine
     - python setup.py sdist --formats=gztar
     - twine upload --repository-url "$PIP_REPO_UPLOAD_URL" -u "$PIP_REPO_UPLOAD_USER_NAME" -p "$PIP_REPO_UPLOAD_USER_PASSWORD" dist/*tar.gz --verbose
-  only:
-    refs:
-      - main
-    changes: *vdk_control_cli_changes_locations
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes: *vdk_control_cli_changes_locations

--- a/projects/vdk-core/.gitlab-ci.yml
+++ b/projects/vdk-core/.gitlab-ci.yml
@@ -108,7 +108,6 @@ vdk-core-release:
     - ./cicd/set-patch-version.sh "$VDK_RELEASE_OVERRIDE_PATCH_VERSION"
     - ./cicd/release-vdk-core.sh
   retry: !reference [.retry, retry_options]
-  only:
-    refs:
-      - main
-    changes: *vdk_core_locations
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes: *vdk_core_locations

--- a/projects/vdk-heartbeat/.gitlab-ci.yml
+++ b/projects/vdk-heartbeat/.gitlab-ci.yml
@@ -35,7 +35,6 @@ vdk-heartbeat-release:
     - pip install -U pip setuptools wheel twine
     - python setup.py sdist --formats=gztar
     - twine upload --repository-url $PIP_REPO_UPLOAD_URL -u "$PIP_REPO_UPLOAD_USER_NAME" -p "$PIP_REPO_UPLOAD_USER_PASSWORD" dist/*tar.gz --verbose
-  only:
-    refs:
-      - main
-    changes: *vdk_heartbeat_changes_locations
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes: *vdk_heartbeat_changes_locations


### PR DESCRIPTION
# Why
We want to support scheduled jobs in the near future. 
As a first step we should clean up what is there already. 

# What

This involves. 
1. rewriting `only` conditions as `rules`. which are more extensible in the future. 
2. upgrading helm. 

# How has this been tested. 
I will babysit the pipelines after this is merged to identify any anomalies. 

