### PR TITLE
control-service: graphql revert part of the wildcard filter matching

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLJobTeamAndNameFilterMatcherIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLJobTeamAndNameFilterMatcherIT.java
@@ -26,7 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = ControlplaneApplication.class)
 @AutoConfigureMockMvc(addFilters = false)
-public class GraphQLJobTeamAndNameFilterMatcherIT extends BaseIT {
+public class GraphQLJobTeamAndNameFilterMatcherIT extends BaseIT{
 
   @Autowired JobsRepository jobsRepository;
 
@@ -131,22 +131,6 @@ public class GraphQLJobTeamAndNameFilterMatcherIT extends BaseIT {
     createJobWithTeam("another-team", "another-job");
     testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected(
         "test-team", "unrelated-*", "\"jobName\"");
-  }
-
-  @Test
-  public void testFilterByTeamNameWildcardMatch_multipleJobs_shouldRetrieve() throws Exception {
-    createJobWithTeam("test-team", "test-job");
-    createJobWithTeam("another-team", "another-job");
-    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(
-        "test-team", "test-*", "\"config.team\"");
-  }
-
-  @Test
-  public void testFilterByTeamNameWildcardMatch_multipleJobs_shouldNotRetrieve() throws Exception {
-    createJobWithTeam("test-team", "test-job");
-    createJobWithTeam("another-team", "another-job");
-    testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected(
-        "test-team", "unrelated-*", "\"config.team\"");
   }
 
   private void testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLJobTeamAndNameFilterMatcherIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLJobTeamAndNameFilterMatcherIT.java
@@ -26,7 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = ControlplaneApplication.class)
 @AutoConfigureMockMvc(addFilters = false)
-public class GraphQLJobTeamAndNameFilterMatcherIT extends BaseIT{
+public class GraphQLJobTeamAndNameFilterMatcherIT extends BaseIT {
 
   @Autowired JobsRepository jobsRepository;
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByName.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByName.java
@@ -11,6 +11,7 @@ import com.vmware.taurus.service.graphql.model.V2DataJob;
 import com.vmware.taurus.service.graphql.strategy.FieldStrategy;
 import java.util.Comparator;
 import java.util.function.Predicate;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
@@ -37,6 +38,6 @@ public class JobFieldStrategyByName extends FieldStrategy<V2DataJob> {
 
   @Override
   public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
-    return dataJob -> checkMatch(dataJob.getJobName(), searchStr);
+    return dataJob -> StringUtils.containsIgnoreCase(dataJob.getJobName(), searchStr);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByTeam.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/strategy/datajob/JobFieldStrategyByTeam.java
@@ -12,6 +12,7 @@ import com.vmware.taurus.service.graphql.model.V2DataJobConfig;
 import com.vmware.taurus.service.graphql.strategy.FieldStrategy;
 import java.util.Comparator;
 import java.util.function.Predicate;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
@@ -41,7 +42,8 @@ public class JobFieldStrategyByTeam extends FieldStrategy<V2DataJob> {
                 part = part.replace("%", ".*").trim();
                 var configTeamLower = config.getTeam().toLowerCase();
                 var partLower = part.toLowerCase();
-                return checkMatch(configTeamLower, partLower);
+                return configTeamLower.matches(partLower)
+                    || configTeamLower.trim().equals(partLower.trim());
               });
     }
 
@@ -51,7 +53,8 @@ public class JobFieldStrategyByTeam extends FieldStrategy<V2DataJob> {
   @Override
   public Predicate<V2DataJob> computeSearchCriteria(@NonNull String searchStr) {
     return dataJob ->
-        dataJob.getConfig() != null && checkMatch(dataJob.getConfig().getTeam(), searchStr);
+        dataJob.getConfig() != null
+            && StringUtils.containsIgnoreCase(dataJob.getConfig().getTeam(), searchStr);
   }
 
   @Override

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLJobTeamFetcherIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLJobTeamFetcherIT.java
@@ -101,7 +101,6 @@ public class GraphQLJobTeamFetcherIT {
         .andExpect(jsonPath("$.data.content[0].config.team").value(jobTeam));
   }
 
-
   private void testJobApiRetrievalWithTeamName_retrieveExpected(String jobTeam) throws Exception {
     testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(jobTeam, jobTeam);
   }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLJobTeamFetcherIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLJobTeamFetcherIT.java
@@ -80,37 +80,6 @@ public class GraphQLJobTeamFetcherIT {
     testJobApiRetrievalWithTeamName_retrieveExpected("VIDA");
   }
 
-  @Test
-  public void testRetrieveJobNameWithTrailingWildcard() throws Exception {
-    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(
-        "some-long-data-job-name", "some-*");
-  }
-
-  @Test
-  public void testRetrieveJobNameWithTrailingAndLeadingWildcard() throws Exception {
-    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(
-        "some-long-data-job-name", "*-long-*");
-  }
-
-  @Test
-  public void testRetrieveJobNameWithLeadingWildcard() throws Exception {
-    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(
-        "some-long-data-job-name", "*-name");
-  }
-
-  @Test
-  public void testRetrieveJobNameWithComplicatedWildcard() throws Exception {
-    testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(
-        "some-long-data-job-name", "*-long-*-name");
-  }
-
-  @Test
-  public void testRetrieveJobNameWithWildcard_shouldNotRetrieve() throws Exception {
-
-    testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected(
-        "some-long-data-job-name", "*-other-*");
-  }
-
   /**
    * Re-usable test that creates a data job with a given team name and attempts to retrieve it via
    * the graphQL API, expecting to find it.
@@ -132,25 +101,6 @@ public class GraphQLJobTeamFetcherIT {
         .andExpect(jsonPath("$.data.content[0].config.team").value(jobTeam));
   }
 
-  /**
-   * Re-usable test that creates a data job with a given team name and attempts to retrieve it via
-   * the graphQL API, expecting to not find it, due to the provided search string.
-   *
-   * @param jobTeam - the team name.
-   * @param searchString - the graphQl search string.
-   * @throws Exception
-   */
-  private void testJobApiRetrievalWithTeamNameAndSearchString_retrieveNotExpected(
-      String jobTeam, String searchString) throws Exception {
-    createJobWithTeam(jobTeam);
-    mockMvc
-        .perform(
-            MockMvcRequestBuilders.get(getJobsUri(jobTeam))
-                .queryParam("query", getQuery(searchString))
-                .with(user("test")))
-        .andExpect(status().is(200))
-        .andExpect(jsonPath("$.data.content").isEmpty());
-  }
 
   private void testJobApiRetrievalWithTeamName_retrieveExpected(String jobTeam) throws Exception {
     testJobApiRetrievalWithTeamNameAndSearchString_retrieveExpected(jobTeam, jobTeam);


### PR DESCRIPTION
what: reverted some of the changes introduced in https://github.com/vmware/versatile-data-kit/pull/1459 . Reverted code and removed relevant tests.

why: users of the control-service have had a hard time adjusting to the changes, and we agreed to roll them out in a more controlled manner, one by one for each filter/search field individually.

testing: n/a since the change reverts to old functionality, existing tests already cover it.

Signed-off-by: Momchil Zhivkov <mzhivkov@vmware.com>