### PR TITLE
versatile-data-kit: git pre-commit hooks config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # To get started with Dependabot version updates, you'll need to specify which

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 # This workflow uses actions that are not certified by GitHub.
 # They are provided by a third-party and are governed by
 # separate terms of service, privacy policy, and support

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # This workflow uses actions that are not certified by GitHub.

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 name: Google Java Format
 
 on:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 name: Google Java Format

--- a/.gitlint
+++ b/.gitlint
@@ -6,4 +6,4 @@ contrib=contrib-body-requires-signed-off-by
 # commit-msg title must be matched to.
 # Note that the regex can contradict with other rules if not used correctly
 # (e.g. title-must-not-contain-word).
-regex=(vdk-.*|versatile-data-kit|control-service|examples): .*
+regex=(vdk-.*|versatile-data-kit|control-service|examples|frontend): .*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,6 +82,7 @@ repos:
       - id: insert-license
         files: \.ts$
         args:
+          - --use-current-year
           - --license-filepath
           - NOTICE.txt
           - --comment-style
@@ -89,6 +90,7 @@ repos:
       - id: insert-license
         files: \.js$
         args:
+          - --use-current-year
           - --license-filepath
           - NOTICE.txt
           - --comment-style
@@ -96,6 +98,7 @@ repos:
       - id: insert-license
         files: \.html
         args:
+          - --use-current-year
           - --license-filepath
           - NOTICE.txt
           - --comment-style
@@ -103,10 +106,17 @@ repos:
       - id: insert-license
         files: (\.scss$|\.css$)
         args:
+          - --use-current-year
           - --license-filepath
           - NOTICE.txt
           - --comment-style
           - /*| *| */
+      - id: insert-license
+        files: (\.yaml$|\.yml$)
+        args:
+          - --use-current-year
+          - --license-filepath
+          - NOTICE.txt
       - id: insert-license
         files: \.py$
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,11 +10,11 @@ repos:
         # exclude helm chart templates
         exclude: ^projects/control-service/projects/helm_charts
       - id: check-json
-        exclude: (^projects/frontend/data-pipelines/gui/tsconfig.json|^projects/frontend/data-pipelines/gui/package-lock.json|^projects/frontend/data-pipelines/gui/projects/data-pipelines/.eslintrc.json|^projects/frontend/data-pipelines/gui/projects/data-pipelines/tsconfig.lib.prod.json|^projects/frontend/data-pipelines/gui/projects/data-pipelines/tsconfig.spec.json|^projects/frontend/data-pipelines/gui/projects/data-pipelines/tsconfig.lib.json)
+        exclude: (^projects/frontend/data-pipelines/gui/tsconfig.json|^projects/frontend/data-pipelines/gui/package-lock.json|^projects/frontend/data-pipelines/gui/projects/data-pipelines/.eslintrc.json|^projects/frontend/data-pipelines/gui/projects/data-pipelines/tsconfig.lib.prod.json|^projects/frontend/data-pipelines/gui/projects/data-pipelines/tsconfig.spec.json|^projects/frontend/data-pipelines/gui/projects/data-pipelines/tsconfig.lib.json|^projects/frontend/data-pipelines/gui/projects/ui/.eslintrc.json|^projects/frontend/data-pipelines/gui/projects/ui/tsconfig.app.json|^projects/frontend/data-pipelines/gui/projects/ui/tsconfig.spec.json)
       - id: check-ast
         exclude: ^projects/vdk-core/tests/functional/run/jobs/syntax-error-job/1_step.py
       - id: check-added-large-files
-        exclude: (^projects/frontend/data-pipelines/gui/tsconfig.json|^projects/frontend/data-pipelines/gui/package-lock.json)
+        exclude: (^projects/frontend/data-pipelines/gui/tsconfig.json|^projects/frontend/data-pipelines/gui/package-lock.json|^projects/frontend/data-pipelines/gui/projects/ui/src/assets/css/clr-ui.min.css)
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-executables-have-shebangs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
         # exclude helm chart templates
         exclude: ^projects/control-service/projects/helm_charts
       - id: check-json
