### PR TITLE
frontend: data-pipelines build and test running CI/CD

### DIFF
--- a/projects/frontend/cicd/.gitlab-ci.yml
+++ b/projects/frontend/cicd/.gitlab-ci.yml
@@ -2,16 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 .frontend_shared_components_changes: &frontend_shared_components_locations
-  - "projects/frontend/cicd/**/*"
-  - "projects/frontend/shared-components/**/*"
-
-.frontend_data_pipelines_changes: &frontend_data_pipelines_locations
-  - "projects/frontend/cicd/**/*"
-  - "projects/frontend/data-pipelines/**/*"
-
-image: "versatiledatakit/vdk-cicd-base-gui:2.0.0"
-
-.frontend_shared_components_changes: &frontend_shared_components_locations
   - projects/frontend/cicd/**/*
   - projects/frontend/shared-components/**/*
 
@@ -20,6 +10,7 @@ image: "versatiledatakit/vdk-cicd-base-gui:2.0.0"
   - projects/frontend/data-pipelines/**/*
 
 frontend-data-pipelines-build:
+  image: "versatiledatakit/vdk-cicd-base-gui:2.0.0"
   stage: build
   before_script:
     - cd projects/frontend/

--- a/projects/frontend/cicd/.gitlab-ci.yml
+++ b/projects/frontend/cicd/.gitlab-ci.yml
@@ -12,12 +12,12 @@
 image: "versatiledatakit/vdk-cicd-base-gui:2.0.0"
 
 .frontend_shared_components_changes: &frontend_shared_components_changes_locations
-  - projects/frontend/cicd/**/*
-  - projects/frontend/shared-components/**/*
+  - "projects/frontend/cicd/**/*"
+  - "projects/frontend/shared-components/**/*"
 
 .frontend_data_pipelines_changes: &frontend_data_pipelines_changes_locations
-  - projects/frontend/cicd/**/*
-  - projects/frontend/data-pipelines/**/*
+  - "projects/frontend/cicd/**/*"
+  - "projects/frontend/data-pipelines/**/*"
 
 frontend-data-pipelines-build:
   stage: build

--- a/projects/frontend/cicd/.gitlab-ci.yml
+++ b/projects/frontend/cicd/.gitlab-ci.yml
@@ -12,7 +12,9 @@
 frontend-data-pipelines-build:
   image: "versatiledatakit/vdk-cicd-base-gui:2.0.0"
   stage: build
-  needs: [frontend-shared-components-build]
+  needs:
+    - job: frontend-shared-components-build
+      optional: true
   before_script:
     - cd projects/frontend/
   script:

--- a/projects/frontend/cicd/.gitlab-ci.yml
+++ b/projects/frontend/cicd/.gitlab-ci.yml
@@ -12,19 +12,19 @@
 image: "versatiledatakit/vdk-cicd-base-gui:2.0.0"
 
 .frontend_shared_components_changes: &frontend_shared_components_locations
-  - "projects/frontend/cicd/**/*"
-  - "projects/frontend/shared-components/**/*"
+  - projects/frontend/cicd/**/*
+  - projects/frontend/shared-components/**/*
 
 .frontend_data_pipelines_changes: &frontend_data_pipelines_locations
-  - "projects/frontend/cicd/**/*"
-  - "projects/frontend/data-pipelines/**/*"
+  - projects/frontend/cicd/**/*
+  - projects/frontend/data-pipelines/**/*
 
 frontend-data-pipelines-build:
   stage: build
   script:
     - ./cicd/install_data_pipelines.sh
   coverage: /^TOTAL\s+\d+\s+\d+\s+(\d+\%)$/
-  retry: !reference [ .retry, retry_options ]
+  retry: !reference [.retry, retry_options]
   rules:
     - if: '$CI_COMMIT_BRANCH == "main"'
       changes: *frontend_shared_components_locations

--- a/projects/frontend/cicd/.gitlab-ci.yml
+++ b/projects/frontend/cicd/.gitlab-ci.yml
@@ -68,7 +68,7 @@ frontend-shared-components-build:
     - ../../cicd/build_shared.sh
   retry: !reference [.retry, retry_options]
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "external_pull_request_event"'
+    - if: '$CI_COMMIT_BRANCH == "main" || $CI_PIPELINE_SOURCE == "external_pull_request_event"'
       changes: *frontend_shared_components_locations
   artifacts:
     when: always
