### PR TITLE
control-service: Cronjob API backwards compatibility

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudIT.java
@@ -28,6 +28,7 @@ import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.time.format.DateTimeFormatter;
@@ -42,6 +43,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @Import({DataJobDeploymentCrudIT.TaskExecutorConfig.class})
+@TestPropertySource(
+        properties = {
+                "datajobs.control.k8s.k8sSupportsV1CronJob=true",
+        })
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = ControlplaneApplication.class)

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudIT.java
@@ -44,9 +44,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @Import({DataJobDeploymentCrudIT.TaskExecutorConfig.class})
 @TestPropertySource(
-        properties = {
-                "datajobs.control.k8s.k8sSupportsV1CronJob=true",
-        })
+    properties = {
+      "datajobs.control.k8s.k8sSupportsV1CronJob=true",
+    })
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = ControlplaneApplication.class)

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -492,10 +492,11 @@ public abstract class KubernetesService implements InitializingBean {
    */
   public List<JobDeploymentStatus> readJobDeploymentStatuses() {
     if (getK8sSupportsV1CronJob()) {
-      return Stream.concat(readV1CronJobDeploymentStatuses().stream(), readV1beta1CronJobDeploymentStatuses().stream())
-              .collect(Collectors.toList());
-    }
-    else {
+      return Stream.concat(
+              readV1CronJobDeploymentStatuses().stream(),
+              readV1beta1CronJobDeploymentStatuses().stream())
+          .collect(Collectors.toList());
+    } else {
       return readV1beta1CronJobDeploymentStatuses();
     }
   }
@@ -768,15 +769,15 @@ public abstract class KubernetesService implements InitializingBean {
     log.debug("Listing k8s cron jobs");
     Set<String> v1Set = Collections.emptySet();
 
-    if(getK8sSupportsV1CronJob()) {
+    if (getK8sSupportsV1CronJob()) {
       var v1CronJobs =
-              new BatchV1Api(client)
-                      .listNamespacedCronJob(
-                              namespace, null, null, null, null, null, null, null, null, null, null);
+          new BatchV1Api(client)
+              .listNamespacedCronJob(
+                  namespace, null, null, null, null, null, null, null, null, null, null);
       v1Set =
-              v1CronJobs.getItems().stream()
-                      .map(j -> j.getMetadata().getName())
-                      .collect(Collectors.toSet());
+          v1CronJobs.getItems().stream()
+              .map(j -> j.getMetadata().getName())
+              .collect(Collectors.toSet());
       log.debug("K8s V1 cron jobs: {}", v1Set);
     }
 
@@ -1194,13 +1195,11 @@ public abstract class KubernetesService implements InitializingBean {
     if (getK8sSupportsV1CronJob()) {
       try {
         new BatchV1Api(client)
-                .deleteNamespacedCronJob(name, namespace, null, null, null, null, null, null);
+            .deleteNamespacedCronJob(name, namespace, null, null, null, null, null, null);
         log.debug("Deleted k8s cron job: {}", name);
         return;
       } catch (Exception e) {
-        log.debug(
-                "An exception occurred while trying to delete cron job. Message was: ",
-                e);
+        log.debug("An exception occurred while trying to delete cron job. Message was: ", e);
       }
     }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -468,7 +468,7 @@ public abstract class KubernetesService implements InitializingBean {
     log.debug("Reading k8s V1beta1 cron job: {}", cronJobName);
     V1beta1CronJob cronJob = null;
     try {
-      cronJob = new BatchV1beta1Api(client).readNamespacedCronJob(cronJobName, namespace, null);
+      cronJob = initBatchV1beta1Api().readNamespacedCronJob(cronJobName, namespace, null);
     } catch (ApiException e) {
       log.warn(
           "Could not read cron job: {}; reason: {}",
@@ -483,7 +483,7 @@ public abstract class KubernetesService implements InitializingBean {
     log.debug("Reading k8s V1 cron job: {}", cronJobName);
     V1CronJob cronJob = null;
     try {
-      cronJob = new BatchV1Api(client).readNamespacedCronJob(cronJobName, namespace, null);
+      cronJob = initBatchV1Api().readNamespacedCronJob(cronJobName, namespace, null);
     } catch (ApiException e) {
       log.warn(
           "Could not read cron job: {}; reason: {}",
@@ -516,7 +516,7 @@ public abstract class KubernetesService implements InitializingBean {
     V1beta1CronJobList cronJobs = null;
     try {
       cronJobs =
-          new BatchV1beta1Api(client)
+          initBatchV1beta1Api()
               .listNamespacedCronJob(
                   namespace, null, null, null, null, null, null, null, null, null, null);
     } catch (ApiException e) {
@@ -536,7 +536,7 @@ public abstract class KubernetesService implements InitializingBean {
     V1CronJobList cronJobs = null;
     try {
       cronJobs =
-          new BatchV1Api(client)
+          initBatchV1Api()
               .listNamespacedCronJob(
                   namespace, null, null, null, null, null, null, null, null, null, null);
     } catch (ApiException e) {
@@ -786,20 +786,18 @@ public abstract class KubernetesService implements InitializingBean {
     log.debug("Listing k8s cron jobs");
     Set<String> V1CronJobNames = Collections.emptySet();
 
-    if (getK8sSupportsV1CronJob()) {
-      var v1CronJobs =
-          new BatchV1Api(client)
-              .listNamespacedCronJob(
-                  namespace, null, null, null, null, null, null, null, null, null, null);
-      V1CronJobNames =
-          v1CronJobs.getItems().stream()
-              .map(j -> j.getMetadata().getName())
-              .collect(Collectors.toSet());
-      log.debug("K8s V1 cron jobs: {}", V1CronJobNames);
-    }
+    var v1CronJobs =
+        initBatchV1Api()
+            .listNamespacedCronJob(
+                namespace, null, null, null, null, null, null, null, null, null, null);
+    V1CronJobNames =
+        v1CronJobs.getItems().stream()
+            .map(j -> j.getMetadata().getName())
+            .collect(Collectors.toSet());
+    log.debug("K8s V1 cron jobs: {}", V1CronJobNames);
 
     var v1BetaCronJobs =
-        new BatchV1beta1Api(client)
+        initBatchV1beta1Api()
             .listNamespacedCronJob(
                 namespace, null, null, null, null, null, null, null, null, null, null);
     var V1BetaCronJobNames =

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -449,13 +449,13 @@ public abstract class KubernetesService implements InitializingBean {
 
   public Optional<JobDeploymentStatus> readCronJob(String cronJobName) {
     /**
-     * Reads the deployment status of a cron job in a Kubernetes cluster.
-     * The method first tries to read the cron job using the V1Beta API,
-     * and if it fails, it falls back to reading the cron job using the V1 API.
+     * Reads the deployment status of a cron job in a Kubernetes cluster. The method first tries to
+     * read the cron job using the V1Beta API, and if it fails, it falls back to reading the cron
+     * job using the V1 API.
      *
      * @param cronJobName the name of the cron job to be read
-     * @return an Optional containing the deployment status of the cron job if it exists,
-     *         or an empty Optional if the cron job does not exist or cannot be read
+     * @return an Optional containing the deployment status of the cron job if it exists, or an
+     *     empty Optional if the cron job does not exist or cannot be read
      */
     var jobStatus = readV1beta1CronJob(cronJobName);
 
@@ -775,8 +775,8 @@ public abstract class KubernetesService implements InitializingBean {
 
   public Set<String> listCronJobs() throws ApiException {
     /**
-     * Returns a set of cron job names for a given namespace in a Kubernetes cluster.
-     * The cron jobs can be of version V1 or V1Beta.
+     * Returns a set of cron job names for a given namespace in a Kubernetes cluster. The cron jobs
+     * can be of version V1 or V1Beta.
      *
      * @return a set of cron job names
      * @throws ApiException if there is a problem accessing the Kubernetes API
@@ -805,7 +805,8 @@ public abstract class KubernetesService implements InitializingBean {
             .map(j -> j.getMetadata().getName())
             .collect(Collectors.toSet());
     log.debug("K8s V1Beta cron jobs: {}", V1BetaCronJobNames);
-    return Stream.concat(V1CronJobNames.stream(), V1BetaCronJobNames.stream()).collect(Collectors.toSet());
+    return Stream.concat(V1CronJobNames.stream(), V1BetaCronJobNames.stream())
+        .collect(Collectors.toSet());
   }
 
   public void createCronJob(

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -241,8 +241,7 @@ public abstract class KubernetesService implements InitializingBean {
     // Step 1 - load the internal datajob template in order to validate it.
     try {
       if (getK8sSupportsV1CronJob()) {
-        loadV1CronjobTemplate(
-            new ClassPathResource(V1_K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
+        loadV1CronjobTemplate(new ClassPathResource(V1_K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
       } else {
         loadV1beta1CronjobTemplate(new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
       }
@@ -452,12 +451,12 @@ public abstract class KubernetesService implements InitializingBean {
 
   /**
    * Reads the deployment status of a cron job in a Kubernetes cluster. The method first tries to
-   * read the cron job using the V1Beta API, and if it fails, it falls back to reading the cron
-   * job using the V1 API.
+   * read the cron job using the V1Beta API, and if it fails, it falls back to reading the cron job
+   * using the V1 API.
    *
    * @param cronJobName the name of the cron job to be read
-   * @return an Optional containing the deployment status of the cron job if it exists, or an
-   *     empty Optional if the cron job does not exist or cannot be read
+   * @return an Optional containing the deployment status of the cron job if it exists, or an empty
+   *     Optional if the cron job does not exist or cannot be read
    */
   public Optional<JobDeploymentStatus> readCronJob(String cronJobName) {
     var jobStatus = readV1beta1CronJob(cronJobName);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -1024,7 +1024,7 @@ public abstract class KubernetesService implements InitializingBean {
       List<V1Volume> volumes,
       Map<String, String> jobDeploymentAnnotations)
       throws ApiException {
-    if (readV1CronJob(name).isPresent()) {
+    if (getK8sSupportsV1CronJob()) {
       updateV1CronJob(
           name,
           image,
@@ -1081,7 +1081,7 @@ public abstract class KubernetesService implements InitializingBean {
       Map<String, String> jobLabels,
       List<String> imagePullSecrets)
       throws ApiException {
-    if (readV1CronJob(name).isPresent()) {
+    if (getK8sSupportsV1CronJob()) {
       updateV1CronJob(
           name,
           image,

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -240,7 +240,7 @@ public abstract class KubernetesService implements InitializingBean {
     // Step 1 - load the internal datajob template in order to validate it.
     try {
       if (getK8sSupportsV1CronJob()) {
-        loadV1CronjobTemplate(new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
+        loadV1CronjobTemplate(new ClassPathResource("v1-" + K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
       } else {
         loadV1beta1CronjobTemplate(new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
       }
@@ -313,7 +313,7 @@ public abstract class KubernetesService implements InitializingBean {
 
   private V1CronJob loadInternalV1CronjobTemplate() {
     try {
-      return loadV1CronjobTemplate(new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
+      return loadV1CronjobTemplate(new ClassPathResource("v1-" + K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
     } catch (Exception e) {
       // This should never happen unless we are testing locally and we've messed up
       // with the internal template resource file.

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -240,7 +240,8 @@ public abstract class KubernetesService implements InitializingBean {
     // Step 1 - load the internal datajob template in order to validate it.
     try {
       if (getK8sSupportsV1CronJob()) {
-        loadV1CronjobTemplate(new ClassPathResource("v1-" + K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
+        loadV1CronjobTemplate(
+            new ClassPathResource("v1-" + K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
       } else {
         loadV1beta1CronjobTemplate(new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
       }
@@ -313,7 +314,8 @@ public abstract class KubernetesService implements InitializingBean {
 
   private V1CronJob loadInternalV1CronjobTemplate() {
     try {
-      return loadV1CronjobTemplate(new ClassPathResource("v1-" + K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
+      return loadV1CronjobTemplate(
+          new ClassPathResource("v1-" + K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
     } catch (Exception e) {
       // This should never happen unless we are testing locally and we've messed up
       // with the internal template resource file.

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/v1-k8s-data-job-template.yaml
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/v1-k8s-data-job-template.yaml
@@ -1,0 +1,40 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations:                   # merged with additional annotations from TPCS
+  name: cronjob-template-name    # overridden by TPCS
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 2
+  schedule: "*/10 * * * *"       # overridden by TPCS
+  startingDeadlineSeconds: 1800
+  successfulJobsHistoryLimit: 1
+  suspend: false                 # overridden by TPCS
+  jobTemplate:
+    metadata:
+      annotations: # merged with additional annotations from TPCS
+      labels: # merged with additional labels from TPCS
+    spec:
+      activeDeadlineSeconds: 43200
+      backoffLimit: 3
+      template:
+        metadata:
+          labels:                # merged with additional labels from TPCS
+        spec:
+          containers:            # overridden by TPCS
+          - command:
+            - /bin/sh
+            - -c
+            - date; echo '************** Cronjob Template ******************'
+            name: cronjob-template-container-name
+            image: busybox
+            imagePullPolicy: IfNotPresent
+          restartPolicy: OnFailure
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+      ttlSecondsAfterFinished: 600

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/v1-k8s-data-job-template.yaml
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/v1-k8s-data-job-template.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: batch/v1

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -446,8 +446,8 @@ public class KubernetesServiceTest {
     v1DeploymentStatus.setCronJobName("v1TestJob");
     v1TestList.add(v1DeploymentStatus);
 
-    var mergedTestLists = Stream.concat(v1TestList.stream(), v1BetaTestList.stream())
-            .collect(Collectors.toList());
+    var mergedTestLists =
+        Stream.concat(v1TestList.stream(), v1BetaTestList.stream()).collect(Collectors.toList());
 
     Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(true);
     Mockito.when(mock.readV1CronJobDeploymentStatuses()).thenReturn(v1TestList);

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -17,9 +17,6 @@ import com.vmware.taurus.service.model.JobAnnotation;
 import com.vmware.taurus.service.model.JobDeploymentStatus;
 import com.vmware.taurus.service.model.JobLabel;
 import io.kubernetes.client.custom.Quantity;
-import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.openapi.apis.BatchV1Api;
-import io.kubernetes.client.openapi.apis.BatchV1beta1Api;
 import io.kubernetes.client.openapi.models.*;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.jupiter.api.Assertions;
@@ -479,17 +476,19 @@ public class KubernetesServiceTest {
     Mockito.when(mock.readV1CronJob(testCronjobName)).thenReturn(Optional.of(testDeploymentStatus));
 
     Assertions.assertNotNull(mock.readCronJob(testCronjobName));
-    Assertions.assertEquals(testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
+    Assertions.assertEquals(
+        testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
     verify(mock, times(2)).readV1beta1CronJob(testCronjobName);
     verify(mock, times(2)).readV1CronJob(testCronjobName);
 
-
     // Scenario 2: readV1beta1CronJob method should return status.
-    Mockito.when(mock.readV1beta1CronJob(testCronjobName)).thenReturn(Optional.of(testDeploymentStatus));
+    Mockito.when(mock.readV1beta1CronJob(testCronjobName))
+        .thenReturn(Optional.of(testDeploymentStatus));
     Mockito.when(mock.readV1CronJob(testCronjobName)).thenReturn(Optional.empty());
 
     Assertions.assertNotNull(mock.readCronJob(testCronjobName));
-    Assertions.assertEquals(testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
+    Assertions.assertEquals(
+        testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
     verify(mock, times(4)).readV1beta1CronJob(testCronjobName);
     verify(mock, times(2)).readV1CronJob(testCronjobName);
   }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -493,12 +493,12 @@ public class KubernetesServiceTest {
     Mockito.when(mock.readCronJob(testCronjobName)).thenCallRealMethod();
 
     Mockito.when(mock.readV1beta1CronJob(testCronjobName))
-            .thenReturn(Optional.of(testDeploymentStatus));
+        .thenReturn(Optional.of(testDeploymentStatus));
     Mockito.when(mock.readV1CronJob(testCronjobName)).thenReturn(Optional.empty());
 
     Assertions.assertNotNull(mock.readCronJob(testCronjobName));
     Assertions.assertEquals(
-            testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
+        testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
     verify(mock, times(2)).readV1beta1CronJob(testCronjobName);
     verify(mock, times(0)).readV1CronJob(testCronjobName);
   }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -461,7 +461,7 @@ public class KubernetesServiceTest {
   }
 
   @Test
-  public void testReadCronJob() {
+  public void testReadCronJob_readV1CronJobShouldReturnStatus() {
     String testCronjobName = "testCronjob";
     KubernetesService mock = Mockito.mock(KubernetesService.class);
 
@@ -471,7 +471,6 @@ public class KubernetesServiceTest {
     testDeploymentStatus.setCronJobName(testCronjobName);
     Mockito.when(mock.readCronJob(testCronjobName)).thenCallRealMethod();
 
-    // Scenario 1: readV1CronJob method should return status.
     Mockito.when(mock.readV1beta1CronJob(testCronjobName)).thenReturn(Optional.empty());
     Mockito.when(mock.readV1CronJob(testCronjobName)).thenReturn(Optional.of(testDeploymentStatus));
 
@@ -480,17 +479,28 @@ public class KubernetesServiceTest {
         testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
     verify(mock, times(2)).readV1beta1CronJob(testCronjobName);
     verify(mock, times(2)).readV1CronJob(testCronjobName);
+  }
 
-    // Scenario 2: readV1beta1CronJob method should return status.
+  @Test
+  public void testReadCronJob_readV1beta1CronJobShouldReturnStatus() {
+    String testCronjobName = "testCronjob";
+    KubernetesService mock = Mockito.mock(KubernetesService.class);
+
+    JobDeploymentStatus testDeploymentStatus = new JobDeploymentStatus();
+    testDeploymentStatus.setEnabled(false);
+    testDeploymentStatus.setDataJobName(testCronjobName);
+    testDeploymentStatus.setCronJobName(testCronjobName);
+    Mockito.when(mock.readCronJob(testCronjobName)).thenCallRealMethod();
+
     Mockito.when(mock.readV1beta1CronJob(testCronjobName))
-        .thenReturn(Optional.of(testDeploymentStatus));
+            .thenReturn(Optional.of(testDeploymentStatus));
     Mockito.when(mock.readV1CronJob(testCronjobName)).thenReturn(Optional.empty());
 
     Assertions.assertNotNull(mock.readCronJob(testCronjobName));
     Assertions.assertEquals(
-        testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
-    verify(mock, times(4)).readV1beta1CronJob(testCronjobName);
-    verify(mock, times(2)).readV1CronJob(testCronjobName);
+            testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
+    verify(mock, times(2)).readV1beta1CronJob(testCronjobName);
+    verify(mock, times(0)).readV1CronJob(testCronjobName);
   }
 
   @Test

--- a/projects/control-service/projects/pipelines_control_service/src/test/resources/v1-k8s-data-job-template.yaml
+++ b/projects/control-service/projects/pipelines_control_service/src/test/resources/v1-k8s-data-job-template.yaml
@@ -1,0 +1,44 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations:                   # merged with additional annotations from TPCS
+    annotation1: valueAnnotation1
+    annotation2: valueAnnotation2
+  name: to-be-tested             # overridden by TPCS
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 2
+  schedule: "to-be-tested"       # overridden by TPCS
+  startingDeadlineSeconds: 1800
+  successfulJobsHistoryLimit: 1
+  suspend: false                 # overridden by TPCS
+  jobTemplate:
+    metadata:
+      annotations: # merged with additional annotations from TPCS
+      labels: # merged with additional labels from TPCS
+    spec:
+      activeDeadlineSeconds: 129600
+      backoffLimit: 3
+      template:
+        metadata:
+          labels:                # merged with additional labels from TPCS
+            label1: valueLabel1
+            label2: valueLabel2
+        spec:
+          containers:            # overridden by TPCS
+          - command:
+            - /bin/sh
+            - -c
+            - date; echo '************** Cronjob Template ******************'
+            name: cronjob-template-container-name
+            image: busybox
+            imagePullPolicy: IfNotPresent
+          restartPolicy: OnFailure
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+      ttlSecondsAfterFinished: 600


### PR DESCRIPTION
Currently there is no backwards compatibility support when a user switches to the V1 Kubernetes Cronjob API (from the currently default V1beta1). This results in situations, where if there are deployed data jobs which use the v1beta1 API, and a switch is made to the V1 API, these jobs are suddenly shown as `NOT DEPLOYED`, and cannot be properly managed.

This change adds backwards compatibility support in the Kubernetes Service, to allow for a switch to V1 Cronjob API in clusters, where V1beta1 API cronjobs are deployed.

Testing Done: Unit and Integration tests (new and existing).

Signed-off-by: Andon Andonov <andonova@vmware.com>