+        exclude: (^projects/frontend/data-pipelines/gui/tsconfig.json|^projects/frontend/data-pipelines/gui/package-lock.json)
       - id: check-ast
         exclude: ^projects/vdk-core/tests/functional/run/jobs/syntax-error-job/1_step.py
       - id: check-added-large-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
       - id: check-ast
         exclude: ^projects/vdk-core/tests/functional/run/jobs/syntax-error-job/1_step.py
       - id: check-added-large-files
+        exclude: ^projects/frontend/data-pipelines/gui/tsconfig.json
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-executables-have-shebangs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,6 +77,34 @@ repos:
           - --comment-style
           - /*| *| */
       - id: insert-license
+        files: \.ts$
+        args:
+          - --license-filepath
+          - NOTICE.txt
+          - --comment-style
+          - /*| *| */
+      - id: insert-license
+        files: \.js$
+        args:
+          - --license-filepath
+          - NOTICE.txt
+          - --comment-style
+          - /*| *| */
+      - id: insert-license
+        files: \.html
+        args:
+          - --license-filepath
+          - NOTICE.txt
+          - --comment-style
+          - <!--|   ~|  -->
+      - id: insert-license
+        files: \.scss$
+        args:
+          - --license-filepath
+          - NOTICE.txt
+          - --comment-style
+          - /*| *| */
+      - id: insert-license
         files: \.py$
         args:
           - --license-filepath

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         # exclude helm chart templates
         exclude: ^projects/control-service/projects/helm_charts
       - id: check-json
-        exclude: (^projects/frontend/data-pipelines/gui/tsconfig.json|^projects/frontend/data-pipelines/gui/package-lock.json)
+        exclude: (^projects/frontend/data-pipelines/gui/tsconfig.json|^projects/frontend/data-pipelines/gui/package-lock.json|^projects/frontend/data-pipelines/gui/projects/data-pipelines/.eslintrc.json|^projects/frontend/data-pipelines/gui/projects/data-pipelines/tsconfig.lib.prod.json|^projects/frontend/data-pipelines/gui/projects/data-pipelines/tsconfig.spec.json|^projects/frontend/data-pipelines/gui/projects/data-pipelines/tsconfig.lib.json)
       - id: check-ast
         exclude: ^projects/vdk-core/tests/functional/run/jobs/syntax-error-job/1_step.py
       - id: check-added-large-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: check-ast
         exclude: ^projects/vdk-core/tests/functional/run/jobs/syntax-error-job/1_step.py
       - id: check-added-large-files
-        exclude: ^projects/frontend/data-pipelines/gui/tsconfig.json
+        exclude: (^projects/frontend/data-pipelines/gui/tsconfig.json|^projects/frontend/data-pipelines/gui/package-lock.json)
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-executables-have-shebangs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,7 +100,7 @@ repos:
           - --comment-style
           - <!--|   ~|  -->
       - id: insert-license
-        files: \.scss$
+        files: (\.scss$|\.css$)
         args:
           - --license-filepath
           - NOTICE.txt

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 .control_service_retry:

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 .control_service_retry:
   retry_options:
     max: 1

--- a/projects/control-service/cicd/trino-values.yaml
+++ b/projects/control-service/cicd/trino-values.yaml
@@ -1,6 +1,4 @@
-
-
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 image:

