### PR TITLE
control-service: Update helm template license headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ tests.xml
 temp
 gradlew
 gradlew.bat
+
+# Ignore downloaded helm charts
+projects/control-service/projects/helm_charts/pipelines-control-service/charts/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,10 +113,20 @@ repos:
           - /*| *| */
       - id: insert-license
         files: (\.yaml$|\.yml$)
+        # exclude control service helm chart templates as they require template-style comments
+        exclude: ^projects/control-service/projects/helm_charts/pipelines-control-service/templates
         args:
           - --use-current-year
           - --license-filepath
           - NOTICE.txt
+      - id: insert-license
+        files: (^projects/control-service/projects/helm_charts/pipelines-control-service/templates/.+\.yaml$|^projects/control-service/projects/helm_charts/pipelines-control-service/templates/.+\.yml$)
+        args:
+          - --use-current-year
+          - --license-filepath
+          - NOTICE.txt
+          - --comment-style
+          - '{{- /*| | */}}'
       - id: insert-license
         files: \.py$
         args:

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/configmap_datajob_template_file.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/configmap_datajob_template_file.yaml
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
 
 {{- if .Values.datajobTemplate.enabled }}
 apiVersion: v1

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/fluentdconfig.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/fluentdconfig.yaml
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+  Copyright 2023-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
 
 {{- if .Values.fluentd.enabled }}
 apiVersion: logs.vdp.vmware.com/v1beta1

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/fluentdconfig_datajobs.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/fluentdconfig_datajobs.yaml
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
 
 {{- if .Values.dataJob.fluentd.enabled }}
 apiVersion: logs.vdp.vmware.com/v1beta1

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/ingress.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/ingress.yaml
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
 
 {{- if .Values.ingress.enabled -}}
 kind: Ingress

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/prometheusrules.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/prometheusrules.yaml
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
 
 {{- if .Values.alerting.enabled }}
 apiVersion: monitoring.coreos.com/v1

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/role.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/role.yaml
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
 
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/role_datajobs.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/role_datajobs.yaml
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
 
 {{- if and .Values.rbac.create .Values.rbac.datajobsDeployment.create -}}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/rolebindings.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/rolebindings.yaml
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
 
 {{- if and .Values.serviceAccount.create .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/rolebindings_datajobs.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/rolebindings_datajobs.yaml
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
 
 {{- if and .Values.serviceAccount.create .Values.rbac.create .Values.rbac.datajobsDeployment.create }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_jdbc.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_jdbc.yaml
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
 
 ## Create a secret with JDBC credentials for embedded database (PostgreSQL or CockroachDB) only if externalSecretName is not supplied.
 ## If any of the fields are empty, we fall-back to defaults (f.e. local dev environment)

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_kubernetes_authenticator.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_kubernetes_authenticator.yaml
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
 
 ## Create a secret with Kerberos keytab for authentication if kerberos authentication flag is turned on.
 ## The keytab file contents are set from the values.yaml file and are intended to be populated by an env

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_base_img.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_base_img.yaml
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
 
 {{- if .Values.deploymentDataJobBaseImage.password }}
 apiVersion: v1

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_builder_img.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_builder_img.yaml
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
 
 {{- if .Values.deploymentBuilderImage.password }}
 apiVersion: v1

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_img.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_img.yaml
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
 
 {{- if and (eq .Values.deploymentDockerRegistryType "generic") .Values.deploymentDockerRegistryUsernameReadOnly .Values.deploymentDockerRegistryPasswordReadOnly }}
 apiVersion: v1

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_pipelines_control_service_img.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_pipelines_control_service_img.yaml
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
 
 {{- if (include "shouldCreatePipelinesControlServiceDockerRepoSecret" .) }}
 apiVersion: v1

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_vdk_sdk_img.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_pull_vdk_sdk_img.yaml
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
 
 {{- if (include "shouldCreateVdkSdkDockerRepoSecret" .) }}
 apiVersion: v1

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secrets.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secrets.yaml
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
 
 apiVersion: v1
 kind: Secret

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/service.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/service.yaml
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
 
 apiVersion: v1
 kind: Service

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/serviceaccount.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/serviceaccount.yaml
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
 
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/servicemonitor.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/servicemonitor.yaml
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
 
 {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1


### PR DESCRIPTION
### What
Update helm template license headers to use template-style comments Ignore helm templates in pre-commit yaml license hook Create new pre-commit license hook to add template-style comments to helm templates

### Why
Regular yaml comments at the top of files break parsing for helm charts This breaks control-service deployments

### How was this tested

Tested installing the charts on a local k8s cluster using helm

Ran `helm upgrade --install --debug --wait --timeout 10m0s cicd-control-service .` on the chart, which gave me the same output as the failing pipeline. Edited the comments until the apiVersion error disappeared.

```
Error: UPGRADE FAILED: error validating "": error validating data: apiVersion not set
```

https://gitlab.com/vmware-analytics/versatile-data-kit/-/jobs/3813924321