### PR TITLE
vdk-jupyter: vdk-notebook README improvements

### DIFF
--- a/projects/vdk-plugins/vdk-notebook/README.md
+++ b/projects/vdk-plugins/vdk-notebook/README.md
@@ -1,9 +1,8 @@
-# notebook
+# vdk-notebook
 
-A new VDK plugin which will support running data jobs which consists of .ipynb files.
-You can see [VDK Jupyter Integration VEP](https://github.com/vmware/versatile-data-kit/blob/main/specs/vep-994-jupyter-notebook-integration/README.md)
+A new VDK plugin which supports running data jobs which consists of .ipynb files.
+You can see [VDK Jupyter Integration VEP](https://github.com/vmware/versatile-data-kit/blob/main/specs/vep-994-jupyter-notebook-integration/README.md) for more information.
 
-TODO: what the project is about, what is its purpose
 
 ## Usage
 To install the plugin you need to run:
@@ -15,8 +14,22 @@ pip install vdk-notebook
 No specific notebook configurations are needed currently.
 
 ### Example
+Here is a directory structure which consist of one parent directory "parent-dir" and two subdirectories.
+One of the subdirectories is a data job("example-job"). This is how the structure looks like:
+```
+parent-dir
+└── example-job
+    ├── notebook.ipynb
+    ├── requirements.txt
+    └── config.ini
+└── some-other-dir
+```
+To run the data job from the parent-dir we need to use:
 
-TODO
+```
+vdk run example-job
+```
+
 
 ### Testing
 Testing this plugin locally requires installing the dependencies listed in vdk-plugins/vdk-notebook/requirements.txt
@@ -25,5 +38,6 @@ Run
 ```
 pip install -r requirements.txt
 ```
+
 ## Architecture
-See the [vdk enhancement proposal spec here](https://github.com/vmware/versatile-data-kit/blob/main/specs/vep-994-jupyter-notebook-integration/README.md)
+See the architecture of the plugin in the "Detailed design" section of [the VEP](https://github.com/vmware/versatile-data-kit/blob/main/specs/vep-994-jupyter-notebook-integration/README.md).


### PR DESCRIPTION
What:
Introduced some changes on the vdk-notebook README

Why:
It didn't have a proper example and some information needed to be changed.

Signed-off-by: Duygu Hasan [hduygu@vmware.com](mailto:hduygu@vmware.com)