--- a/projects/control-service/cicd/trino-values.yaml
+++ b/projects/control-service/cicd/trino-values.yaml
@@ -1,5 +1,8 @@
 
 
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 image:
   repository: trinodb/trino
 

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/Chart.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/Chart.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v2
 name: pipelines-control-service
 description: A Helm chart for Versatile Data Kit Control Service

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/Chart.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: v2

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/configmap_datajob_template_file.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/configmap_datajob_template_file.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.datajobTemplate.enabled }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/configmap_datajob_template_file.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/configmap_datajob_template_file.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if .Values.datajobTemplate.enabled }}
 apiVersion: v1
 kind: ConfigMap

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apps/v1

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/fluentdconfig.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/fluentdconfig.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.fluentd.enabled }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/fluentdconfig.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/fluentdconfig.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if .Values.fluentd.enabled }}
 apiVersion: logs.vdp.vmware.com/v1beta1
 kind: FluentdConfig

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/fluentdconfig_datajobs.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/fluentdconfig_datajobs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if .Values.dataJob.fluentd.enabled }}
 apiVersion: logs.vdp.vmware.com/v1beta1
 kind: FluentdConfig

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/fluentdconfig_datajobs.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/fluentdconfig_datajobs.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.dataJob.fluentd.enabled }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/ingress.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/ingress.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if .Values.ingress.enabled -}}
 kind: Ingress
 metadata:

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/ingress.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/ingress.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.ingress.enabled -}}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/prometheusrules.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/prometheusrules.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if .Values.alerting.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/prometheusrules.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/prometheusrules.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.alerting.enabled }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/role.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/role.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.rbac.create -}}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/role.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/role.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/role_datajobs.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/role_datajobs.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if and .Values.rbac.create .Values.rbac.datajobsDeployment.create -}}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/role_datajobs.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/role_datajobs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if and .Values.rbac.create .Values.rbac.datajobsDeployment.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/rolebindings.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/rolebindings.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if and .Values.serviceAccount.create .Values.rbac.create }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/rolebindings.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/rolebindings.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if and .Values.serviceAccount.create .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/rolebindings_datajobs.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/rolebindings_datajobs.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if and .Values.serviceAccount.create .Values.rbac.create .Values.rbac.datajobsDeployment.create }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/rolebindings_datajobs.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/rolebindings_datajobs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if and .Values.serviceAccount.create .Values.rbac.create .Values.rbac.datajobsDeployment.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_jdbc.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_jdbc.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 ## Create a secret with JDBC credentials for embedded database (PostgreSQL or CockroachDB) only if externalSecretName is not supplied.
 ## If any of the fields are empty, we fall-back to defaults (f.e. local dev environment)
 {{- if not .Values.database.externalSecretName }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_jdbc.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_jdbc.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 ## Create a secret with JDBC credentials for embedded database (PostgreSQL or CockroachDB) only if externalSecretName is not supplied.

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_kubernetes_authenticator.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_kubernetes_authenticator.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 ## Create a secret with Kerberos keytab for authentication if kerberos authentication flag is turned on.
 ## The keytab file contents are set from the values.yaml file and are intended to be populated by an env
 ## variable.

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_kubernetes_authenticator.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_kubernetes_authenticator.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 ## Create a secret with Kerberos keytab for authentication if kerberos authentication flag is turned on.

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_base_img.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_base_img.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if .Values.deploymentDataJobBaseImage.password }}
 apiVersion: v1
 kind: Secret

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_base_img.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_base_img.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.deploymentDataJobBaseImage.password }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_builder_img.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_builder_img.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.deploymentBuilderImage.password }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_builder_img.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_builder_img.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if .Values.deploymentBuilderImage.password }}
 apiVersion: v1
 kind: Secret

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_img.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_img.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if and (eq .Values.deploymentDockerRegistryType "generic") .Values.deploymentDockerRegistryUsernameReadOnly .Values.deploymentDockerRegistryPasswordReadOnly }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_img.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_img.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if and (eq .Values.deploymentDockerRegistryType "generic") .Values.deploymentDockerRegistryUsernameReadOnly .Values.deploymentDockerRegistryPasswordReadOnly }}
 apiVersion: v1
 kind: Secret

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_pipelines_control_service_img.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_pipelines_control_service_img.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if (include "shouldCreatePipelinesControlServiceDockerRepoSecret" .) }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_pipelines_control_service_img.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_pipelines_control_service_img.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if (include "shouldCreatePipelinesControlServiceDockerRepoSecret" .) }}
 apiVersion: v1
 kind: Secret

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_vdk_sdk_img.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_vdk_sdk_img.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if (include "shouldCreateVdkSdkDockerRepoSecret" .) }}
 apiVersion: v1
 kind: Secret

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_vdk_sdk_img.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_vdk_sdk_img.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if (include "shouldCreateVdkSdkDockerRepoSecret" .) }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secrets.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secrets.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: v1

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secrets.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secrets.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Secret
 metadata:

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/service.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/service.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: v1

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/service.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/service.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/serviceaccount.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.serviceAccount.create }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/serviceaccount.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/serviceaccount.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/servicemonitor.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/servicemonitor.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/servicemonitor.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
 ## Current available global Docker image parameter(s): imageRegistry

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 ## Global Docker image parameters

