### PR TITLE
vdk-frontend: include readmes for the data-pipelines folders

### DIFF
--- a/projects/frontend/data-pipelines/README.md
+++ b/projects/frontend/data-pipelines/README.md
@@ -1,0 +1,7 @@
+# VDK Data Pipelines UI
+
+Welcome to VDK Data Pipelines UI, part of [Project Taurus](https://confluence.eng.vmware.com/display/TAURUS/Project+Taurus).
+
+To get started using Data Pipelines check the [Angular project Readme](projects/gui/README.md)
+To learn more about the project, see:
+- [README.md](/specs/vep-1507-vdk-operations-ui/README.md)

--- a/projects/frontend/data-pipelines/README.md
+++ b/projects/frontend/data-pipelines/README.md
@@ -1,7 +1,5 @@
 # VDK Data Pipelines UI
 
-Welcome to VDK Data Pipelines UI, part of [Project Taurus](https://confluence.eng.vmware.com/display/TAURUS/Project+Taurus).
-
 To get started using Data Pipelines check the [Angular project Readme](projects/gui/README.md)
 To learn more about the project, see:
 - [README.md](/specs/vep-1507-vdk-operations-ui/README.md)

--- a/projects/frontend/data-pipelines/projects/gui/README.md
+++ b/projects/frontend/data-pipelines/projects/gui/README.md
@@ -3,7 +3,7 @@
 The gui part of data-pipelines contains:
 
   * **[Data Pipelines](projects/data-pipelines/README.md)** Library that holds UI Components for managing Data Pipeline API.
-  * **[UI](projects/ui/src)** Reference UI Wrapper Implementation of the Data Pipeline library
+  * **[UI](projects/ui/src)** Default UI Wrapper Implementation of the Data Pipeline library
 
 The wrapper ([ui](projects/ui/src)) provides standard OAuth2 authorization flow, configuration of which could be found in [auth.ts](projects/ui/src/app/auth.ts)
 

--- a/projects/frontend/data-pipelines/projects/gui/README.md
+++ b/projects/frontend/data-pipelines/projects/gui/README.md
@@ -86,7 +86,7 @@ _**Note**_: Code coverage report will be generated in `reports/coverage`(for the
 
 _**Note**_: Code coverage report for the Data Pipeline library will be also logged in the Console(and consumed by the CI/CD)
 
-TODO re-visit when OAuth is agreed on
+[TODO](https://github.com/vmware/versatile-data-kit/issues/1610) re-visit when OAuth is agreed on
 [E2E] Run `npx cypress open --env OAUTH2_API_TOKEN=<the API token>` to open [Cypress](https://www.cypress.io/) dev tool for e2e testing
 * Configuring the e2e tests environment: In `cypress.json > env` section are configured `login_url` and `data_jobs_url`
  that are used by the e2e tests. To override the values a feasible option is to create a local file: `cypress.env.json`
@@ -105,7 +105,7 @@ _**Note**_: Chrome may have sporadic issues running the tests in headed mode. To
 1. Use an other browser(Firefox, Chromium, or  Electron)
 2. Run the tests in headless mode: `npx cypress run --browser chrome --headless --env OAUTH2_API_TOKEN=<the API token>`
 
-TODO re-visit when OAuth is agreed on
+[TODO](https://github.com/vmware/versatile-data-kit/issues/1610) re-visit when OAuth is agreed on
 _**Important note**_: e2e tests require OAuth2 API token to initiate the Code login flow against OAuth endpoint.
 *  On _**Unix environments**_(one time): `export OAUTH2_API_TOKEN=<the API token | OAuth_DP_USER_API_TOKEN variable value from CI/CD>`
 *  On _**Windows environments**_(each time): `npx cypress open --env OAUTH2_API_TOKEN=<the API token | OAuth_DP_USER_API_TOKEN variable value from CI/CD>`

--- a/projects/frontend/data-pipelines/projects/gui/README.md
+++ b/projects/frontend/data-pipelines/projects/gui/README.md
@@ -119,8 +119,6 @@ _**Note**_: There are two levels of filtering of the E2E tests that constitutes 
 2. More granular tag selection: `grepTags=@integration`. e.g.: `it('Manage page - grid search', { tags: '@integration' }, () => {` or
    `describe('Data Jobs Manage Page', { tags: '@integration' }, () => {`
 
-_**Important note**_: In order to ensure the ability to run the Integration Suite against the Data Jobs Wrapper UI and the Management Console UI
-as part of the TMS Staging pipeline, it is required to ensure that the test suite runs successfully against both the UIs(local and/or TMS Staging instance)
 
 ### Local Proxy Configuration
 

--- a/projects/frontend/data-pipelines/projects/gui/README.md
+++ b/projects/frontend/data-pipelines/projects/gui/README.md
@@ -1,0 +1,128 @@
+# VDK Data Pipeline UI
+
+The gui part of data-pipelines contains:
+
+  * **[Data Pipelines](projects/data-pipelines/README.md)** Library that holds UI Components for managing Data Pipeline API.
+  * **[UI](projects/ui/src)** Reference UI Wrapper Implementation of the Data Pipeline library
+
+The wrapper ([ui](projects/ui/src)) provides standard OAuth2 authorization flow, configuration of which could be found in [auth.ts](projects/ui/src/app/auth.ts)
+
+## Running and Testing
+
+You can use the reference implementation in `projects/ui` as showcase of the library.
+Using `npm link` you can achieve real-time development of the library without the need to upload it to repository
+
+_**Note**_: If you run directly npm install without linking it will tell you that there is no such package.
+That's why you need to link it the first time you build your development environment.
+
+Refer to [.gitlab-ci.yml](../../.gitlab-ci.yml) file for correct setup guaranteed to work by automation.
+Bug in general the steps are:
+
+0. Set npm registry to use
+   ```bash
+   $ npm config set legacy-peer-deps true
+   ```
+1. Install Angular Cli and all other dependencies except '@vdk/data-pipelines'
+   ```bash
+   npm i -g @angular/cli@13
+   ```
+   ```bash
+   npm ci --omit=optional
+   ```
+2. Build the data-pipelines UI library
+   ```bash
+   npm run build
+   ```
+3. Go to the build dir
+   ```bash
+   cd dist/data-pipelines
+   ```
+4. Link it to local repo
+   ```bash
+   npm link
+   ```
+5. Return to project dir
+   ```bash
+   cd ../../
+   ```
+6. Create symlink from build artifact to the wrapper ui (ui)
+   ```bash
+   npm link @vdk/data-pipelines
+   ```
+7. Start the wrapper ui application, serve on [http://localhost.vmware.com:4200](http://localhost.vmware.com:4200)
+   ```bash
+   npm start
+   ```
+
+## Adding boilerplate code
+
+This project is using [NX](https://nx.dev/latest/angular/getting-started/getting-started).
+It supports many plugins which add capabilities for developing different types of applications and different tools.
+These capabilities include generating applications, libraries, etc as well as the devtools to test, and build projects as well.
+
+### Generate a library
+
+Run `ng g @nrwl/angular:lib <my-lib>` to generate a library.
+
+Libraries are shareable across libraries and applications. They can be imported from `@vdk/<mylib>`.
+
+### Code scaffolding
+Run `ng generate component component-name --project ui` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module --project ui`.
+> Note: Don't forget to add `--project ui` or else it will be added to the default project in your `angular.json` file.
+
+Also, this project uses [NgRx](https://ngrx.io/) for state management, you can check their [schematics](https://ngrx.io/guide/schematics) for code generation like:
+```shell
+ng generate @ngrx/schematics:effect Teams --module app.module.ts
+```
+
+### Linting
+Run `npm run lint` to execute lint via [ESLint](https://eslint.org/docs/user-guide/getting-started).
+
+### Running tests
+
+[Unit] Run `npm run test` to execute the unit tests via [Karma](https://karma-runner.github.io).
+
+_**Note**_: Code coverage report will be generated in `reports/coverage`(for the UI Wrapper and the Data Pipeline Library)
+
+_**Note**_: Code coverage report for the Data Pipeline library will be also logged in the Console(and consumed by the CI/CD)
+
+TODO re-visit when OAuth is agreed on
+[E2E] Run `npx cypress open --env OAUTH2_API_TOKEN=<the API token>` to open [Cypress](https://www.cypress.io/) dev tool for e2e testing
+* Configuring the e2e tests environment: In `cypress.json > env` section are configured `login_url` and `data_jobs_url`
+ that are used by the e2e tests. To override the values a feasible option is to create a local file: `cypress.env.json`
+ that will provide the overriden values like:
+  `{
+  "data_jobs_url": "http://localhost:8092"
+  }`
+
+   See: https://docs.cypress.io/guides/guides/environment-variables.html#Setting
+
+_**Note**_: Capturing HAR reports. In order to capture the HAR reports(default location: `e2e/hars`) during the e2e tests execution
+ you need to run the tests using Chrome browser.
+Example run: `npx cypress run --browser chrome --env OAUTH2_API_TOKEN=<the API token>`
+
+_**Note**_: Chrome may have sporadic issues running the tests in headed mode. To overcome this you can:
+1. Use an other browser(Firefox, Chromium, or  Electron)
+2. Run the tests in headless mode: `npx cypress run --browser chrome --headless --env OAUTH2_API_TOKEN=<the API token>`
+
+TODO re-visit when OAuth is agreed on
+_**Important note**_: e2e tests require OAuth2 API token to initiate the Code login flow against OAuth endpoint.
+*  On _**Unix environments**_(one time): `export OAUTH2_API_TOKEN=<the API token | OAuth_DP_USER_API_TOKEN variable value from CI/CD>`
+*  On _**Windows environments**_(each time): `npx cypress open --env OAUTH2_API_TOKEN=<the API token | OAuth_DP_USER_API_TOKEN variable value from CI/CD>`
+
+[Integration Suite] The integration suite of Data Jobs UIs(that runs against TMS Staging env) as part of the Management Service console Integration Tests
+is a subset of the E2E cypress tests that are filtered with `--env grepTags=@integration` and `--spec "e2e/integration/**/*.int.spec.js"`
+Example run: `npx cypress run --env OAUTH2_API_TOKEN=<the API token>,grepTags=@integration --spec "e2e/integration/**/*.int.spec.js"`
+
+_**Note**_: There are two levels of filtering of the E2E tests that constitutes the Integration Suite:
+1. Naming convention for the test filename: *.int.spec.js - to avoid unnecessary scanning and execution of before etc. hooks
+2. More granular tag selection: `grepTags=@integration`. e.g.: `it('Manage page - grid search', { tags: '@integration' }, () => {` or
+   `describe('Data Jobs Manage Page', { tags: '@integration' }, () => {`
+
+_**Important note**_: In order to ensure the ability to run the Integration Suite against the Data Jobs Wrapper UI and the Management Console UI
+as part of the TMS Staging pipeline, it is required to ensure that the test suite runs successfully against both the UIs(local and/or TMS Staging instance)
+
+### Local Proxy Configuration
+
+You can check [proxy.config.json](proxy.config.json) file to route the data pipelines to specific server
+either local or some other test env.

--- a/projects/frontend/data-pipelines/projects/gui/README.md
+++ b/projects/frontend/data-pipelines/projects/gui/README.md
@@ -9,7 +9,7 @@ The wrapper ([ui](projects/ui/src)) provides standard OAuth2 authorization flow,
 
 ## Running and Testing
 
-You can use the reference implementation in `projects/ui` as showcase of the library.
+You can use Frontend implementation in `projects/ui`.
 Using `npm link` you can achieve real-time development of the library without the need to upload it to repository
 
 _**Note**_: If you run directly npm install without linking it will tell you that there is no such package.

--- a/projects/frontend/data-pipelines/projects/gui/projects/data-pipelines/README.md
+++ b/projects/frontend/data-pipelines/projects/gui/projects/data-pipelines/README.md
@@ -20,7 +20,7 @@ npm i @clr/{angular,icons,ui} # Clarity (UI Components like DataGrid)
 ```typescript
 imports: [
   ...
-  TaurusharedCoreModule.forRoot(), // taurus shared core services
+  TaurusSharedCoreModule.forRoot(), // taurus shared core services
   TaurusSharedFeaturesModule.forRoot(), // taurus shared features
   TaurusSharedNgRxModule.forRootWithDevtools(), // vdk redux actual ngrx implementation
   ...

--- a/projects/frontend/data-pipelines/projects/gui/projects/data-pipelines/README.md
+++ b/projects/frontend/data-pipelines/projects/gui/projects/data-pipelines/README.md
@@ -1,4 +1,4 @@
-# Taurus Data Pipelines
+# Data Pipelines Frontend
 
 Data Pipelines help Data Engineers develop, deploy, run, and manage data processing workloads (called "Data Job").
 This library provides UI screens that helps to manage data jobs via Data Pipelines API.

--- a/projects/frontend/data-pipelines/projects/gui/projects/data-pipelines/README.md
+++ b/projects/frontend/data-pipelines/projects/gui/projects/data-pipelines/README.md
@@ -5,7 +5,6 @@ This library provides UI screens that helps to manage data jobs via [Data Pipeli
 
 ## Implementation
 
-
 ### Include the packages and ngrx dependencies
 ```shell
 npm i @vdk/{data-pipelines,shared} # Actual library

--- a/projects/frontend/data-pipelines/projects/gui/projects/data-pipelines/README.md
+++ b/projects/frontend/data-pipelines/projects/gui/projects/data-pipelines/README.md
@@ -79,4 +79,4 @@ Run `npm run test` to execute the unit tests via [Karma](https://karma-runner.gi
 ### Testing
 
 You can use the reference implementation in <project_root>/projects/gui/projects/ui as showcase of the library.
-Using `npm link` you can achieve real-time development of the library without the need to upload it to repository
+Using `npm link`(https://docs.npmjs.com/cli/v9/commands/npm-link) you can achieve real-time development of the library without the need to upload it to repository

--- a/projects/frontend/data-pipelines/projects/gui/projects/data-pipelines/README.md
+++ b/projects/frontend/data-pipelines/projects/gui/projects/data-pipelines/README.md
@@ -1,7 +1,7 @@
 # Data Pipelines Frontend
 
 Data Pipelines help Data Engineers develop, deploy, run, and manage data processing workloads (called "Data Job").
-This library provides UI screens that helps to manage data jobs via Data Pipelines API.
+This library provides UI screens that helps to manage data jobs via [Data Pipelines API](/projects/control-service/projects/model/apidefs/datajob-api/api.yaml).
 
 ## Implementation
 

--- a/projects/frontend/data-pipelines/projects/gui/projects/data-pipelines/README.md
+++ b/projects/frontend/data-pipelines/projects/gui/projects/data-pipelines/README.md
@@ -20,9 +20,9 @@ npm i @clr/{angular,icons,ui} # Clarity (UI Components like DataGrid)
 ```typescript
 imports: [
   ...
-  VdkSharedCoreModule.forRoot(), // vdk shared core services
-  VdkSharedFeaturesModule.forRoot(), // vdk shared features
-  VdkSharedNgRxModule.forRootWithDevtools(), // vdk redux actual ngrx implementation
+  TaurusharedCoreModule.forRoot(), // vdk taurus core services
+  TaurusSharedFeaturesModule.forRoot(), // vdk taurus features
+  TaurusSharedNgRxModule.forRootWithDevtools(), // vdk redux actual ngrx implementation
   ...
 ]
 ```

--- a/projects/frontend/data-pipelines/projects/gui/projects/data-pipelines/README.md
+++ b/projects/frontend/data-pipelines/projects/gui/projects/data-pipelines/README.md
@@ -20,8 +20,8 @@ npm i @clr/{angular,icons,ui} # Clarity (UI Components like DataGrid)
 ```typescript
 imports: [
   ...
-  TaurusharedCoreModule.forRoot(), // vdk taurus core services
-  TaurusSharedFeaturesModule.forRoot(), // vdk taurus features
+  TaurusharedCoreModule.forRoot(), // taurus shared core services
+  TaurusSharedFeaturesModule.forRoot(), // taurus shared features
   TaurusSharedNgRxModule.forRootWithDevtools(), // vdk redux actual ngrx implementation
   ...
 ]

--- a/projects/frontend/data-pipelines/projects/gui/projects/data-pipelines/README.md
+++ b/projects/frontend/data-pipelines/projects/gui/projects/data-pipelines/README.md
@@ -1,0 +1,82 @@
+# Taurus Data Pipelines
+
+Data Pipelines help Data Engineers develop, deploy, run, and manage data processing workloads (called "Data Job").
+This library provides UI screens that helps to manage data jobs via Data Pipelines API.
+
+## Implementation
+
+
+### Include the packages and ngrx dependencies
+```shell
+npm i @vdk/{data-pipelines,shared} # Actual library
+npm i @ngrx/{effects,entity,router-store,@ngrx/store} # NgRx (store management)
+npm i @clr/{angular,icons,ui} # Clarity (UI Components like DataGrid)
+
+```
+
+### Include the module and router
+
+1. In `app.module.ts` include ngrx modules and actual Data Pipeline module
+```typescript
+imports: [
+  ...
+  VdkSharedCoreModule.forRoot(), // vdk shared core services
+  VdkSharedFeaturesModule.forRoot(), // vdk shared features
+  VdkSharedNgRxModule.forRootWithDevtools(), // vdk redux actual ngrx implementation
+  ...
+]
+```
+
+2. in `app.router.ts` you can specify the parent path for data pipelines screens.
+   This example shows how can we expose the data jobs list by using `data-pipelines` string as parent.
+```typescript
+const routes: Routes = [
+  ...
+  {
+    path: 'data-pipelines',
+    loadChildren: () => import('@vdk/data-pipelines').then(m => m.DataPipelinesRouting)
+  },
+  ...
+]
+
+@NgModule({
+  imports: [RouterModule.forRoot(routes, routerOptions)],
+  exports: [RouterModule]
+})
+export class AppRouting {
+}
+```
+**Note:** You can inspect the [data-pipelines.routing.ts](src/lib/data-pipelines.routing.ts) to see what pages could be routed
+
+### Configure the route
+
+3. In `app.component.ts` somewhere in you menu you can include a link to the data jobs list, like:
+```angular2html
+<a id="navDataJobs" routerLink="/data-pipelines/list">Data Jobs</a>
+```
+
+## Code scaffolding
+
+Run `ng generate component component-name --project data-pipelines` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module --project data-pipelines`.
+> Note: Don't forget to add `--project data-pipelines` or else it will be added to the default project in your `angular.json` file.
+
+Also, this project uses [NgRx](https://ngrx.io/) for state management, you can check their [schematics](https://ngrx.io/guide/schematics) for code generation like:
+```shell
+ng generate @ngrx/schematics:effect DataJobs --module data-pipelines.module.ts
+```
+## Build & Running
+
+Run `npm run build` to build the project. The build artifacts will be stored in the `dist/` directory.
+
+### Publishing
+
+After building your library with `npm run build`, go to the dist folder `cd dist/data-pipelines` and run `npm publish`.
+
+### Running unit tests
+
+Run `npm run test` to execute the unit tests via [Karma](https://karma-runner.github.io).
+
+### Testing
+
+You can use the reference implementation in <project_root>/projects/gui/projects/ui as showcase of the library.
+Using `npm link` you can achieve real-time development of the library without the need to upload it to repository

--- a/projects/frontend/data-pipelines/projects/gui/projects/data-pipelines/README.md
+++ b/projects/frontend/data-pipelines/projects/gui/projects/data-pipelines/README.md
@@ -1,6 +1,6 @@
-# Data Pipelines Frontend
+# VDK Frontend
 
-Data Pipelines help Data Engineers develop, deploy, run, and manage data processing workloads (called "Data Job").
+VDK Frontend help Data Engineers develop, deploy, run, and manage data processing workloads (called "Data Job").
 This library provides UI screens that helps to manage data jobs via [Data Pipelines API](/projects/control-service/projects/model/apidefs/datajob-api/api.yaml).
 
 ## Implementation

--- a/projects/frontend/data-pipelines/projects/gui/projects/data-pipelines/README.md
+++ b/projects/frontend/data-pipelines/projects/gui/projects/data-pipelines/README.md
@@ -78,5 +78,5 @@ Run `npm run test` to execute the unit tests via [Karma](https://karma-runner.gi
 
 ### Testing
 
-You can use the reference implementation in <project_root>/projects/gui/projects/ui as showcase of the library.
+You can use the implementation in <project_root>/projects/gui/projects/ui as showcase of the library.
 Using `npm link`(https://docs.npmjs.com/cli/v9/commands/npm-link) you can achieve real-time development of the library without the need to upload it to repository


### PR DESCRIPTION
# Why
Before merging the frontend code we want to make sure the readmes are clearly explaining the project/where to find everything and how to buid everything. 

# What
1. Copied the readmes from the private repo. 
2. Removed references to CSP auth and replaced it with TODOs to be tackled once we can authenticate with a different oauth provider. 
3. removed references to extensibility. 


