### PR TITLE
control-service: Remove license headers from helm charts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,11 +44,6 @@ repos:
     hooks:
       - id: pylint
         args: [ --exit-zero ]
-  #-   repo: https://github.com/pre-commit/mirrors-mypy
-  #    rev: v0.812
-  #    hooks:
-  #        -   id: mypy
-  #            files: ^(src/|tests/|plugins/)
   - repo: https://github.com/asottile/reorder_python_imports
     rev: v3.9.0
     hooks:
@@ -60,14 +55,6 @@ repos:
     hooks:
       - id: pyupgrade
         args: [ --py37-plus ]
-  # security check
-  #- repo: https://github.com/PyCQA/bandit
-  #  rev: '1.7.0'
-  #  hooks:
-  #      - id: bandit
-  #        exclude: tests
-  #        args: [ -s, B101 ]
-  # add copyright notice
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.4.2
     hooks:
@@ -113,6 +100,8 @@ repos:
           - /*| *| */
       - id: insert-license
         files: (\.yaml$|\.yml$)
+        # exclude helm chart templates
+        exclude: ^projects/control-service/projects/helm_charts
         args:
           - --use-current-year
           - --license-filepath
@@ -129,15 +118,3 @@ repos:
           - --use-current-year
           - --license-filepath
           - NOTICE.txt
-# License header create issues in helm chart yaml files
-# https://github.com/helm/helm/issues/4409
-#    - id: insert-license
-#      files: \.yml$
-#      args:
-#        - --license-filepath
-#        - NOTICE.txt
-#    - id: insert-license
-#      files: \.yaml$
-#      args:
-#          - --license-filepath
-#          - NOTICE.txt

--- a/projects/control-service/projects/helm_charts/airflow/limit_range.yaml
+++ b/projects/control-service/projects/helm_charts/airflow/limit_range.yaml
@@ -1,6 +1,3 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 apiVersion: v1
 kind: LimitRange
 metadata:

--- a/projects/control-service/projects/helm_charts/airflow/values.yaml
+++ b/projects/control-service/projects/helm_charts/airflow/values.yaml
@@ -1,6 +1,3 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 global:
   storageClass: 3671cd71625c4312a2aee130db182e4c
 

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/Chart.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/Chart.yaml
@@ -1,6 +1,3 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 apiVersion: v2
 name: pipelines-control-service
 description: A Helm chart for Versatile Data Kit Control Service

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -1,6 +1,3 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
 ## Current available global Docker image parameter(s): imageRegistry


### PR DESCRIPTION
### What

Remove existing license headers from helm charts
Disable auto-insert of pre-commit hooks for helm charts Clean up pre-commit config

### Why

License headers break parsing for helm charts
This breaks control-service deployments