### PR TITLE
versatile-data-kit: update readme with mail list

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Create an [issue](https://github.com/vmware/versatile-data-kit/issues) or [pull 
     2. Joining the [#versatile-data-kit](https://cloud-native.slack.com/archives/C033PSLKCPR) channel.
 - Follow us on [Twitter](https://twitter.com/VDKProject).
 - Subscribe to the [Versatile Data Kit YouTube Channel](https://www.youtube.com/channel/UCasf2Q7X8nF7S4VEmcTHJ0Q).
-- Join our [dev mailing list](mailto:join-versatiledatakit@groups.vmware.com) (used by developers and maintainers of VDK).
+- Join our [development mailing list](mailto:join-versatiledatakit@groups.vmware.com), used by developers and maintainers of VDK.
 
 # Code of Conduct
 Everyone involved in working on the project's source code, or engaging in any issue trackers, Slack channels, and mailing lists is expected to be familiar with and follow the [Code of Conduct](https://github.com/vmware/versatile-data-kit/blob/main/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Create an [issue](https://github.com/vmware/versatile-data-kit/issues) or [pull 
     2. Joining the [#versatile-data-kit](https://cloud-native.slack.com/archives/C033PSLKCPR) channel.
 - Follow us on [Twitter](https://twitter.com/VDKProject).
 - Subscribe to the [Versatile Data Kit YouTube Channel](https://www.youtube.com/channel/UCasf2Q7X8nF7S4VEmcTHJ0Q).
-- Join our [mailing list](join-versatiledatakit@groups.vmware.com).
+- Join our [dev mailing list](mailto:join-versatiledatakit@groups.vmware.com) (used by developers and maintainers of VDK).
 
 # Code of Conduct
 Everyone involved in working on the project's source code, or engaging in any issue trackers, Slack channels, and mailing lists is expected to be familiar with and follow the [Code of Conduct](https://github.com/vmware/versatile-data-kit/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Our mailing list posted in https://github.com/vmware/versatile-data-kit#contacts is being used for project development/maintainer purposes (Gitlab CICD failure notifications,  expiring tokens, etc) so I will update the doc to reflect this. Also joining it is 3 step process and is not that easy (you need to click, then send an email and finally someone from the team manually need to add you to teh group)
We need mailing list for users that only a click but that is separate issue. 

Here I am updating it to make clear its usage. 
The mailing list was missing "mailto:" so it was not opening mail but trying to redirect browser and this is fixed also.

Signed-off-by: Antoni Ivnaov <aivanov@vmware.com>
 