--- a/projects/frontend/cicd/.gitlab-ci.yml
+++ b/projects/frontend/cicd/.gitlab-ci.yml
@@ -1,6 +1,4 @@
-
-
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 frontend_publish_test_image:

--- a/projects/frontend/cicd/.gitlab-ci.yml
+++ b/projects/frontend/cicd/.gitlab-ci.yml
@@ -1,5 +1,8 @@
 
 
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 frontend_publish_test_image:
   image: docker:19.03.15
   variables:

--- a/projects/frontend/shared-components/cicd/.gitlab.yml
+++ b/projects/frontend/shared-components/cicd/.gitlab.yml
@@ -1,0 +1,3 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+

--- a/projects/frontend/shared-components/cicd/.gitlab.yml
+++ b/projects/frontend/shared-components/cicd/.gitlab.yml
@@ -1,3 +1,2 @@
 # Copyright 2023-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/projects/frontend/shared-components/cicd/.gitlab.yml
+++ b/projects/frontend/shared-components/cicd/.gitlab.yml
@@ -1,2 +1,2 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0

--- a/projects/vdk-heartbeat/.gitlab-ci.yml
+++ b/projects/vdk-heartbeat/.gitlab-ci.yml
@@ -1,4 +1,7 @@
 
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 image: "python:3.9"
 
 .vdk_heartbeat_changes: &vdk_heartbeat_changes_locations

