### PR TITLE
control-service: cleanup kubernetesService class

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -5,21 +5,12 @@
 
 package com.vmware.taurus.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
-import com.google.common.collect.Iterables;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
-import com.vmware.taurus.exception.JsonDissectException;
 import com.vmware.taurus.exception.KubernetesException;
-import com.vmware.taurus.exception.KubernetesJobDefinitionException;
-import com.vmware.taurus.exception.DataJobExecutionCannotBeCancelledException;
-import com.vmware.taurus.exception.ExecutionCancellationFailureReason;
-import com.vmware.taurus.service.deploy.DockerImageName;
-import com.vmware.taurus.service.deploy.JobCommandProvider;
 import com.vmware.taurus.service.model.JobAnnotation;
-import com.vmware.taurus.service.model.JobDeploymentStatus;
 import com.vmware.taurus.service.model.JobLabel;
 import com.vmware.taurus.service.threads.ThreadPoolConf;
 import io.kubernetes.client.openapi.ApiClient;
@@ -29,22 +20,18 @@ import io.kubernetes.client.PodLogs;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
 import io.kubernetes.client.openapi.apis.BatchV1beta1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
-import io.kubernetes.client.openapi.apis.VersionApi;
 import io.kubernetes.client.custom.IntOrString;
 import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.openapi.models.*;
 import io.kubernetes.client.util.ClientBuilder;
 import io.kubernetes.client.util.KubeConfig;
 import io.kubernetes.client.util.Watch;
-import io.kubernetes.client.util.Yaml;
 import lombok.*;
 import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
