### PR TITLE
control-service: cleanup tests to ease testing on control service

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -1518,7 +1518,8 @@ public abstract class KubernetesService implements InitializingBean {
    * @return A {@link JobExecution} object representing the Data Job execution status.
    */
   @VisibleForTesting
-  public Optional<JobExecution> getJobExecutionStatus(V1Job job, JobStatusCondition jobStatusCondition) {
+  public Optional<JobExecution> getJobExecutionStatus(
+      V1Job job, JobStatusCondition jobStatusCondition) {
     JobExecution.JobExecutionBuilder jobExecutionStatusBuilder = JobExecution.builder();
     // jobCondition = null means that the K8S Job is still running
     if (jobStatusCondition != null) {

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -1516,8 +1516,7 @@ public abstract class KubernetesService implements InitializingBean {
    * @param job The job whose status to return.
    * @return A {@link JobExecution} object representing the Data Job execution status.
    */
-  Optional<JobExecution> getJobExecutionStatus(
-      V1Job job, JobStatusCondition jobStatusCondition) {
+  Optional<JobExecution> getJobExecutionStatus(V1Job job, JobStatusCondition jobStatusCondition) {
     JobExecution.JobExecutionBuilder jobExecutionStatusBuilder = JobExecution.builder();
     // jobCondition = null means that the K8S Job is still running
     if (jobStatusCondition != null) {

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -1387,8 +1387,8 @@ public abstract class KubernetesService implements InitializingBean {
     return new BatchV1Api(client);
   }
 
-  // Default for testing purposes
-  BatchV1beta1Api initBatchV1beta1Api() {
+  @VisibleForTesting
+  public BatchV1beta1Api initBatchV1beta1Api() {
     return new BatchV1beta1Api(client);
   }
 
@@ -1483,7 +1483,8 @@ public abstract class KubernetesService implements InitializingBean {
    * @return A {@link V1ContainerStateTerminated} object representing the termination status of the
    *     job.
    */
-  Optional<V1ContainerStateTerminated> getTerminationStatus(V1Job job) {
+  @VisibleForTesting
+  public Optional<V1ContainerStateTerminated> getTerminationStatus(V1Job job) {
     List<V1Pod> jobPods;
 
     try {
@@ -1516,7 +1517,8 @@ public abstract class KubernetesService implements InitializingBean {
    * @param job The job whose status to return.
    * @return A {@link JobExecution} object representing the Data Job execution status.
    */
-  Optional<JobExecution> getJobExecutionStatus(V1Job job, JobStatusCondition jobStatusCondition) {
+  @VisibleForTesting
+  public Optional<JobExecution> getJobExecutionStatus(V1Job job, JobStatusCondition jobStatusCondition) {
     JobExecution.JobExecutionBuilder jobExecutionStatusBuilder = JobExecution.builder();
     // jobCondition = null means that the K8S Job is still running
     if (jobStatusCondition != null) {
@@ -2047,7 +2049,8 @@ public abstract class KubernetesService implements InitializingBean {
     }
   }
 
-  V1beta1CronJob v1beta1CronJobFromTemplate(
+  @VisibleForTesting
+  public V1beta1CronJob v1beta1CronJobFromTemplate(
       String name,
       String schedule,
       boolean suspend,
@@ -2113,7 +2116,8 @@ public abstract class KubernetesService implements InitializingBean {
     return cronjob;
   }
 
-  V1CronJob v1CronJobFromTemplate(
+  @VisibleForTesting
+  public V1CronJob v1CronJobFromTemplate(
       String name,
       String schedule,
       boolean suspend,

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -2047,8 +2047,7 @@ public abstract class KubernetesService implements InitializingBean {
     }
   }
 
-  @VisibleForTesting
-  public V1beta1CronJob v1beta1CronJobFromTemplate(
+  V1beta1CronJob v1beta1CronJobFromTemplate(
       String name,
       String schedule,
       boolean suspend,

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -1387,8 +1387,8 @@ public abstract class KubernetesService implements InitializingBean {
     return new BatchV1Api(client);
   }
 
-  @VisibleForTesting
-  public BatchV1beta1Api initBatchV1beta1Api() {
+  // Default for testing purposes
+  BatchV1beta1Api initBatchV1beta1Api() {
     return new BatchV1beta1Api(client);
   }
 
@@ -1483,8 +1483,7 @@ public abstract class KubernetesService implements InitializingBean {
    * @return A {@link V1ContainerStateTerminated} object representing the termination status of the
    *     job.
    */
-  @VisibleForTesting
-  public Optional<V1ContainerStateTerminated> getTerminationStatus(V1Job job) {
+  Optional<V1ContainerStateTerminated> getTerminationStatus(V1Job job) {
     List<V1Pod> jobPods;
 
     try {
@@ -1517,8 +1516,7 @@ public abstract class KubernetesService implements InitializingBean {
    * @param job The job whose status to return.
    * @return A {@link JobExecution} object representing the Data Job execution status.
    */
-  @VisibleForTesting
-  public Optional<JobExecution> getJobExecutionStatus(
+  Optional<JobExecution> getJobExecutionStatus(
       V1Job job, JobStatusCondition jobStatusCondition) {
     JobExecution.JobExecutionBuilder jobExecutionStatusBuilder = JobExecution.builder();
     // jobCondition = null means that the K8S Job is still running
@@ -2117,8 +2115,7 @@ public abstract class KubernetesService implements InitializingBean {
     return cronjob;
   }
 
-  @VisibleForTesting
-  public V1CronJob v1CronJobFromTemplate(
+  V1CronJob v1CronJobFromTemplate(
       String name,
       String schedule,
       boolean suspend,

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartNewCronJobExecutionTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartNewCronJobExecutionTest.java
@@ -26,7 +26,7 @@ public class KubernetesServiceStartNewCronJobExecutionTest {
   public void testStartNewCronJobExecution_nullCronJobDefinition_shouldThrowException()
       throws ApiException {
     String jobName = "test-job";
-    KubernetesService kubernetesService = mockKubernetesService(jobName, null);
+    var kubernetesService = mockKubernetesService(jobName, null);
 
     Exception exception =
         Assertions.assertThrows(
@@ -54,7 +54,7 @@ public class KubernetesServiceStartNewCronJobExecutionTest {
             .spec(
                 new V1beta1CronJobSpec()
                     .jobTemplate(new V1beta1JobTemplateSpec().spec(new V1JobSpec())));
-    KubernetesService kubernetesService = mockKubernetesService(jobName, expectedResult);
+    var kubernetesService = mockKubernetesService(jobName, expectedResult);
 
     Exception exception =
         Assertions.assertThrows(
@@ -95,7 +95,7 @@ public class KubernetesServiceStartNewCronJobExecutionTest {
                                                     .addContainersItem(
                                                         new V1Container().addEnvItem(testEnv)))))));
 
-    KubernetesService kubernetesService = mockKubernetesService(jobName, expectedResult);
+    var kubernetesService = mockKubernetesService(jobName, expectedResult);
     kubernetesService.startNewCronJobExecution(
         jobName,
         executionId,
@@ -172,7 +172,7 @@ public class KubernetesServiceStartNewCronJobExecutionTest {
                                                 new V1PodSpec()
                                                     .addContainersItem(new V1Container()))))));
 
-    KubernetesService kubernetesService = mockKubernetesService(jobName, expectedResult);
+    var kubernetesService = mockKubernetesService(jobName, expectedResult);
     kubernetesService.startNewCronJobExecution(
         jobName,
         executionId,
@@ -204,7 +204,7 @@ public class KubernetesServiceStartNewCronJobExecutionTest {
 
   private KubernetesService mockKubernetesService(String jobName, V1beta1CronJob result)
       throws ApiException {
-    KubernetesService kubernetesService = Mockito.mock(KubernetesService.class);
+    var kubernetesService = Mockito.mock(KubernetesService.class);
     Mockito.doCallRealMethod()
         .when(kubernetesService)
         .startNewCronJobExecution(

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -86,7 +86,7 @@ public class KubernetesServiceTest {
   @Test
   public void testGetJobExecutionStatus_emptyJob_shouldReturnEmptyJobExecutionStatus() {
     V1Job v1Job = new V1Job();
-    var mock = Mockito.mock(DataJobsKubernetesService.class);
+    var mock = Mockito.mock(KubernetesService.class);
     Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
     Mockito.when(mock.getTerminationStatus(v1Job)).thenReturn(Optional.empty());
     Mockito.when(mock.getJobExecutionStatus(v1Job, null)).thenCallRealMethod();

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -86,7 +86,7 @@ public class KubernetesServiceTest {
   @Test
   public void testGetJobExecutionStatus_emptyJob_shouldReturnEmptyJobExecutionStatus() {
     V1Job v1Job = new V1Job();
-    KubernetesService mock = Mockito.mock(KubernetesService.class);
+    var mock = Mockito.mock(DataJobsKubernetesService.class);
     Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
     Mockito.when(mock.getTerminationStatus(v1Job)).thenReturn(Optional.empty());
     Mockito.when(mock.getJobExecutionStatus(v1Job, null)).thenCallRealMethod();
@@ -455,7 +455,7 @@ public class KubernetesServiceTest {
 
   @Test
   public void testV1beta1CronJobFromTemplate_emptyImagePullSecretsList() {
-    KubernetesService mock = mockCronJobFromTemplate();
+    var mock = mockCronJobFromTemplate();
     V1beta1CronJob v1beta1CronJob =
         mock.v1beta1CronJobFromTemplate(
             "",
@@ -482,7 +482,7 @@ public class KubernetesServiceTest {
 
   @Test
   public void testV1CronJobFromTemplate_emptyImagePullSecretsList() {
-    KubernetesService mock = mockCronJobFromTemplate();
+    var mock = mockCronJobFromTemplate();
     V1CronJob v1CronJob =
         mock.v1CronJobFromTemplate(
             "",
@@ -509,7 +509,7 @@ public class KubernetesServiceTest {
 
   @Test
   public void testV1beta1CronJobFromTemplate_imagePullSecretsListWithEmptyValues() {
-    KubernetesService mock = mockCronJobFromTemplate();
+    var mock = mockCronJobFromTemplate();
     V1beta1CronJob v1beta1CronJob =
         mock.v1beta1CronJobFromTemplate(
             "",
@@ -536,7 +536,7 @@ public class KubernetesServiceTest {
 
   @Test
   public void testV1CronJobFromTemplate_imagePullSecretsListWithEmptyValues() {
-    KubernetesService mock = mockCronJobFromTemplate();
+    var mock = mockCronJobFromTemplate();
     V1CronJob v1CronJob =
         mock.v1CronJobFromTemplate(
             "",
@@ -564,7 +564,7 @@ public class KubernetesServiceTest {
   @Test
   public void
       testV1beta1CronJobFromTemplate_imagePullSecretsListWithOneNonEmptyValueAndOneEmptyValue() {
-    KubernetesService mock = mockCronJobFromTemplate();
+    var mock = mockCronJobFromTemplate();
     String secretName = "test_secret_name";
     V1beta1CronJob v1beta1CronJob =
         mock.v1beta1CronJobFromTemplate(
@@ -596,7 +596,7 @@ public class KubernetesServiceTest {
 
   @Test
   public void testV1CronJobFromTemplate_imagePullSecretsListWithOneNonEmptyValueAndOneEmptyValue() {
-    KubernetesService mock = mockCronJobFromTemplate();
+    var mock = mockCronJobFromTemplate();
     String secretName = "test_secret_name";
     V1CronJob v1CronJob =
         mock.v1CronJobFromTemplate(
@@ -634,7 +634,7 @@ public class KubernetesServiceTest {
   }
 
   private KubernetesService mockCronJobFromTemplate() {
-    KubernetesService mock = Mockito.mock(KubernetesService.class);
+    var mock = Mockito.mock(KubernetesService.class);
     Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
     Mockito.when(
             mock.v1beta1CronJobFromTemplate(


### PR DESCRIPTION
# Why
Alot of tests which are written on the KubernetesService should actually be written on the DataJobsControlService as the tests themselves are focused on Cron job functionality which should only happens on the data jobs. 
For more info regarding this please look here: https://github.com/vmware/versatile-data-kit/issues/1600

# What
Within this PR I have modified a lot of tests to use declare the controlService with var instead of ControlService, so we can change it for DataJobsControlService very easily in an upcoming PR. 
This is a stand alone PR to make reviewing easier. 