--- a/projects/vdk-heartbeat/.gitlab-ci.yml
+++ b/projects/vdk-heartbeat/.gitlab-ci.yml
@@ -1,5 +1,4 @@
-
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 image: "python:3.9"

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/.eslintrc.js
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/.eslintrc.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 module.exports = {
   extends: [
     'eslint:recommended',

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/.eslintrc.js
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/.eslintrc.js
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
- * Copyright 2021 VMware, Inc.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 module.exports = {
   extends: [
     'eslint:recommended',

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/.eslintrc.js
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/.eslintrc.js
@@ -1,4 +1,9 @@
 /*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Copyright 2021 VMware, Inc.
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/babel.config.js
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/babel.config.js
@@ -1,1 +1,6 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 module.exports = require('@jupyterlab/testutils/lib/babel.config');

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/babel.config.js
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/babel.config.js
@@ -3,9 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
- * Copyright 2021 VMware, Inc.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 module.exports = require('@jupyterlab/testutils/lib/babel.config');

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/babel.config.js
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/babel.config.js
@@ -1,4 +1,9 @@
 /*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Copyright 2021 VMware, Inc.
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/jest.config.js
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/jest.config.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 const jestJupyterLab = require('@jupyterlab/testutils/lib/jest-config');
 
 const esModules = [

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/jest.config.js
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/jest.config.js
@@ -1,4 +1,9 @@
 /*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Copyright 2021 VMware, Inc.
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/jest.config.js
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/jest.config.js
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
- * Copyright 2021 VMware, Inc.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 const jestJupyterLab = require('@jupyterlab/testutils/lib/jest-config');
 
 const esModules = [

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/vdk-jupyterlab-extension.spec.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/vdk-jupyterlab-extension.spec.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /**
  * Example of [Jest](https://jestjs.io/docs/getting-started) unit tests
  */

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/vdk-jupyterlab-extension.spec.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/vdk-jupyterlab-extension.spec.ts
@@ -1,4 +1,9 @@
 /*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Copyright 2021 VMware, Inc.
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/vdk-jupyterlab-extension.spec.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/vdk-jupyterlab-extension.spec.ts
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
- * Copyright 2021 VMware, Inc.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 /**
  * Example of [Jest](https://jestjs.io/docs/getting-started) unit tests
  */

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/handler.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/handler.ts
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
- * Copyright 2021 VMware, Inc.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { URLExt } from '@jupyterlab/coreutils';
 
 import { ServerConnection } from '@jupyterlab/services';

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/handler.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/handler.ts
@@ -1,4 +1,9 @@
 /*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Copyright 2021 VMware, Inc.
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/handler.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/handler.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { URLExt } from '@jupyterlab/coreutils';
 
 import { ServerConnection } from '@jupyterlab/services';

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/index.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/index.ts
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
- * Copyright 2021 VMware, Inc.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/index.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/index.ts
@@ -1,4 +1,9 @@
 /*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Copyright 2021 VMware, Inc.
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/index.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/index.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/serverRequests.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/serverRequests.ts
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
- * Copyright 2021 VMware, Inc.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { requestAPI } from './handler';
 import { Dialog, showErrorMessage } from '@jupyterlab/apputils';
 /**

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/serverRequests.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/serverRequests.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { requestAPI } from './handler';
 import { Dialog, showErrorMessage } from '@jupyterlab/apputils';
 /**

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/serverRequests.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/serverRequests.ts
@@ -1,4 +1,9 @@
 /*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Copyright 2021 VMware, Inc.
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/utils.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/utils.ts
@@ -1,5 +1,10 @@
 
 
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export function removeCreateJobDataFromSessionStorage(){
     sessionStorage.removeItem('create-job-name');
     sessionStorage.removeItem('create-job-team');

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/utils.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/utils.ts
@@ -1,12 +1,5 @@
-
-
 /*
  * Copyright 2021-2023 VMware, Inc.
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/*
- * Copyright 2021 VMware, Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/utils.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/utils.ts
@@ -1,6 +1,11 @@
 
 
 /*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Copyright 2021 VMware, Inc.
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/base.css
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/base.css
@@ -1,4 +1,9 @@
 /*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
     See the JupyterLab Developer Guide for useful CSS Patterns:
 
     https://jupyterlab.readthedocs.io/en/stable/developer/css.html

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/base.css
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/base.css
@@ -2,12 +2,6 @@
  * Copyright 2021-2023 VMware, Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-
-/*
- * Copyright 2021 VMware, Inc.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 /*
     See the JupyterLab Developer Guide for useful CSS Patterns:
 

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/base.css
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/base.css
@@ -1,4 +1,9 @@
 /*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Copyright 2021 VMware, Inc.
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/index.css
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/index.css
@@ -1,1 +1,6 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 @import url('base.css');

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/index.css
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/index.css
@@ -1,4 +1,9 @@
 /*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Copyright 2021 VMware, Inc.
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/index.css
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/index.css
@@ -3,9 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
- * Copyright 2021 VMware, Inc.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 @import url('base.css');

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/index.js
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/index.js
@@ -3,9 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
- * Copyright 2021 VMware, Inc.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import './base.css';

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/index.js
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/index.js
@@ -1,4 +1,9 @@
 /*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Copyright 2021 VMware, Inc.
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/index.js
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/index.js
@@ -1,1 +1,6 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import './base.css';

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/vdkDialogs.css
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/vdkDialogs.css
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
- * Copyright 2021 VMware, Inc.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 .jp-vdk-input-wrapper {
   display: flex;
   flex-direction: column;

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/vdkDialogs.css
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/vdkDialogs.css
@@ -1,4 +1,9 @@
 /*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Copyright 2021 VMware, Inc.
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/vdkDialogs.css
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/vdkDialogs.css
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 .jp-vdk-input-wrapper {
   display: flex;
   flex-direction: column;

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/ui-tests/playwright.config.js
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/ui-tests/playwright.config.js
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
- * Copyright 2021 VMware, Inc.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 /**
  * Configuration for Playwright using default from @jupyterlab/galata
  */

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/ui-tests/playwright.config.js
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/ui-tests/playwright.config.js
@@ -1,4 +1,9 @@
 /*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Copyright 2021 VMware, Inc.
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/ui-tests/playwright.config.js
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/ui-tests/playwright.config.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /**
  * Configuration for Playwright using default from @jupyterlab/galata
  */

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/ui-tests/tests/vdk-jupyterlab-extension.spec.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/ui-tests/tests/vdk-jupyterlab-extension.spec.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { expect, test } from '@jupyterlab/galata';
 import { assert } from 'console';
 

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/ui-tests/tests/vdk-jupyterlab-extension.spec.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/ui-tests/tests/vdk-jupyterlab-extension.spec.ts
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
- * Copyright 2021 VMware, Inc.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { expect, test } from '@jupyterlab/galata';
 import { assert } from 'console';
 

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/ui-tests/tests/vdk-jupyterlab-extension.spec.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/ui-tests/tests/vdk-jupyterlab-extension.spec.ts
@@ -1,4 +1,9 @@
 /*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Copyright 2021 VMware, Inc.
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/projects/vdk-plugins/vdk-lineage/src/vdk/plugin/marquez/docker-compose.yaml
+++ b/projects/vdk-plugins/vdk-lineage/src/vdk/plugin/marquez/docker-compose.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 version: "3.7"
 services:
   api:

--- a/projects/vdk-plugins/vdk-lineage/src/vdk/plugin/marquez/docker-compose.yaml
+++ b/projects/vdk-plugins/vdk-lineage/src/vdk/plugin/marquez/docker-compose.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 version: "3.7"

--- a/projects/vdk-plugins/vdk-server/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-server/.plugin-ci.yml
@@ -1,7 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
-# Copyright (c) 2021 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 image: "python:3.7"

--- a/projects/vdk-plugins/vdk-server/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-server/.plugin-ci.yml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright (c) 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/configmap-local-registry-hosting-template.yaml
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/configmap-local-registry-hosting-template.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: v1

--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/configmap-local-registry-hosting-template.yaml
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/configmap-local-registry-hosting-template.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/ingress-nginx-deploy.yaml
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/ingress-nginx-deploy.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 # This is a copy of the ingress-nginx manifest for KinD, available here:
 # https://github.com/kubernetes/ingress-nginx/blob/main/deploy/static/provider/kind/deploy.yaml
 apiVersion: v1

--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/ingress-nginx-deploy.yaml
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/ingress-nginx-deploy.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # This is a copy of the ingress-nginx manifest for KinD, available here:

--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/kind-cluster-config-template.yaml
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/kind-cluster-config-template.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:

--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/kind-cluster-config-template.yaml
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/kind-cluster-config-template.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 kind: Cluster

--- a/support/gitlab-runners/kubeconfig.yaml
+++ b/support/gitlab-runners/kubeconfig.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2023 VMware, Inc.
+# Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: v1

--- a/support/gitlab-runners/kubeconfig.yaml
+++ b/support/gitlab-runners/kubeconfig.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 clusters:
 - cluster:


### PR DESCRIPTION
Frontend config files were failing git pre-coming hooks due:
* too large 
* JSON format inspection
* PR title prefix

License insertion now covers TypeScript, JavaScript, (S)CSS, 
HTML, Y(A)ML file types in addition.
PR titles can be now associated with "frontend" component.
Modified the pre-commit and gitlint configurations accordingly.

Testing done: installed the hook locally, and verified all
frontend/data-pipelines changes from multiple stacked PRs 
were committed and auto-modified correctly
with the code header expected.