### PR TITLE
job-base-image-secure: remove unused parameter from publication script

### DIFF
--- a/projects/control-service/projects/job-base-image-secure/publish-job-base.sh
+++ b/projects/control-service/projects/job-base-image-secure/publish-job-base.sh
@@ -10,14 +10,13 @@ VDK_DOCKER_REGISTRY_URL=${VDK_DOCKER_REGISTRY_URL:-"registry.hub.docker.com/vers
 function build_and_push_image() {
     name="$1"
     docker_file="$2"
-    arguments="$3"
 
     image_repo="$VDK_DOCKER_REGISTRY_URL/$name"
     image_tag_local="$image_repo:local"
     image_tag_version="$image_repo:$VERSION_TAG"
     image_tag_latest="$image_repo:latest"
 
-    docker build -t "$image_tag_local" -f "$SCRIPT_DIR/$docker_file" "$arguments" "$SCRIPT_DIR"
+    docker build -t "$image_tag_local" -f "$SCRIPT_DIR/$docker_file" "$SCRIPT_DIR"
 
     docker-slim build \
     --target "$image_tag_local" \


### PR DESCRIPTION
There is an unused parameter to the docker build command called "arguments" which breaks the command when it is empty.

https://gitlab.com/vmware-analytics/versatile-data-kit/-/jobs/3790587531

Signed-off-by: Miroslav Ivanov [miroslavi@vmware.com](mailto:miroslavi@vmware.com)