### PR TITLE
control-service: cleanup tests to ease testing on control service (v2)

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
@@ -24,7 +24,7 @@ public class KubernetesServiceCancelRunningCronJobTest {
   @Test
   public void testIsRunningJob_nullResponse_shouldThrowDataJobExecutionCannotBeCancelledException()
       throws ApiException {
-    KubernetesService kubernetesService = mockKubernetesService(null);
+    var kubernetesService = mockKubernetesService(null);
 
     Assertions.assertThrows(
         DataJobExecutionCannotBeCancelledException.class,
@@ -37,7 +37,7 @@ public class KubernetesServiceCancelRunningCronJobTest {
   public void
       testIsRunningJob_notNullResponseAndNullStatus_shouldThrowDataJobExecutionCannotBeCancelledException()
           throws ApiException {
-    KubernetesService kubernetesService =
+    var kubernetesService =
         mockKubernetesService(new V1Status().status(null).code(404));
 
     Assertions.assertThrows(
@@ -50,7 +50,7 @@ public class KubernetesServiceCancelRunningCronJobTest {
   @Test
   public void testIsRunningJob_notNullResponseAndStatusSuccess_shouldNotThrowException()
       throws ApiException {
-    KubernetesService kubernetesService = mockKubernetesService(new V1Status().code(200));
+    var kubernetesService = mockKubernetesService(new V1Status().code(200));
 
     Assertions.assertDoesNotThrow(
         () ->
@@ -68,7 +68,7 @@ public class KubernetesServiceCancelRunningCronJobTest {
             .code(1)
             .message("test-message")
             .details(new V1StatusDetails());
-    KubernetesService kubernetesService = mockKubernetesService(v1Status);
+    var kubernetesService = mockKubernetesService(v1Status);
 
     Assertions.assertThrows(
         KubernetesException.class,
@@ -78,7 +78,7 @@ public class KubernetesServiceCancelRunningCronJobTest {
   }
 
   private KubernetesService mockKubernetesService(V1Status v1Status) throws ApiException {
-    KubernetesService kubernetesService = Mockito.mock(KubernetesService.class);
+    var kubernetesService = Mockito.mock(KubernetesService.class);
     ReflectionTestUtils.setField(
         kubernetesService, // inject into this object
         "log", // assign to this field

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
@@ -37,8 +37,7 @@ public class KubernetesServiceCancelRunningCronJobTest {
   public void
       testIsRunningJob_notNullResponseAndNullStatus_shouldThrowDataJobExecutionCannotBeCancelledException()
           throws ApiException {
-    var kubernetesService =
-        mockKubernetesService(new V1Status().status(null).code(404));
+    var kubernetesService = mockKubernetesService(new V1Status().status(null).code(404));
 
     Assertions.assertThrows(
         DataJobExecutionCannotBeCancelledException.class,


### PR DESCRIPTION
Very similar to https://github.com/vmware/versatile-data-kit/pull/1604

# Why
Alot of tests which are written on the KubernetesService should actually be written on the DataJobsControlService as the tests themselves are focused on Cron job functionality which should only happens on the data jobs. 
For more info regarding this please look here: https://github.com/vmware/versatile-data-kit/issues/1600

# What
Within this PR I have modified a lot of tests to use declare the controlService with var instead of ControlService, so we can change it for DataJobsControlService very easily in an upcoming PR. 
This is a stand alone PR to make reviewing easier. 