### PR TITLE
control-service: handle init container OOM

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobInitContainerOOMIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobInitContainerOOMIT.java
@@ -15,16 +15,22 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 
 @Slf4j
+@TestPropertySource(
+        properties = {
+                "datajobs.deployment.initContainer.resources.requests.memory=6Mi",
+                "datajobs.deployment.initContainer.resources.limits.memory=6Mi",
+        })
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = ControlplaneApplication.class)
-public class DataJobOOMIT extends BaseIT {
+public class DataJobInitContainerOOMIT extends BaseIT {
 
   @RegisterExtension
   static DataJobDeploymentExtension dataJobDeploymentExtension =
-      new DataJobDeploymentExtension("oom_job.zip");
+      new DataJobDeploymentExtension();
 
   @Test
   public void testDataJob_causesOOM_shouldCompleteWithUserError(
@@ -38,7 +44,7 @@ public class DataJobOOMIT extends BaseIT {
     // Check the data job execution status
     JobExecutionUtil.checkDataJobExecutionStatus(
         executionId,
-        DataJobExecution.StatusEnum.USER_ERROR,
+        DataJobExecution.StatusEnum.PLATFORM_ERROR,
         opId,
         jobName,
         teamName,

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobInitContainerOOMIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobInitContainerOOMIT.java
@@ -19,18 +19,17 @@ import org.springframework.test.context.TestPropertySource;
 
 @Slf4j
 @TestPropertySource(
-        properties = {
-                "datajobs.deployment.initContainer.resources.requests.memory=6Mi",
-                "datajobs.deployment.initContainer.resources.limits.memory=6Mi",
-        })
+    properties = {
+      "datajobs.deployment.initContainer.resources.requests.memory=6Mi",
+      "datajobs.deployment.initContainer.resources.limits.memory=6Mi",
+    })
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = ControlplaneApplication.class)
 public class DataJobInitContainerOOMIT extends BaseIT {
 
   @RegisterExtension
-  static DataJobDeploymentExtension dataJobDeploymentExtension =
-      new DataJobDeploymentExtension();
+  static DataJobDeploymentExtension dataJobDeploymentExtension = new DataJobDeploymentExtension();
 
   @Test
   public void testDataJob_causesOOM_shouldCompleteWithUserError(

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobMainContainerOOMIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobMainContainerOOMIT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.datajobs.it;
+
+import com.vmware.taurus.ControlplaneApplication;
+import com.vmware.taurus.controlplane.model.data.DataJobExecution;
+import com.vmware.taurus.datajobs.it.common.BaseIT;
+import com.vmware.taurus.datajobs.it.common.DataJobDeploymentExtension;
+import com.vmware.taurus.datajobs.it.common.JobExecutionUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@Slf4j
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = ControlplaneApplication.class)
+public class DataJobMainContainerOOMIT extends BaseIT {
+
+  @RegisterExtension
+  static DataJobDeploymentExtension dataJobDeploymentExtension =
+      new DataJobDeploymentExtension("oom_job.zip");
+
+  @Test
+  public void testDataJob_causesOOM_shouldCompleteWithUserError(
+      String jobName, String teamName, String username, String deploymentId) throws Exception {
+    // manually start job execution
+    ImmutablePair<String, String> executeDataJobResult =
+        JobExecutionUtil.executeDataJob(jobName, teamName, username, deploymentId, mockMvc);
+    String opId = executeDataJobResult.getLeft();
+    String executionId = executeDataJobResult.getRight();
+
+    // Check the data job execution status
+    JobExecutionUtil.checkDataJobExecutionStatus(
+        executionId,
+        DataJobExecution.StatusEnum.USER_ERROR,
+        opId,
+        jobName,
+        teamName,
+        username,
+        mockMvc);
+  }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -40,6 +40,7 @@ import io.kubernetes.client.util.Yaml;
 import lombok.*;
 import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.InitializingBean;
@@ -58,6 +59,7 @@ import java.time.ZoneOffset;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.function.Predicate.not;
@@ -145,7 +147,7 @@ public abstract class KubernetesService implements InitializingBean {
     String executionId;
     String executionType;
     String jobName;
-    String podTerminationMessage;
+    String mainContainerTerminationMessage;
     String jobTerminationReason;
     Boolean succeeded;
     String opId;
@@ -159,7 +161,8 @@ public abstract class KubernetesService implements InitializingBean {
     Integer resourcesMemoryLimit;
     OffsetDateTime deployedDate;
     String deployedBy;
-    String containerTerminationReason;
+    String mainContainerTerminationReason;
+    String initContainerTerminationReason;
   }
 
   @AllArgsConstructor
@@ -1456,7 +1459,7 @@ public abstract class KubernetesService implements InitializingBean {
     return (containers != null && !containers.isEmpty()) ? containers.get(0).getName() : null;
   }
 
-  private static Optional<V1ContainerStateTerminated> getTerminatedState(V1Pod pod) {
+  private static Optional<V1ContainerStateTerminated> getTerminatedState(V1Pod pod, Function<V1PodStatus, List<V1ContainerStatus>> containerStatusFunction) {
     Objects.requireNonNull(pod, "The pod cannot be null");
     var status = pod.getStatus();
     if (status == null
@@ -1464,7 +1467,7 @@ public abstract class KubernetesService implements InitializingBean {
         || status.getContainerStatuses().isEmpty()) {
       return Optional.empty();
     }
-    final var containerStatus = status.getContainerStatuses().get(0);
+    final var containerStatus = containerStatusFunction.apply(status).get(0);
     return getTerminatedState(containerStatus.getState())
         .or(() -> getTerminatedState(containerStatus.getLastState()));
   }
@@ -1483,7 +1486,7 @@ public abstract class KubernetesService implements InitializingBean {
    * @return A {@link V1ContainerStateTerminated} object representing the termination status of the
    *     job.
    */
-  Optional<V1ContainerStateTerminated> getTerminationStatus(V1Job job) {
+  ImmutablePair<Optional<V1ContainerStateTerminated>, Optional<V1ContainerStateTerminated>> getTerminationStatus(V1Job job) {
     List<V1Pod> jobPods;
 
     try {
@@ -1493,21 +1496,42 @@ public abstract class KubernetesService implements InitializingBean {
           "Could not list pods for job {}",
           job.getMetadata().getName(),
           new KubernetesException("", ex));
-      return Optional.empty();
+      return ImmutablePair.of(Optional.empty(), Optional.empty());
     }
 
-    var lastTerminatedPodState =
+    var lastMainTerminatedPodState =
         jobPods.stream()
-            .map(KubernetesService::getTerminatedState)
+            .map(v1Pod -> getTerminatedState(v1Pod, new Function<V1PodStatus, List<V1ContainerStatus>>() {
+              @Override
+              public List<V1ContainerStatus> apply(V1PodStatus v1PodStatus) {
+                return v1PodStatus.getContainerStatuses();
+              }
+            }))
             .filter(Optional::isPresent)
             .map(Optional::get)
             .max(Comparator.comparing(V1ContainerStateTerminated::getFinishedAt));
 
-    if (lastTerminatedPodState.isEmpty()) {
-      log.info("Could not find a terminated pod for job {}", job.getMetadata().getName());
+    if (lastMainTerminatedPodState.isEmpty()) {
+      log.info("Could not find a main terminated pod for job {}", job.getMetadata().getName());
     }
 
-    return lastTerminatedPodState;
+    var lastInitTerminatedPodState =
+            jobPods.stream()
+                    .map(v1Pod -> getTerminatedState(v1Pod, new Function<V1PodStatus, List<V1ContainerStatus>>() {
+                      @Override
+                      public List<V1ContainerStatus> apply(V1PodStatus v1PodStatus) {
+                        return v1PodStatus.getInitContainerStatuses();
+                      }
+                    }))
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .max(Comparator.comparing(V1ContainerStateTerminated::getFinishedAt));
+
+    if (lastInitTerminatedPodState.isEmpty()) {
+      log.info("Could not find a data job terminated pod for job {}", job.getMetadata().getName());
+    }
+
+    return ImmutablePair.of(lastInitTerminatedPodState, lastMainTerminatedPodState);
   }
 
   /**
@@ -1521,23 +1545,32 @@ public abstract class KubernetesService implements InitializingBean {
     // jobCondition = null means that the K8S Job is still running
     if (jobStatusCondition != null) {
       // Job termination status
-      Optional<V1ContainerStateTerminated> lastTerminatedPodState = getTerminationStatus(job);
+      ImmutablePair<Optional<V1ContainerStateTerminated>, Optional<V1ContainerStateTerminated>> podTerminationStatus = getTerminationStatus(job);
+
+      Optional<V1ContainerStateTerminated> lastInitContainerStateTerminated = podTerminationStatus.getLeft();
+      // Termination Reason of the pod init container
+      lastInitContainerStateTerminated
+              .map(
+                      v1ContainerStateTerminated ->
+                              StringUtils.trim(v1ContainerStateTerminated.getReason()))
+              .ifPresent(s -> jobExecutionStatusBuilder.initContainerTerminationReason(s));
+
+      Optional<V1ContainerStateTerminated> lastMainContainerStateTerminated = podTerminationStatus.getRight();
       // If the job completed but its pod did not produce a termination message, we infer the
-      // termination
-      // status later, based on the status of the job itself.
-      lastTerminatedPodState
+      // termination status later, based on the status of the job itself.
+      lastMainContainerStateTerminated
           .map(
               v1ContainerStateTerminated ->
                   StringUtils.trim(v1ContainerStateTerminated.getMessage()))
-          .ifPresent(s -> jobExecutionStatusBuilder.podTerminationMessage(s));
+          .ifPresent(s -> jobExecutionStatusBuilder.mainContainerTerminationMessage(s));
       jobExecutionStatusBuilder.jobTerminationReason(jobStatusCondition.getReason());
 
       // Termination Reason of the data job pod container
-      lastTerminatedPodState
+      lastMainContainerStateTerminated
           .map(
               v1ContainerStateTerminated ->
                   StringUtils.trim(v1ContainerStateTerminated.getReason()))
-          .ifPresent(s -> jobExecutionStatusBuilder.containerTerminationReason(s));
+          .ifPresent(s -> jobExecutionStatusBuilder.mainContainerTerminationReason(s));
     }
 
     // Job resources
@@ -1654,7 +1687,7 @@ public abstract class KubernetesService implements InitializingBean {
 
     // omits events that come after the Data Job completion
     if (jobExecutionStatusBuilder.succeeded != null
-        && StringUtils.isBlank(jobExecutionStatusBuilder.containerTerminationReason)) {
+        && StringUtils.isBlank(jobExecutionStatusBuilder.initContainerTerminationReason)) {
       return Optional.empty();
     }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionResultManager.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionResultManager.java
@@ -48,13 +48,13 @@ public class JobExecutionResultManager {
    */
   public static ExecutionResult getResult(KubernetesService.JobExecution jobExecution) {
     PodTerminationMessage podTerminationMessage =
-        parsePodTerminationMessage(jobExecution.getPodTerminationMessage());
+        parsePodTerminationMessage(jobExecution.getMainContainerTerminationMessage());
     ExecutionStatus executionStatus =
         getExecutionStatus(
             jobExecution.getSucceeded(),
             podTerminationMessage.getStatus(),
             jobExecution.getJobTerminationReason(),
-            jobExecution.getContainerTerminationReason(),
+            jobExecution.getMainContainerTerminationReason(),
             jobExecution.getStartTime());
 
     return ExecutionResult.builder()
@@ -78,11 +78,11 @@ public class JobExecutionResultManager {
    * </ul>
    *
    * @param executionSucceeded K8s Job status (true - succeeded, false - failed, null - running)
-   * @param podTerminationStatus termination status returned from K8S Pod (e.g. "Success", "User
+   * @param mainContainerTerminationMessage termination status returned from K8S Pod (e.g. "Success", "User
    *     error", etc.)
    * @param jobTerminationReason condition reason as reported by K8s Job (e.g. "DeadlineExceeded",
    *     "BackoffLimitExceeded", etc.)
-   * @param containerTerminationReason termination reason for pod container as returned by K8s pod
+   * @param mainContainerTerminationReason termination reason for pod container as returned by K8s pod
    *     container (e.g., "OOMKilled", etc.)
    * @param executionStarTime K8S Job execution start time
    * @return if there is no termination message due to the missing K8S Pod returns execution status
@@ -91,9 +91,9 @@ public class JobExecutionResultManager {
    */
   private static ExecutionStatus getExecutionStatus(
       Boolean executionSucceeded,
-      String podTerminationStatus,
+      String mainContainerTerminationMessage,
       String jobTerminationReason,
-      String containerTerminationReason,
+      String mainContainerTerminationReason,
       OffsetDateTime executionStarTime) {
 
     ExecutionStatus executionStatus;
@@ -101,14 +101,14 @@ public class JobExecutionResultManager {
     if (executionSucceeded == null) {
       executionStatus =
           executionStarTime == null ? ExecutionStatus.SUBMITTED : ExecutionStatus.RUNNING;
-    } else if (executionSucceeded && StringUtils.isEmpty(podTerminationStatus)) {
+    } else if (executionSucceeded && StringUtils.isEmpty(mainContainerTerminationMessage)) {
       executionStatus = ExecutionStatus.SUCCEEDED;
-    } else if (!executionSucceeded && StringUtils.isEmpty(podTerminationStatus)) {
-      executionStatus = inferError(jobTerminationReason, containerTerminationReason);
+    } else if (!executionSucceeded && StringUtils.isEmpty(mainContainerTerminationMessage)) {
+      executionStatus = inferError(jobTerminationReason, mainContainerTerminationReason);
     } else {
       executionStatus =
           Arrays.stream(ExecutionStatus.values())
-              .filter(status -> status.getPodStatus().equals(podTerminationStatus))
+              .filter(status -> status.getPodStatus().equals(mainContainerTerminationMessage))
               .findAny()
               .orElse(ExecutionStatus.PLATFORM_ERROR);
     }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionResultManager.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionResultManager.java
@@ -78,12 +78,12 @@ public class JobExecutionResultManager {
    * </ul>
    *
    * @param executionSucceeded K8s Job status (true - succeeded, false - failed, null - running)
-   * @param mainContainerTerminationMessage termination status returned from K8S Pod (e.g. "Success", "User
-   *     error", etc.)
+   * @param mainContainerTerminationMessage termination status returned from K8S Pod (e.g.
+   *     "Success", "User error", etc.)
    * @param jobTerminationReason condition reason as reported by K8s Job (e.g. "DeadlineExceeded",
    *     "BackoffLimitExceeded", etc.)
-   * @param mainContainerTerminationReason termination reason for pod container as returned by K8s pod
-   *     container (e.g., "OOMKilled", etc.)
+   * @param mainContainerTerminationReason termination reason for pod container as returned by K8s
+   *     pod container (e.g., "OOMKilled", etc.)
    * @param executionStarTime K8S Job execution start time
    * @return if there is no termination message due to the missing K8S Pod returns execution status
    *     based on K8S Job status otherwise returns execution status based on the K8S Pod termination

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
@@ -327,7 +327,7 @@ public class JobExecutionService {
             .status(executionStatus)
             .message(
                 getJobExecutionApiMessage(
-                    executionStatus, jobExecution.getContainerTerminationReason()))
+                    executionStatus, jobExecution.getMainContainerTerminationReason()))
             .opId(jobExecution.getOpId())
             .endTime(jobExecution.getEndTime())
             .vdkVersion(executionResult.getVdkVersion())

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMonitor.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMonitor.java
@@ -105,7 +105,7 @@ public class DataJobMonitor {
                 "Termination message of Data Job {} with execution {}: {}",
                 s.getJobName(),
                 s.getExecutionId(),
-                s.getPodTerminationMessage());
+                s.getMainContainerTerminationMessage());
             recordJobExecutionStatus(s);
           },
           runningJobExecutionIds -> {

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -89,7 +89,8 @@ public class KubernetesServiceTest {
     V1Job v1Job = new V1Job();
     var mock = Mockito.mock(KubernetesService.class);
     Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
-    Mockito.when(mock.getTerminationStatus(v1Job)).thenReturn(ImmutablePair.of(Optional.empty(), Optional.empty()));
+    Mockito.when(mock.getTerminationStatus(v1Job))
+        .thenReturn(ImmutablePair.of(Optional.empty(), Optional.empty()));
     Mockito.when(mock.getJobExecutionStatus(v1Job, null)).thenCallRealMethod();
     Optional<KubernetesService.JobExecution> actualJobExecutionStatusOptional =
         mock.getJobExecutionStatus(v1Job, null);
@@ -176,7 +177,10 @@ public class KubernetesServiceTest {
     KubernetesService mock = Mockito.mock(KubernetesService.class);
     Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
     Mockito.when(mock.getTerminationStatus(expectedJob))
-        .thenReturn(ImmutablePair.of(Optional.ofNullable(new V1ContainerStateTerminated().reason("test")), Optional.ofNullable(new V1ContainerStateTerminated().reason("test"))));
+        .thenReturn(
+            ImmutablePair.of(
+                Optional.ofNullable(new V1ContainerStateTerminated().reason("test")),
+                Optional.ofNullable(new V1ContainerStateTerminated().reason("test"))));
     Mockito.when(mock.getJobExecutionStatus(expectedJob, condition)).thenCallRealMethod();
     Optional<KubernetesService.JobExecution> actualJobExecutionStatusOptional =
         mock.getJobExecutionStatus(expectedJob, condition);

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -15,6 +15,7 @@ import com.vmware.taurus.service.model.JobAnnotation;
 import com.vmware.taurus.service.model.JobLabel;
 import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.openapi.models.*;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -88,7 +89,7 @@ public class KubernetesServiceTest {
     V1Job v1Job = new V1Job();
     var mock = Mockito.mock(KubernetesService.class);
     Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
-    Mockito.when(mock.getTerminationStatus(v1Job)).thenReturn(Optional.empty());
+    Mockito.when(mock.getTerminationStatus(v1Job)).thenReturn(ImmutablePair.of(Optional.empty(), Optional.empty()));
     Mockito.when(mock.getJobExecutionStatus(v1Job, null)).thenCallRealMethod();
     Optional<KubernetesService.JobExecution> actualJobExecutionStatusOptional =
         mock.getJobExecutionStatus(v1Job, null);
@@ -175,7 +176,7 @@ public class KubernetesServiceTest {
     KubernetesService mock = Mockito.mock(KubernetesService.class);
     Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
     Mockito.when(mock.getTerminationStatus(expectedJob))
-        .thenReturn(Optional.ofNullable(new V1ContainerStateTerminated().reason("test")));
+        .thenReturn(ImmutablePair.of(Optional.ofNullable(new V1ContainerStateTerminated().reason("test")), Optional.ofNullable(new V1ContainerStateTerminated().reason("test"))));
     Mockito.when(mock.getJobExecutionStatus(expectedJob, condition)).thenCallRealMethod();
     Optional<KubernetesService.JobExecution> actualJobExecutionStatusOptional =
         mock.getJobExecutionStatus(expectedJob, condition);

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionResultManagerTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionResultManagerTest.java
@@ -15,8 +15,6 @@ import com.vmware.taurus.service.KubernetesService;
 import com.vmware.taurus.service.model.ExecutionStatus;
 import com.vmware.taurus.service.model.ExecutionResult;
 
-import java.time.OffsetDateTime;
-
 public class JobExecutionResultManagerTest {
 
   @Test
@@ -24,7 +22,7 @@ public class JobExecutionResultManagerTest {
     KubernetesService.JobExecution jobExecution =
         KubernetesService.JobExecution.builder()
             .succeeded(true)
-            .podTerminationMessage(null)
+            .mainContainerTerminationMessage(null)
             .build();
     ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
 
@@ -38,7 +36,7 @@ public class JobExecutionResultManagerTest {
     KubernetesService.JobExecution jobExecution =
         KubernetesService.JobExecution.builder()
             .succeeded(false)
-            .podTerminationMessage(null)
+            .mainContainerTerminationMessage(null)
             .build();
     ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
 
@@ -54,7 +52,7 @@ public class JobExecutionResultManagerTest {
         KubernetesService.JobExecution.builder()
             .succeeded(null)
             .startTime(OffsetDateTime.now())
-            .podTerminationMessage(null)
+            .mainContainerTerminationMessage(null)
             .build();
 
     ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
@@ -64,7 +62,7 @@ public class JobExecutionResultManagerTest {
   @Test
   public void testGetResult_succeededTrueAndEmptyTerminationMessage_shouldReturnMessage() {
     KubernetesService.JobExecution jobExecution =
-        KubernetesService.JobExecution.builder().succeeded(true).podTerminationMessage("").build();
+        KubernetesService.JobExecution.builder().succeeded(true).mainContainerTerminationMessage("").build();
     ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
 
     Assertions.assertEquals(
@@ -75,7 +73,7 @@ public class JobExecutionResultManagerTest {
   @Test
   public void testGetResult_succeededFalseAndEmptyTerminationMessage_shouldReturnMessage() {
     KubernetesService.JobExecution jobExecution =
-        KubernetesService.JobExecution.builder().succeeded(false).podTerminationMessage("").build();
+        KubernetesService.JobExecution.builder().succeeded(false).mainContainerTerminationMessage("").build();
     ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
 
     Assertions.assertEquals(
@@ -90,7 +88,7 @@ public class JobExecutionResultManagerTest {
         KubernetesService.JobExecution.builder()
             .succeeded(null)
             .startTime(OffsetDateTime.now())
-            .podTerminationMessage("")
+            .mainContainerTerminationMessage("")
             .build();
 
     ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
@@ -102,7 +100,7 @@ public class JobExecutionResultManagerTest {
     KubernetesService.JobExecution jobExecution =
         KubernetesService.JobExecution.builder()
             .succeeded(true)
-            .podTerminationMessage("not-existing-termination-message")
+            .mainContainerTerminationMessage("not-existing-termination-message")
             .build();
     ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
 
@@ -116,7 +114,7 @@ public class JobExecutionResultManagerTest {
     KubernetesService.JobExecution jobExecution =
         KubernetesService.JobExecution.builder()
             .succeeded(false)
-            .podTerminationMessage("not-existing-termination-message")
+            .mainContainerTerminationMessage("not-existing-termination-message")
             .build();
     ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
 
@@ -132,7 +130,7 @@ public class JobExecutionResultManagerTest {
         KubernetesService.JobExecution.builder()
             .succeeded(null)
             .startTime(OffsetDateTime.now())
-            .podTerminationMessage("not-existing-termination-message")
+            .mainContainerTerminationMessage("not-existing-termination-message")
             .build();
     ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
 
@@ -154,7 +152,7 @@ public class JobExecutionResultManagerTest {
     KubernetesService.JobExecution jobExecution =
         KubernetesService.JobExecution.builder()
             .succeeded(false)
-            .podTerminationMessage(expectedTerminationMessage.toString())
+            .mainContainerTerminationMessage(expectedTerminationMessage.toString())
             .build();
     ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
 
@@ -169,7 +167,7 @@ public class JobExecutionResultManagerTest {
     KubernetesService.JobExecution jobExecution =
         KubernetesService.JobExecution.builder()
             .succeeded(false)
-            .podTerminationMessage(expectedTerminationStatus.getPodStatus())
+            .mainContainerTerminationMessage(expectedTerminationStatus.getPodStatus())
             .build();
 
     ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
@@ -184,7 +182,7 @@ public class JobExecutionResultManagerTest {
     KubernetesService.JobExecution jobExecution =
         KubernetesService.JobExecution.builder()
             .succeeded(true)
-            .podTerminationMessage(expectedExecutionStatus.getPodStatus())
+            .mainContainerTerminationMessage(expectedExecutionStatus.getPodStatus())
             .build();
 
     ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
@@ -198,7 +196,7 @@ public class JobExecutionResultManagerTest {
     KubernetesService.JobExecution jobExecution =
         KubernetesService.JobExecution.builder()
             .succeeded(false)
-            .podTerminationMessage(expectedExecutionStatus.getPodStatus())
+            .mainContainerTerminationMessage(expectedExecutionStatus.getPodStatus())
             .build();
 
     ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
@@ -212,7 +210,7 @@ public class JobExecutionResultManagerTest {
         KubernetesService.JobExecution.builder()
             .succeeded(null)
             .startTime(OffsetDateTime.now())
-            .podTerminationMessage(ExecutionStatus.USER_ERROR.getPodStatus())
+            .mainContainerTerminationMessage(ExecutionStatus.USER_ERROR.getPodStatus())
             .build();
 
     ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
@@ -226,7 +224,7 @@ public class JobExecutionResultManagerTest {
     KubernetesService.JobExecution jobExecution =
         KubernetesService.JobExecution.builder()
             .succeeded(true)
-            .podTerminationMessage(expectedExecutionStatus.getPodStatus())
+            .mainContainerTerminationMessage(expectedExecutionStatus.getPodStatus())
             .build();
 
     ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
@@ -240,7 +238,7 @@ public class JobExecutionResultManagerTest {
     KubernetesService.JobExecution jobExecution =
         KubernetesService.JobExecution.builder()
             .succeeded(false)
-            .podTerminationMessage(expectedExecutionStatus.getPodStatus())
+            .mainContainerTerminationMessage(expectedExecutionStatus.getPodStatus())
             .build();
 
     ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
@@ -254,7 +252,7 @@ public class JobExecutionResultManagerTest {
         KubernetesService.JobExecution.builder()
             .succeeded(null)
             .startTime(OffsetDateTime.now())
-            .podTerminationMessage(ExecutionStatus.PLATFORM_ERROR.getPodStatus())
+            .mainContainerTerminationMessage(ExecutionStatus.PLATFORM_ERROR.getPodStatus())
             .build();
 
     ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
@@ -265,7 +263,7 @@ public class JobExecutionResultManagerTest {
   public void
       testGetResult_emptyTerminationMessageAndExecutionStatusSucceeded_shouldReturnTerminationStatusSuccess() {
     KubernetesService.JobExecution jobExecution =
-        KubernetesService.JobExecution.builder().succeeded(true).podTerminationMessage("").build();
+        KubernetesService.JobExecution.builder().succeeded(true).mainContainerTerminationMessage("").build();
 
     ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
     Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualResult.getExecutionStatus());
@@ -275,7 +273,7 @@ public class JobExecutionResultManagerTest {
   public void
       testGetResult_emptyTerminationMessageAndExecutionStatusFailed_shouldReturnTerminationStatusPlatformError() {
     KubernetesService.JobExecution jobExecution =
-        KubernetesService.JobExecution.builder().succeeded(false).podTerminationMessage("").build();
+        KubernetesService.JobExecution.builder().succeeded(false).mainContainerTerminationMessage("").build();
 
     ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
     Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualResult.getExecutionStatus());
@@ -328,7 +326,7 @@ public class JobExecutionResultManagerTest {
     KubernetesService.JobExecution jobExecution =
         KubernetesService.JobExecution.builder()
             .succeeded(true)
-            .podTerminationMessage(ExecutionStatus.USER_ERROR.getPodStatus())
+            .mainContainerTerminationMessage(ExecutionStatus.USER_ERROR.getPodStatus())
             .build();
 
     ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
@@ -341,7 +339,7 @@ public class JobExecutionResultManagerTest {
     KubernetesService.JobExecution jobExecution =
         KubernetesService.JobExecution.builder()
             .succeeded(true)
-            .podTerminationMessage(ExecutionStatus.SKIPPED.getPodStatus())
+            .mainContainerTerminationMessage(ExecutionStatus.SKIPPED.getPodStatus())
             .build();
 
     ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
@@ -354,7 +352,7 @@ public class JobExecutionResultManagerTest {
     KubernetesService.JobExecution jobExecution =
         KubernetesService.JobExecution.builder()
             .succeeded(true)
-            .podTerminationMessage(ExecutionStatus.PLATFORM_ERROR.getPodStatus())
+            .mainContainerTerminationMessage(ExecutionStatus.PLATFORM_ERROR.getPodStatus())
             .build();
 
     ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
@@ -367,7 +365,7 @@ public class JobExecutionResultManagerTest {
     KubernetesService.JobExecution jobExecution =
         KubernetesService.JobExecution.builder()
             .succeeded(false)
-            .podTerminationMessage(ExecutionStatus.PLATFORM_ERROR.getPodStatus())
+            .mainContainerTerminationMessage(ExecutionStatus.PLATFORM_ERROR.getPodStatus())
             .build();
 
     ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
@@ -379,7 +377,7 @@ public class JobExecutionResultManagerTest {
       testGetResult_terminationMessageNullAndExecutionStatusFailedAndTerminationReasonDeadlineExceeded_shouldReturnTerminationStatusUserError() {
     KubernetesService.JobExecution jobExecution =
         KubernetesService.JobExecution.builder()
-            .podTerminationMessage(null)
+            .mainContainerTerminationMessage(null)
             .succeeded(false)
             .jobTerminationReason(JobExecutionResultManager.TERMINATION_REASON_DEADLINE_EXCEEDED)
             .build();
@@ -393,7 +391,7 @@ public class JobExecutionResultManagerTest {
       testGetResult_terminationMessageNullAndExecutionStatusFailedAndTerminationReasonAny_shouldReturnTerminationStatusUserError() {
     KubernetesService.JobExecution jobExecution =
         KubernetesService.JobExecution.builder()
-            .podTerminationMessage(null)
+            .mainContainerTerminationMessage(null)
             .succeeded(false)
             .jobTerminationReason("SomeReason")
             .build();
@@ -407,10 +405,10 @@ public class JobExecutionResultManagerTest {
       testGetResult_terminationMessageNullAndExecutionStatusFailedAndTerminationReasonOutOfMemory_shouldReturnTerminationStatusUserError() {
     KubernetesService.JobExecution jobExecution =
         KubernetesService.JobExecution.builder()
-            .podTerminationMessage(null)
+            .mainContainerTerminationMessage(null)
             .succeeded(false)
             .jobTerminationReason("Some Reason")
-            .containerTerminationReason(JobExecutionResultManager.TERMINATION_REASON_OUT_OF_MEMORY)
+            .mainContainerTerminationReason(JobExecutionResultManager.TERMINATION_REASON_OUT_OF_MEMORY)
             .build();
 
     ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionResultManagerTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionResultManagerTest.java
@@ -62,7 +62,10 @@ public class JobExecutionResultManagerTest {
   @Test
   public void testGetResult_succeededTrueAndEmptyTerminationMessage_shouldReturnMessage() {
     KubernetesService.JobExecution jobExecution =
-        KubernetesService.JobExecution.builder().succeeded(true).mainContainerTerminationMessage("").build();
+        KubernetesService.JobExecution.builder()
+            .succeeded(true)
+            .mainContainerTerminationMessage("")
+            .build();
     ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
 
     Assertions.assertEquals(
@@ -73,7 +76,10 @@ public class JobExecutionResultManagerTest {
   @Test
   public void testGetResult_succeededFalseAndEmptyTerminationMessage_shouldReturnMessage() {
     KubernetesService.JobExecution jobExecution =
-        KubernetesService.JobExecution.builder().succeeded(false).mainContainerTerminationMessage("").build();
+        KubernetesService.JobExecution.builder()
+            .succeeded(false)
+            .mainContainerTerminationMessage("")
+            .build();
     ExecutionResult actualTerminationMessage = JobExecutionResultManager.getResult(jobExecution);
 
     Assertions.assertEquals(
@@ -263,7 +269,10 @@ public class JobExecutionResultManagerTest {
   public void
       testGetResult_emptyTerminationMessageAndExecutionStatusSucceeded_shouldReturnTerminationStatusSuccess() {
     KubernetesService.JobExecution jobExecution =
-        KubernetesService.JobExecution.builder().succeeded(true).mainContainerTerminationMessage("").build();
+        KubernetesService.JobExecution.builder()
+            .succeeded(true)
+            .mainContainerTerminationMessage("")
+            .build();
 
     ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
     Assertions.assertEquals(ExecutionStatus.SUCCEEDED, actualResult.getExecutionStatus());
@@ -273,7 +282,10 @@ public class JobExecutionResultManagerTest {
   public void
       testGetResult_emptyTerminationMessageAndExecutionStatusFailed_shouldReturnTerminationStatusPlatformError() {
     KubernetesService.JobExecution jobExecution =
-        KubernetesService.JobExecution.builder().succeeded(false).mainContainerTerminationMessage("").build();
+        KubernetesService.JobExecution.builder()
+            .succeeded(false)
+            .mainContainerTerminationMessage("")
+            .build();
 
     ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);
     Assertions.assertEquals(ExecutionStatus.PLATFORM_ERROR, actualResult.getExecutionStatus());
@@ -408,7 +420,8 @@ public class JobExecutionResultManagerTest {
             .mainContainerTerminationMessage(null)
             .succeeded(false)
             .jobTerminationReason("Some Reason")
-            .mainContainerTerminationReason(JobExecutionResultManager.TERMINATION_REASON_OUT_OF_MEMORY)
+            .mainContainerTerminationReason(
+                JobExecutionResultManager.TERMINATION_REASON_OUT_OF_MEMORY)
             .build();
 
     ExecutionResult actualResult = JobExecutionResultManager.getResult(jobExecution);

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceUpdateExecutionIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceUpdateExecutionIT.java
@@ -236,8 +236,8 @@ public class JobExecutionServiceUpdateExecutionIT {
             .resourcesMemoryRequest(1)
             .deployedBy("test_deployed_by")
             .deployedDate(getTimeAccurateToMicroSecond())
-            .podTerminationMessage(terminationMessage)
-            .containerTerminationReason(containerTerminationMessage)
+            .mainContainerTerminationMessage(terminationMessage)
+            .mainContainerTerminationReason(containerTerminationMessage)
             .build();
     ExecutionResult executionResult = JobExecutionResultManager.getResult(jobExecution);
     jobExecutionService.updateJobExecution(dataJob, jobExecution, executionResult);
@@ -272,7 +272,7 @@ public class JobExecutionServiceUpdateExecutionIT {
         expectedJobExecutionStatus,
         expectedJobExecutionMessage != null
             ? expectedJobExecutionMessage
-            : expectedJobExecution.getPodTerminationMessage(),
+            : expectedJobExecution.getMainContainerTerminationMessage(),
         actualJobExecution,
         expectedVdkVersion);
   }
@@ -398,7 +398,7 @@ public class JobExecutionServiceUpdateExecutionIT {
             .resourcesMemoryRequest(1)
             .deployedBy("test_deployed_by")
             .deployedDate(OffsetDateTime.now())
-            .podTerminationMessage(expectedStatus.getPodStatus())
+            .mainContainerTerminationMessage(expectedStatus.getPodStatus())
             .build();
     ExecutionResult executionResult = JobExecutionResultManager.getResult(attemptedExecutionUpdate);
     jobExecutionService.updateJobExecution(

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DataJobMonitorTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DataJobMonitorTest.java
@@ -406,7 +406,7 @@ public class DataJobMonitorTest {
         JobExecution.builder()
             .jobName(jobExecutionBeforeUpdate.getDataJob().getName())
             .executionId(jobExecutionBeforeUpdate.getId())
-            .podTerminationMessage(ExecutionStatus.SUCCEEDED.getPodStatus())
+            .mainContainerTerminationMessage(ExecutionStatus.SUCCEEDED.getPodStatus())
             .executionType("scheduled")
             .opId("opId")
             .startTime(jobExecutionBeforeUpdate.getStartTime())
@@ -858,7 +858,7 @@ public class DataJobMonitorTest {
     return JobExecution.builder()
         .jobName(jobName)
         .executionId(executionId)
-        .podTerminationMessage(terminationMessage)
+        .mainContainerTerminationMessage(terminationMessage)
         .executionType("scheduled")
         .opId("opId")
         .startTime(startTime)
@@ -923,7 +923,7 @@ public class DataJobMonitorTest {
         actualDataJobExecution.getResourcesMemoryLimit());
     Assertions.assertEquals(
         expectedExecutionMessage == null
-            ? expectedJobExecution.getPodTerminationMessage()
+            ? expectedJobExecution.getMainContainerTerminationMessage()
             : expectedExecutionMessage,
         actualDataJobExecution.getMessage());
     Assertions.assertEquals(


### PR DESCRIPTION
# Why
Currently, if the init container fails with OOM
the control service will mark the job as successful execution.

# What
Changed the CS logic to the following:
if the init container fails with OOM
the control service will mark the job as Platform Error.

# Testing done
Integration test

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com