@@ -78,6 +78,7 @@ frontend-shared-components-build:
         - projects/frontend/shared-components/gui/reports/test-results/shared/*.xml
     paths:
       - projects/frontend/shared-components/gui/package-lock.json
+      - projects/frontend/shared-components/gui/dist/
     expire_in: 1 week
 
 frontend-shared-components-release:
@@ -86,7 +87,6 @@ frontend-shared-components-release:
   before_script:
     - cd projects/frontend/shared-components/gui
   script:
-    - ../../cicd/build_shared.sh
     - ../../cicd/publish_shared.sh $CI_PIPELINE_ID $NPM_REGISTRY $NPM_TOKEN
   retry: !reference [.retry, retry_options]
   rules:
@@ -94,10 +94,6 @@ frontend-shared-components-release:
       changes: *frontend_shared_components_locations
   artifacts:
     when: always
-    reports:
-      junit:
-        - projects/frontend/shared-components/gui/reports/test-results/shared/*.xml
-        - projects/frontend/shared-components/gui/reports/test-results/shared/*.xml
     paths:
       - projects/frontend/shared-components/gui/package-lock.json
     expire_in: 1 week

--- a/projects/frontend/cicd/.gitlab-ci.yml
+++ b/projects/frontend/cicd/.gitlab-ci.yml
@@ -21,6 +21,8 @@ image: "versatiledatakit/vdk-cicd-base-gui:2.0.0"
 
 frontend-data-pipelines-build:
   stage: build
+  before_script:
+    - cd projects/frontend/
   script:
     - ./cicd/install_data_pipelines.sh
   coverage: /^TOTAL\s+\d+\s+\d+\s+(\d+\%)$/

--- a/projects/frontend/cicd/.gitlab-ci.yml
+++ b/projects/frontend/cicd/.gitlab-ci.yml
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 .frontend_shared_components_changes: &frontend_shared_components_locations
-  - projects/frontend/cicd/**/*
-  - projects/frontend/shared-components/**/*
+  - "projects/frontend/cicd/**/*"
+  - "projects/frontend/shared-components/**/*"
 
 .frontend_data_pipelines_changes: &frontend_data_pipelines_locations
-  - projects/frontend/cicd/**/*
-  - projects/frontend/data-pipelines/**/*
+  - "projects/frontend/cicd/**/*"
+  - "projects/frontend/data-pipelines/**/*"
 
 frontend-data-pipelines-build:
   image: "versatiledatakit/vdk-cicd-base-gui:2.0.0"

--- a/projects/frontend/cicd/.gitlab-ci.yml
+++ b/projects/frontend/cicd/.gitlab-ci.yml
@@ -81,6 +81,7 @@ frontend-shared-components-build:
     paths:
       - projects/frontend/shared-components/gui/package-lock.json
       - projects/frontend/shared-components/gui/dist/
+      - projects/frontend/shared-components/gui/node_modules/
     expire_in: 1 week
 
 frontend-shared-components-release:

--- a/projects/frontend/cicd/.gitlab-ci.yml
+++ b/projects/frontend/cicd/.gitlab-ci.yml
@@ -26,9 +26,9 @@ frontend-data-pipelines-build:
   coverage: /^TOTAL\s+\d+\s+\d+\s+(\d+\%)$/
   retry: !reference [.retry, retry_options]
   rules:
-    - if: '$CI_COMMIT_BRANCH == "main"'
+    - if: '$CI_COMMIT_BRANCH == "main" || $CI_PIPELINE_SOURCE == "external_pull_request_event"'
       changes: *frontend_shared_components_locations
-    - if: '$CI_COMMIT_BRANCH == "main"'
+    - if: '$CI_COMMIT_BRANCH == "main" || $CI_PIPELINE_SOURCE == "external_pull_request_event"'
       changes: *frontend_data_pipelines_locations
   artifacts:
     when: always

--- a/projects/frontend/cicd/.gitlab-ci.yml
+++ b/projects/frontend/cicd/.gitlab-ci.yml
@@ -12,6 +12,7 @@
 frontend-data-pipelines-build:
   image: "versatiledatakit/vdk-cicd-base-gui:2.0.0"
   stage: build
+  needs: [frontend-shared-components-build]
   before_script:
     - cd projects/frontend/
   script:

--- a/projects/frontend/cicd/.gitlab-ci.yml
+++ b/projects/frontend/cicd/.gitlab-ci.yml
@@ -11,11 +11,11 @@
 
 image: "versatiledatakit/vdk-cicd-base-gui:2.0.0"
 
-.frontend_shared_components_changes: &frontend_shared_components_changes_locations
+.frontend_shared_components_changes: &frontend_shared_components_locations
   - "projects/frontend/cicd/**/*"
   - "projects/frontend/shared-components/**/*"
 
-.frontend_data_pipelines_changes: &frontend_data_pipelines_changes_locations
+.frontend_data_pipelines_changes: &frontend_data_pipelines_locations
   - "projects/frontend/cicd/**/*"
   - "projects/frontend/data-pipelines/**/*"
 
@@ -27,11 +27,9 @@ frontend-data-pipelines-build:
   retry: !reference [ .retry, retry_options ]
   rules:
     - if: '$CI_COMMIT_BRANCH == "main"'
-      changes:
-        - *frontend_shared_components_changes_locations
+      changes: *frontend_shared_components_locations
     - if: '$CI_COMMIT_BRANCH == "main"'
-      changes:
-        - *frontend_data_pipelines_changes_locations
+      changes: *frontend_data_pipelines_locations
   artifacts:
     when: always
     reports:

--- a/projects/frontend/cicd/.gitlab-ci.yml
+++ b/projects/frontend/cicd/.gitlab-ci.yml
@@ -9,6 +9,41 @@
   - "projects/frontend/cicd/**/*"
   - "projects/frontend/data-pipelines/**/*"
 