@@ -84,7 +71,6 @@ public abstract class KubernetesService implements InitializingBean {
 
   public static final String LABEL_PREFIX = "com.vmware.taurus";
   private static final int WATCH_JOBS_TIMEOUT_SECONDS = 300;
-  private static final String K8S_DATA_JOB_TEMPLATE_RESOURCE = "k8s-data-job-template.yaml";
 
   private static int fromInteger(Integer value) {
     return Optional.ofNullable(value).orElse(0);
@@ -170,42 +156,30 @@ public abstract class KubernetesService implements InitializingBean {
     @Getter private final String value;
   }
 
-  // The 'Value' annotation from Lombok collides with the 'Value' annotation from Spring.
-  @org.springframework.beans.factory.annotation.Value(
-      "${datajobs.control.k8s.data.job.template.file}")
-  private String datajobTemplateFileLocation;
 
   @org.springframework.beans.factory.annotation.Value(
       "${datajobs.control.k8s.jobTTLAfterFinishedSeconds}")
-  private int jobTTLAfterFinishedSeconds;
+  protected int jobTTLAfterFinishedSeconds;
 
-  private String namespace;
+  protected String namespace;
   private String kubeconfig;
   private Logger log;
-  private boolean k8sSupportsV1CronJob;
-  private ApiClient client;
+
+  protected ApiClient client;
 
   @Autowired private UserAgentService userAgentService;
-
-  @Autowired private JobCommandProvider jobCommandProvider;
 
   /**
    * @param namespace the namespace where the kubernetes operation will act on. leave empty to infer
    *     from kubeconfig
    * @param kubeconfig The kubeconfig configuration of the Kubernetes cluster to connect to
-   * @param k8sSupportsV1CronJob Whether the target K8s cluster supports the V1CronJob API
    * @param log log to use - used in subclasses in order to set classname to subclass.
    */
   protected KubernetesService(
-      String namespace, String kubeconfig, boolean k8sSupportsV1CronJob, Logger log) {
+      String namespace, String kubeconfig, Logger log) {
     this.namespace = namespace;
     this.kubeconfig = kubeconfig;
-    this.k8sSupportsV1CronJob = k8sSupportsV1CronJob;
     this.log = log;
-  }
-
-  protected boolean getK8sSupportsV1CronJob() {
-    return this.k8sSupportsV1CronJob;
   }
 
   @Override
@@ -235,161 +209,8 @@ public abstract class KubernetesService implements InitializingBean {
     client.setHttpClient(
         client.getHttpClient().newBuilder().readTimeout(0, TimeUnit.SECONDS).build());
     // client.getHttpClient().setReadTimeout(0, TimeUnit.SECONDS);
-
-    // Step 1 - load the internal datajob template in order to validate it.
-    try {
-      if (getK8sSupportsV1CronJob()) {
-        loadV1CronjobTemplate(new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
-      } else {
-        loadV1beta1CronjobTemplate(new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
-      }
-      log.info("The internal datajob template is valid.");
-    } catch (Exception e) {
-      // Log the error and fail fast (cannot continue).
-      log.error("Fatal error while loading the internal datajob template. Cannot continue", e);
-      throw e;
-    }
-    // Step 2 - load the configurable datajob template in order to validate it
-    // when environment variable 'K8S_DATA_JOB_TEMPLATE_FILE' is set.
-    if (!StringUtils.isEmpty(datajobTemplateFileLocation)) {
-      if (getK8sSupportsV1CronJob()) {
-        if (loadConfigurableV1CronjobTemplate() == null) {
-          log.warn(
-              "The configurable datajob template '{}' could not be loaded.",
-              datajobTemplateFileLocation);
-        } else {
-          log.info("The configurable datajob template '{}' is valid.", datajobTemplateFileLocation);
-        }
-      } else {
-        if (loadConfigurableV1beta1CronjobTemplate() == null) {
-          log.warn(
-              "The configurable datajob template '{}' could not be loaded.",
-              datajobTemplateFileLocation);
-        } else {
-          log.info("The configurable datajob template '{}' is valid.", datajobTemplateFileLocation);
-        }
-      }
-    }
   }
 
-  private V1CronJob loadV1CronjobTemplate() {
-    if (StringUtils.isEmpty(datajobTemplateFileLocation)) {
-      log.debug("Datajob template file location is not set. Using internal datajob template.");
-      return loadInternalV1CronjobTemplate();
-    }
-    V1CronJob cronjobTemplate = loadConfigurableV1CronjobTemplate();
-    if (cronjobTemplate == null) {
-      return loadInternalV1CronjobTemplate();
-    }
-
-    return cronjobTemplate;
-  }
-
-  private V1beta1CronJob loadV1beta1CronjobTemplate() {
-    if (StringUtils.isEmpty(datajobTemplateFileLocation)) {
-      log.debug("Datajob template file location is not set. Using internal datajob template.");
-      return loadInternalV1beta1CronjobTemplate();
-    }
-    V1beta1CronJob cronjobTemplate = loadConfigurableV1beta1CronjobTemplate();
-    if (cronjobTemplate == null) {
-      return loadInternalV1beta1CronjobTemplate();
-    }
-
-    return cronjobTemplate;
-  }
-
-  private V1beta1CronJob loadInternalV1beta1CronjobTemplate() {
-    try {
-      return loadV1beta1CronjobTemplate(
-          new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
-    } catch (Exception e) {
-      // This should never happen unless we are testing locally and we've messed up
-      // with the internal template resource file.
-      throw new RuntimeException(
-          "Unrecoverable error while loading the internal datajob template. Cannot continue.", e);
-    }
-  }
-
-  private V1CronJob loadInternalV1CronjobTemplate() {
-    try {
-      return loadV1CronjobTemplate(new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
-    } catch (Exception e) {
-      // This should never happen unless we are testing locally and we've messed up
-      // with the internal template resource file.
-      throw new RuntimeException(
-          "Unrecoverable error while loading the internal datajob template. Cannot continue.", e);
-    }
-  }
-
-  private V1beta1CronJob loadConfigurableV1beta1CronjobTemplate() {
-    // Check whether to use configurable datajob template at all.
-    if (StringUtils.isEmpty(datajobTemplateFileLocation)) {
-      log.debug("Datajob template file location is not set.");
-      return null;
-    }
-
-    // Check whether the configurable datajob template file exists.
-    File datajobTemplateFile = new File(datajobTemplateFileLocation);
-    if (!datajobTemplateFile.isFile()) {
-      log.warn("Datajob template location '{}' is not a file.", datajobTemplateFileLocation);
-      return null;
-    }
-
-    try {
-      // Load the configurable datajob template file.
-      return loadV1beta1CronjobTemplate(datajobTemplateFile);
-    } catch (Exception e) {
-      log.error("Error while loading the datajob template file.", e);
-      return null;
-    }
-  }
-
-  private V1CronJob loadConfigurableV1CronjobTemplate() {
-    // Check whether to use configurable datajob template at all.
-    if (StringUtils.isEmpty(datajobTemplateFileLocation)) {
-      log.debug("Datajob template file location is not set.");
-      return null;
-    }
-
-    // Check whether the configurable datajob template file exists.
-    File datajobTemplateFile = new File(datajobTemplateFileLocation);
-    if (!datajobTemplateFile.isFile()) {
-      log.warn("Datajob template location '{}' is not a file.", datajobTemplateFileLocation);
-      return null;
-    }
-
-    try {
-      // Load the configurable datajob template file.
-      return loadV1CronjobTemplate(datajobTemplateFile);
-    } catch (Exception e) {
-      log.error("Error while loading the datajob template file.", e);
-      return null;
-    }
-  }
-
-  private V1beta1CronJob loadV1beta1CronjobTemplate(File datajobTemplateFile) throws Exception {
-    String cronjobTemplateString = Files.readString(datajobTemplateFile.toPath());
-    // Check whether the string template is a valid datajob template.
-    V1beta1CronJob cronjobTemplate = Yaml.loadAs(cronjobTemplateString, V1beta1CronJob.class);
-    log.debug(
-        "Datajob template for file '{}': \n{}",
-        datajobTemplateFile.getCanonicalPath(),
-        cronjobTemplate);
-
-    return cronjobTemplate;
-  }
-
-  private V1CronJob loadV1CronjobTemplate(File datajobTemplateFile) throws Exception {
-    String cronjobTemplateString = Files.readString(datajobTemplateFile.toPath());
-    // Check whether the string template is a valid datajob template.
-    V1CronJob cronjobTemplate = Yaml.loadAs(cronjobTemplateString, V1CronJob.class);
-    log.debug(
-        "Datajob template for file '{}': \n{}",
-        datajobTemplateFile.getCanonicalPath(),
-        cronjobTemplate);
-
-    return cronjobTemplate;
-  }
 
   private String getCurrentNamespace() {
     return getNamespaceFileContents().stream()
@@ -405,15 +226,6 @@ public abstract class KubernetesService implements InitializingBean {
       return Files.readAllLines(Paths.get(namespaceFile));
     } catch (IOException e) {
       return Collections.emptyList();
-    }
-  }
-
-  public Pair<Boolean, String> health() {
-    try {
-      var info = new VersionApi(client).getCode();
-      return Pair.of(true, info.getGitVersion());
-    } catch (Exception e) {
-      return Pair.of(false, e.getMessage());
     }
   }
 
@@ -444,743 +256,6 @@ public abstract class KubernetesService implements InitializingBean {
         jobs.getItems().stream().map(j -> j.getMetadata().getName()).collect(Collectors.toSet());
     log.debug("K8s jobs: {}", set);
     return set;
-  }
-
-  public Optional<JobDeploymentStatus> readCronJob(String cronJobName) {
-    return getK8sSupportsV1CronJob() ? readV1CronJob(cronJobName) : readV1beta1CronJob(cronJobName);
-  }
-
-  public Optional<JobDeploymentStatus> readV1beta1CronJob(String cronJobName) {
-    log.debug("Reading k8s cron job: {}", cronJobName);
-    V1beta1CronJob cronJob = null;
-    try {
-      cronJob = new BatchV1beta1Api(client).readNamespacedCronJob(cronJobName, namespace, null);
-    } catch (ApiException e) {
-      log.warn(
-          "Could not read cron job: {}; reason: {}",
-          cronJobName,
-          new KubernetesException("", e).toString());
-    }
-
-    return mapV1beta1CronJobToDeploymentStatus(cronJob, cronJobName);
-  }
-
-  public Optional<JobDeploymentStatus> readV1CronJob(String cronJobName) {
-    log.debug("Reading k8s cron job: {}", cronJobName);
-    V1CronJob cronJob = null;
-    try {
-      cronJob = new BatchV1Api(client).readNamespacedCronJob(cronJobName, namespace, null);
-    } catch (ApiException e) {
-      log.warn(
-          "Could not read cron job: {}; reason: {}",
-          cronJobName,
-          new KubernetesException("", e).toString());
-    }
-
-    return mapV1CronJobToDeploymentStatus(cronJob, cronJobName);
-  }
-
-  /**
-   * Fetch all deployment statuses from Kubernetes
-   *
-   * @return List of {@link JobDeploymentStatus} or empty list if there is an error while fetching
-   *     data
-   */
-  public List<JobDeploymentStatus> readJobDeploymentStatuses() {
-    return getK8sSupportsV1CronJob()
-        ? readV1CronJobDeploymentStatuses()
-        : readV1beta1CronJobDeploymentStatuses();
-  }
-
-  public List<JobDeploymentStatus> readV1beta1CronJobDeploymentStatuses() {
-    log.debug("Reading all k8s cron jobs");
-    V1beta1CronJobList cronJobs = null;
-    try {
-      cronJobs =
-          new BatchV1beta1Api(client)
-              .listNamespacedCronJob(
-                  namespace, null, null, null, null, null, null, null, null, null, null);
-    } catch (ApiException e) {
-      log.warn("Failed to read k8s cron jobs: ", new KubernetesException("", e));
-    }
-
-    return cronJobs == null
-        ? Collections.emptyList()
-        : cronJobs.getItems().stream()
-            .map(cronJob -> mapV1beta1CronJobToDeploymentStatus(cronJob, null))
-            .flatMap(Optional::stream)
-            .collect(Collectors.toList());
-  }
-
-  public List<JobDeploymentStatus> readV1CronJobDeploymentStatuses() {
-    log.debug("Reading all k8s cron jobs");
-    V1CronJobList cronJobs = null;
-    try {
-      cronJobs =
-          new BatchV1Api(client)
-              .listNamespacedCronJob(
-                  namespace, null, null, null, null, null, null, null, null, null, null);
-    } catch (ApiException e) {
-      log.warn("Failed to read k8s cron jobs: ", new KubernetesException("", e));
-    }
-
-    return cronJobs == null
-        ? Collections.emptyList()
-        : cronJobs.getItems().stream()
-            .map(cronJob -> mapV1CronJobToDeploymentStatus(cronJob, null))
-            .flatMap(Optional::stream)
-            .collect(Collectors.toList());
-  }
-
-  public void startNewCronJobExecution(
-      String cronJobName,
-      String executionId,
-      Map<String, String> annotations,
-      Map<String, String> envs,
-      Map<String, Object> extraJobArguments,
-      String jobName)
-      throws ApiException {
-    if (getK8sSupportsV1CronJob()) {
-      startNewV1CronJobExecution(
-          cronJobName, executionId, annotations, envs, extraJobArguments, jobName);
-    } else {
-      startNewV1beta1CronJobExecution(
-          cronJobName, executionId, annotations, envs, extraJobArguments, jobName);
-    }
-  }
-
-  private void startNewV1beta1CronJobExecution(
-      String cronJobName,
-      String executionId,
-      Map<String, String> annotations,
-      Map<String, String> envs,
-      Map<String, Object> extraJobArguments,
-      String jobName)
-      throws ApiException {
-    var cron = initBatchV1beta1Api().readNamespacedCronJob(cronJobName, namespace, null);
-    Optional<V1beta1JobTemplateSpec> jobTemplateSpec =
-        Optional.ofNullable(cron)
-            .map(V1beta1CronJob::getSpec)
-            .map(V1beta1CronJobSpec::getJobTemplate);
-
-    Map<String, String> jobLabels =
-        jobTemplateSpec
-            .map(V1beta1JobTemplateSpec::getMetadata)
-            .map(V1ObjectMeta::getLabels)
-            .orElse(Collections.emptyMap());
-
-    Map<String, String> jobAnnotations =
-        jobTemplateSpec
-            .map(V1beta1JobTemplateSpec::getMetadata)
-            .map(V1ObjectMeta::getAnnotations)
-            .map(
-                v1ObjectMetaAnnotations -> {
-                  v1ObjectMetaAnnotations.putAll(annotations);
-                  return v1ObjectMetaAnnotations;
-                })
-            .orElse(annotations);
-
-    V1JobSpec jobSpec =
-        jobTemplateSpec
-            .map(V1beta1JobTemplateSpec::getSpec)
-            .orElseThrow(
-                () ->
-                    new ApiException(
-                        String.format(
-                            "K8S Cron Job '%s' does not exist or is not properly defined.",
-                            cronJobName)));
-
-    jobSpec.setTtlSecondsAfterFinished(jobTTLAfterFinishedSeconds);
-
-    V1Container v1Container =
-        Optional.ofNullable(jobSpec.getTemplate())
-            .map(V1PodTemplateSpec::getSpec)
-            .map(V1PodSpec::getContainers)
-            .map(v1Containers -> v1Containers.get(0))
-            .orElseThrow(
-                () ->
-                    new ApiException(
-                        String.format("K8S Cron Job '%s' is not properly defined.", cronJobName)));
-    if (!CollectionUtils.isEmpty(envs)) {
-      envs.forEach((name, value) -> v1Container.addEnvItem(new V1EnvVar().name(name).value(value)));
-    }
-
-    if (!CollectionUtils.isEmpty(extraJobArguments)) {
-      addExtraJobArgumentsToVdkContainer(v1Container, extraJobArguments, jobName);
-    }
-
-    createNewJob(executionId, jobSpec, jobLabels, jobAnnotations);
-  }
-
-  private void startNewV1CronJobExecution(
-      String cronJobName,
-      String executionId,
-      Map<String, String> annotations,
-      Map<String, String> envs,
-      Map<String, Object> extraJobArguments,
-      String jobName)
-      throws ApiException {
-    var cron = initBatchV1Api().readNamespacedCronJob(cronJobName, namespace, null);
-
-    Optional<V1JobTemplateSpec> jobTemplateSpec =
-        Optional.ofNullable(cron).map(V1CronJob::getSpec).map(V1CronJobSpec::getJobTemplate);
-
-    Map<String, String> jobLabels =
-        jobTemplateSpec
-            .map(V1JobTemplateSpec::getMetadata)
-            .map(V1ObjectMeta::getLabels)
-            .orElse(Collections.emptyMap());
-
-    Map<String, String> jobAnnotations =
-        jobTemplateSpec
-            .map(V1JobTemplateSpec::getMetadata)
-            .map(V1ObjectMeta::getAnnotations)
-            .map(
-                v1ObjectMetaAnnotations -> {
-                  v1ObjectMetaAnnotations.putAll(annotations);
-                  return v1ObjectMetaAnnotations;
-                })
-            .orElse(annotations);
-
-    V1JobSpec jobSpec =
-        jobTemplateSpec
-            .map(V1JobTemplateSpec::getSpec)
-            .orElseThrow(
-                () ->
-                    new ApiException(
-                        String.format(
-                            "K8S Cron Job '%s' does not exist or is not properly defined.",
-                            cronJobName)));
-
-    jobSpec.setTtlSecondsAfterFinished(jobTTLAfterFinishedSeconds);
-
-    V1Container v1Container =
-        Optional.ofNullable(jobSpec.getTemplate())
-            .map(V1PodTemplateSpec::getSpec)
-            .map(V1PodSpec::getContainers)
-            .map(v1Containers -> v1Containers.get(0))
-            .orElseThrow(
-                () ->
-                    new ApiException(
-                        String.format("K8S Cron Job '%s' is not properly defined.", cronJobName)));
-    if (!CollectionUtils.isEmpty(envs)) {
-      envs.forEach((name, value) -> v1Container.addEnvItem(new V1EnvVar().name(name).value(value)));
-    }
-
-    if (!CollectionUtils.isEmpty(extraJobArguments)) {
-      addExtraJobArgumentsToVdkContainer(v1Container, extraJobArguments, jobName);
-    }
-
-    createNewJob(executionId, jobSpec, jobLabels, jobAnnotations);
-  }
-
-  private void addExtraJobArgumentsToVdkContainer(
-      V1Container container, Map<String, Object> extraJobArguments, String jobName) {
-    var commandList =
-        new ArrayList<>(container.getCommand()); // create a new List, since old might be immutable.
-
-    if (commandList.size() < 3 || !Iterables.getLast(commandList).contains("vdk run")) {
-      // If current job template definition changes we will throw an exception and will have to
-      // change this implementation.
-      log.debug("Command list: {}", commandList);
-      throw new KubernetesJobDefinitionException(jobName);
-    }
-
-    try {
-      var newCommand =
-          jobCommandProvider.getJobCommand(
-              jobName, extraJobArguments); // vdk run command is last in the list
-      container.setCommand(newCommand);
-    } catch (JsonProcessingException e) {
-      log.debug("JsonProcessingException", e);
-      throw new JsonDissectException(e);
-    }
-  }
-
-  public void cancelRunningCronJob(String teamName, String jobName, String executionId)
-      throws ApiException {
-    log.info(
-        "K8S deleting job for team: {} data job name: {} execution: {} namespace: {}",
-        teamName,
-        jobName,
-        executionId,
-        namespace);
-    try {
-      var operationResponse =
-          initBatchV1Api()
-              .deleteNamespacedJobWithHttpInfo(
-                  executionId, namespace, null, null, null, null, "Foreground", null);
-      // Status of the operation. One of: "Success" or "Failure"
-      if (operationResponse == null || operationResponse.getStatusCode() == 404) {
-        log.info(
-            "Execution: {} for data job: {} with team: {} not found! The data job has likely"
-                + " completed before it could be cancelled.",
-            executionId,
-            jobName,
-            teamName);
-        throw new DataJobExecutionCannotBeCancelledException(
-            executionId, ExecutionCancellationFailureReason.DataJobExecutionNotFound);
-      } else if (operationResponse.getStatusCode() != 200) {
-        log.warn(
-            "Failed to delete K8S job. Reason: {} Details: {}",
-            operationResponse.getData().getReason(),
-            operationResponse.getData().getDetails());
-        throw new KubernetesException(
-            operationResponse.getData().getMessage(),
-            new ApiException(
-                operationResponse.getStatusCode(), operationResponse.getData().getMessage()));
-      }
-    } catch (JsonSyntaxException e) {
-      if (e.getCause() instanceof IllegalStateException) {
-        IllegalStateException ise = (IllegalStateException) e.getCause();
-        if (ise.getMessage() != null
-            && ise.getMessage().contains("Expected a string but was BEGIN_OBJECT"))
-          log.debug(
-              "Catching exception because of issue"
-                  + " https://github.com/kubernetes-client/java/issues/86",
-              e);
-        else throw e;
-      } else throw e;
-
-    } catch (ApiException e) {
-      // If no response body is present this might be a transport layer failure.
-      if (e.getCode() == 404) {
-        log.debug(
-            "Job execution: {} team: {}, job: {} cannot be found. K8S response body {}. Will set"
-                + " its status to Cancelled in the DB.",
-            executionId,
-            teamName,
-            jobName,
-            e.getResponseBody());
-      } else throw e;
-    }
-  }
-
-  public Set<String> listCronJobs() throws ApiException {
-    log.debug("Listing k8s cron jobs");
-    var cronJobs =
-        new BatchV1beta1Api(client)
-            .listNamespacedCronJob(
-                namespace, null, null, null, null, null, null, null, null, null, null);
-    var set =
-        cronJobs.getItems().stream()
-            .map(j -> j.getMetadata().getName())
-            .collect(Collectors.toSet());
-    log.debug("K8s cron jobs: {}", set);
-    return set;
-  }
-
-  public void createCronJob(
-      String name,
-      String image,
-      Map<String, String> envs,
-      String schedule,
-      boolean enable,
-      List<String> args,
-      Resources request,
-      Resources limit,
-      V1Container jobContainer,
-      V1Container initContainer,
-      List<V1Volume> volumes,
-      Map<String, String> jobDeploymentAnnotations)
-      throws ApiException {
-    if (getK8sSupportsV1CronJob()) {
-      createV1CronJob(
-          name,
-          image,
-          envs,
-          schedule,
-          enable,
-          args,
-          request,
-          limit,
-          jobContainer,
-          initContainer,
-          volumes,
-          jobDeploymentAnnotations,
-          Collections.emptyMap(),
-          Collections.emptyMap(),
-          Collections.emptyMap(),
-          List.of(""));
-    } else {
-      createV1beta1CronJob(
-          name,
-          image,
-          envs,
-          schedule,
-          enable,
-          args,
-          request,
-          limit,
-          jobContainer,
-          initContainer,
-          volumes,
-          jobDeploymentAnnotations,
-          Collections.emptyMap(),
-          Collections.emptyMap(),
-          Collections.emptyMap(),
-          List.of(""));
-    }
-  }
-
-  public void createCronJob(
-      String name,
-      String image,
-      Map<String, String> envs,
-      String schedule,
-      boolean enable,
-      List<String> args,
-      Resources request,
-      Resources limit,
-      V1Container jobContainer,
-      V1Container initContainer,
-      List<V1Volume> volumes,
-      Map<String, String> jobDeploymentAnnotations,
-      Map<String, String> jobPodLabels,
-      Map<String, String> jobAnnotations,
-      Map<String, String> jobLabels,
-      List<String> imagePullSecrets)
-      throws ApiException {
-    if (getK8sSupportsV1CronJob()) {
-      createV1CronJob(
-          name,
-          image,
-          envs,
-          schedule,
-          enable,
-          args,
-          request,
-          limit,
-          jobContainer,
-          initContainer,
-          volumes,
-          jobDeploymentAnnotations,
-          jobPodLabels,
-          jobAnnotations,
-          jobLabels,
-          imagePullSecrets);
-    } else {
-      createV1beta1CronJob(
-          name,
-          image,
-          envs,
-          schedule,
-          enable,
-          args,
-          request,
-          limit,
-          jobContainer,
-          initContainer,
-          volumes,
-          jobDeploymentAnnotations,
-          jobPodLabels,
-          jobAnnotations,
-          jobLabels,
-          imagePullSecrets);
-    }
-  }
-
-  // TODO:  container/volume args are breaking a bit abstraction of KubernetesService by leaking
-  // impl. details
-  public void createV1beta1CronJob(
-      String name,
-      String image,
-      Map<String, String> envs,
-      String schedule,
-      boolean enable,
-      List<String> args,
-      Resources request,
-      Resources limit,
-      V1Container jobContainer,
-      V1Container initContainer,
-      List<V1Volume> volumes,
-      Map<String, String> jobDeploymentAnnotations,
-      Map<String, String> jobPodLabels,
-      Map<String, String> jobAnnotations,
-      Map<String, String> jobLabels,
-      List<String> imagePullSecrets)
-      throws ApiException {
-    log.debug("Creating k8s cron job name:{}, image:{}", name, image);
-    var cronJob =
-        v1beta1CronJobFromTemplate(
-            name,
-            schedule,
-            !enable,
-            jobContainer,
-            initContainer,
-            volumes,
-            jobDeploymentAnnotations,
-            jobPodLabels,
-            jobAnnotations,
-            jobLabels,
-            imagePullSecrets);
-    V1beta1CronJob nsJob =
-        new BatchV1beta1Api(client)
-            .createNamespacedCronJob(namespace, cronJob, null, null, null, null);
-    log.debug("Created k8s cron job: {}", nsJob);
-    log.debug(
-        "Created k8s cron job name: {}, uid:{}, link:{}",
-        nsJob.getMetadata().getName(),
-        nsJob.getMetadata().getUid(),
-        nsJob.getMetadata().getSelfLink());
-  }
-
-  // TODO:  container/volume args are breaking a bit abstraction of KubernetesService by leaking
-  // impl. details
-  public void createV1CronJob(
-      String name,
-      String image,
-      Map<String, String> envs,
-      String schedule,
-      boolean enable,
-      List<String> args,
-      Resources request,
-      Resources limit,
-      V1Container jobContainer,
-      V1Container initContainer,
-      List<V1Volume> volumes,
-      Map<String, String> jobDeploymentAnnotations,
-      Map<String, String> jobPodLabels,
-      Map<String, String> jobAnnotations,
-      Map<String, String> jobLabels,
-      List<String> imagePullSecrets)
-      throws ApiException {
-    log.debug("Creating k8s cron job name:{}, image:{}", name, image);
-    var cronJob =
-        v1CronJobFromTemplate(
-            name,
-            schedule,
-            !enable,
-            jobContainer,
-            initContainer,
-            volumes,
-            jobDeploymentAnnotations,
-            jobPodLabels,
-            jobAnnotations,
-            jobLabels,
-            imagePullSecrets);
-    V1CronJob nsJob =
-        new BatchV1Api(client).createNamespacedCronJob(namespace, cronJob, null, null, null, null);
-    log.debug("Created k8s cron job: {}", nsJob);
-    log.debug(
-        "Created k8s cron job name: {}, uid:{}, link:{}",
-        nsJob.getMetadata().getName(),
-        nsJob.getMetadata().getUid(),
-        nsJob.getMetadata().getSelfLink());
-  }
-
-  public void updateCronJob(
-      String name,
-      String image,
-      Map<String, String> envs,
-      String schedule,
-      boolean enable,
-      List<String> args,
-      Resources request,
-      Resources limit,
-      V1Container jobContainer,
-      V1Container initContainer,
-      List<V1Volume> volumes,
-      Map<String, String> jobDeploymentAnnotations)
-      throws ApiException {
-    if (getK8sSupportsV1CronJob()) {
-      updateV1CronJob(
-          name,
-          image,
-          envs,
-          schedule,
-          enable,
-          args,
-          request,
-          limit,
-          jobContainer,
-          initContainer,
-          volumes,
-          jobDeploymentAnnotations,
-          Collections.emptyMap(),
-          Collections.emptyMap(),
-          Collections.emptyMap(),
-          List.of(""));
-    } else {
-      updateV1beta1CronJob(
-          name,
-          image,
-          envs,
-          schedule,
-          enable,
-          args,
-          request,
-          limit,
-          jobContainer,
-          initContainer,
-          volumes,
-          jobDeploymentAnnotations,
-          Collections.emptyMap(),
-          Collections.emptyMap(),
-          Collections.emptyMap(),
-          List.of(""));
-    }
-  }
-
-  public void updateCronJob(
-      String name,
-      String image,
-      Map<String, String> envs,
-      String schedule,
-      boolean enable,
-      List<String> args,
-      Resources request,
-      Resources limit,
-      V1Container jobContainer,
-      V1Container initContainer,
-      List<V1Volume> volumes,
-      Map<String, String> jobDeploymentAnnotations,
-      Map<String, String> jobPodLabels,
-      Map<String, String> jobAnnotations,
-      Map<String, String> jobLabels,
-      List<String> imagePullSecrets)
-      throws ApiException {
-    if (getK8sSupportsV1CronJob()) {
-      updateV1CronJob(
-          name,
-          image,
-          envs,
-          schedule,
-          enable,
-          args,
-          request,
-          limit,
-          jobContainer,
-          initContainer,
-          volumes,
-          jobDeploymentAnnotations,
-          jobPodLabels,
-          jobAnnotations,
-          jobLabels,
-          imagePullSecrets);
-    } else {
-      updateV1beta1CronJob(
-          name,
-          image,
-          envs,
-          schedule,
-          enable,
-          args,
-          request,
-          limit,
-          jobContainer,
-          initContainer,
-          volumes,
-          jobDeploymentAnnotations,
-          jobPodLabels,
-          jobAnnotations,
-          jobLabels,
-          imagePullSecrets);
-    }
-  }
-
-  public void updateV1beta1CronJob(
-      String name,
-      String image,
-      Map<String, String> envs,
-      String schedule,
-      boolean enable,
-      List<String> args,
-      Resources request,
-      Resources limit,
-      V1Container jobContainer,
-      V1Container initContainer,
-      List<V1Volume> volumes,
-      Map<String, String> jobDeploymentAnnotations,
-      Map<String, String> jobPodLabels,
-      Map<String, String> jobAnnotations,
-      Map<String, String> jobLabels,
-      List<String> imagePullSecrets)
-      throws ApiException {
-    var cronJob =
-        v1beta1CronJobFromTemplate(
-            name,
-            schedule,
-            !enable,
-            jobContainer,
-            initContainer,
-            volumes,
-            jobDeploymentAnnotations,
-            jobPodLabels,
-            jobAnnotations,
-            jobLabels,
-            imagePullSecrets);
-    V1beta1CronJob nsJob =
-        new BatchV1beta1Api(client)
-            .replaceNamespacedCronJob(name, namespace, cronJob, null, null, null, null);
-    log.debug(
-        "Updated k8s cron job status for name:{}, image:{}, uid:{}, link:{}",
-        name,
-        image,
-        nsJob.getMetadata().getUid(),
-        nsJob.getMetadata().getSelfLink());
-  }
-
-  public void updateV1CronJob(
-      String name,
-      String image,
-      Map<String, String> envs,
-      String schedule,
-      boolean enable,
-      List<String> args,
-      Resources request,
-      Resources limit,
-      V1Container jobContainer,
-      V1Container initContainer,
-      List<V1Volume> volumes,
-      Map<String, String> jobDeploymentAnnotations,
-      Map<String, String> jobPodLabels,
-      Map<String, String> jobAnnotations,
-      Map<String, String> jobLabels,
-      List<String> imagePullSecrets)
-      throws ApiException {
-    var cronJob =
-        v1CronJobFromTemplate(
-            name,
-            schedule,
-            !enable,
-            jobContainer,
-            initContainer,
-            volumes,
-            jobDeploymentAnnotations,
-            jobPodLabels,
-            jobAnnotations,
-            jobLabels,
-            imagePullSecrets);
-    V1CronJob nsJob =
-        new BatchV1Api(client)
-            .replaceNamespacedCronJob(name, namespace, cronJob, null, null, null, null);
-    log.debug(
-        "Updated k8s cron job status for name:{}, image:{}, uid:{}, link:{}",
-        name,
-        image,
-        nsJob.getMetadata().getUid(),
-        nsJob.getMetadata().getSelfLink());
-  }
-
-  public void deleteCronJob(String name) throws ApiException {
-    log.debug("Deleting k8s cron job: {}", name);
-    try {
-      new BatchV1beta1Api(client)
-          .deleteNamespacedCronJob(name, namespace, null, null, null, null, null, null);
-    } catch (JsonSyntaxException e) {
-      if (e.getCause() instanceof IllegalStateException) {
-        IllegalStateException ise = (IllegalStateException) e.getCause();
-        if (ise.getMessage() != null
-            && ise.getMessage().contains("Expected a string but was BEGIN_OBJECT"))
-          log.debug(
-              "Catching exception because of issue"
-                  + " https://github.com/kubernetes-client/java/issues/86",
-              e);
-        else throw e;
-      } else throw e;
-    }
-    log.debug("Deleted k8s cron job: {}", name);
   }
 
   public void createJob(
@@ -1243,7 +318,7 @@ public abstract class KubernetesService implements InitializingBean {
   }
 
   // Default for testing purposes
-  void createNewJob(
+  protected void createNewJob(
       String name, V1JobSpec spec, Map<String, String> labels, Map<String, String> annotations)
       throws ApiException {
     var job =
@@ -1382,13 +457,13 @@ public abstract class KubernetesService implements InitializingBean {
     return condition;
   }
 
-  // Default for testing purposes
-  BatchV1Api initBatchV1Api() {
+  @VisibleForTesting
+  public BatchV1Api initBatchV1Api() {
     return new BatchV1Api(client);
   }
 
-  // Default for testing purposes
-  BatchV1beta1Api initBatchV1beta1Api() {
+  @VisibleForTesting
+  public BatchV1beta1Api initBatchV1beta1Api() {
     return new BatchV1beta1Api(client);
   }
 
@@ -1483,7 +558,8 @@ public abstract class KubernetesService implements InitializingBean {
    * @return A {@link V1ContainerStateTerminated} object representing the termination status of the
    *     job.
    */
-  Optional<V1ContainerStateTerminated> getTerminationStatus(V1Job job) {
+  @VisibleForTesting
+  public Optional<V1ContainerStateTerminated> getTerminationStatus(V1Job job) {
     List<V1Pod> jobPods;
 
     try {
@@ -1516,7 +592,8 @@ public abstract class KubernetesService implements InitializingBean {
    * @param job The job whose status to return.
    * @return A {@link JobExecution} object representing the Data Job execution status.
    */
-  Optional<JobExecution> getJobExecutionStatus(V1Job job, JobStatusCondition jobStatusCondition) {
+  @VisibleForTesting
+  public Optional<JobExecution> getJobExecutionStatus(V1Job job, JobStatusCondition jobStatusCondition) {
     JobExecution.JobExecutionBuilder jobExecutionStatusBuilder = JobExecution.builder();
     // jobCondition = null means that the K8S Job is still running
     if (jobStatusCondition != null) {
@@ -1927,257 +1004,6 @@ public abstract class KubernetesService implements InitializingBean {
     return Optional.empty();
   }
 
-  // TODO - in the future we want to merge the (1) configurable datajob template
-  //        with the (2) default internal datajob template when something from (1)
-  //        is missing. For now we just check for missing entries in (1) and overwrite
-  //        them with the corresponding entries in (2).
-  private void v1beta1checkForMissingEntries(V1beta1CronJob cronjob) {
-    V1beta1CronJob internalCronjobTemplate = loadInternalV1beta1CronjobTemplate();
-    if (cronjob.getMetadata() == null) {
-      cronjob.setMetadata(internalCronjobTemplate.getMetadata());
-    }
-    V1ObjectMeta metadata = cronjob.getMetadata();
-    if (metadata.getAnnotations() == null) {
-      metadata.setAnnotations(new HashMap<>());
-    }
-    if (cronjob.getSpec() == null) {
-      cronjob.setSpec(internalCronjobTemplate.getSpec());
-    }
-    V1beta1CronJobSpec spec = cronjob.getSpec();
-    if (spec.getJobTemplate() == null) {
-      spec.setJobTemplate(internalCronjobTemplate.getSpec().getJobTemplate());
-    }
-    if (spec.getJobTemplate().getMetadata() == null) {
-      spec.getJobTemplate()
-          .setMetadata(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
-    }
-    if (spec.getJobTemplate().getMetadata().getLabels() == null) {
-      spec.getJobTemplate().getMetadata().setLabels(new HashMap<>());
-    }
-    if (spec.getJobTemplate().getMetadata().getAnnotations() == null) {
-      spec.getJobTemplate().getMetadata().setAnnotations(new HashMap<>());
-    }
-    if (spec.getJobTemplate().getSpec() == null) {
-      spec.getJobTemplate().setSpec(internalCronjobTemplate.getSpec().getJobTemplate().getSpec());
-    }
-    if (spec.getJobTemplate().getSpec().getTemplate() == null) {
-      spec.getJobTemplate()
-          .getSpec()
-          .setTemplate(internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate());
-    }
-    if (spec.getJobTemplate().getSpec().getTemplate().getSpec() == null) {
-      spec.getJobTemplate()
-          .getSpec()
-          .getTemplate()
-          .setSpec(
-              internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
-    }
-    if (spec.getJobTemplate().getSpec().getTemplate().getMetadata() == null) {
-      spec.getJobTemplate()
-          .getSpec()
-          .getTemplate()
-          .setMetadata(
-              internalCronjobTemplate
-                  .getSpec()
-                  .getJobTemplate()
-                  .getSpec()
-                  .getTemplate()
-                  .getMetadata());
-    }
-    if (spec.getJobTemplate().getSpec().getTemplate().getMetadata().getLabels() == null) {
-      spec.getJobTemplate().getSpec().getTemplate().getMetadata().setLabels(new HashMap<>());
-    }
-  }
-
-  private void v1checkForMissingEntries(V1CronJob cronjob) {
-    V1CronJob internalCronjobTemplate = loadInternalV1CronjobTemplate();
-    if (cronjob.getMetadata() == null) {
-      cronjob.setMetadata(internalCronjobTemplate.getMetadata());
-    }
-    V1ObjectMeta metadata = cronjob.getMetadata();
-    if (metadata.getAnnotations() == null) {
-      metadata.setAnnotations(new HashMap<>());
-    }
-    if (cronjob.getSpec() == null) {
-      cronjob.setSpec(internalCronjobTemplate.getSpec());
-    }
-    V1CronJobSpec spec = cronjob.getSpec();
-    if (spec.getJobTemplate() == null) {
-      spec.setJobTemplate(internalCronjobTemplate.getSpec().getJobTemplate());
-    }
-    if (spec.getJobTemplate().getMetadata() == null) {
-      spec.getJobTemplate()
-          .setMetadata(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
-    }
-    if (spec.getJobTemplate().getMetadata().getLabels() == null) {
-      spec.getJobTemplate().getMetadata().setLabels(new HashMap<>());
-    }
-    if (spec.getJobTemplate().getMetadata().getAnnotations() == null) {
-      spec.getJobTemplate().getMetadata().setAnnotations(new HashMap<>());
-    }
-    if (spec.getJobTemplate().getSpec() == null) {
-      spec.getJobTemplate().setSpec(internalCronjobTemplate.getSpec().getJobTemplate().getSpec());
-    }
-    if (spec.getJobTemplate().getSpec().getTemplate() == null) {
-      spec.getJobTemplate()
-          .getSpec()
-          .setTemplate(internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate());
-    }
-    if (spec.getJobTemplate().getSpec().getTemplate().getSpec() == null) {
-      spec.getJobTemplate()
-          .getSpec()
-          .getTemplate()
-          .setSpec(
-              internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
-    }
-    if (spec.getJobTemplate().getSpec().getTemplate().getMetadata() == null) {
-      spec.getJobTemplate()
-          .getSpec()
-          .getTemplate()
-          .setMetadata(
-              internalCronjobTemplate
-                  .getSpec()
-                  .getJobTemplate()
-                  .getSpec()
-                  .getTemplate()
-                  .getMetadata());
-    }
-    if (spec.getJobTemplate().getSpec().getTemplate().getMetadata().getLabels() == null) {
-      spec.getJobTemplate().getSpec().getTemplate().getMetadata().setLabels(new HashMap<>());
-    }
-  }
-
-  V1beta1CronJob v1beta1CronJobFromTemplate(
-      String name,
-      String schedule,
-      boolean suspend,
-      V1Container jobContainer,
-      V1Container initContainer,
-      List<V1Volume> volumes,
-      Map<String, String> jobDeploymentAnnotations,
-      Map<String, String> jobPodLabels,
-      Map<String, String> jobAnnotations,
-      Map<String, String> jobLabels,
-      List<String> imagePullSecrets) {
-    V1beta1CronJob cronjob = loadV1beta1CronjobTemplate();
-    v1beta1checkForMissingEntries(cronjob);
-    cronjob.getMetadata().setName(name);
-    cronjob.getSpec().setSchedule(schedule);
-    cronjob.getSpec().setSuspend(suspend);
-    cronjob
-        .getSpec()
-        .getJobTemplate()
-        .getSpec()
-        .getTemplate()
-        .getSpec()
-        .setContainers(Collections.singletonList(jobContainer));
-    cronjob
-        .getSpec()
-        .getJobTemplate()
-        .getSpec()
-        .getTemplate()
-        .getSpec()
-        .setInitContainers(Collections.singletonList(initContainer));
-    cronjob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().setVolumes(volumes);
-    // Merge the annotations and the labels.
-    cronjob.getMetadata().getAnnotations().putAll(jobDeploymentAnnotations);
-    cronjob
-        .getSpec()
-        .getJobTemplate()
-        .getSpec()
-        .getTemplate()
-        .getMetadata()
-        .getLabels()
-        .putAll(jobPodLabels);
-
-    cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations().putAll(jobAnnotations);
-    cronjob.getSpec().getJobTemplate().getMetadata().getLabels().putAll(jobLabels);
-
-    List<V1LocalObjectReference> imagePullSecretsObj =
-        Optional.ofNullable(imagePullSecrets).stream()
-            .flatMap(secrets -> secrets.stream())
-            .filter(secret -> StringUtils.isNotEmpty(secret))
-            .map(secret -> new V1LocalObjectReferenceBuilder().withName(secret).build())
-            .collect(Collectors.toList());
-
-    if (!CollectionUtils.isEmpty(imagePullSecretsObj)) {
-      cronjob
-          .getSpec()
-          .getJobTemplate()
-          .getSpec()
-          .getTemplate()
-          .getSpec()
-          .setImagePullSecrets(imagePullSecretsObj);
-    }
-
-    return cronjob;
-  }
-
-  V1CronJob v1CronJobFromTemplate(
-      String name,
-      String schedule,
-      boolean suspend,
-      V1Container jobContainer,
-      V1Container initContainer,
-      List<V1Volume> volumes,
-      Map<String, String> jobDeploymentAnnotations,
-      Map<String, String> jobPodLabels,
-      Map<String, String> jobAnnotations,
-      Map<String, String> jobLabels,
-      List<String> imagePullSecrets) {
-    V1CronJob cronjob = loadV1CronjobTemplate();
-    v1checkForMissingEntries(cronjob);
-    cronjob.getMetadata().setName(name);
-    cronjob.getSpec().setSchedule(schedule);
-    cronjob.getSpec().setSuspend(suspend);
-    cronjob
-        .getSpec()
-        .getJobTemplate()
-        .getSpec()
-        .getTemplate()
-        .getSpec()
-        .setContainers(Collections.singletonList(jobContainer));
-    cronjob
-        .getSpec()
-        .getJobTemplate()
-        .getSpec()
-        .getTemplate()
-        .getSpec()
-        .setInitContainers(Collections.singletonList(initContainer));
-    cronjob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().setVolumes(volumes);
-    // Merge the annotations and the labels.
-    cronjob.getMetadata().getAnnotations().putAll(jobDeploymentAnnotations);
-    cronjob
-        .getSpec()
-        .getJobTemplate()
-        .getSpec()
-        .getTemplate()
-        .getMetadata()
-        .getLabels()
-        .putAll(jobPodLabels);
-
-    cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations().putAll(jobAnnotations);
-    cronjob.getSpec().getJobTemplate().getMetadata().getLabels().putAll(jobLabels);
-
-    List<V1LocalObjectReference> imagePullSecretsObj =
-        Optional.ofNullable(imagePullSecrets).stream()
-            .flatMap(secrets -> secrets.stream())
-            .filter(secret -> StringUtils.isNotEmpty(secret))
-            .map(secret -> new V1LocalObjectReferenceBuilder().withName(secret).build())
-            .collect(Collectors.toList());
-
-    if (!CollectionUtils.isEmpty(imagePullSecretsObj)) {
-      cronjob
-          .getSpec()
-          .getJobTemplate()
-          .getSpec()
-          .getTemplate()
-          .getSpec()
-          .setImagePullSecrets(imagePullSecretsObj);
-    }
-
-    return cronjob;
-  }
 
   public static V1Container container(
       String name,
@@ -2385,119 +1211,13 @@ public abstract class KubernetesService implements InitializingBean {
         .build();
   }
 
-  private Optional<JobDeploymentStatus> mapV1beta1CronJobToDeploymentStatus(
-      V1beta1CronJob cronJob, String cronJobName) {
-    JobDeploymentStatus deployment = null;
-    if (cronJob != null) {
-      deployment = new JobDeploymentStatus();
-      deployment.setEnabled(!cronJob.getSpec().getSuspend());
-      deployment.setDataJobName(cronJob.getMetadata().getName());
-      deployment.setMode(
-          "release"); // TODO: Get from cron job config when we support testing environments
-      deployment.setCronJobName(
-          cronJobName == null ? cronJob.getMetadata().getName() : cronJobName);
-
-      // all fields until pod spec are required so no need to check for null
-      var annotations = cronJob.getSpec().getJobTemplate().getMetadata().getAnnotations();
-      if (annotations != null) {
-        deployment.setLastDeployedBy(annotations.get(JobAnnotation.DEPLOYED_BY.getValue()));
-        deployment.setLastDeployedDate(annotations.get(JobAnnotation.DEPLOYED_DATE.getValue()));
-      }
-
-      List<V1Container> containers =
-          cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getContainers();
-      if (!containers.isEmpty()) {
-        String image =
-            containers.get(0).getImage(); // TODO: Have 2 containers. 1 for VDK and 1 for the job.
-        deployment.setImageName(image); // TODO do we really need to return image_name?
-      }
-      var initContainers =
-          cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getInitContainers();
-      if (!CollectionUtils.isEmpty(initContainers)) {
-        String vdkImage = initContainers.get(0).getImage();
-        deployment.setVdkImageName(vdkImage);
-        deployment.setVdkVersion(DockerImageName.getTag(vdkImage));
-      } else {
-        log.warn("Missing init container for cronjob {}", cronJobName);
-      }
-
-      var labels = cronJob.getSpec().getJobTemplate().getMetadata().getLabels();
-      if (labels == null) {
-        log.warn(
-            "The cronjob of data job '{}' does not have any labels defined.",
-            deployment.getDataJobName());
-      }
-      if (labels != null && labels.containsKey(JobLabel.VERSION.getValue())) {
-        deployment.setGitCommitSha(labels.get(JobLabel.VERSION.getValue()));
-      } else {
-        // Legacy approach to get version:
-        deployment.setGitCommitSha(DockerImageName.getTag(deployment.getImageName()));
-      }
-    }
-
-    return Optional.ofNullable(deployment);
-  }
-
-  private Optional<JobDeploymentStatus> mapV1CronJobToDeploymentStatus(
-      V1CronJob cronJob, String cronJobName) {
-    JobDeploymentStatus deployment = null;
-    if (cronJob != null) {
-      deployment = new JobDeploymentStatus();
-      deployment.setEnabled(!cronJob.getSpec().getSuspend());
-      deployment.setDataJobName(cronJob.getMetadata().getName());
-      deployment.setMode(
-          "release"); // TODO: Get from cron job config when we support testing environments
-      deployment.setCronJobName(
-          cronJobName == null ? cronJob.getMetadata().getName() : cronJobName);
-
-      // all fields until pod spec are required so no need to check for null
-      var annotations = cronJob.getSpec().getJobTemplate().getMetadata().getAnnotations();
-      if (annotations != null) {
-        deployment.setLastDeployedBy(annotations.get(JobAnnotation.DEPLOYED_BY.getValue()));
-        deployment.setLastDeployedDate(annotations.get(JobAnnotation.DEPLOYED_DATE.getValue()));
-      }
-
-      List<V1Container> containers =
-          cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getContainers();
-      if (!containers.isEmpty()) {
-        String image =
-            containers.get(0).getImage(); // TODO: Have 2 containers. 1 for VDK and 1 for the job.
-        deployment.setImageName(image); // TODO do we really need to return image_name?
-      }
-      var initContainers =
-          cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getInitContainers();
-      if (!CollectionUtils.isEmpty(initContainers)) {
-        String vdkImage = initContainers.get(0).getImage();
-        deployment.setVdkImageName(vdkImage);
-        deployment.setVdkVersion(DockerImageName.getTag(vdkImage));
-      } else {
-        log.warn("Missing init container for cronjob {}", cronJobName);
-      }
-
-      var labels = cronJob.getSpec().getJobTemplate().getMetadata().getLabels();
-      if (labels == null) {
-        log.warn(
-            "The cronjob of data job '{}' does not have any labels defined.",
-            deployment.getDataJobName());
-      }
-      if (labels != null && labels.containsKey(JobLabel.VERSION.getValue())) {
-        deployment.setGitCommitSha(labels.get(JobLabel.VERSION.getValue()));
-      } else {
-        // Legacy approach to get version:
-        deployment.setGitCommitSha(DockerImageName.getTag(deployment.getImageName()));
-      }
-    }
-
-    return Optional.ofNullable(deployment);
-  }
-
   /**
    * Default for testing purposes. This method returns the megabytes amount contained in a quantity.
    *
    * @param quantity the quantity to convert.
    * @return integer MB's in the quantity
    */
-  static int convertMemoryToMBs(Quantity quantity) {
+  public static int convertMemoryToMBs(Quantity quantity) {
     var divider = BigInteger.valueOf(1024);
     if (quantity.getFormat().getBase() == 10) {
       divider = BigInteger.valueOf(1000);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -156,7 +156,6 @@ public abstract class KubernetesService implements InitializingBean {
     @Getter private final String value;
   }
 
-
   @org.springframework.beans.factory.annotation.Value(
       "${datajobs.control.k8s.jobTTLAfterFinishedSeconds}")
   protected int jobTTLAfterFinishedSeconds;
@@ -175,8 +174,7 @@ public abstract class KubernetesService implements InitializingBean {
    * @param kubeconfig The kubeconfig configuration of the Kubernetes cluster to connect to
    * @param log log to use - used in subclasses in order to set classname to subclass.
    */
-  protected KubernetesService(
-      String namespace, String kubeconfig, Logger log) {
+  protected KubernetesService(String namespace, String kubeconfig, Logger log) {
     this.namespace = namespace;
     this.kubeconfig = kubeconfig;
     this.log = log;
@@ -210,7 +208,6 @@ public abstract class KubernetesService implements InitializingBean {
         client.getHttpClient().newBuilder().readTimeout(0, TimeUnit.SECONDS).build());
     // client.getHttpClient().setReadTimeout(0, TimeUnit.SECONDS);
   }
-
 
   private String getCurrentNamespace() {
     return getNamespaceFileContents().stream()
@@ -593,7 +590,8 @@ public abstract class KubernetesService implements InitializingBean {
    * @return A {@link JobExecution} object representing the Data Job execution status.
    */
   @VisibleForTesting
-  public Optional<JobExecution> getJobExecutionStatus(V1Job job, JobStatusCondition jobStatusCondition) {
+  public Optional<JobExecution> getJobExecutionStatus(
+      V1Job job, JobStatusCondition jobStatusCondition) {
     JobExecution.JobExecutionBuilder jobExecutionStatusBuilder = JobExecution.builder();
     // jobCondition = null means that the K8S Job is still running
     if (jobStatusCondition != null) {
@@ -1003,7 +1001,6 @@ public abstract class KubernetesService implements InitializingBean {
     }
     return Optional.empty();
   }
-
 
   public static V1Container container(
       String name,

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/ControlKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/ControlKubernetesService.java
@@ -7,7 +7,6 @@ package com.vmware.taurus.service.kubernetes;
 
 import com.vmware.taurus.service.KubernetesService;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -25,5 +24,4 @@ public class ControlKubernetesService extends KubernetesService {
       @Value("${datajobs.control.k8s.kubeconfig:}") String kubeconfig) {
     super(namespace, kubeconfig, log);
   }
-
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/ControlKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/ControlKubernetesService.java
@@ -7,6 +7,7 @@ package com.vmware.taurus.service.kubernetes;
 
 import com.vmware.taurus.service.KubernetesService;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -21,8 +22,8 @@ public class ControlKubernetesService extends KubernetesService {
   // those should be null/empty when Control service is deployed in k8s hence default is empty
   public ControlKubernetesService(
       @Value("${datajobs.control.k8s.namespace:}") String namespace,
-      @Value("${datajobs.control.k8s.kubeconfig:}") String kubeconfig,
-      @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob) {
-    super(namespace, kubeconfig, k8sSupportsV1CronJob, log);
+      @Value("${datajobs.control.k8s.kubeconfig:}") String kubeconfig) {
+    super(namespace, kubeconfig, log);
   }
+
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
@@ -43,34 +43,31 @@ import java.util.stream.Collectors;
 @Slf4j
 public class DataJobsKubernetesService extends KubernetesService {
 
-  @Autowired
-  private JobCommandProvider jobCommandProvider;
+  @Autowired private JobCommandProvider jobCommandProvider;
 
   // The 'Value' annotation from Lombok collides with the 'Value' annotation from Spring.
   @org.springframework.beans.factory.annotation.Value(
-          "${datajobs.control.k8s.data.job.template.file}")
+      "${datajobs.control.k8s.data.job.template.file}")
   private String datajobTemplateFileLocation;
 
   private final boolean k8sSupportsV1CronJob;
 
   private static final String K8S_DATA_JOB_TEMPLATE_RESOURCE = "k8s-data-job-template.yaml";
 
-
   public DataJobsKubernetesService(
-          @Value("${datajobs.deployment.k8s.namespace:}") String namespace,
-          @Value("${datajobs.deployment.k8s.kubeconfig:}") String kubeconfig,
-          @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob) {
+      @Value("${datajobs.deployment.k8s.namespace:}") String namespace,
+      @Value("${datajobs.deployment.k8s.kubeconfig:}") String kubeconfig,
+      @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob) {
     super(namespace, kubeconfig, log);
     this.k8sSupportsV1CronJob = k8sSupportsV1CronJob;
     if (StringUtils.isBlank(kubeconfig) && !new File(kubeconfig).isFile()) {
       log.warn(
-              "Data Jobs (Deployment) Kubernetes service may not have been correctly bootstrapped. {}"
-                      + " file is missing Will try to use same cluster as control Plane. But this is not"
-                      + " recommended in production.",
-              kubeconfig);
+          "Data Jobs (Deployment) Kubernetes service may not have been correctly bootstrapped. {}"
+              + " file is missing Will try to use same cluster as control Plane. But this is not"
+              + " recommended in production.",
+          kubeconfig);
     }
   }
-
 
   @Override
   public void afterPropertiesSet() throws Exception {
@@ -95,16 +92,16 @@ public class DataJobsKubernetesService extends KubernetesService {
       if (getK8sSupportsV1CronJob()) {
         if (loadConfigurableV1CronjobTemplate() == null) {
           log.warn(
-                  "The configurable datajob template '{}' could not be loaded.",
-                  datajobTemplateFileLocation);
+              "The configurable datajob template '{}' could not be loaded.",
+              datajobTemplateFileLocation);
         } else {
           log.info("The configurable datajob template '{}' is valid.", datajobTemplateFileLocation);
         }
       } else {
         if (loadConfigurableV1beta1CronjobTemplate() == null) {
           log.warn(
-                  "The configurable datajob template '{}' could not be loaded.",
-                  datajobTemplateFileLocation);
+              "The configurable datajob template '{}' could not be loaded.",
+              datajobTemplateFileLocation);
         } else {
           log.info("The configurable datajob template '{}' is valid.", datajobTemplateFileLocation);
         }
@@ -112,8 +109,7 @@ public class DataJobsKubernetesService extends KubernetesService {
     }
   }
 
-
-  public boolean getK8sSupportsV1CronJob(){
+  public boolean getK8sSupportsV1CronJob() {
     return this.k8sSupportsV1CronJob;
   }
 
@@ -146,12 +142,12 @@ public class DataJobsKubernetesService extends KubernetesService {
   private V1beta1CronJob loadInternalV1beta1CronjobTemplate() {
     try {
       return loadV1beta1CronjobTemplate(
-              new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
+          new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
     } catch (Exception e) {
       // This should never happen unless we are testing locally and we've messed up
       // with the internal template resource file.
       throw new RuntimeException(
-              "Unrecoverable error while loading the internal datajob template. Cannot continue.", e);
+          "Unrecoverable error while loading the internal datajob template. Cannot continue.", e);
     }
   }
 
@@ -162,7 +158,7 @@ public class DataJobsKubernetesService extends KubernetesService {
       // This should never happen unless we are testing locally and we've messed up
       // with the internal template resource file.
       throw new RuntimeException(
-              "Unrecoverable error while loading the internal datajob template. Cannot continue.", e);
+          "Unrecoverable error while loading the internal datajob template. Cannot continue.", e);
     }
   }
 
@@ -217,9 +213,9 @@ public class DataJobsKubernetesService extends KubernetesService {
     // Check whether the string template is a valid datajob template.
     V1beta1CronJob cronjobTemplate = Yaml.loadAs(cronjobTemplateString, V1beta1CronJob.class);
     log.debug(
-            "Datajob template for file '{}': \n{}",
-            datajobTemplateFile.getCanonicalPath(),
-            cronjobTemplate);
+        "Datajob template for file '{}': \n{}",
+        datajobTemplateFile.getCanonicalPath(),
+        cronjobTemplate);
 
     return cronjobTemplate;
   }
@@ -229,57 +225,55 @@ public class DataJobsKubernetesService extends KubernetesService {
     // Check whether the string template is a valid datajob template.
     V1CronJob cronjobTemplate = Yaml.loadAs(cronjobTemplateString, V1CronJob.class);
     log.debug(
-            "Datajob template for file '{}': \n{}",
-            datajobTemplateFile.getCanonicalPath(),
-            cronjobTemplate);
+        "Datajob template for file '{}': \n{}",
+        datajobTemplateFile.getCanonicalPath(),
+        cronjobTemplate);
 
     return cronjobTemplate;
   }
 
-
-
   public void cancelRunningCronJob(String teamName, String jobName, String executionId)
-          throws ApiException {
+      throws ApiException {
     log.info(
-            "K8S deleting job for team: {} data job name: {} execution: {} namespace: {}",
-            teamName,
-            jobName,
-            executionId,
-            namespace);
+        "K8S deleting job for team: {} data job name: {} execution: {} namespace: {}",
+        teamName,
+        jobName,
+        executionId,
+        namespace);
     try {
       var operationResponse =
-              initBatchV1Api()
-                      .deleteNamespacedJobWithHttpInfo(
-                              executionId, namespace, null, null, null, null, "Foreground", null);
+          initBatchV1Api()
+              .deleteNamespacedJobWithHttpInfo(
+                  executionId, namespace, null, null, null, null, "Foreground", null);
       // Status of the operation. One of: "Success" or "Failure"
       if (operationResponse == null || operationResponse.getStatusCode() == 404) {
         log.info(
-                "Execution: {} for data job: {} with team: {} not found! The data job has likely"
-                        + " completed before it could be cancelled.",
-                executionId,
-                jobName,
-                teamName);
+            "Execution: {} for data job: {} with team: {} not found! The data job has likely"
+                + " completed before it could be cancelled.",
+            executionId,
+            jobName,
+            teamName);
         throw new DataJobExecutionCannotBeCancelledException(
-                executionId, ExecutionCancellationFailureReason.DataJobExecutionNotFound);
+            executionId, ExecutionCancellationFailureReason.DataJobExecutionNotFound);
       } else if (operationResponse.getStatusCode() != 200) {
         log.warn(
-                "Failed to delete K8S job. Reason: {} Details: {}",
-                operationResponse.getData().getReason(),
-                operationResponse.getData().getDetails());
+            "Failed to delete K8S job. Reason: {} Details: {}",
+            operationResponse.getData().getReason(),
+            operationResponse.getData().getDetails());
         throw new KubernetesException(
-                operationResponse.getData().getMessage(),
-                new ApiException(
-                        operationResponse.getStatusCode(), operationResponse.getData().getMessage()));
+            operationResponse.getData().getMessage(),
+            new ApiException(
+                operationResponse.getStatusCode(), operationResponse.getData().getMessage()));
       }
     } catch (JsonSyntaxException e) {
       if (e.getCause() instanceof IllegalStateException) {
         IllegalStateException ise = (IllegalStateException) e.getCause();
         if (ise.getMessage() != null
-                && ise.getMessage().contains("Expected a string but was BEGIN_OBJECT"))
+            && ise.getMessage().contains("Expected a string but was BEGIN_OBJECT"))
           log.debug(
-                  "Catching exception because of issue"
-                          + " https://github.com/kubernetes-client/java/issues/86",
-                  e);
+              "Catching exception because of issue"
+                  + " https://github.com/kubernetes-client/java/issues/86",
+              e);
         else throw e;
       } else throw e;
 
@@ -287,12 +281,12 @@ public class DataJobsKubernetesService extends KubernetesService {
       // If no response body is present this might be a transport layer failure.
       if (e.getCode() == 404) {
         log.debug(
-                "Job execution: {} team: {}, job: {} cannot be found. K8S response body {}. Will set"
-                        + " its status to Cancelled in the DB.",
-                executionId,
-                teamName,
-                jobName,
-                e.getResponseBody());
+            "Job execution: {} team: {}, job: {} cannot be found. K8S response body {}. Will set"
+                + " its status to Cancelled in the DB.",
+            executionId,
+            teamName,
+            jobName,
+            e.getResponseBody());
       } else throw e;
     }
   }
@@ -300,569 +294,562 @@ public class DataJobsKubernetesService extends KubernetesService {
   public Set<String> listCronJobs() throws ApiException {
     log.debug("Listing k8s cron jobs");
     var cronJobs =
-            new BatchV1beta1Api(client)
-                    .listNamespacedCronJob(
-                            namespace, null, null, null, null, null, null, null, null, null, null);
+        new BatchV1beta1Api(client)
+            .listNamespacedCronJob(
+                namespace, null, null, null, null, null, null, null, null, null, null);
     var set =
-            cronJobs.getItems().stream()
-                    .map(j -> j.getMetadata().getName())
-                    .collect(Collectors.toSet());
+        cronJobs.getItems().stream()
+            .map(j -> j.getMetadata().getName())
+            .collect(Collectors.toSet());
     log.debug("K8s cron jobs: {}", set);
     return set;
   }
 
   public void createCronJob(
-          String name,
-          String image,
-          Map<String, String> envs,
-          String schedule,
-          boolean enable,
-          List<String> args,
-          Resources request,
-          Resources limit,
-          V1Container jobContainer,
-          V1Container initContainer,
-          List<V1Volume> volumes,
-          Map<String, String> jobDeploymentAnnotations)
-          throws ApiException {
+      String name,
+      String image,
+      Map<String, String> envs,
+      String schedule,
+      boolean enable,
+      List<String> args,
+      Resources request,
+      Resources limit,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobDeploymentAnnotations)
+      throws ApiException {
     if (getK8sSupportsV1CronJob()) {
       createV1CronJob(
-              name,
-              image,
-              envs,
-              schedule,
-              enable,
-              args,
-              request,
-              limit,
-              jobContainer,
-              initContainer,
-              volumes,
-              jobDeploymentAnnotations,
-              Collections.emptyMap(),
-              Collections.emptyMap(),
-              Collections.emptyMap(),
-              List.of(""));
+          name,
+          image,
+          envs,
+          schedule,
+          enable,
+          args,
+          request,
+          limit,
+          jobContainer,
+          initContainer,
+          volumes,
+          jobDeploymentAnnotations,
+          Collections.emptyMap(),
+          Collections.emptyMap(),
+          Collections.emptyMap(),
+          List.of(""));
     } else {
       createV1beta1CronJob(
-              name,
-              image,
-              envs,
-              schedule,
-              enable,
-              args,
-              request,
-              limit,
-              jobContainer,
-              initContainer,
-              volumes,
-              jobDeploymentAnnotations,
-              Collections.emptyMap(),
-              Collections.emptyMap(),
-              Collections.emptyMap(),
-              List.of(""));
+          name,
+          image,
+          envs,
+          schedule,
+          enable,
+          args,
+          request,
+          limit,
+          jobContainer,
+          initContainer,
+          volumes,
+          jobDeploymentAnnotations,
+          Collections.emptyMap(),
+          Collections.emptyMap(),
+          Collections.emptyMap(),
+          List.of(""));
     }
   }
 
   public void createCronJob(
-          String name,
-          String image,
-          Map<String, String> envs,
-          String schedule,
-          boolean enable,
-          List<String> args,
-          Resources request,
-          Resources limit,
-          V1Container jobContainer,
-          V1Container initContainer,
-          List<V1Volume> volumes,
-          Map<String, String> jobDeploymentAnnotations,
-          Map<String, String> jobPodLabels,
-          Map<String, String> jobAnnotations,
-          Map<String, String> jobLabels,
-          List<String> imagePullSecrets)
-          throws ApiException {
+      String name,
+      String image,
+      Map<String, String> envs,
+      String schedule,
+      boolean enable,
+      List<String> args,
+      Resources request,
+      Resources limit,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobDeploymentAnnotations,
+      Map<String, String> jobPodLabels,
+      Map<String, String> jobAnnotations,
+      Map<String, String> jobLabels,
+      List<String> imagePullSecrets)
+      throws ApiException {
     if (getK8sSupportsV1CronJob()) {
       createV1CronJob(
-              name,
-              image,
-              envs,
-              schedule,
-              enable,
-              args,
-              request,
-              limit,
-              jobContainer,
-              initContainer,
-              volumes,
-              jobDeploymentAnnotations,
-              jobPodLabels,
-              jobAnnotations,
-              jobLabels,
-              imagePullSecrets);
+          name,
+          image,
+          envs,
+          schedule,
+          enable,
+          args,
+          request,
+          limit,
+          jobContainer,
+          initContainer,
+          volumes,
+          jobDeploymentAnnotations,
+          jobPodLabels,
+          jobAnnotations,
+          jobLabels,
+          imagePullSecrets);
     } else {
       createV1beta1CronJob(
-              name,
-              image,
-              envs,
-              schedule,
-              enable,
-              args,
-              request,
-              limit,
-              jobContainer,
-              initContainer,
-              volumes,
-              jobDeploymentAnnotations,
-              jobPodLabels,
-              jobAnnotations,
-              jobLabels,
-              imagePullSecrets);
+          name,
+          image,
+          envs,
+          schedule,
+          enable,
+          args,
+          request,
+          limit,
+          jobContainer,
+          initContainer,
+          volumes,
+          jobDeploymentAnnotations,
+          jobPodLabels,
+          jobAnnotations,
+          jobLabels,
+          imagePullSecrets);
     }
   }
 
   // TODO:  container/volume args are breaking a bit abstraction of KubernetesService by leaking
   // impl. details
   public void createV1beta1CronJob(
-          String name,
-          String image,
-          Map<String, String> envs,
-          String schedule,
-          boolean enable,
-          List<String> args,
-          Resources request,
-          Resources limit,
-          V1Container jobContainer,
-          V1Container initContainer,
-          List<V1Volume> volumes,
-          Map<String, String> jobDeploymentAnnotations,
-          Map<String, String> jobPodLabels,
-          Map<String, String> jobAnnotations,
-          Map<String, String> jobLabels,
-          List<String> imagePullSecrets)
-          throws ApiException {
+      String name,
+      String image,
+      Map<String, String> envs,
+      String schedule,
+      boolean enable,
+      List<String> args,
+      Resources request,
+      Resources limit,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobDeploymentAnnotations,
+      Map<String, String> jobPodLabels,
+      Map<String, String> jobAnnotations,
+      Map<String, String> jobLabels,
+      List<String> imagePullSecrets)
+      throws ApiException {
     log.debug("Creating k8s cron job name:{}, image:{}", name, image);
     var cronJob =
-            v1beta1CronJobFromTemplate(
-                    name,
-                    schedule,
-                    !enable,
-                    jobContainer,
-                    initContainer,
-                    volumes,
-                    jobDeploymentAnnotations,
-                    jobPodLabels,
-                    jobAnnotations,
-                    jobLabels,
-                    imagePullSecrets);
+        v1beta1CronJobFromTemplate(
+            name,
+            schedule,
+            !enable,
+            jobContainer,
+            initContainer,
+            volumes,
+            jobDeploymentAnnotations,
+            jobPodLabels,
+            jobAnnotations,
+            jobLabels,
+            imagePullSecrets);
     V1beta1CronJob nsJob =
-            new BatchV1beta1Api(client)
-                    .createNamespacedCronJob(namespace, cronJob, null, null, null, null);
+        new BatchV1beta1Api(client)
+            .createNamespacedCronJob(namespace, cronJob, null, null, null, null);
     log.debug("Created k8s cron job: {}", nsJob);
     log.debug(
-            "Created k8s cron job name: {}, uid:{}, link:{}",
-            nsJob.getMetadata().getName(),
-            nsJob.getMetadata().getUid(),
-            nsJob.getMetadata().getSelfLink());
+        "Created k8s cron job name: {}, uid:{}, link:{}",
+        nsJob.getMetadata().getName(),
+        nsJob.getMetadata().getUid(),
+        nsJob.getMetadata().getSelfLink());
   }
 
   // TODO:  container/volume args are breaking a bit abstraction of KubernetesService by leaking
   // impl. details
   public void createV1CronJob(
-          String name,
-          String image,
-          Map<String, String> envs,
-          String schedule,
-          boolean enable,
-          List<String> args,
-          Resources request,
-          Resources limit,
-          V1Container jobContainer,
-          V1Container initContainer,
-          List<V1Volume> volumes,
-          Map<String, String> jobDeploymentAnnotations,
-          Map<String, String> jobPodLabels,
-          Map<String, String> jobAnnotations,
-          Map<String, String> jobLabels,
-          List<String> imagePullSecrets)
-          throws ApiException {
+      String name,
+      String image,
+      Map<String, String> envs,
+      String schedule,
+      boolean enable,
+      List<String> args,
+      Resources request,
+      Resources limit,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobDeploymentAnnotations,
+      Map<String, String> jobPodLabels,
+      Map<String, String> jobAnnotations,
+      Map<String, String> jobLabels,
+      List<String> imagePullSecrets)
+      throws ApiException {
     log.debug("Creating k8s cron job name:{}, image:{}", name, image);
     var cronJob =
-            v1CronJobFromTemplate(
-                    name,
-                    schedule,
-                    !enable,
-                    jobContainer,
-                    initContainer,
-                    volumes,
-                    jobDeploymentAnnotations,
-                    jobPodLabels,
-                    jobAnnotations,
-                    jobLabels,
-                    imagePullSecrets);
+        v1CronJobFromTemplate(
+            name,
+            schedule,
+            !enable,
+            jobContainer,
+            initContainer,
+            volumes,
+            jobDeploymentAnnotations,
+            jobPodLabels,
+            jobAnnotations,
+            jobLabels,
+            imagePullSecrets);
     V1CronJob nsJob =
-            new BatchV1Api(client).createNamespacedCronJob(namespace, cronJob, null, null, null, null);
+        new BatchV1Api(client).createNamespacedCronJob(namespace, cronJob, null, null, null, null);
     log.debug("Created k8s cron job: {}", nsJob);
     log.debug(
-            "Created k8s cron job name: {}, uid:{}, link:{}",
-            nsJob.getMetadata().getName(),
-            nsJob.getMetadata().getUid(),
-            nsJob.getMetadata().getSelfLink());
+        "Created k8s cron job name: {}, uid:{}, link:{}",
+        nsJob.getMetadata().getName(),
+        nsJob.getMetadata().getUid(),
+        nsJob.getMetadata().getSelfLink());
   }
 
   public void updateCronJob(
-          String name,
-          String image,
-          Map<String, String> envs,
-          String schedule,
-          boolean enable,
-          List<String> args,
-          Resources request,
-          Resources limit,
-          V1Container jobContainer,
-          V1Container initContainer,
-          List<V1Volume> volumes,
-          Map<String, String> jobDeploymentAnnotations)
-          throws ApiException {
+      String name,
+      String image,
+      Map<String, String> envs,
+      String schedule,
+      boolean enable,
+      List<String> args,
+      Resources request,
+      Resources limit,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobDeploymentAnnotations)
+      throws ApiException {
     if (getK8sSupportsV1CronJob()) {
       updateV1CronJob(
-              name,
-              image,
-              envs,
-              schedule,
-              enable,
-              args,
-              request,
-              limit,
-              jobContainer,
-              initContainer,
-              volumes,
-              jobDeploymentAnnotations,
-              Collections.emptyMap(),
-              Collections.emptyMap(),
-              Collections.emptyMap(),
-              List.of(""));
+          name,
+          image,
+          envs,
+          schedule,
+          enable,
+          args,
+          request,
+          limit,
+          jobContainer,
+          initContainer,
+          volumes,
+          jobDeploymentAnnotations,
+          Collections.emptyMap(),
+          Collections.emptyMap(),
+          Collections.emptyMap(),
+          List.of(""));
     } else {
       updateV1beta1CronJob(
-              name,
-              image,
-              envs,
-              schedule,
-              enable,
-              args,
-              request,
-              limit,
-              jobContainer,
-              initContainer,
-              volumes,
-              jobDeploymentAnnotations,
-              Collections.emptyMap(),
-              Collections.emptyMap(),
-              Collections.emptyMap(),
-              List.of(""));
+          name,
+          image,
+          envs,
+          schedule,
+          enable,
+          args,
+          request,
+          limit,
+          jobContainer,
+          initContainer,
+          volumes,
+          jobDeploymentAnnotations,
+          Collections.emptyMap(),
+          Collections.emptyMap(),
+          Collections.emptyMap(),
+          List.of(""));
     }
   }
 
   public void updateCronJob(
-          String name,
-          String image,
-          Map<String, String> envs,
-          String schedule,
-          boolean enable,
-          List<String> args,
-          Resources request,
-          Resources limit,
-          V1Container jobContainer,
-          V1Container initContainer,
-          List<V1Volume> volumes,
-          Map<String, String> jobDeploymentAnnotations,
-          Map<String, String> jobPodLabels,
-          Map<String, String> jobAnnotations,
-          Map<String, String> jobLabels,
-          List<String> imagePullSecrets)
-          throws ApiException {
+      String name,
+      String image,
+      Map<String, String> envs,
+      String schedule,
+      boolean enable,
+      List<String> args,
+      Resources request,
+      Resources limit,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobDeploymentAnnotations,
+      Map<String, String> jobPodLabels,
+      Map<String, String> jobAnnotations,
+      Map<String, String> jobLabels,
+      List<String> imagePullSecrets)
+      throws ApiException {
     if (getK8sSupportsV1CronJob()) {
       updateV1CronJob(
-              name,
-              image,
-              envs,
-              schedule,
-              enable,
-              args,
-              request,
-              limit,
-              jobContainer,
-              initContainer,
-              volumes,
-              jobDeploymentAnnotations,
-              jobPodLabels,
-              jobAnnotations,
-              jobLabels,
-              imagePullSecrets);
+          name,
+          image,
+          envs,
+          schedule,
+          enable,
+          args,
+          request,
+          limit,
+          jobContainer,
+          initContainer,
+          volumes,
+          jobDeploymentAnnotations,
+          jobPodLabels,
+          jobAnnotations,
+          jobLabels,
+          imagePullSecrets);
     } else {
       updateV1beta1CronJob(
-              name,
-              image,
-              envs,
-              schedule,
-              enable,
-              args,
-              request,
-              limit,
-              jobContainer,
-              initContainer,
-              volumes,
-              jobDeploymentAnnotations,
-              jobPodLabels,
-              jobAnnotations,
-              jobLabels,
-              imagePullSecrets);
+          name,
+          image,
+          envs,
+          schedule,
+          enable,
+          args,
+          request,
+          limit,
+          jobContainer,
+          initContainer,
+          volumes,
+          jobDeploymentAnnotations,
+          jobPodLabels,
+          jobAnnotations,
+          jobLabels,
+          imagePullSecrets);
     }
   }
 
   public void updateV1beta1CronJob(
-          String name,
-          String image,
-          Map<String, String> envs,
-          String schedule,
-          boolean enable,
-          List<String> args,
-          Resources request,
-          Resources limit,
-          V1Container jobContainer,
-          V1Container initContainer,
-          List<V1Volume> volumes,
-          Map<String, String> jobDeploymentAnnotations,
-          Map<String, String> jobPodLabels,
-          Map<String, String> jobAnnotations,
-          Map<String, String> jobLabels,
-          List<String> imagePullSecrets)
-          throws ApiException {
+      String name,
+      String image,
+      Map<String, String> envs,
+      String schedule,
+      boolean enable,
+      List<String> args,
+      Resources request,
+      Resources limit,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobDeploymentAnnotations,
+      Map<String, String> jobPodLabels,
+      Map<String, String> jobAnnotations,
+      Map<String, String> jobLabels,
+      List<String> imagePullSecrets)
+      throws ApiException {
     var cronJob =
-            v1beta1CronJobFromTemplate(
-                    name,
-                    schedule,
-                    !enable,
-                    jobContainer,
-                    initContainer,
-                    volumes,
-                    jobDeploymentAnnotations,
-                    jobPodLabels,
-                    jobAnnotations,
-                    jobLabels,
-                    imagePullSecrets);
-    V1beta1CronJob nsJob =
-            new BatchV1beta1Api(client)
-                    .replaceNamespacedCronJob(name, namespace, cronJob, null, null, null, null);
-    log.debug(
-            "Updated k8s cron job status for name:{}, image:{}, uid:{}, link:{}",
+        v1beta1CronJobFromTemplate(
             name,
-            image,
-            nsJob.getMetadata().getUid(),
-            nsJob.getMetadata().getSelfLink());
+            schedule,
+            !enable,
+            jobContainer,
+            initContainer,
+            volumes,
+            jobDeploymentAnnotations,
+            jobPodLabels,
+            jobAnnotations,
+            jobLabels,
+            imagePullSecrets);
+    V1beta1CronJob nsJob =
+        new BatchV1beta1Api(client)
+            .replaceNamespacedCronJob(name, namespace, cronJob, null, null, null, null);
+    log.debug(
+        "Updated k8s cron job status for name:{}, image:{}, uid:{}, link:{}",
+        name,
+        image,
+        nsJob.getMetadata().getUid(),
+        nsJob.getMetadata().getSelfLink());
   }
 
   public void updateV1CronJob(
-          String name,
-          String image,
-          Map<String, String> envs,
-          String schedule,
-          boolean enable,
-          List<String> args,
-          Resources request,
-          Resources limit,
-          V1Container jobContainer,
-          V1Container initContainer,
-          List<V1Volume> volumes,
-          Map<String, String> jobDeploymentAnnotations,
-          Map<String, String> jobPodLabels,
-          Map<String, String> jobAnnotations,
-          Map<String, String> jobLabels,
-          List<String> imagePullSecrets)
-          throws ApiException {
+      String name,
+      String image,
+      Map<String, String> envs,
+      String schedule,
+      boolean enable,
+      List<String> args,
+      Resources request,
+      Resources limit,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobDeploymentAnnotations,
+      Map<String, String> jobPodLabels,
+      Map<String, String> jobAnnotations,
+      Map<String, String> jobLabels,
+      List<String> imagePullSecrets)
+      throws ApiException {
     var cronJob =
-            v1CronJobFromTemplate(
-                    name,
-                    schedule,
-                    !enable,
-                    jobContainer,
-                    initContainer,
-                    volumes,
-                    jobDeploymentAnnotations,
-                    jobPodLabels,
-                    jobAnnotations,
-                    jobLabels,
-                    imagePullSecrets);
-    V1CronJob nsJob =
-            new BatchV1Api(client)
-                    .replaceNamespacedCronJob(name, namespace, cronJob, null, null, null, null);
-    log.debug(
-            "Updated k8s cron job status for name:{}, image:{}, uid:{}, link:{}",
+        v1CronJobFromTemplate(
             name,
-            image,
-            nsJob.getMetadata().getUid(),
-            nsJob.getMetadata().getSelfLink());
+            schedule,
+            !enable,
+            jobContainer,
+            initContainer,
+            volumes,
+            jobDeploymentAnnotations,
+            jobPodLabels,
+            jobAnnotations,
+            jobLabels,
+            imagePullSecrets);
+    V1CronJob nsJob =
+        new BatchV1Api(client)
+            .replaceNamespacedCronJob(name, namespace, cronJob, null, null, null, null);
+    log.debug(
+        "Updated k8s cron job status for name:{}, image:{}, uid:{}, link:{}",
+        name,
+        image,
+        nsJob.getMetadata().getUid(),
+        nsJob.getMetadata().getSelfLink());
   }
 
   public void deleteCronJob(String name) throws ApiException {
     log.debug("Deleting k8s cron job: {}", name);
     try {
       new BatchV1beta1Api(client)
-              .deleteNamespacedCronJob(name, namespace, null, null, null, null, null, null);
+          .deleteNamespacedCronJob(name, namespace, null, null, null, null, null, null);
     } catch (JsonSyntaxException e) {
       if (e.getCause() instanceof IllegalStateException) {
         IllegalStateException ise = (IllegalStateException) e.getCause();
         if (ise.getMessage() != null
-                && ise.getMessage().contains("Expected a string but was BEGIN_OBJECT"))
+            && ise.getMessage().contains("Expected a string but was BEGIN_OBJECT"))
           log.debug(
-                  "Catching exception because of issue"
-                          + " https://github.com/kubernetes-client/java/issues/86",
-                  e);
+              "Catching exception because of issue"
+                  + " https://github.com/kubernetes-client/java/issues/86",
+              e);
         else throw e;
       } else throw e;
     }
     log.debug("Deleted k8s cron job: {}", name);
   }
 
-
-
-
   @VisibleForTesting
   public V1CronJob v1CronJobFromTemplate(
-          String name,
-          String schedule,
-          boolean suspend,
-          V1Container jobContainer,
-          V1Container initContainer,
-          List<V1Volume> volumes,
-          Map<String, String> jobDeploymentAnnotations,
-          Map<String, String> jobPodLabels,
-          Map<String, String> jobAnnotations,
-          Map<String, String> jobLabels,
-          List<String> imagePullSecrets) {
+      String name,
+      String schedule,
+      boolean suspend,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobDeploymentAnnotations,
+      Map<String, String> jobPodLabels,
+      Map<String, String> jobAnnotations,
+      Map<String, String> jobLabels,
+      List<String> imagePullSecrets) {
     V1CronJob cronjob = loadV1CronjobTemplate();
     v1checkForMissingEntries(cronjob);
     cronjob.getMetadata().setName(name);
     cronjob.getSpec().setSchedule(schedule);
     cronjob.getSpec().setSuspend(suspend);
     cronjob
-            .getSpec()
-            .getJobTemplate()
-            .getSpec()
-            .getTemplate()
-            .getSpec()
-            .setContainers(Collections.singletonList(jobContainer));
+        .getSpec()
+        .getJobTemplate()
+        .getSpec()
+        .getTemplate()
+        .getSpec()
+        .setContainers(Collections.singletonList(jobContainer));
     cronjob
-            .getSpec()
-            .getJobTemplate()
-            .getSpec()
-            .getTemplate()
-            .getSpec()
-            .setInitContainers(Collections.singletonList(initContainer));
+        .getSpec()
+        .getJobTemplate()
+        .getSpec()
+        .getTemplate()
+        .getSpec()
+        .setInitContainers(Collections.singletonList(initContainer));
     cronjob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().setVolumes(volumes);
     // Merge the annotations and the labels.
     cronjob.getMetadata().getAnnotations().putAll(jobDeploymentAnnotations);
     cronjob
-            .getSpec()
-            .getJobTemplate()
-            .getSpec()
-            .getTemplate()
-            .getMetadata()
-            .getLabels()
-            .putAll(jobPodLabels);
+        .getSpec()
+        .getJobTemplate()
+        .getSpec()
+        .getTemplate()
+        .getMetadata()
+        .getLabels()
+        .putAll(jobPodLabels);
 
     cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations().putAll(jobAnnotations);
     cronjob.getSpec().getJobTemplate().getMetadata().getLabels().putAll(jobLabels);
 
     List<V1LocalObjectReference> imagePullSecretsObj =
-            Optional.ofNullable(imagePullSecrets).stream()
-                    .flatMap(secrets -> secrets.stream())
-                    .filter(secret -> StringUtils.isNotEmpty(secret))
-                    .map(secret -> new V1LocalObjectReferenceBuilder().withName(secret).build())
-                    .collect(Collectors.toList());
+        Optional.ofNullable(imagePullSecrets).stream()
+            .flatMap(secrets -> secrets.stream())
+            .filter(secret -> StringUtils.isNotEmpty(secret))
+            .map(secret -> new V1LocalObjectReferenceBuilder().withName(secret).build())
+            .collect(Collectors.toList());
 
     if (!CollectionUtils.isEmpty(imagePullSecretsObj)) {
       cronjob
-              .getSpec()
-              .getJobTemplate()
-              .getSpec()
-              .getTemplate()
-              .getSpec()
-              .setImagePullSecrets(imagePullSecretsObj);
+          .getSpec()
+          .getJobTemplate()
+          .getSpec()
+          .getTemplate()
+          .getSpec()
+          .setImagePullSecrets(imagePullSecretsObj);
     }
 
     return cronjob;
   }
 
-
   public V1beta1CronJob v1beta1CronJobFromTemplate(
-          String name,
-          String schedule,
-          boolean suspend,
-          V1Container jobContainer,
-          V1Container initContainer,
-          List<V1Volume> volumes,
-          Map<String, String> jobDeploymentAnnotations,
-          Map<String, String> jobPodLabels,
-          Map<String, String> jobAnnotations,
-          Map<String, String> jobLabels,
-          List<String> imagePullSecrets) {
+      String name,
+      String schedule,
+      boolean suspend,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobDeploymentAnnotations,
+      Map<String, String> jobPodLabels,
+      Map<String, String> jobAnnotations,
+      Map<String, String> jobLabels,
+      List<String> imagePullSecrets) {
     V1beta1CronJob cronjob = loadV1beta1CronjobTemplate();
     v1beta1checkForMissingEntries(cronjob);
     cronjob.getMetadata().setName(name);
     cronjob.getSpec().setSchedule(schedule);
     cronjob.getSpec().setSuspend(suspend);
     cronjob
-            .getSpec()
-            .getJobTemplate()
-            .getSpec()
-            .getTemplate()
-            .getSpec()
-            .setContainers(Collections.singletonList(jobContainer));
+        .getSpec()
+        .getJobTemplate()
+        .getSpec()
+        .getTemplate()
+        .getSpec()
+        .setContainers(Collections.singletonList(jobContainer));
     cronjob
-            .getSpec()
-            .getJobTemplate()
-            .getSpec()
-            .getTemplate()
-            .getSpec()
-            .setInitContainers(Collections.singletonList(initContainer));
+        .getSpec()
+        .getJobTemplate()
+        .getSpec()
+        .getTemplate()
+        .getSpec()
+        .setInitContainers(Collections.singletonList(initContainer));
     cronjob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().setVolumes(volumes);
     // Merge the annotations and the labels.
     cronjob.getMetadata().getAnnotations().putAll(jobDeploymentAnnotations);
     cronjob
-            .getSpec()
-            .getJobTemplate()
-            .getSpec()
-            .getTemplate()
-            .getMetadata()
-            .getLabels()
-            .putAll(jobPodLabels);
+        .getSpec()
+        .getJobTemplate()
+        .getSpec()
+        .getTemplate()
+        .getMetadata()
+        .getLabels()
+        .putAll(jobPodLabels);
 
     cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations().putAll(jobAnnotations);
     cronjob.getSpec().getJobTemplate().getMetadata().getLabels().putAll(jobLabels);
 
     List<V1LocalObjectReference> imagePullSecretsObj =
-            Optional.ofNullable(imagePullSecrets).stream()
-                    .flatMap(secrets -> secrets.stream())
-                    .filter(secret -> StringUtils.isNotEmpty(secret))
-                    .map(secret -> new V1LocalObjectReferenceBuilder().withName(secret).build())
-                    .collect(Collectors.toList());
+        Optional.ofNullable(imagePullSecrets).stream()
+            .flatMap(secrets -> secrets.stream())
+            .filter(secret -> StringUtils.isNotEmpty(secret))
+            .map(secret -> new V1LocalObjectReferenceBuilder().withName(secret).build())
+            .collect(Collectors.toList());
 
     if (!CollectionUtils.isEmpty(imagePullSecretsObj)) {
       cronjob
-              .getSpec()
-              .getJobTemplate()
-              .getSpec()
-              .getTemplate()
-              .getSpec()
-              .setImagePullSecrets(imagePullSecretsObj);
+          .getSpec()
+          .getJobTemplate()
+          .getSpec()
+          .getTemplate()
+          .getSpec()
+          .setImagePullSecrets(imagePullSecretsObj);
     }
 
     return cronjob;
   }
-
-
-
 
   private void v1checkForMissingEntries(V1CronJob cronjob) {
     V1CronJob internalCronjobTemplate = loadInternalV1CronjobTemplate();
@@ -882,7 +869,7 @@ public class DataJobsKubernetesService extends KubernetesService {
     }
     if (spec.getJobTemplate().getMetadata() == null) {
       spec.getJobTemplate()
-              .setMetadata(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
+          .setMetadata(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
     }
     if (spec.getJobTemplate().getMetadata().getLabels() == null) {
       spec.getJobTemplate().getMetadata().setLabels(new HashMap<>());
@@ -895,33 +882,32 @@ public class DataJobsKubernetesService extends KubernetesService {
     }
     if (spec.getJobTemplate().getSpec().getTemplate() == null) {
       spec.getJobTemplate()
-              .getSpec()
-              .setTemplate(internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate());
+          .getSpec()
+          .setTemplate(internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate());
     }
     if (spec.getJobTemplate().getSpec().getTemplate().getSpec() == null) {
       spec.getJobTemplate()
-              .getSpec()
-              .getTemplate()
-              .setSpec(
-                      internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
+          .getSpec()
+          .getTemplate()
+          .setSpec(
+              internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
     }
     if (spec.getJobTemplate().getSpec().getTemplate().getMetadata() == null) {
       spec.getJobTemplate()
-              .getSpec()
-              .getTemplate()
-              .setMetadata(
-                      internalCronjobTemplate
-                              .getSpec()
-                              .getJobTemplate()
-                              .getSpec()
-                              .getTemplate()
-                              .getMetadata());
+          .getSpec()
+          .getTemplate()
+          .setMetadata(
+              internalCronjobTemplate
+                  .getSpec()
+                  .getJobTemplate()
+                  .getSpec()
+                  .getTemplate()
+                  .getMetadata());
     }
     if (spec.getJobTemplate().getSpec().getTemplate().getMetadata().getLabels() == null) {
       spec.getJobTemplate().getSpec().getTemplate().getMetadata().setLabels(new HashMap<>());
     }
   }
-
 
   // TODO - in the future we want to merge the (1) configurable datajob template
   //        with the (2) default internal datajob template when something from (1)
@@ -945,7 +931,7 @@ public class DataJobsKubernetesService extends KubernetesService {
     }
     if (spec.getJobTemplate().getMetadata() == null) {
       spec.getJobTemplate()
-              .setMetadata(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
+          .setMetadata(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
     }
     if (spec.getJobTemplate().getMetadata().getLabels() == null) {
       spec.getJobTemplate().getMetadata().setLabels(new HashMap<>());
@@ -958,33 +944,32 @@ public class DataJobsKubernetesService extends KubernetesService {
     }
     if (spec.getJobTemplate().getSpec().getTemplate() == null) {
       spec.getJobTemplate()
-              .getSpec()
-              .setTemplate(internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate());
+          .getSpec()
+          .setTemplate(internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate());
     }
     if (spec.getJobTemplate().getSpec().getTemplate().getSpec() == null) {
       spec.getJobTemplate()
-              .getSpec()
-              .getTemplate()
-              .setSpec(
-                      internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
+          .getSpec()
+          .getTemplate()
+          .setSpec(
+              internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
     }
     if (spec.getJobTemplate().getSpec().getTemplate().getMetadata() == null) {
       spec.getJobTemplate()
-              .getSpec()
-              .getTemplate()
-              .setMetadata(
-                      internalCronjobTemplate
-                              .getSpec()
-                              .getJobTemplate()
-                              .getSpec()
-                              .getTemplate()
-                              .getMetadata());
+          .getSpec()
+          .getTemplate()
+          .setMetadata(
+              internalCronjobTemplate
+                  .getSpec()
+                  .getJobTemplate()
+                  .getSpec()
+                  .getTemplate()
+                  .getMetadata());
     }
     if (spec.getJobTemplate().getSpec().getTemplate().getMetadata().getLabels() == null) {
       spec.getJobTemplate().getSpec().getTemplate().getMetadata().setLabels(new HashMap<>());
     }
   }
-
 
   public Optional<JobDeploymentStatus> readCronJob(String cronJobName) {
     return getK8sSupportsV1CronJob() ? readV1CronJob(cronJobName) : readV1beta1CronJob(cronJobName);
@@ -997,9 +982,9 @@ public class DataJobsKubernetesService extends KubernetesService {
       cronJob = new BatchV1beta1Api(client).readNamespacedCronJob(cronJobName, namespace, null);
     } catch (ApiException e) {
       log.warn(
-              "Could not read cron job: {}; reason: {}",
-              cronJobName,
-              new KubernetesException("", e).toString());
+          "Could not read cron job: {}; reason: {}",
+          cronJobName,
+          new KubernetesException("", e).toString());
     }
 
     return mapV1beta1CronJobToDeploymentStatus(cronJob, cronJobName);
@@ -1012,9 +997,9 @@ public class DataJobsKubernetesService extends KubernetesService {
       cronJob = new BatchV1Api(client).readNamespacedCronJob(cronJobName, namespace, null);
     } catch (ApiException e) {
       log.warn(
-              "Could not read cron job: {}; reason: {}",
-              cronJobName,
-              new KubernetesException("", e).toString());
+          "Could not read cron job: {}; reason: {}",
+          cronJobName,
+          new KubernetesException("", e).toString());
     }
 
     return mapV1CronJobToDeploymentStatus(cronJob, cronJobName);
@@ -1028,8 +1013,8 @@ public class DataJobsKubernetesService extends KubernetesService {
    */
   public List<JobDeploymentStatus> readJobDeploymentStatuses() {
     return getK8sSupportsV1CronJob()
-            ? readV1CronJobDeploymentStatuses()
-            : readV1beta1CronJobDeploymentStatuses();
+        ? readV1CronJobDeploymentStatuses()
+        : readV1beta1CronJobDeploymentStatuses();
   }
 
   public List<JobDeploymentStatus> readV1beta1CronJobDeploymentStatuses() {
@@ -1037,16 +1022,16 @@ public class DataJobsKubernetesService extends KubernetesService {
     V1beta1CronJobList cronJobs = null;
     try {
       cronJobs =
-              new BatchV1beta1Api(client)
-                      .listNamespacedCronJob(
-                              namespace, null, null, null, null, null, null, null, null, null, null);
+          new BatchV1beta1Api(client)
+              .listNamespacedCronJob(
+                  namespace, null, null, null, null, null, null, null, null, null, null);
     } catch (ApiException e) {
       log.warn("Failed to read k8s cron jobs: ", new KubernetesException("", e));
     }
 
     return cronJobs == null
-            ? Collections.emptyList()
-            : cronJobs.getItems().stream()
+        ? Collections.emptyList()
+        : cronJobs.getItems().stream()
             .map(cronJob -> mapV1beta1CronJobToDeploymentStatus(cronJob, null))
             .flatMap(Optional::stream)
             .collect(Collectors.toList());
@@ -1057,90 +1042,90 @@ public class DataJobsKubernetesService extends KubernetesService {
     V1CronJobList cronJobs = null;
     try {
       cronJobs =
-              new BatchV1Api(client)
-                      .listNamespacedCronJob(
-                              namespace, null, null, null, null, null, null, null, null, null, null);
+          new BatchV1Api(client)
+              .listNamespacedCronJob(
+                  namespace, null, null, null, null, null, null, null, null, null, null);
     } catch (ApiException e) {
       log.warn("Failed to read k8s cron jobs: ", new KubernetesException("", e));
     }
 
     return cronJobs == null
-            ? Collections.emptyList()
-            : cronJobs.getItems().stream()
+        ? Collections.emptyList()
+        : cronJobs.getItems().stream()
             .map(cronJob -> mapV1CronJobToDeploymentStatus(cronJob, null))
             .flatMap(Optional::stream)
             .collect(Collectors.toList());
   }
 
   public void startNewCronJobExecution(
-          String cronJobName,
-          String executionId,
-          Map<String, String> annotations,
-          Map<String, String> envs,
-          Map<String, Object> extraJobArguments,
-          String jobName)
-          throws ApiException {
+      String cronJobName,
+      String executionId,
+      Map<String, String> annotations,
+      Map<String, String> envs,
+      Map<String, Object> extraJobArguments,
+      String jobName)
+      throws ApiException {
     if (getK8sSupportsV1CronJob()) {
       startNewV1CronJobExecution(
-              cronJobName, executionId, annotations, envs, extraJobArguments, jobName);
+          cronJobName, executionId, annotations, envs, extraJobArguments, jobName);
     } else {
       startNewV1beta1CronJobExecution(
-              cronJobName, executionId, annotations, envs, extraJobArguments, jobName);
+          cronJobName, executionId, annotations, envs, extraJobArguments, jobName);
     }
   }
 
   private void startNewV1beta1CronJobExecution(
-          String cronJobName,
-          String executionId,
-          Map<String, String> annotations,
-          Map<String, String> envs,
-          Map<String, Object> extraJobArguments,
-          String jobName)
-          throws ApiException {
+      String cronJobName,
+      String executionId,
+      Map<String, String> annotations,
+      Map<String, String> envs,
+      Map<String, Object> extraJobArguments,
+      String jobName)
+      throws ApiException {
     var cron = initBatchV1beta1Api().readNamespacedCronJob(cronJobName, namespace, null);
     Optional<V1beta1JobTemplateSpec> jobTemplateSpec =
-            Optional.ofNullable(cron)
-                    .map(V1beta1CronJob::getSpec)
-                    .map(V1beta1CronJobSpec::getJobTemplate);
+        Optional.ofNullable(cron)
+            .map(V1beta1CronJob::getSpec)
+            .map(V1beta1CronJobSpec::getJobTemplate);
 
     Map<String, String> jobLabels =
-            jobTemplateSpec
-                    .map(V1beta1JobTemplateSpec::getMetadata)
-                    .map(V1ObjectMeta::getLabels)
-                    .orElse(Collections.emptyMap());
+        jobTemplateSpec
+            .map(V1beta1JobTemplateSpec::getMetadata)
+            .map(V1ObjectMeta::getLabels)
+            .orElse(Collections.emptyMap());
 
     Map<String, String> jobAnnotations =
-            jobTemplateSpec
-                    .map(V1beta1JobTemplateSpec::getMetadata)
-                    .map(V1ObjectMeta::getAnnotations)
-                    .map(
-                            v1ObjectMetaAnnotations -> {
-                              v1ObjectMetaAnnotations.putAll(annotations);
-                              return v1ObjectMetaAnnotations;
-                            })
-                    .orElse(annotations);
+        jobTemplateSpec
+            .map(V1beta1JobTemplateSpec::getMetadata)
+            .map(V1ObjectMeta::getAnnotations)
+            .map(
+                v1ObjectMetaAnnotations -> {
+                  v1ObjectMetaAnnotations.putAll(annotations);
+                  return v1ObjectMetaAnnotations;
+                })
+            .orElse(annotations);
 
     V1JobSpec jobSpec =
-            jobTemplateSpec
-                    .map(V1beta1JobTemplateSpec::getSpec)
-                    .orElseThrow(
-                            () ->
-                                    new ApiException(
-                                            String.format(
-                                                    "K8S Cron Job '%s' does not exist or is not properly defined.",
-                                                    cronJobName)));
+        jobTemplateSpec
+            .map(V1beta1JobTemplateSpec::getSpec)
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        String.format(
+                            "K8S Cron Job '%s' does not exist or is not properly defined.",
+                            cronJobName)));
 
     jobSpec.setTtlSecondsAfterFinished(jobTTLAfterFinishedSeconds);
 
     V1Container v1Container =
-            Optional.ofNullable(jobSpec.getTemplate())
-                    .map(V1PodTemplateSpec::getSpec)
-                    .map(V1PodSpec::getContainers)
-                    .map(v1Containers -> v1Containers.get(0))
-                    .orElseThrow(
-                            () ->
-                                    new ApiException(
-                                            String.format("K8S Cron Job '%s' is not properly defined.", cronJobName)));
+        Optional.ofNullable(jobSpec.getTemplate())
+            .map(V1PodTemplateSpec::getSpec)
+            .map(V1PodSpec::getContainers)
+            .map(v1Containers -> v1Containers.get(0))
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        String.format("K8S Cron Job '%s' is not properly defined.", cronJobName)));
     if (!CollectionUtils.isEmpty(envs)) {
       envs.forEach((name, value) -> v1Container.addEnvItem(new V1EnvVar().name(name).value(value)));
     }
@@ -1153,56 +1138,56 @@ public class DataJobsKubernetesService extends KubernetesService {
   }
 
   private void startNewV1CronJobExecution(
-          String cronJobName,
-          String executionId,
-          Map<String, String> annotations,
-          Map<String, String> envs,
-          Map<String, Object> extraJobArguments,
-          String jobName)
-          throws ApiException {
+      String cronJobName,
+      String executionId,
+      Map<String, String> annotations,
+      Map<String, String> envs,
+      Map<String, Object> extraJobArguments,
+      String jobName)
+      throws ApiException {
     var cron = initBatchV1Api().readNamespacedCronJob(cronJobName, namespace, null);
 
     Optional<V1JobTemplateSpec> jobTemplateSpec =
-            Optional.ofNullable(cron).map(V1CronJob::getSpec).map(V1CronJobSpec::getJobTemplate);
+        Optional.ofNullable(cron).map(V1CronJob::getSpec).map(V1CronJobSpec::getJobTemplate);
 
     Map<String, String> jobLabels =
-            jobTemplateSpec
-                    .map(V1JobTemplateSpec::getMetadata)
-                    .map(V1ObjectMeta::getLabels)
-                    .orElse(Collections.emptyMap());
+        jobTemplateSpec
+            .map(V1JobTemplateSpec::getMetadata)
+            .map(V1ObjectMeta::getLabels)
+            .orElse(Collections.emptyMap());
 
     Map<String, String> jobAnnotations =
-            jobTemplateSpec
-                    .map(V1JobTemplateSpec::getMetadata)
-                    .map(V1ObjectMeta::getAnnotations)
-                    .map(
-                            v1ObjectMetaAnnotations -> {
-                              v1ObjectMetaAnnotations.putAll(annotations);
-                              return v1ObjectMetaAnnotations;
-                            })
-                    .orElse(annotations);
+        jobTemplateSpec
+            .map(V1JobTemplateSpec::getMetadata)
+            .map(V1ObjectMeta::getAnnotations)
+            .map(
+                v1ObjectMetaAnnotations -> {
+                  v1ObjectMetaAnnotations.putAll(annotations);
+                  return v1ObjectMetaAnnotations;
+                })
+            .orElse(annotations);
 
     V1JobSpec jobSpec =
-            jobTemplateSpec
-                    .map(V1JobTemplateSpec::getSpec)
-                    .orElseThrow(
-                            () ->
-                                    new ApiException(
-                                            String.format(
-                                                    "K8S Cron Job '%s' does not exist or is not properly defined.",
-                                                    cronJobName)));
+        jobTemplateSpec
+            .map(V1JobTemplateSpec::getSpec)
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        String.format(
+                            "K8S Cron Job '%s' does not exist or is not properly defined.",
+                            cronJobName)));
 
     jobSpec.setTtlSecondsAfterFinished(jobTTLAfterFinishedSeconds);
 
     V1Container v1Container =
-            Optional.ofNullable(jobSpec.getTemplate())
-                    .map(V1PodTemplateSpec::getSpec)
-                    .map(V1PodSpec::getContainers)
-                    .map(v1Containers -> v1Containers.get(0))
-                    .orElseThrow(
-                            () ->
-                                    new ApiException(
-                                            String.format("K8S Cron Job '%s' is not properly defined.", cronJobName)));
+        Optional.ofNullable(jobSpec.getTemplate())
+            .map(V1PodTemplateSpec::getSpec)
+            .map(V1PodSpec::getContainers)
+            .map(v1Containers -> v1Containers.get(0))
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        String.format("K8S Cron Job '%s' is not properly defined.", cronJobName)));
     if (!CollectionUtils.isEmpty(envs)) {
       envs.forEach((name, value) -> v1Container.addEnvItem(new V1EnvVar().name(name).value(value)));
     }
@@ -1214,19 +1199,17 @@ public class DataJobsKubernetesService extends KubernetesService {
     createNewJob(executionId, jobSpec, jobLabels, jobAnnotations);
   }
 
-
-
   private Optional<JobDeploymentStatus> mapV1beta1CronJobToDeploymentStatus(
-          V1beta1CronJob cronJob, String cronJobName) {
+      V1beta1CronJob cronJob, String cronJobName) {
     JobDeploymentStatus deployment = null;
     if (cronJob != null) {
       deployment = new JobDeploymentStatus();
       deployment.setEnabled(!cronJob.getSpec().getSuspend());
       deployment.setDataJobName(cronJob.getMetadata().getName());
       deployment.setMode(
-              "release"); // TODO: Get from cron job config when we support testing environments
+          "release"); // TODO: Get from cron job config when we support testing environments
       deployment.setCronJobName(
-              cronJobName == null ? cronJob.getMetadata().getName() : cronJobName);
+          cronJobName == null ? cronJob.getMetadata().getName() : cronJobName);
 
       // all fields until pod spec are required so no need to check for null
       var annotations = cronJob.getSpec().getJobTemplate().getMetadata().getAnnotations();
@@ -1236,14 +1219,14 @@ public class DataJobsKubernetesService extends KubernetesService {
       }
 
       List<V1Container> containers =
-              cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getContainers();
+          cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getContainers();
       if (!containers.isEmpty()) {
         String image =
-                containers.get(0).getImage(); // TODO: Have 2 containers. 1 for VDK and 1 for the job.
+            containers.get(0).getImage(); // TODO: Have 2 containers. 1 for VDK and 1 for the job.
         deployment.setImageName(image); // TODO do we really need to return image_name?
       }
       var initContainers =
-              cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getInitContainers();
+          cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getInitContainers();
       if (!CollectionUtils.isEmpty(initContainers)) {
         String vdkImage = initContainers.get(0).getImage();
         deployment.setVdkImageName(vdkImage);
@@ -1255,8 +1238,8 @@ public class DataJobsKubernetesService extends KubernetesService {
       var labels = cronJob.getSpec().getJobTemplate().getMetadata().getLabels();
       if (labels == null) {
         log.warn(
-                "The cronjob of data job '{}' does not have any labels defined.",
-                deployment.getDataJobName());
+            "The cronjob of data job '{}' does not have any labels defined.",
+            deployment.getDataJobName());
       }
       if (labels != null && labels.containsKey(JobLabel.VERSION.getValue())) {
         deployment.setGitCommitSha(labels.get(JobLabel.VERSION.getValue()));
@@ -1270,16 +1253,16 @@ public class DataJobsKubernetesService extends KubernetesService {
   }
 
   private Optional<JobDeploymentStatus> mapV1CronJobToDeploymentStatus(
-          V1CronJob cronJob, String cronJobName) {
+      V1CronJob cronJob, String cronJobName) {
     JobDeploymentStatus deployment = null;
     if (cronJob != null) {
       deployment = new JobDeploymentStatus();
       deployment.setEnabled(!cronJob.getSpec().getSuspend());
       deployment.setDataJobName(cronJob.getMetadata().getName());
       deployment.setMode(
-              "release"); // TODO: Get from cron job config when we support testing environments
+          "release"); // TODO: Get from cron job config when we support testing environments
       deployment.setCronJobName(
-              cronJobName == null ? cronJob.getMetadata().getName() : cronJobName);
+          cronJobName == null ? cronJob.getMetadata().getName() : cronJobName);
 
       // all fields until pod spec are required so no need to check for null
       var annotations = cronJob.getSpec().getJobTemplate().getMetadata().getAnnotations();
@@ -1289,14 +1272,14 @@ public class DataJobsKubernetesService extends KubernetesService {
       }
 
       List<V1Container> containers =
-              cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getContainers();
+          cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getContainers();
       if (!containers.isEmpty()) {
         String image =
-                containers.get(0).getImage(); // TODO: Have 2 containers. 1 for VDK and 1 for the job.
+            containers.get(0).getImage(); // TODO: Have 2 containers. 1 for VDK and 1 for the job.
         deployment.setImageName(image); // TODO do we really need to return image_name?
       }
       var initContainers =
-              cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getInitContainers();
+          cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getInitContainers();
       if (!CollectionUtils.isEmpty(initContainers)) {
         String vdkImage = initContainers.get(0).getImage();
         deployment.setVdkImageName(vdkImage);
@@ -1308,8 +1291,8 @@ public class DataJobsKubernetesService extends KubernetesService {
       var labels = cronJob.getSpec().getJobTemplate().getMetadata().getLabels();
       if (labels == null) {
         log.warn(
-                "The cronjob of data job '{}' does not have any labels defined.",
-                deployment.getDataJobName());
+            "The cronjob of data job '{}' does not have any labels defined.",
+            deployment.getDataJobName());
       }
       if (labels != null && labels.containsKey(JobLabel.VERSION.getValue())) {
         deployment.setGitCommitSha(labels.get(JobLabel.VERSION.getValue()));
@@ -1322,11 +1305,10 @@ public class DataJobsKubernetesService extends KubernetesService {
     return Optional.ofNullable(deployment);
   }
 
-
   private void addExtraJobArgumentsToVdkContainer(
-          V1Container container, Map<String, Object> extraJobArguments, String jobName) {
+      V1Container container, Map<String, Object> extraJobArguments, String jobName) {
     var commandList =
-            new ArrayList<>(container.getCommand()); // create a new List, since old might be immutable.
+        new ArrayList<>(container.getCommand()); // create a new List, since old might be immutable.
 
     if (commandList.size() < 3 || !Iterables.getLast(commandList).contains("vdk run")) {
       // If current job template definition changes we will throw an exception and will have to
@@ -1337,15 +1319,12 @@ public class DataJobsKubernetesService extends KubernetesService {
 
     try {
       var newCommand =
-              jobCommandProvider.getJobCommand(
-                      jobName, extraJobArguments); // vdk run command is last in the list
+          jobCommandProvider.getJobCommand(
+              jobName, extraJobArguments); // vdk run command is last in the list
       container.setCommand(newCommand);
     } catch (JsonProcessingException e) {
       log.debug("JsonProcessingException", e);
       throw new JsonDissectException(e);
     }
   }
-
-
-
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
@@ -5,13 +5,34 @@
 
 package com.vmware.taurus.service.kubernetes;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Iterables;
+import com.google.gson.JsonSyntaxException;
+import com.vmware.taurus.exception.*;
 import com.vmware.taurus.service.KubernetesService;
+import com.vmware.taurus.service.deploy.DockerImageName;
+import com.vmware.taurus.service.deploy.JobCommandProvider;
+import com.vmware.taurus.service.model.JobAnnotation;
+import com.vmware.taurus.service.model.JobDeploymentStatus;
+import com.vmware.taurus.service.model.JobLabel;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.BatchV1Api;
+import io.kubernetes.client.openapi.apis.BatchV1beta1Api;
+import io.kubernetes.client.openapi.models.*;
+import io.kubernetes.client.util.Yaml;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Kubernetes service used for serving data jobs deployments. All deployed data jobs are executed in
@@ -22,17 +43,1309 @@ import java.io.File;
 @Slf4j
 public class DataJobsKubernetesService extends KubernetesService {
 
+  @Autowired
+  private JobCommandProvider jobCommandProvider;
+
+  // The 'Value' annotation from Lombok collides with the 'Value' annotation from Spring.
+  @org.springframework.beans.factory.annotation.Value(
+          "${datajobs.control.k8s.data.job.template.file}")
+  private String datajobTemplateFileLocation;
+
+  private final boolean k8sSupportsV1CronJob;
+
+  private static final String K8S_DATA_JOB_TEMPLATE_RESOURCE = "k8s-data-job-template.yaml";
+
+
   public DataJobsKubernetesService(
-      @Value("${datajobs.deployment.k8s.namespace:}") String namespace,
-      @Value("${datajobs.deployment.k8s.kubeconfig:}") String kubeconfig,
-      @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob) {
-    super(namespace, kubeconfig, k8sSupportsV1CronJob, log);
+          @Value("${datajobs.deployment.k8s.namespace:}") String namespace,
+          @Value("${datajobs.deployment.k8s.kubeconfig:}") String kubeconfig,
+          @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob) {
+    super(namespace, kubeconfig, log);
+    this.k8sSupportsV1CronJob = k8sSupportsV1CronJob;
     if (StringUtils.isBlank(kubeconfig) && !new File(kubeconfig).isFile()) {
       log.warn(
-          "Data Jobs (Deployment) Kubernetes service may not have been correctly bootstrapped. {}"
-              + " file is missing Will try to use same cluster as control Plane. But this is not"
-              + " recommended in production.",
-          kubeconfig);
+              "Data Jobs (Deployment) Kubernetes service may not have been correctly bootstrapped. {}"
+                      + " file is missing Will try to use same cluster as control Plane. But this is not"
+                      + " recommended in production.",
+              kubeconfig);
     }
   }
+
+
+  @Override
+  public void afterPropertiesSet() throws Exception {
+    super.afterPropertiesSet();
+
+    // Step 1 - load the internal datajob template in order to validate it.
+    try {
+      if (getK8sSupportsV1CronJob()) {
+        loadV1CronjobTemplate(new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
+      } else {
+        loadV1beta1CronjobTemplate(new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
+      }
+      log.info("The internal datajob template is valid.");
+    } catch (Exception e) {
+      // Log the error and fail fast (cannot continue).
+      log.error("Fatal error while loading the internal datajob template. Cannot continue", e);
+      throw e;
+    }
+    // Step 2 - load the configurable datajob template in order to validate it
+    // when environment variable 'K8S_DATA_JOB_TEMPLATE_FILE' is set.
+    if (!StringUtils.isEmpty(datajobTemplateFileLocation)) {
+      if (getK8sSupportsV1CronJob()) {
+        if (loadConfigurableV1CronjobTemplate() == null) {
+          log.warn(
+                  "The configurable datajob template '{}' could not be loaded.",
+                  datajobTemplateFileLocation);
+        } else {
+          log.info("The configurable datajob template '{}' is valid.", datajobTemplateFileLocation);
+        }
+      } else {
+        if (loadConfigurableV1beta1CronjobTemplate() == null) {
+          log.warn(
+                  "The configurable datajob template '{}' could not be loaded.",
+                  datajobTemplateFileLocation);
+        } else {
+          log.info("The configurable datajob template '{}' is valid.", datajobTemplateFileLocation);
+        }
+      }
+    }
+  }
+
+
+  public boolean getK8sSupportsV1CronJob(){
+    return this.k8sSupportsV1CronJob;
+  }
+
+  private V1CronJob loadV1CronjobTemplate() {
+    if (StringUtils.isEmpty(datajobTemplateFileLocation)) {
+      log.debug("Datajob template file location is not set. Using internal datajob template.");
+      return loadInternalV1CronjobTemplate();
+    }
+    V1CronJob cronjobTemplate = loadConfigurableV1CronjobTemplate();
+    if (cronjobTemplate == null) {
+      return loadInternalV1CronjobTemplate();
+    }
+
+    return cronjobTemplate;
+  }
+
+  private V1beta1CronJob loadV1beta1CronjobTemplate() {
+    if (StringUtils.isEmpty(datajobTemplateFileLocation)) {
+      log.debug("Datajob template file location is not set. Using internal datajob template.");
+      return loadInternalV1beta1CronjobTemplate();
+    }
+    V1beta1CronJob cronjobTemplate = loadConfigurableV1beta1CronjobTemplate();
+    if (cronjobTemplate == null) {
+      return loadInternalV1beta1CronjobTemplate();
+    }
+
+    return cronjobTemplate;
+  }
+
+  private V1beta1CronJob loadInternalV1beta1CronjobTemplate() {
+    try {
+      return loadV1beta1CronjobTemplate(
+              new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
+    } catch (Exception e) {
+      // This should never happen unless we are testing locally and we've messed up
+      // with the internal template resource file.
+      throw new RuntimeException(
+              "Unrecoverable error while loading the internal datajob template. Cannot continue.", e);
+    }
+  }
+
+  private V1CronJob loadInternalV1CronjobTemplate() {
+    try {
+      return loadV1CronjobTemplate(new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
+    } catch (Exception e) {
+      // This should never happen unless we are testing locally and we've messed up
+      // with the internal template resource file.
+      throw new RuntimeException(
+              "Unrecoverable error while loading the internal datajob template. Cannot continue.", e);
+    }
+  }
+
+  private V1beta1CronJob loadConfigurableV1beta1CronjobTemplate() {
+    // Check whether to use configurable datajob template at all.
+    if (StringUtils.isEmpty(datajobTemplateFileLocation)) {
+      log.debug("Datajob template file location is not set.");
+      return null;
+    }
+
+    // Check whether the configurable datajob template file exists.
+    File datajobTemplateFile = new File(datajobTemplateFileLocation);
+    if (!datajobTemplateFile.isFile()) {
+      log.warn("Datajob template location '{}' is not a file.", datajobTemplateFileLocation);
+      return null;
+    }
+
+    try {
+      // Load the configurable datajob template file.
+      return loadV1beta1CronjobTemplate(datajobTemplateFile);
+    } catch (Exception e) {
+      log.error("Error while loading the datajob template file.", e);
+      return null;
+    }
+  }
+
+  private V1CronJob loadConfigurableV1CronjobTemplate() {
+    // Check whether to use configurable datajob template at all.
+    if (StringUtils.isEmpty(datajobTemplateFileLocation)) {
+      log.debug("Datajob template file location is not set.");
+      return null;
+    }
+
+    // Check whether the configurable datajob template file exists.
+    File datajobTemplateFile = new File(datajobTemplateFileLocation);
+    if (!datajobTemplateFile.isFile()) {
+      log.warn("Datajob template location '{}' is not a file.", datajobTemplateFileLocation);
+      return null;
+    }
+
+    try {
+      // Load the configurable datajob template file.
+      return loadV1CronjobTemplate(datajobTemplateFile);
+    } catch (Exception e) {
+      log.error("Error while loading the datajob template file.", e);
+      return null;
+    }
+  }
+
+  private V1beta1CronJob loadV1beta1CronjobTemplate(File datajobTemplateFile) throws Exception {
+    String cronjobTemplateString = Files.readString(datajobTemplateFile.toPath());
+    // Check whether the string template is a valid datajob template.
+    V1beta1CronJob cronjobTemplate = Yaml.loadAs(cronjobTemplateString, V1beta1CronJob.class);
+    log.debug(
+            "Datajob template for file '{}': \n{}",
+            datajobTemplateFile.getCanonicalPath(),
+            cronjobTemplate);
+
+    return cronjobTemplate;
+  }
+
+  private V1CronJob loadV1CronjobTemplate(File datajobTemplateFile) throws Exception {
+    String cronjobTemplateString = Files.readString(datajobTemplateFile.toPath());
+    // Check whether the string template is a valid datajob template.
+    V1CronJob cronjobTemplate = Yaml.loadAs(cronjobTemplateString, V1CronJob.class);
+    log.debug(
+            "Datajob template for file '{}': \n{}",
+            datajobTemplateFile.getCanonicalPath(),
+            cronjobTemplate);
+
+    return cronjobTemplate;
+  }
+
+
+
+  public void cancelRunningCronJob(String teamName, String jobName, String executionId)
+          throws ApiException {
+    log.info(
+            "K8S deleting job for team: {} data job name: {} execution: {} namespace: {}",
+            teamName,
+            jobName,
+            executionId,
+            namespace);
+    try {
+      var operationResponse =
+              initBatchV1Api()
+                      .deleteNamespacedJobWithHttpInfo(
+                              executionId, namespace, null, null, null, null, "Foreground", null);
+      // Status of the operation. One of: "Success" or "Failure"
+      if (operationResponse == null || operationResponse.getStatusCode() == 404) {
+        log.info(
+                "Execution: {} for data job: {} with team: {} not found! The data job has likely"
+                        + " completed before it could be cancelled.",
+                executionId,
+                jobName,
+                teamName);
+        throw new DataJobExecutionCannotBeCancelledException(
+                executionId, ExecutionCancellationFailureReason.DataJobExecutionNotFound);
+      } else if (operationResponse.getStatusCode() != 200) {
+        log.warn(
+                "Failed to delete K8S job. Reason: {} Details: {}",
+                operationResponse.getData().getReason(),
+                operationResponse.getData().getDetails());
+        throw new KubernetesException(
+                operationResponse.getData().getMessage(),
+                new ApiException(
+                        operationResponse.getStatusCode(), operationResponse.getData().getMessage()));
+      }
+    } catch (JsonSyntaxException e) {
+      if (e.getCause() instanceof IllegalStateException) {
+        IllegalStateException ise = (IllegalStateException) e.getCause();
+        if (ise.getMessage() != null
+                && ise.getMessage().contains("Expected a string but was BEGIN_OBJECT"))
+          log.debug(
+                  "Catching exception because of issue"
+                          + " https://github.com/kubernetes-client/java/issues/86",
+                  e);
+        else throw e;
+      } else throw e;
+
+    } catch (ApiException e) {
+      // If no response body is present this might be a transport layer failure.
+      if (e.getCode() == 404) {
+        log.debug(
+                "Job execution: {} team: {}, job: {} cannot be found. K8S response body {}. Will set"
+                        + " its status to Cancelled in the DB.",
+                executionId,
+                teamName,
+                jobName,
+                e.getResponseBody());
+      } else throw e;
+    }
+  }
+
+  public Set<String> listCronJobs() throws ApiException {
+    log.debug("Listing k8s cron jobs");
+    var cronJobs =
+            new BatchV1beta1Api(client)
+                    .listNamespacedCronJob(
+                            namespace, null, null, null, null, null, null, null, null, null, null);
+    var set =
+            cronJobs.getItems().stream()
+                    .map(j -> j.getMetadata().getName())
+                    .collect(Collectors.toSet());
+    log.debug("K8s cron jobs: {}", set);
+    return set;
+  }
+
+  public void createCronJob(
+          String name,
+          String image,
+          Map<String, String> envs,
+          String schedule,
+          boolean enable,
+          List<String> args,
+          Resources request,
+          Resources limit,
+          V1Container jobContainer,
+          V1Container initContainer,
+          List<V1Volume> volumes,
+          Map<String, String> jobDeploymentAnnotations)
+          throws ApiException {
+    if (getK8sSupportsV1CronJob()) {
+      createV1CronJob(
+              name,
+              image,
+              envs,
+              schedule,
+              enable,
+              args,
+              request,
+              limit,
+              jobContainer,
+              initContainer,
+              volumes,
+              jobDeploymentAnnotations,
+              Collections.emptyMap(),
+              Collections.emptyMap(),
+              Collections.emptyMap(),
+              List.of(""));
+    } else {
+      createV1beta1CronJob(
+              name,
+              image,
+              envs,
+              schedule,
+              enable,
+              args,
+              request,
+              limit,
+              jobContainer,
+              initContainer,
+              volumes,
+              jobDeploymentAnnotations,
+              Collections.emptyMap(),
+              Collections.emptyMap(),
+              Collections.emptyMap(),
+              List.of(""));
+    }
+  }
+
+  public void createCronJob(
+          String name,
+          String image,
+          Map<String, String> envs,
+          String schedule,
+          boolean enable,
+          List<String> args,
+          Resources request,
+          Resources limit,
+          V1Container jobContainer,
+          V1Container initContainer,
+          List<V1Volume> volumes,
+          Map<String, String> jobDeploymentAnnotations,
+          Map<String, String> jobPodLabels,
+          Map<String, String> jobAnnotations,
+          Map<String, String> jobLabels,
+          List<String> imagePullSecrets)
+          throws ApiException {
+    if (getK8sSupportsV1CronJob()) {
+      createV1CronJob(
+              name,
+              image,
+              envs,
+              schedule,
+              enable,
+              args,
+              request,
+              limit,
+              jobContainer,
+              initContainer,
+              volumes,
+              jobDeploymentAnnotations,
+              jobPodLabels,
+              jobAnnotations,
+              jobLabels,
+              imagePullSecrets);
+    } else {
+      createV1beta1CronJob(
+              name,
+              image,
+              envs,
+              schedule,
+              enable,
+              args,
+              request,
+              limit,
+              jobContainer,
+              initContainer,
+              volumes,
+              jobDeploymentAnnotations,
+              jobPodLabels,
+              jobAnnotations,
+              jobLabels,
+              imagePullSecrets);
+    }
+  }
+
+  // TODO:  container/volume args are breaking a bit abstraction of KubernetesService by leaking
+  // impl. details
+  public void createV1beta1CronJob(
+          String name,
+          String image,
+          Map<String, String> envs,
+          String schedule,
+          boolean enable,
+          List<String> args,
+          Resources request,
+          Resources limit,
+          V1Container jobContainer,
+          V1Container initContainer,
+          List<V1Volume> volumes,
+          Map<String, String> jobDeploymentAnnotations,
+          Map<String, String> jobPodLabels,
+          Map<String, String> jobAnnotations,
+          Map<String, String> jobLabels,
+          List<String> imagePullSecrets)
+          throws ApiException {
+    log.debug("Creating k8s cron job name:{}, image:{}", name, image);
+    var cronJob =
+            v1beta1CronJobFromTemplate(
+                    name,
+                    schedule,
+                    !enable,
+                    jobContainer,
+                    initContainer,
+                    volumes,
+                    jobDeploymentAnnotations,
+                    jobPodLabels,
+                    jobAnnotations,
+                    jobLabels,
+                    imagePullSecrets);
+    V1beta1CronJob nsJob =
+            new BatchV1beta1Api(client)
+                    .createNamespacedCronJob(namespace, cronJob, null, null, null, null);
+    log.debug("Created k8s cron job: {}", nsJob);
+    log.debug(
+            "Created k8s cron job name: {}, uid:{}, link:{}",
+            nsJob.getMetadata().getName(),
+            nsJob.getMetadata().getUid(),
+            nsJob.getMetadata().getSelfLink());
+  }
+
+  // TODO:  container/volume args are breaking a bit abstraction of KubernetesService by leaking
+  // impl. details
+  public void createV1CronJob(
+          String name,
+          String image,
+          Map<String, String> envs,
+          String schedule,
+          boolean enable,
+          List<String> args,
+          Resources request,
+          Resources limit,
+          V1Container jobContainer,
+          V1Container initContainer,
+          List<V1Volume> volumes,
+          Map<String, String> jobDeploymentAnnotations,
+          Map<String, String> jobPodLabels,
+          Map<String, String> jobAnnotations,
+          Map<String, String> jobLabels,
+          List<String> imagePullSecrets)
+          throws ApiException {
+    log.debug("Creating k8s cron job name:{}, image:{}", name, image);
+    var cronJob =
+            v1CronJobFromTemplate(
+                    name,
+                    schedule,
+                    !enable,
+                    jobContainer,
+                    initContainer,
+                    volumes,
+                    jobDeploymentAnnotations,
+                    jobPodLabels,
+                    jobAnnotations,
+                    jobLabels,
+                    imagePullSecrets);
+    V1CronJob nsJob =
+            new BatchV1Api(client).createNamespacedCronJob(namespace, cronJob, null, null, null, null);
+    log.debug("Created k8s cron job: {}", nsJob);
+    log.debug(
+            "Created k8s cron job name: {}, uid:{}, link:{}",
+            nsJob.getMetadata().getName(),
+            nsJob.getMetadata().getUid(),
+            nsJob.getMetadata().getSelfLink());
+  }
+
+  public void updateCronJob(
+          String name,
+          String image,
+          Map<String, String> envs,
+          String schedule,
+          boolean enable,
+          List<String> args,
+          Resources request,
+          Resources limit,
+          V1Container jobContainer,
+          V1Container initContainer,
+          List<V1Volume> volumes,
+          Map<String, String> jobDeploymentAnnotations)
+          throws ApiException {
+    if (getK8sSupportsV1CronJob()) {
+      updateV1CronJob(
+              name,
+              image,
+              envs,
+              schedule,
+              enable,
+              args,
+              request,
+              limit,
+              jobContainer,
+              initContainer,
+              volumes,
+              jobDeploymentAnnotations,
+              Collections.emptyMap(),
+              Collections.emptyMap(),
+              Collections.emptyMap(),
+              List.of(""));
+    } else {
+      updateV1beta1CronJob(
+              name,
+              image,
+              envs,
+              schedule,
+              enable,
+              args,
+              request,
+              limit,
+              jobContainer,
+              initContainer,
+              volumes,
+              jobDeploymentAnnotations,
+              Collections.emptyMap(),
+              Collections.emptyMap(),
+              Collections.emptyMap(),
+              List.of(""));
+    }
+  }
+
+  public void updateCronJob(
+          String name,
+          String image,
+          Map<String, String> envs,
+          String schedule,
+          boolean enable,
+          List<String> args,
+          Resources request,
+          Resources limit,
+          V1Container jobContainer,
+          V1Container initContainer,
+          List<V1Volume> volumes,
+          Map<String, String> jobDeploymentAnnotations,
+          Map<String, String> jobPodLabels,
+          Map<String, String> jobAnnotations,
+          Map<String, String> jobLabels,
+          List<String> imagePullSecrets)
+          throws ApiException {
+    if (getK8sSupportsV1CronJob()) {
+      updateV1CronJob(
+              name,
+              image,
+              envs,
+              schedule,
+              enable,
+              args,
+              request,
+              limit,
+              jobContainer,
+              initContainer,
+              volumes,
+              jobDeploymentAnnotations,
+              jobPodLabels,
+              jobAnnotations,
+              jobLabels,
+              imagePullSecrets);
+    } else {
+      updateV1beta1CronJob(
+              name,
+              image,
+              envs,
+              schedule,
+              enable,
+              args,
+              request,
+              limit,
+              jobContainer,
+              initContainer,
+              volumes,
+              jobDeploymentAnnotations,
+              jobPodLabels,
+              jobAnnotations,
+              jobLabels,
+              imagePullSecrets);
+    }
+  }
+
+  public void updateV1beta1CronJob(
+          String name,
+          String image,
+          Map<String, String> envs,
+          String schedule,
+          boolean enable,
+          List<String> args,
+          Resources request,
+          Resources limit,
+          V1Container jobContainer,
+          V1Container initContainer,
+          List<V1Volume> volumes,
+          Map<String, String> jobDeploymentAnnotations,
+          Map<String, String> jobPodLabels,
+          Map<String, String> jobAnnotations,
+          Map<String, String> jobLabels,
+          List<String> imagePullSecrets)
+          throws ApiException {
+    var cronJob =
+            v1beta1CronJobFromTemplate(
+                    name,
+                    schedule,
+                    !enable,
+                    jobContainer,
+                    initContainer,
+                    volumes,
+                    jobDeploymentAnnotations,
+                    jobPodLabels,
+                    jobAnnotations,
+                    jobLabels,
+                    imagePullSecrets);
+    V1beta1CronJob nsJob =
+            new BatchV1beta1Api(client)
+                    .replaceNamespacedCronJob(name, namespace, cronJob, null, null, null, null);
+    log.debug(
+            "Updated k8s cron job status for name:{}, image:{}, uid:{}, link:{}",
+            name,
+            image,
+            nsJob.getMetadata().getUid(),
+            nsJob.getMetadata().getSelfLink());
+  }
+
+  public void updateV1CronJob(
+          String name,
+          String image,
+          Map<String, String> envs,
+          String schedule,
+          boolean enable,
+          List<String> args,
+          Resources request,
+          Resources limit,
+          V1Container jobContainer,
+          V1Container initContainer,
+          List<V1Volume> volumes,
+          Map<String, String> jobDeploymentAnnotations,
+          Map<String, String> jobPodLabels,
+          Map<String, String> jobAnnotations,
+          Map<String, String> jobLabels,
+          List<String> imagePullSecrets)
+          throws ApiException {
+    var cronJob =
+            v1CronJobFromTemplate(
+                    name,
+                    schedule,
+                    !enable,
+                    jobContainer,
+                    initContainer,
+                    volumes,
+                    jobDeploymentAnnotations,
+                    jobPodLabels,
+                    jobAnnotations,
+                    jobLabels,
+                    imagePullSecrets);
+    V1CronJob nsJob =
+            new BatchV1Api(client)
+                    .replaceNamespacedCronJob(name, namespace, cronJob, null, null, null, null);
+    log.debug(
+            "Updated k8s cron job status for name:{}, image:{}, uid:{}, link:{}",
+            name,
+            image,
+            nsJob.getMetadata().getUid(),
+            nsJob.getMetadata().getSelfLink());
+  }
+
+  public void deleteCronJob(String name) throws ApiException {
+    log.debug("Deleting k8s cron job: {}", name);
+    try {
+      new BatchV1beta1Api(client)
+              .deleteNamespacedCronJob(name, namespace, null, null, null, null, null, null);
+    } catch (JsonSyntaxException e) {
+      if (e.getCause() instanceof IllegalStateException) {
+        IllegalStateException ise = (IllegalStateException) e.getCause();
+        if (ise.getMessage() != null
+                && ise.getMessage().contains("Expected a string but was BEGIN_OBJECT"))
+          log.debug(
+                  "Catching exception because of issue"
+                          + " https://github.com/kubernetes-client/java/issues/86",
+                  e);
+        else throw e;
+      } else throw e;
+    }
+    log.debug("Deleted k8s cron job: {}", name);
+  }
+
+
+
+
+  @VisibleForTesting
+  public V1CronJob v1CronJobFromTemplate(
+          String name,
+          String schedule,
+          boolean suspend,
+          V1Container jobContainer,
+          V1Container initContainer,
+          List<V1Volume> volumes,
+          Map<String, String> jobDeploymentAnnotations,
+          Map<String, String> jobPodLabels,
+          Map<String, String> jobAnnotations,
+          Map<String, String> jobLabels,
+          List<String> imagePullSecrets) {
+    V1CronJob cronjob = loadV1CronjobTemplate();
+    v1checkForMissingEntries(cronjob);
+    cronjob.getMetadata().setName(name);
+    cronjob.getSpec().setSchedule(schedule);
+    cronjob.getSpec().setSuspend(suspend);
+    cronjob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .setContainers(Collections.singletonList(jobContainer));
+    cronjob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .setInitContainers(Collections.singletonList(initContainer));
+    cronjob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().setVolumes(volumes);
+    // Merge the annotations and the labels.
+    cronjob.getMetadata().getAnnotations().putAll(jobDeploymentAnnotations);
+    cronjob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getMetadata()
+            .getLabels()
+            .putAll(jobPodLabels);
+
+    cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations().putAll(jobAnnotations);
+    cronjob.getSpec().getJobTemplate().getMetadata().getLabels().putAll(jobLabels);
+
+    List<V1LocalObjectReference> imagePullSecretsObj =
+            Optional.ofNullable(imagePullSecrets).stream()
+                    .flatMap(secrets -> secrets.stream())
+                    .filter(secret -> StringUtils.isNotEmpty(secret))
+                    .map(secret -> new V1LocalObjectReferenceBuilder().withName(secret).build())
+                    .collect(Collectors.toList());
+
+    if (!CollectionUtils.isEmpty(imagePullSecretsObj)) {
+      cronjob
+              .getSpec()
+              .getJobTemplate()
+              .getSpec()
+              .getTemplate()
+              .getSpec()
+              .setImagePullSecrets(imagePullSecretsObj);
+    }
+
+    return cronjob;
+  }
+
+
+  public V1beta1CronJob v1beta1CronJobFromTemplate(
+          String name,
+          String schedule,
+          boolean suspend,
+          V1Container jobContainer,
+          V1Container initContainer,
+          List<V1Volume> volumes,
+          Map<String, String> jobDeploymentAnnotations,
+          Map<String, String> jobPodLabels,
+          Map<String, String> jobAnnotations,
+          Map<String, String> jobLabels,
+          List<String> imagePullSecrets) {
+    V1beta1CronJob cronjob = loadV1beta1CronjobTemplate();
+    v1beta1checkForMissingEntries(cronjob);
+    cronjob.getMetadata().setName(name);
+    cronjob.getSpec().setSchedule(schedule);
+    cronjob.getSpec().setSuspend(suspend);
+    cronjob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .setContainers(Collections.singletonList(jobContainer));
+    cronjob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .setInitContainers(Collections.singletonList(initContainer));
+    cronjob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().setVolumes(volumes);
+    // Merge the annotations and the labels.
+    cronjob.getMetadata().getAnnotations().putAll(jobDeploymentAnnotations);
+    cronjob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getMetadata()
+            .getLabels()
+            .putAll(jobPodLabels);
+
+    cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations().putAll(jobAnnotations);
+    cronjob.getSpec().getJobTemplate().getMetadata().getLabels().putAll(jobLabels);
+
+    List<V1LocalObjectReference> imagePullSecretsObj =
+            Optional.ofNullable(imagePullSecrets).stream()
+                    .flatMap(secrets -> secrets.stream())
+                    .filter(secret -> StringUtils.isNotEmpty(secret))
+                    .map(secret -> new V1LocalObjectReferenceBuilder().withName(secret).build())
+                    .collect(Collectors.toList());
+
+    if (!CollectionUtils.isEmpty(imagePullSecretsObj)) {
+      cronjob
+              .getSpec()
+              .getJobTemplate()
+              .getSpec()
+              .getTemplate()
+              .getSpec()
+              .setImagePullSecrets(imagePullSecretsObj);
+    }
+
+    return cronjob;
+  }
+
+
+
+
+  private void v1checkForMissingEntries(V1CronJob cronjob) {
+    V1CronJob internalCronjobTemplate = loadInternalV1CronjobTemplate();
+    if (cronjob.getMetadata() == null) {
+      cronjob.setMetadata(internalCronjobTemplate.getMetadata());
+    }
+    V1ObjectMeta metadata = cronjob.getMetadata();
+    if (metadata.getAnnotations() == null) {
+      metadata.setAnnotations(new HashMap<>());
+    }
+    if (cronjob.getSpec() == null) {
+      cronjob.setSpec(internalCronjobTemplate.getSpec());
+    }
+    V1CronJobSpec spec = cronjob.getSpec();
+    if (spec.getJobTemplate() == null) {
+      spec.setJobTemplate(internalCronjobTemplate.getSpec().getJobTemplate());
+    }
+    if (spec.getJobTemplate().getMetadata() == null) {
+      spec.getJobTemplate()
+              .setMetadata(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
+    }
+    if (spec.getJobTemplate().getMetadata().getLabels() == null) {
+      spec.getJobTemplate().getMetadata().setLabels(new HashMap<>());
+    }
+    if (spec.getJobTemplate().getMetadata().getAnnotations() == null) {
+      spec.getJobTemplate().getMetadata().setAnnotations(new HashMap<>());
+    }
+    if (spec.getJobTemplate().getSpec() == null) {
+      spec.getJobTemplate().setSpec(internalCronjobTemplate.getSpec().getJobTemplate().getSpec());
+    }
+    if (spec.getJobTemplate().getSpec().getTemplate() == null) {
+      spec.getJobTemplate()
+              .getSpec()
+              .setTemplate(internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate());
+    }
+    if (spec.getJobTemplate().getSpec().getTemplate().getSpec() == null) {
+      spec.getJobTemplate()
+              .getSpec()
+              .getTemplate()
+              .setSpec(
+                      internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
+    }
+    if (spec.getJobTemplate().getSpec().getTemplate().getMetadata() == null) {
+      spec.getJobTemplate()
+              .getSpec()
+              .getTemplate()
+              .setMetadata(
+                      internalCronjobTemplate
+                              .getSpec()
+                              .getJobTemplate()
+                              .getSpec()
+                              .getTemplate()
+                              .getMetadata());
+    }
+    if (spec.getJobTemplate().getSpec().getTemplate().getMetadata().getLabels() == null) {
+      spec.getJobTemplate().getSpec().getTemplate().getMetadata().setLabels(new HashMap<>());
+    }
+  }
+
+
+  // TODO - in the future we want to merge the (1) configurable datajob template
+  //        with the (2) default internal datajob template when something from (1)
+  //        is missing. For now we just check for missing entries in (1) and overwrite
+  //        them with the corresponding entries in (2).
+  private void v1beta1checkForMissingEntries(V1beta1CronJob cronjob) {
+    V1beta1CronJob internalCronjobTemplate = loadInternalV1beta1CronjobTemplate();
+    if (cronjob.getMetadata() == null) {
+      cronjob.setMetadata(internalCronjobTemplate.getMetadata());
+    }
+    V1ObjectMeta metadata = cronjob.getMetadata();
+    if (metadata.getAnnotations() == null) {
+      metadata.setAnnotations(new HashMap<>());
+    }
+    if (cronjob.getSpec() == null) {
+      cronjob.setSpec(internalCronjobTemplate.getSpec());
+    }
+    V1beta1CronJobSpec spec = cronjob.getSpec();
+    if (spec.getJobTemplate() == null) {
+      spec.setJobTemplate(internalCronjobTemplate.getSpec().getJobTemplate());
+    }
+    if (spec.getJobTemplate().getMetadata() == null) {
+      spec.getJobTemplate()
+              .setMetadata(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
+    }
+    if (spec.getJobTemplate().getMetadata().getLabels() == null) {
+      spec.getJobTemplate().getMetadata().setLabels(new HashMap<>());
+    }
+    if (spec.getJobTemplate().getMetadata().getAnnotations() == null) {
+      spec.getJobTemplate().getMetadata().setAnnotations(new HashMap<>());
+    }
+    if (spec.getJobTemplate().getSpec() == null) {
+      spec.getJobTemplate().setSpec(internalCronjobTemplate.getSpec().getJobTemplate().getSpec());
+    }
+    if (spec.getJobTemplate().getSpec().getTemplate() == null) {
+      spec.getJobTemplate()
+              .getSpec()
+              .setTemplate(internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate());
+    }
+    if (spec.getJobTemplate().getSpec().getTemplate().getSpec() == null) {
+      spec.getJobTemplate()
+              .getSpec()
+              .getTemplate()
+              .setSpec(
+                      internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
+    }
+    if (spec.getJobTemplate().getSpec().getTemplate().getMetadata() == null) {
+      spec.getJobTemplate()
+              .getSpec()
+              .getTemplate()
+              .setMetadata(
+                      internalCronjobTemplate
+                              .getSpec()
+                              .getJobTemplate()
+                              .getSpec()
+                              .getTemplate()
+                              .getMetadata());
+    }
+    if (spec.getJobTemplate().getSpec().getTemplate().getMetadata().getLabels() == null) {
+      spec.getJobTemplate().getSpec().getTemplate().getMetadata().setLabels(new HashMap<>());
+    }
+  }
+
+
+  public Optional<JobDeploymentStatus> readCronJob(String cronJobName) {
+    return getK8sSupportsV1CronJob() ? readV1CronJob(cronJobName) : readV1beta1CronJob(cronJobName);
+  }
+
+  public Optional<JobDeploymentStatus> readV1beta1CronJob(String cronJobName) {
+    log.debug("Reading k8s cron job: {}", cronJobName);
+    V1beta1CronJob cronJob = null;
+    try {
+      cronJob = new BatchV1beta1Api(client).readNamespacedCronJob(cronJobName, namespace, null);
+    } catch (ApiException e) {
+      log.warn(
+              "Could not read cron job: {}; reason: {}",
+              cronJobName,
+              new KubernetesException("", e).toString());
+    }
+
+    return mapV1beta1CronJobToDeploymentStatus(cronJob, cronJobName);
+  }
+
+  public Optional<JobDeploymentStatus> readV1CronJob(String cronJobName) {
+    log.debug("Reading k8s cron job: {}", cronJobName);
+    V1CronJob cronJob = null;
+    try {
+      cronJob = new BatchV1Api(client).readNamespacedCronJob(cronJobName, namespace, null);
+    } catch (ApiException e) {
+      log.warn(
+              "Could not read cron job: {}; reason: {}",
+              cronJobName,
+              new KubernetesException("", e).toString());
+    }
+
+    return mapV1CronJobToDeploymentStatus(cronJob, cronJobName);
+  }
+
+  /**
+   * Fetch all deployment statuses from Kubernetes
+   *
+   * @return List of {@link JobDeploymentStatus} or empty list if there is an error while fetching
+   *     data
+   */
+  public List<JobDeploymentStatus> readJobDeploymentStatuses() {
+    return getK8sSupportsV1CronJob()
+            ? readV1CronJobDeploymentStatuses()
+            : readV1beta1CronJobDeploymentStatuses();
+  }
+
+  public List<JobDeploymentStatus> readV1beta1CronJobDeploymentStatuses() {
+    log.debug("Reading all k8s cron jobs");
+    V1beta1CronJobList cronJobs = null;
+    try {
+      cronJobs =
+              new BatchV1beta1Api(client)
+                      .listNamespacedCronJob(
+                              namespace, null, null, null, null, null, null, null, null, null, null);
+    } catch (ApiException e) {
+      log.warn("Failed to read k8s cron jobs: ", new KubernetesException("", e));
+    }
+
+    return cronJobs == null
+            ? Collections.emptyList()
+            : cronJobs.getItems().stream()
+            .map(cronJob -> mapV1beta1CronJobToDeploymentStatus(cronJob, null))
+            .flatMap(Optional::stream)
+            .collect(Collectors.toList());
+  }
+
+  public List<JobDeploymentStatus> readV1CronJobDeploymentStatuses() {
+    log.debug("Reading all k8s cron jobs");
+    V1CronJobList cronJobs = null;
+    try {
+      cronJobs =
+              new BatchV1Api(client)
+                      .listNamespacedCronJob(
+                              namespace, null, null, null, null, null, null, null, null, null, null);
+    } catch (ApiException e) {
+      log.warn("Failed to read k8s cron jobs: ", new KubernetesException("", e));
+    }
+
+    return cronJobs == null
+            ? Collections.emptyList()
+            : cronJobs.getItems().stream()
+            .map(cronJob -> mapV1CronJobToDeploymentStatus(cronJob, null))
+            .flatMap(Optional::stream)
+            .collect(Collectors.toList());
+  }
+
+  public void startNewCronJobExecution(
+          String cronJobName,
+          String executionId,
+          Map<String, String> annotations,
+          Map<String, String> envs,
+          Map<String, Object> extraJobArguments,
+          String jobName)
+          throws ApiException {
+    if (getK8sSupportsV1CronJob()) {
+      startNewV1CronJobExecution(
+              cronJobName, executionId, annotations, envs, extraJobArguments, jobName);
+    } else {
+      startNewV1beta1CronJobExecution(
+              cronJobName, executionId, annotations, envs, extraJobArguments, jobName);
+    }
+  }
+
+  private void startNewV1beta1CronJobExecution(
+          String cronJobName,
+          String executionId,
+          Map<String, String> annotations,
+          Map<String, String> envs,
+          Map<String, Object> extraJobArguments,
+          String jobName)
+          throws ApiException {
+    var cron = initBatchV1beta1Api().readNamespacedCronJob(cronJobName, namespace, null);
+    Optional<V1beta1JobTemplateSpec> jobTemplateSpec =
+            Optional.ofNullable(cron)
+                    .map(V1beta1CronJob::getSpec)
+                    .map(V1beta1CronJobSpec::getJobTemplate);
+
+    Map<String, String> jobLabels =
+            jobTemplateSpec
+                    .map(V1beta1JobTemplateSpec::getMetadata)
+                    .map(V1ObjectMeta::getLabels)
+                    .orElse(Collections.emptyMap());
+
+    Map<String, String> jobAnnotations =
+            jobTemplateSpec
+                    .map(V1beta1JobTemplateSpec::getMetadata)
+                    .map(V1ObjectMeta::getAnnotations)
+                    .map(
+                            v1ObjectMetaAnnotations -> {
+                              v1ObjectMetaAnnotations.putAll(annotations);
+                              return v1ObjectMetaAnnotations;
+                            })
+                    .orElse(annotations);
+
+    V1JobSpec jobSpec =
+            jobTemplateSpec
+                    .map(V1beta1JobTemplateSpec::getSpec)
+                    .orElseThrow(
+                            () ->
+                                    new ApiException(
+                                            String.format(
+                                                    "K8S Cron Job '%s' does not exist or is not properly defined.",
+                                                    cronJobName)));
+
+    jobSpec.setTtlSecondsAfterFinished(jobTTLAfterFinishedSeconds);
+
+    V1Container v1Container =
+            Optional.ofNullable(jobSpec.getTemplate())
+                    .map(V1PodTemplateSpec::getSpec)
+                    .map(V1PodSpec::getContainers)
+                    .map(v1Containers -> v1Containers.get(0))
+                    .orElseThrow(
+                            () ->
+                                    new ApiException(
+                                            String.format("K8S Cron Job '%s' is not properly defined.", cronJobName)));
+    if (!CollectionUtils.isEmpty(envs)) {
+      envs.forEach((name, value) -> v1Container.addEnvItem(new V1EnvVar().name(name).value(value)));
+    }
+
+    if (!CollectionUtils.isEmpty(extraJobArguments)) {
+      addExtraJobArgumentsToVdkContainer(v1Container, extraJobArguments, jobName);
+    }
+
+    createNewJob(executionId, jobSpec, jobLabels, jobAnnotations);
+  }
+
+  private void startNewV1CronJobExecution(
+          String cronJobName,
+          String executionId,
+          Map<String, String> annotations,
+          Map<String, String> envs,
+          Map<String, Object> extraJobArguments,
+          String jobName)
+          throws ApiException {
+    var cron = initBatchV1Api().readNamespacedCronJob(cronJobName, namespace, null);
+
+    Optional<V1JobTemplateSpec> jobTemplateSpec =
+            Optional.ofNullable(cron).map(V1CronJob::getSpec).map(V1CronJobSpec::getJobTemplate);
+
+    Map<String, String> jobLabels =
+            jobTemplateSpec
+                    .map(V1JobTemplateSpec::getMetadata)
+                    .map(V1ObjectMeta::getLabels)
+                    .orElse(Collections.emptyMap());
+
+    Map<String, String> jobAnnotations =
+            jobTemplateSpec
+                    .map(V1JobTemplateSpec::getMetadata)
+                    .map(V1ObjectMeta::getAnnotations)
+                    .map(
+                            v1ObjectMetaAnnotations -> {
+                              v1ObjectMetaAnnotations.putAll(annotations);
+                              return v1ObjectMetaAnnotations;
+                            })
+                    .orElse(annotations);
+
+    V1JobSpec jobSpec =
+            jobTemplateSpec
+                    .map(V1JobTemplateSpec::getSpec)
+                    .orElseThrow(
+                            () ->
+                                    new ApiException(
+                                            String.format(
+                                                    "K8S Cron Job '%s' does not exist or is not properly defined.",
+                                                    cronJobName)));
+
+    jobSpec.setTtlSecondsAfterFinished(jobTTLAfterFinishedSeconds);
+
+    V1Container v1Container =
+            Optional.ofNullable(jobSpec.getTemplate())
+                    .map(V1PodTemplateSpec::getSpec)
+                    .map(V1PodSpec::getContainers)
+                    .map(v1Containers -> v1Containers.get(0))
+                    .orElseThrow(
+                            () ->
+                                    new ApiException(
+                                            String.format("K8S Cron Job '%s' is not properly defined.", cronJobName)));
+    if (!CollectionUtils.isEmpty(envs)) {
+      envs.forEach((name, value) -> v1Container.addEnvItem(new V1EnvVar().name(name).value(value)));
+    }
+
+    if (!CollectionUtils.isEmpty(extraJobArguments)) {
+      addExtraJobArgumentsToVdkContainer(v1Container, extraJobArguments, jobName);
+    }
+
+    createNewJob(executionId, jobSpec, jobLabels, jobAnnotations);
+  }
+
+
+
+  private Optional<JobDeploymentStatus> mapV1beta1CronJobToDeploymentStatus(
+          V1beta1CronJob cronJob, String cronJobName) {
+    JobDeploymentStatus deployment = null;
+    if (cronJob != null) {
+      deployment = new JobDeploymentStatus();
+      deployment.setEnabled(!cronJob.getSpec().getSuspend());
+      deployment.setDataJobName(cronJob.getMetadata().getName());
+      deployment.setMode(
+              "release"); // TODO: Get from cron job config when we support testing environments
+      deployment.setCronJobName(
+              cronJobName == null ? cronJob.getMetadata().getName() : cronJobName);
+
+      // all fields until pod spec are required so no need to check for null
+      var annotations = cronJob.getSpec().getJobTemplate().getMetadata().getAnnotations();
+      if (annotations != null) {
+        deployment.setLastDeployedBy(annotations.get(JobAnnotation.DEPLOYED_BY.getValue()));
+        deployment.setLastDeployedDate(annotations.get(JobAnnotation.DEPLOYED_DATE.getValue()));
+      }
+
+      List<V1Container> containers =
+              cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getContainers();
+      if (!containers.isEmpty()) {
+        String image =
+                containers.get(0).getImage(); // TODO: Have 2 containers. 1 for VDK and 1 for the job.
+        deployment.setImageName(image); // TODO do we really need to return image_name?
+      }
+      var initContainers =
+              cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getInitContainers();
+      if (!CollectionUtils.isEmpty(initContainers)) {
+        String vdkImage = initContainers.get(0).getImage();
+        deployment.setVdkImageName(vdkImage);
+        deployment.setVdkVersion(DockerImageName.getTag(vdkImage));
+      } else {
+        log.warn("Missing init container for cronjob {}", cronJobName);
+      }
+
+      var labels = cronJob.getSpec().getJobTemplate().getMetadata().getLabels();
+      if (labels == null) {
+        log.warn(
+                "The cronjob of data job '{}' does not have any labels defined.",
+                deployment.getDataJobName());
+      }
+      if (labels != null && labels.containsKey(JobLabel.VERSION.getValue())) {
+        deployment.setGitCommitSha(labels.get(JobLabel.VERSION.getValue()));
+      } else {
+        // Legacy approach to get version:
+        deployment.setGitCommitSha(DockerImageName.getTag(deployment.getImageName()));
+      }
+    }
+
+    return Optional.ofNullable(deployment);
+  }
+
+  private Optional<JobDeploymentStatus> mapV1CronJobToDeploymentStatus(
+          V1CronJob cronJob, String cronJobName) {
+    JobDeploymentStatus deployment = null;
+    if (cronJob != null) {
+      deployment = new JobDeploymentStatus();
+      deployment.setEnabled(!cronJob.getSpec().getSuspend());
+      deployment.setDataJobName(cronJob.getMetadata().getName());
+      deployment.setMode(
+              "release"); // TODO: Get from cron job config when we support testing environments
+      deployment.setCronJobName(
+              cronJobName == null ? cronJob.getMetadata().getName() : cronJobName);
+
+      // all fields until pod spec are required so no need to check for null
+      var annotations = cronJob.getSpec().getJobTemplate().getMetadata().getAnnotations();
+      if (annotations != null) {
+        deployment.setLastDeployedBy(annotations.get(JobAnnotation.DEPLOYED_BY.getValue()));
+        deployment.setLastDeployedDate(annotations.get(JobAnnotation.DEPLOYED_DATE.getValue()));
+      }
+
+      List<V1Container> containers =
+              cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getContainers();
+      if (!containers.isEmpty()) {
+        String image =
+                containers.get(0).getImage(); // TODO: Have 2 containers. 1 for VDK and 1 for the job.
+        deployment.setImageName(image); // TODO do we really need to return image_name?
+      }
+      var initContainers =
+              cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getInitContainers();
+      if (!CollectionUtils.isEmpty(initContainers)) {
+        String vdkImage = initContainers.get(0).getImage();
+        deployment.setVdkImageName(vdkImage);
+        deployment.setVdkVersion(DockerImageName.getTag(vdkImage));
+      } else {
+        log.warn("Missing init container for cronjob {}", cronJobName);
+      }
+
+      var labels = cronJob.getSpec().getJobTemplate().getMetadata().getLabels();
+      if (labels == null) {
+        log.warn(
+                "The cronjob of data job '{}' does not have any labels defined.",
+                deployment.getDataJobName());
+      }
+      if (labels != null && labels.containsKey(JobLabel.VERSION.getValue())) {
+        deployment.setGitCommitSha(labels.get(JobLabel.VERSION.getValue()));
+      } else {
+        // Legacy approach to get version:
+        deployment.setGitCommitSha(DockerImageName.getTag(deployment.getImageName()));
+      }
+    }
+
+    return Optional.ofNullable(deployment);
+  }
+
+
+  private void addExtraJobArgumentsToVdkContainer(
+          V1Container container, Map<String, Object> extraJobArguments, String jobName) {
+    var commandList =
+            new ArrayList<>(container.getCommand()); // create a new List, since old might be immutable.
+
+    if (commandList.size() < 3 || !Iterables.getLast(commandList).contains("vdk run")) {
+      // If current job template definition changes we will throw an exception and will have to
+      // change this implementation.
+      log.debug("Command list: {}", commandList);
+      throw new KubernetesJobDefinitionException(jobName);
+    }
+
+    try {
+      var newCommand =
+              jobCommandProvider.getJobCommand(
+                      jobName, extraJobArguments); // vdk run command is last in the list
+      container.setCommand(newCommand);
+    } catch (JsonProcessingException e) {
+      log.debug("JsonProcessingException", e);
+      throw new JsonDissectException(e);
+    }
+  }
+
+
+
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/MockKubernetes.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/MockKubernetes.java
@@ -65,9 +65,8 @@ public class MockKubernetes {
     return new SyncTaskExecutor();
   }
 
-
   private void mockKubernetesService(KubernetesService mock)
-          throws ApiException, IOException, InterruptedException {
+      throws ApiException, IOException, InterruptedException {
     // By defautl beans are singleton scoped so we are sure this will be called once
     // hence it's safe to keep the variables here isntead of static.
     final Map<String, Map<String, byte[]>> secrets = new ConcurrentHashMap<>();
@@ -75,29 +74,29 @@ public class MockKubernetes {
     final Map<String, InvocationOnMock> jobs = new ConcurrentHashMap<>();
 
     when(mock.getSecretData(any()))
-            .thenAnswer(inv -> secrets.getOrDefault(inv.getArgument(0), Collections.emptyMap()));
+        .thenAnswer(inv -> secrets.getOrDefault(inv.getArgument(0), Collections.emptyMap()));
     doAnswer(answer(secrets::put)).when(mock).saveSecretData(any(), any());
     doAnswer(inv -> secrets.remove(inv.getArgument(0))).when(mock).removeSecretData(any());
 
     doAnswer(inv -> jobs.put(inv.getArgument(0), inv))
-            .when(mock)
-            .createJob(
-                    anyString(),
-                    anyString(),
-                    anyBoolean(),
-                    anyBoolean(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    anyString(),
-                    any(),
-                    any(),
-                    anyLong(),
-                    anyLong(),
-                    anyLong(),
-                    anyString(),
-                    anyString());
+        .when(mock)
+        .createJob(
+            anyString(),
+            anyString(),
+            anyBoolean(),
+            anyBoolean(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyString(),
+            any(),
+            any(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyString(),
+            anyString());
     doAnswer(inv -> jobs.remove(inv.getArgument(0))).when(mock).deleteJob(anyString());
 
     doAnswer(
@@ -106,15 +105,15 @@ public class MockKubernetes {
               if (jobs.containsKey(jobName)) {
                 if (jobName.startsWith("failure-")) {
                   return new KubernetesService.JobStatusCondition(
-                          false, "Status", "Job name starts with 'failure-'", "", 0);
+                      false, "Status", "Job name starts with 'failure-'", "", 0);
                 } else {
                   return new KubernetesService.JobStatusCondition(true, "Status", "", "", 0);
                 }
               }
               return new KubernetesService.JobStatusCondition(false, null, "No such job", "", 0);
             })
-            .when(mock)
-            .watchJob(anyString(), anyInt(), any());
+        .when(mock)
+        .watchJob(anyString(), anyInt(), any());
 
     doAnswer(inv -> "logs").when(mock).getJobLogs(anyString(), anyInt());
   }
@@ -130,54 +129,54 @@ public class MockKubernetes {
     final Map<String, InvocationOnMock> crons = new ConcurrentHashMap<>();
 
     doAnswer(inv -> crons.put(inv.getArgument(0), inv))
-            .when(mock)
-            .createCronJob(
-                    anyString(),
-                    anyString(),
-                    any(),
-                    anyString(),
-                    anyBoolean(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any());
+        .when(mock)
+        .createCronJob(
+            anyString(),
+            anyString(),
+            any(),
+            anyString(),
+            anyBoolean(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
     doAnswer(inv -> crons.put(inv.getArgument(0), inv))
-            .when(mock)
-            .createCronJob(
-                    anyString(),
-                    anyString(),
-                    any(),
-                    anyString(),
-                    anyBoolean(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    anyList());
+        .when(mock)
+        .createCronJob(
+            anyString(),
+            anyString(),
+            any(),
+            anyString(),
+            anyBoolean(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyList());
     doAnswer(inv -> crons.put(inv.getArgument(0), inv))
-            .when(mock)
-            .updateCronJob(
-                    anyString(),
-                    anyString(),
-                    any(),
-                    anyString(),
-                    anyBoolean(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any());
+        .when(mock)
+        .updateCronJob(
+            anyString(),
+            anyString(),
+            any(),
+            anyString(),
+            anyBoolean(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
     doAnswer(inv -> crons.keySet()).when(mock).listCronJobs();
     doAnswer(inv -> crons.remove(inv.getArgument(0))).when(mock).deleteCronJob(anyString());
     doAnswer(
@@ -192,7 +191,7 @@ public class MockKubernetes {
               }
               return Optional.ofNullable(deployment);
             })
-            .when(mock)
-            .readCronJob(anyString());
+        .when(mock)
+        .readCronJob(anyString());
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
@@ -14,8 +14,6 @@ import io.kubernetes.client.openapi.models.V1StatusDetails;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.slf4j.Logger;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import com.vmware.taurus.exception.DataJobExecutionCannotBeCancelledException;
 import com.vmware.taurus.exception.KubernetesException;
@@ -38,8 +36,7 @@ public class KubernetesServiceCancelRunningCronJobTest {
   public void
       testIsRunningJob_notNullResponseAndNullStatus_shouldThrowDataJobExecutionCannotBeCancelledException()
           throws ApiException {
-    var kubernetesService =
-        mockKubernetesService(new V1Status().status(null).code(404));
+    var kubernetesService = mockKubernetesService(new V1Status().status(null).code(404));
 
     Assertions.assertThrows(
         DataJobExecutionCannotBeCancelledException.class,

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
@@ -75,7 +75,6 @@ public class KubernetesServiceCancelRunningCronJobTest {
                 "test-team", "test-job-name", "test-execution-id"));
   }
 
-
   private DataJobsKubernetesService mockKubernetesService(V1Status v1Status) throws ApiException {
     var kubernetesService = Mockito.mock(DataJobsKubernetesService.class);
 

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
@@ -5,6 +5,7 @@
 
 package com.vmware.taurus.service;
 
+import com.vmware.taurus.service.kubernetes.DataJobsKubernetesService;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.ApiResponse;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
@@ -24,7 +25,7 @@ public class KubernetesServiceCancelRunningCronJobTest {
   @Test
   public void testIsRunningJob_nullResponse_shouldThrowDataJobExecutionCannotBeCancelledException()
       throws ApiException {
-    KubernetesService kubernetesService = mockKubernetesService(null);
+    var kubernetesService = mockKubernetesService(null);
 
     Assertions.assertThrows(
         DataJobExecutionCannotBeCancelledException.class,
@@ -37,7 +38,7 @@ public class KubernetesServiceCancelRunningCronJobTest {
   public void
       testIsRunningJob_notNullResponseAndNullStatus_shouldThrowDataJobExecutionCannotBeCancelledException()
           throws ApiException {
-    KubernetesService kubernetesService =
+    var kubernetesService =
         mockKubernetesService(new V1Status().status(null).code(404));
 
     Assertions.assertThrows(
@@ -50,7 +51,7 @@ public class KubernetesServiceCancelRunningCronJobTest {
   @Test
   public void testIsRunningJob_notNullResponseAndStatusSuccess_shouldNotThrowException()
       throws ApiException {
-    KubernetesService kubernetesService = mockKubernetesService(new V1Status().code(200));
+    var kubernetesService = mockKubernetesService(new V1Status().code(200));
 
     Assertions.assertDoesNotThrow(
         () ->
@@ -68,7 +69,7 @@ public class KubernetesServiceCancelRunningCronJobTest {
             .code(1)
             .message("test-message")
             .details(new V1StatusDetails());
-    KubernetesService kubernetesService = mockKubernetesService(v1Status);
+    var kubernetesService = mockKubernetesService(v1Status);
 
     Assertions.assertThrows(
         KubernetesException.class,
@@ -77,12 +78,9 @@ public class KubernetesServiceCancelRunningCronJobTest {
                 "test-team", "test-job-name", "test-execution-id"));
   }
 
-  private KubernetesService mockKubernetesService(V1Status v1Status) throws ApiException {
-    KubernetesService kubernetesService = Mockito.mock(KubernetesService.class);
-    ReflectionTestUtils.setField(
-        kubernetesService, // inject into this object
-        "log", // assign to this field
-        Mockito.mock(Logger.class)); // object to be injected
+  private DataJobsKubernetesService mockKubernetesService(V1Status v1Status) throws ApiException {
+    var kubernetesService = Mockito.mock(DataJobsKubernetesService.class);
+
     Mockito.doCallRealMethod()
         .when(kubernetesService)
         .cancelRunningCronJob(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartJobWithArgumentsIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartJobWithArgumentsIT.java
@@ -25,12 +25,12 @@ import static org.mockito.ArgumentMatchers.any;
 
 public class KubernetesServiceStartJobWithArgumentsIT {
 
-  private KubernetesService kubernetesService;
+  private DataJobsKubernetesService kubernetesService;
 
   @BeforeEach
   public void getMockKubernetesServiceForVdkRunExtraArgsTests() throws Exception {
 
-    kubernetesService = Mockito.mock(KubernetesService.class);
+    kubernetesService = Mockito.mock(DataJobsKubernetesService.class);
     Mockito.when(kubernetesService.getK8sSupportsV1CronJob()).thenReturn(false);
     V1beta1CronJob internalCronjobTemplate = getValidCronJobForVdkRunExtraArgsTests();
     BatchV1beta1Api mockBatch = Mockito.mock(BatchV1beta1Api.class);
@@ -46,7 +46,7 @@ public class KubernetesServiceStartJobWithArgumentsIT {
     // Kubernetes Service is an abstract class and a lot of the methods which depend on this field
     // and are mocked here
     // cannot be mocked or accessed by the extending classes since they are not public.
-    var f1 = kubernetesService.getClass().getSuperclass().getDeclaredField("jobCommandProvider");
+    var f1 = kubernetesService.getClass().getDeclaredField("jobCommandProvider");
     f1.setAccessible(true);
     f1.set(kubernetesService, new JobCommandProvider());
   }
@@ -164,7 +164,7 @@ public class KubernetesServiceStartJobWithArgumentsIT {
     // V1betaCronJob initializing snippet copied from tests above, using reflection
     service.afterPropertiesSet();
     Method loadInternalV1beta1CronjobTemplate =
-        KubernetesService.class.getDeclaredMethod("loadInternalV1beta1CronjobTemplate");
+            DataJobsKubernetesService.class.getDeclaredMethod("loadInternalV1beta1CronjobTemplate");
     if (loadInternalV1beta1CronjobTemplate == null) {
       Assertions.fail("The method 'loadInternalV1beta1CronjobTemplate' does not exist.");
     }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartJobWithArgumentsIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartJobWithArgumentsIT.java
@@ -164,7 +164,7 @@ public class KubernetesServiceStartJobWithArgumentsIT {
     // V1betaCronJob initializing snippet copied from tests above, using reflection
     service.afterPropertiesSet();
     Method loadInternalV1beta1CronjobTemplate =
-            DataJobsKubernetesService.class.getDeclaredMethod("loadInternalV1beta1CronjobTemplate");
+        DataJobsKubernetesService.class.getDeclaredMethod("loadInternalV1beta1CronjobTemplate");
     if (loadInternalV1beta1CronjobTemplate == null) {
       Assertions.fail("The method 'loadInternalV1beta1CronjobTemplate' does not exist.");
     }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartNewCronJobExecutionTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartNewCronJobExecutionTest.java
@@ -5,6 +5,7 @@
 
 package com.vmware.taurus.service;
 
+import com.vmware.taurus.service.kubernetes.DataJobsKubernetesService;
 import com.vmware.taurus.service.model.JobAnnotation;
 import com.vmware.taurus.service.model.JobEnvVar;
 import io.kubernetes.client.openapi.ApiException;
@@ -26,7 +27,7 @@ public class KubernetesServiceStartNewCronJobExecutionTest {
   public void testStartNewCronJobExecution_nullCronJobDefinition_shouldThrowException()
       throws ApiException {
     String jobName = "test-job";
-    KubernetesService kubernetesService = mockKubernetesService(jobName, null);
+    var kubernetesService = mockKubernetesService(jobName, null);
 
     Exception exception =
         Assertions.assertThrows(
@@ -54,7 +55,7 @@ public class KubernetesServiceStartNewCronJobExecutionTest {
             .spec(
                 new V1beta1CronJobSpec()
                     .jobTemplate(new V1beta1JobTemplateSpec().spec(new V1JobSpec())));
-    KubernetesService kubernetesService = mockKubernetesService(jobName, expectedResult);
+    var kubernetesService = mockKubernetesService(jobName, expectedResult);
 
     Exception exception =
         Assertions.assertThrows(
@@ -95,7 +96,7 @@ public class KubernetesServiceStartNewCronJobExecutionTest {
                                                     .addContainersItem(
                                                         new V1Container().addEnvItem(testEnv)))))));
 
-    KubernetesService kubernetesService = mockKubernetesService(jobName, expectedResult);
+    var kubernetesService = mockKubernetesService(jobName, expectedResult);
     kubernetesService.startNewCronJobExecution(
         jobName,
         executionId,
@@ -172,7 +173,7 @@ public class KubernetesServiceStartNewCronJobExecutionTest {
                                                 new V1PodSpec()
                                                     .addContainersItem(new V1Container()))))));
 
-    KubernetesService kubernetesService = mockKubernetesService(jobName, expectedResult);
+    var kubernetesService = mockKubernetesService(jobName, expectedResult);
     kubernetesService.startNewCronJobExecution(
         jobName,
         executionId,
@@ -202,9 +203,9 @@ public class KubernetesServiceStartNewCronJobExecutionTest {
     Assertions.assertEquals(expectedAnnotations, annotationsArgumentCaptor.getValue());
   }
 
-  private KubernetesService mockKubernetesService(String jobName, V1beta1CronJob result)
+  private DataJobsKubernetesService mockKubernetesService(String jobName, V1beta1CronJob result)
       throws ApiException {
-    KubernetesService kubernetesService = Mockito.mock(KubernetesService.class);
+    var kubernetesService = Mockito.mock(DataJobsKubernetesService.class);
     Mockito.doCallRealMethod()
         .when(kubernetesService)
         .startNewCronJobExecution(

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -18,8 +18,6 @@ import io.kubernetes.client.openapi.models.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.slf4j.Logger;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.lang.reflect.Method;
 import java.time.Instant;
@@ -335,7 +333,8 @@ public class KubernetesServiceTest {
       V1CronJob internalCronjobTemplate = (V1CronJob) loadInternalV1CronjobTemplate.invoke(service);
       // Prepare the 'v1checkForMissingEntries' method.
       Method checkForMissingEntries =
-              DataJobsKubernetesService.class.getDeclaredMethod("v1checkForMissingEntries", V1CronJob.class);
+          DataJobsKubernetesService.class.getDeclaredMethod(
+              "v1checkForMissingEntries", V1CronJob.class);
       if (checkForMissingEntries == null) {
         Assertions.fail("The method 'v1checkForMissingEntries' does not exist.");
       }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -86,7 +86,7 @@ public class KubernetesServiceTest {
   @Test
   public void testGetJobExecutionStatus_emptyJob_shouldReturnEmptyJobExecutionStatus() {
     V1Job v1Job = new V1Job();
-    KubernetesService mock = Mockito.mock(KubernetesService.class);
+    var mock = Mockito.mock(DataJobsKubernetesService.class);
     Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
     Mockito.when(mock.getTerminationStatus(v1Job)).thenReturn(Optional.empty());
     Mockito.when(mock.getJobExecutionStatus(v1Job, null)).thenCallRealMethod();
@@ -172,7 +172,7 @@ public class KubernetesServiceTest {
         new KubernetesService.JobStatusCondition(
             true, "type", "reason", "message", endTime.toInstant().toEpochMilli());
 
-    KubernetesService mock = Mockito.mock(KubernetesService.class);
+    var mock = Mockito.mock(DataJobsKubernetesService.class);
     Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
     Mockito.when(mock.getTerminationStatus(expectedJob))
         .thenReturn(Optional.ofNullable(new V1ContainerStateTerminated().reason("test")));
@@ -220,7 +220,7 @@ public class KubernetesServiceTest {
       //          with corresponding entries from the internal cronjob template.
       // First we load the internal cronjob template.
       Method loadInternalV1beta1CronjobTemplate =
-          KubernetesService.class.getDeclaredMethod("loadInternalV1beta1CronjobTemplate");
+          DataJobsKubernetesService.class.getDeclaredMethod("loadInternalV1beta1CronjobTemplate");
       if (loadInternalV1beta1CronjobTemplate == null) {
         Assertions.fail("The method 'loadInternalV1beta1CronjobTemplate' does not exist.");
       }
@@ -229,7 +229,7 @@ public class KubernetesServiceTest {
           (V1beta1CronJob) loadInternalV1beta1CronjobTemplate.invoke(service);
       // Prepare the 'v1beta1checkForMissingEntries' method.
       Method checkForMissingEntries =
-          KubernetesService.class.getDeclaredMethod(
+          DataJobsKubernetesService.class.getDeclaredMethod(
               "v1beta1checkForMissingEntries", V1beta1CronJob.class);
       if (checkForMissingEntries == null) {
         Assertions.fail("The method 'v1beta1checkForMissingEntries' does not exist.");
@@ -274,7 +274,7 @@ public class KubernetesServiceTest {
 
       Assertions.assertNotNull(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
       // Step 3 - create and check the actual cronjob.
-      Method[] methods = KubernetesService.class.getDeclaredMethods();
+      Method[] methods = DataJobsKubernetesService.class.getDeclaredMethods();
       // This is much easier than describing the whole method signature.
       Optional<Method> method =
           Arrays.stream(methods)
@@ -327,7 +327,7 @@ public class KubernetesServiceTest {
       //          with corresponding entries from the internal cronjob template.
       // First we load the internal cronjob template.
       Method loadInternalV1CronjobTemplate =
-          KubernetesService.class.getDeclaredMethod("loadInternalV1CronjobTemplate");
+          DataJobsKubernetesService.class.getDeclaredMethod("loadInternalV1CronjobTemplate");
       if (loadInternalV1CronjobTemplate == null) {
         Assertions.fail("The method 'loadInternalV1CronjobTemplate' does not exist.");
       }
@@ -335,7 +335,7 @@ public class KubernetesServiceTest {
       V1CronJob internalCronjobTemplate = (V1CronJob) loadInternalV1CronjobTemplate.invoke(service);
       // Prepare the 'v1checkForMissingEntries' method.
       Method checkForMissingEntries =
-          KubernetesService.class.getDeclaredMethod("v1checkForMissingEntries", V1CronJob.class);
+              DataJobsKubernetesService.class.getDeclaredMethod("v1checkForMissingEntries", V1CronJob.class);
       if (checkForMissingEntries == null) {
         Assertions.fail("The method 'v1checkForMissingEntries' does not exist.");
       }
@@ -379,7 +379,7 @@ public class KubernetesServiceTest {
 
       Assertions.assertNotNull(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
       // Step 3 - create and check the actual cronjob.
-      Method[] methods = KubernetesService.class.getDeclaredMethods();
+      Method[] methods = DataJobsKubernetesService.class.getDeclaredMethods();
       // This is much easier than describing the whole method signature.
       Optional<Method> method =
           Arrays.stream(methods)
@@ -455,7 +455,7 @@ public class KubernetesServiceTest {
 
   @Test
   public void testV1beta1CronJobFromTemplate_emptyImagePullSecretsList() {
-    KubernetesService mock = mockCronJobFromTemplate();
+    var mock = mockCronJobFromTemplate();
     V1beta1CronJob v1beta1CronJob =
         mock.v1beta1CronJobFromTemplate(
             "",
@@ -482,7 +482,7 @@ public class KubernetesServiceTest {
 
   @Test
   public void testV1CronJobFromTemplate_emptyImagePullSecretsList() {
-    KubernetesService mock = mockCronJobFromTemplate();
+    var mock = mockCronJobFromTemplate();
     V1CronJob v1CronJob =
         mock.v1CronJobFromTemplate(
             "",
@@ -509,7 +509,7 @@ public class KubernetesServiceTest {
 
   @Test
   public void testV1beta1CronJobFromTemplate_imagePullSecretsListWithEmptyValues() {
-    KubernetesService mock = mockCronJobFromTemplate();
+    var mock = mockCronJobFromTemplate();
     V1beta1CronJob v1beta1CronJob =
         mock.v1beta1CronJobFromTemplate(
             "",
@@ -536,7 +536,7 @@ public class KubernetesServiceTest {
 
   @Test
   public void testV1CronJobFromTemplate_imagePullSecretsListWithEmptyValues() {
-    KubernetesService mock = mockCronJobFromTemplate();
+    var mock = mockCronJobFromTemplate();
     V1CronJob v1CronJob =
         mock.v1CronJobFromTemplate(
             "",
@@ -564,7 +564,7 @@ public class KubernetesServiceTest {
   @Test
   public void
       testV1beta1CronJobFromTemplate_imagePullSecretsListWithOneNonEmptyValueAndOneEmptyValue() {
-    KubernetesService mock = mockCronJobFromTemplate();
+    var mock = mockCronJobFromTemplate();
     String secretName = "test_secret_name";
     V1beta1CronJob v1beta1CronJob =
         mock.v1beta1CronJobFromTemplate(
@@ -596,7 +596,7 @@ public class KubernetesServiceTest {
 
   @Test
   public void testV1CronJobFromTemplate_imagePullSecretsListWithOneNonEmptyValueAndOneEmptyValue() {
-    KubernetesService mock = mockCronJobFromTemplate();
+    var mock = mockCronJobFromTemplate();
     String secretName = "test_secret_name";
     V1CronJob v1CronJob =
         mock.v1CronJobFromTemplate(
@@ -633,8 +633,9 @@ public class KubernetesServiceTest {
     Assertions.assertEquals(expectedMb, actual);
   }
 
-  private KubernetesService mockCronJobFromTemplate() {
-    KubernetesService mock = Mockito.mock(KubernetesService.class);
+  private DataJobsKubernetesService mockCronJobFromTemplate() {
+    var mock = Mockito.mock(DataJobsKubernetesService.class);
+
     Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
     Mockito.when(
             mock.v1beta1CronJobFromTemplate(
@@ -664,11 +665,6 @@ public class KubernetesServiceTest {
                 any(),
                 anyList()))
         .thenCallRealMethod();
-
-    ReflectionTestUtils.setField(
-        mock, // inject into this object
-        "log", // assign to this field
-        Mockito.mock(Logger.class)); // object to be injected
 
     return mock;
   }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -633,7 +633,6 @@ public class KubernetesServiceTest {
     Assertions.assertEquals(expectedMb, actual);
   }
 
-
   private DataJobsKubernetesService mockCronJobFromTemplate() {
     var mock = Mockito.mock(DataJobsKubernetesService.class);
     Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);


### PR DESCRIPTION
# Why
as described in this ticket https://github.com/vmware/versatile-data-kit/issues/1600 KubernetesService class is very bloated. 
Within this PR I move DataJobs specific code to its own class. 

# What
Copy all methods from the KubernetesService to the DataJobsKubernetesService if they only make sense in the context of DataJobs. 

# How has this been tested? 
Unit and integration tests


Signed-off-by: murphp15 <murphp15@tcd.ie>