### PR TITLE
control-service: Expose v1CronJob flag as env var

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -252,6 +252,10 @@ spec:
             - name: DATAJOBS_BUILDER_REGISTRY_SECRET
               value: {{ template "pipelines-control-service.fullname" . }}-dtjb-buldr-rgstry-scrt
             {{- end }}
+            {{- if .Values.controlK8sK8sSupportsV1CronJob }}
+            - name: DATAJOBS_SUPPORT_V1CRONJOB
+            value: "{{ .Values.controlK8sK8sSupportsV1CronJob }}"
+            {{- end }}
 
 
 {{- if .Values.extraVars }}

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -100,7 +100,7 @@ logging.level.io.swagger.models.parameters.AbstractSerializableParameter=ERROR
 
 
 datajobs.control.k8s.kubeconfig=${HOME}/.kube/config
-datajobs.control.k8s.k8sSupportsV1CronJob=false
+datajobs.control.k8s.k8sSupportsV1CronJob=${DATAJOBS_SUPPORT_V1CRONJOB:false}
 datajobs.control.k8s.jobTTLAfterFinishedSeconds=3600
 # Location to a K8s cronjob yaml file which will be used as a template
 # for all data jobs. If the location is missing, the default internal


### PR DESCRIPTION
Currently, if a user decides to use the `batch/v1` version of the kubernetes cronjob API, they need to set the `datajobs.control.k8s.k8sSupportsV1CronJob` application property to true. This, however, is a code change and applies to all deployment environments, which means that if the user has separate test and production setups, they cannot switch first one of the environments and then the second, they need to switch them both at the same time.

This change introduces an environment variable `DATAJOBS_SUPPORT_V1CRONJOB`, and adds support for setting it through the helm chart. The change, therefore, allows for the cronjob API to be switched per environment.

Testing Done: Tested locally against a local kind cluster.

Signed-off-by: Andon Andonov <andonova@vmware.com>