+image: "versatiledatakit/vdk-cicd-base-gui:2.0.0"
+
+.frontend_shared_components_changes: &frontend_shared_components_changes_locations
+  - projects/frontend/cicd/**/*
+  - projects/frontend/shared-components/**/*
+
+.frontend_data_pipelines_changes: &frontend_data_pipelines_changes_locations
+  - projects/frontend/cicd/**/*
+  - projects/frontend/data-pipelines/**/*
+
+frontend-data-pipelines-build:
+  stage: build
+  script:
+    - ./cicd/install_data_pipelines.sh
+  coverage: /^TOTAL\s+\d+\s+\d+\s+(\d+\%)$/
+  retry: !reference [ .retry, retry_options ]
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes:
+        - *frontend_shared_components_changes_locations
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes:
+        - *frontend_data_pipelines_changes_locations
+  artifacts:
+    when: always
+    reports:
+      junit:
+        - projects/frontend/data-pipelines/gui/reports/test-results/data-pipelines-ui/*.xml
+        - projects/frontend/data-pipelines/gui/reports/test-results/data-pipelines-lib/*.xml
+    paths:
+      - projects/frontend/data-pipelines/gui/package-lock.json
+    expire_in: 1 week
+
+# TODO: frontend-data-pipelines-publish: eval publish_artifact.sh <param>
+
 frontend_publish_test_image:
   image: docker:19.03.15
   variables:

--- a/projects/frontend/cicd/build_data_pipelines.sh
+++ b/projects/frontend/cicd/build_data_pipelines.sh
@@ -18,19 +18,19 @@ echo "Logging npm engines version..."
 npm version
 
 cd "$(dirname $0)" || exit 1
-cd ../data-pipelines/gui
+cd "../data-pipelines/gui"
 
 echo "Build the Data Pipelines Library ..."
 npm run build
 
 echo "Going to the dir of the data-pipelines build to create a symlink to the local repo ..."
-cd dist/data-pipelines
+cd "dist/data-pipelines"
 
 echo "Link the library to local npm in order to test it ..."
 npm link
 
 echo "Going to the GUI root ..."
-cd ../../
+cd "../../"
 
 echo "Use the local repo symlink to link it to node_modules ..."
 npm link @vdk/data-pipelines

--- a/projects/frontend/cicd/build_data_pipelines.sh
+++ b/projects/frontend/cicd/build_data_pipelines.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -e
+
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+###
+# For installing the build prerequisites, consider `install_data_pipelines.sh` script.
+# This script is meant to be used, to quickly
+# rebuild and link the the @vdk/data-pipelines in an already bootstrapped development setup.
+###
+
+if ! which npm >/dev/null 2>&1 ; then
+  echo "ERROR:"
+  echo "Please install npm 8.5.5+. Build cannot continue without it."
+  exit 1
+fi
+echo "Logging npm engines version..."
+npm version
+
+cd "$(dirname $0)" || exit 1
+cd ../data-pipelines/gui
+
+echo "Build the Data Pipelines Library ..."
+npm run build
+
+echo "Going to the dir of the data-pipelines build to create a symlink to the local repo ..."
+cd dist/data-pipelines
+
+echo "Link the library to local npm in order to test it ..."
+npm link
+
+echo "Going to the GUI root ..."
+cd ../../
+
+echo "Use the local repo symlink to link it to node_modules ..."
+npm link @vdk/data-pipelines
+
+echo "Logging global npm packages"
+npm ls -g
+
+echo "Logging local npm packages"
+npm ls

--- a/projects/frontend/cicd/build_data_pipelines.sh
+++ b/projects/frontend/cicd/build_data_pipelines.sh
@@ -6,7 +6,7 @@
 ###
 # For installing the build prerequisites, consider `install_data_pipelines.sh` script.
 # This script is meant to be used, to quickly
-# rebuild and link the the @vdk/data-pipelines in an already bootstrapped development setup.
+# rebuild and link the the @versatiledatakit/data-pipelines in an already bootstrapped development setup.
 ###
 
 if ! which npm >/dev/null 2>&1 ; then
@@ -33,7 +33,7 @@ echo "Going to the GUI root ..."
 cd "../../"
 
 echo "Use the local repo symlink to link it to node_modules ..."
-npm link @vdk/data-pipelines
+npm link @versatiledatakit/data-pipelines
 
 echo "Logging global npm packages"
 npm ls -g

--- a/projects/frontend/cicd/install_data_pipelines.sh
+++ b/projects/frontend/cicd/install_data_pipelines.sh
@@ -18,10 +18,10 @@ echo "Logging npm engines version..."
 npm version
 
 cd "$(dirname $0)" || exit 1
-cd ../data-pipelines/gui
+cd "../data-pipelines/gui"
 
 echo "Removing package lock if available..."
-rm -f package-lock.json
+rm -f "package-lock.json"
 
 shared_dist_dir="../../shared-components/gui/dist/shared"
 if [ -d "$shared_dist_dir" ]
@@ -36,7 +36,7 @@ echo "Install Dependencies..."
 npm install
 
 echo "Running linking script..."
-sh ../../cicd/link_data_pipelines.sh
+sh "../../cicd/link_data_pipelines.sh"
 
 echo "Lint all projects & sub-projects..."
 npm run lint

--- a/projects/frontend/cicd/install_data_pipelines.sh
+++ b/projects/frontend/cicd/install_data_pipelines.sh
@@ -38,11 +38,11 @@ npm install
 echo "Running linking script..."
 sh "../../cicd/link_data_pipelines.sh"
 
-echo "Lint all projects & sub-projects..."
+echo "Linting all projects & sub-projects..."
 npm run lint
 
-echo "Build the UI Wrapper Project"
+echo "Building the UI Wrapper Project..."
 npm run build:ui
 
-echo "Test all projects & sub-projects ... (--watch=false to put exit code 0 after finishing)"
+echo "Testing all projects & sub-projects... (--watch=false to put exit code 0 after finishing)"
 npm run test:headless

--- a/projects/frontend/cicd/install_data_pipelines.sh
+++ b/projects/frontend/cicd/install_data_pipelines.sh
@@ -36,7 +36,7 @@ echo "Install Dependencies..."
 npm install
 
 echo "Running linking script..."
-sh "../../cicd/link_data_pipelines.sh"
+sh "../../cicd/build_data_pipelines.sh"
 
 echo "Linting all projects & sub-projects..."
 npm run lint

--- a/projects/frontend/cicd/install_data_pipelines.sh
+++ b/projects/frontend/cicd/install_data_pipelines.sh
@@ -1,0 +1,48 @@
+#!/bin/bash -e
+
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+###
+# This script generates the dependencies tree, installs the packages needed,
+# evaluates the build_data_pipelines_sh script, then
+# lints them to verify format, builds the UI application and runs the unit tests.
+###
+
+if ! which npm >/dev/null 2>&1 ; then
+  echo "ERROR:"
+  echo "Please install npm 8.5.5+. Build cannot continue without it."
+  exit 1
+fi
+echo "Logging npm engines version..."
+npm version
+
+cd "$(dirname $0)" || exit 1
+cd ../data-pipelines/gui
+
+echo "Removing package lock if available..."
+rm -f package-lock.json
+
+shared_dist_dir="../../shared-components/gui/dist/shared"
+if [ -d "$shared_dist_dir" ]
+then
+  echo "Linking the shared-components dist rebuild found..."
+  npm link "$shared_dist_dir"
+else
+  echo "No shared-components dist rebuild found."
+fi
+
+echo "Install Dependencies..."
+npm install
+
+echo "Running linking script..."
+sh ../../cicd/link_data_pipelines.sh
+
+echo "Lint all projects & sub-projects..."
+npm run lint
+
+echo "Build the UI Wrapper Project"
+npm run build:ui
+
+echo "Test all projects & sub-projects ... (--watch=false to put exit code 0 after finishing)"
+npm run test:headless

--- a/projects/frontend/cicd/install_data_pipelines.sh
+++ b/projects/frontend/cicd/install_data_pipelines.sh
@@ -11,7 +11,7 @@
 
 if ! which npm >/dev/null 2>&1 ; then
   echo "ERROR:"
-  echo "Please install npm 8.5.5+. Build cannot continue without it."
+  echo "Please install npm 8.5.5+. Install cannot continue without it."
   exit 1
 fi
 echo "Logging npm engines version..."

--- a/projects/frontend/data-pipelines/README.md
+++ b/projects/frontend/data-pipelines/README.md
@@ -2,4 +2,4 @@
 
 To get started using Data Pipelines check the [Angular project Readme](gui/README.md)
 To learn more about the project, see:
-- [README.md](/specs/vep-1507-vdk-operations-ui/README.md)
+- [README.md](../../../specs/vep-1507-vdk-operations-ui/README.md)

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/execution-duration-chart/execution-duration-chart.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/execution-duration-chart/execution-duration-chart.component.ts
@@ -383,8 +383,8 @@ export class ExecutionDurationChartComponent implements OnInit, OnChanges {
             case 'year':
                 return 1000 * 60 * 60 * 24 * 365;
             default:
-                // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
                 console.error(
+                    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
                     `Taurus DataPipelines ExecutionDurationChartComponent unsupported time format unit ${unit}`
                 );
 

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/time-period-filter/time-period-filter.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/time-period-filter/time-period-filter.component.ts
@@ -237,8 +237,8 @@ export class TimePeriodFilterComponent implements OnInit, OnDestroy {
      * @inheritDoc
      */
     ngOnInit(): void {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         this._refreshIntervalRef = setInterval(
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             this._refreshMaxTime.bind(this),
             15 * 1000
         ); // Update max time every 15s

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/services/data-jobs.api.service.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/services/data-jobs.api.service.spec.ts
@@ -314,8 +314,8 @@ describe('DataJobsApiService', () => {
 
     describe('validateModuleConfig', () => {
         it('validates dataPipelinesModuleConfig with empty defaultOwnerTeamName', () => {
-            // @ts-ignore
             expect(() =>
+                // @ts-ignore
                 service._validateModuleConfig({
                     defaultOwnerTeamName: '',
                 })
@@ -323,8 +323,8 @@ describe('DataJobsApiService', () => {
         });
 
         it('validates dataPipelinesModuleConfig with reserved defaultOwnerTeamName', () => {
-            // @ts-ignore
             expect(() =>
+                // @ts-ignore
                 service._validateModuleConfig({
                     defaultOwnerTeamName: 'default',
                 })


### PR DESCRIPTION
We need to build and run unit tests of data-pipelines library and ui application that uses it. The component is dependent on shared-components library.

Added Bash scripts to
(1) link if any shared-components rebuild was made and is about to be published, or otherwise default to latest already published one 
(2) build the data-pipelines library and link @vdk/data-pipelines 
(3) build the UI application
(4) lint the subprojects to verify format
(5) run the unit tests
One bash script is meant to be used to satisfy build prerequisites, the other one to rebuild and relink continuously, needed during development.
The proposed implementation triggers a data-pipelines rebuild (+test), upon any shared-components change, as well as data-pipelines changes. 
A README.md link fix to the VEP.

Testing done: run the install script (that evaluates the build script) on a clean setup, and verified the unit tests were successful. Also, did start and browse the application manually, to check its operational.