### PR TITLE
vdk-trino: stabilize vdk-trino tests

### DIFF
--- a/projects/vdk-plugins/vdk-trino/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-trino/.plugin-ci.yml
@@ -4,9 +4,11 @@
 image: "python:3.7"
 
 .build-vdk-trino:
-  image: docker:19.03.8
+  image: docker:23.0.1
   services:
-    - docker:19.03.8-dind
+    - name: docker:23.0.1-dind
+      # explicitly disable tls to avoid docker startup interruption
+      command: ["--tls=false"]
   variables:
     DOCKER_HOST: tcp://localhost:2375
     DOCKER_DRIVER: overlay2

--- a/projects/vdk-plugins/vdk-trino/requirements.txt
+++ b/projects/vdk-plugins/vdk-trino/requirements.txt
@@ -2,7 +2,7 @@
 # testing requirements
 click
 docker-compose
-pytest-docker
+testcontainers
 trino
 vdk-core
 vdk-test-utils

--- a/projects/vdk-plugins/vdk-trino/src/vdk/plugin/trino/trino_utils.py
+++ b/projects/vdk-plugins/vdk-trino/src/vdk/plugin/trino/trino_utils.py
@@ -203,7 +203,7 @@ class TrinoTemplateQueries:
                         "Then try to rerun the data job OR\n"
                         "3. Report the issue to support team.""",
                 )
-        if result:
+        if result is not None:
             log.debug("Target table was successfully created, and we can drop backup")
             self.drop_table(to_db, backup_table_name)
 

--- a/projects/vdk-plugins/vdk-trino/tests/docker-compose.yml
+++ b/projects/vdk-plugins/vdk-trino/tests/docker-compose.yml
@@ -1,8 +1,0 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
-services:
-  trino:
-    image: "trinodb/trino:372"
-    ports:
-      - "8080:8080"

--- a/projects/vdk-plugins/vdk-trino/tests/test_vdk_templates.py
+++ b/projects/vdk-plugins/vdk-trino/tests/test_vdk_templates.py
@@ -4,6 +4,7 @@ import json
 import os
 import pathlib
 import unittest
+import uuid
 from unittest import mock
 
 import pytest
@@ -27,7 +28,9 @@ org_move_data_to_table = TrinoTemplateQueries.move_data_to_table
 def trino_move_data_to_table_break_tmp_to_target(
     obj, from_db: str, from_table_name: str, to_db: str, to_table_name: str
 ):
-    if from_table_name == "tmp_dw_scmdb_people" and to_table_name == "dw_scmdb_people":
+    if from_table_name.startswith("tmp_dw_people") and to_table_name.startswith(
+        "dw_people"
+    ):
         obj.drop_table(from_db, from_table_name)
     return org_move_data_to_table(obj, from_db, from_table_name, to_db, to_table_name)
 
@@ -35,34 +38,44 @@ def trino_move_data_to_table_break_tmp_to_target(
 def trino_move_data_to_table_break_tmp_to_target_and_restore(
     obj, from_db: str, from_table_name: str, to_db: str, to_table_name: str
 ):
-    if from_table_name == "tmp_dw_scmdb_people" and to_table_name == "dw_scmdb_people":
-        obj.drop_table(from_db, from_table_name)
-    if (
-        from_table_name == "backup_dw_scmdb_people"
-        and to_table_name == "dw_scmdb_people"
+    if from_table_name.startswith("tmp_dw_people") and to_table_name.startswith(
+        "dw_people"
     ):
         obj.drop_table(from_db, from_table_name)
+
+    if from_table_name.startswith("backup_dw_people") and to_table_name.startswith(
+        "dw_people"
+    ):
+        obj.drop_table(from_db, from_table_name)
+
     return org_move_data_to_table(obj, from_db, from_table_name, to_db, to_table_name)
 
 
+@pytest.fixture(autouse=True)
+def mock_os_environ():
+    with mock.patch.dict(
+        os.environ,
+        {
+            VDK_DB_DEFAULT_TYPE: "TRINO",
+            VDK_TRINO_PORT: "8080",
+            VDK_TRINO_USE_SSL: "False",
+            VDK_TRINO_TEMPLATES_DATA_TO_TARGET_STRATEGY: "INSERT_SELECT",
+        },
+    ):
+        yield
+
+
 @pytest.mark.usefixtures("trino_service")
-@mock.patch.dict(
-    os.environ,
-    {
-        VDK_DB_DEFAULT_TYPE: "TRINO",
-        VDK_TRINO_PORT: "8080",
-        VDK_TRINO_USE_SSL: "False",
-        VDK_TRINO_TEMPLATES_DATA_TO_TARGET_STRATEGY: "INSERT_SELECT",
-    },
-)
-class TemplateRegressionTests(unittest.TestCase):
+class TestTemplates(unittest.TestCase):
     def setUp(self) -> None:
         self.__runner = CliEntryBasedTestRunner(trino_plugin)
+        self.__schema = f"source_{uuid.uuid4().hex[:10]}"
+        self.__trino_query("create schema " + self.__schema)
 
     def test_scd1_template(self) -> None:
-        source_schema = "default"
+        source_schema = self.__schema
         source_view = "vw_dim_org"
-        target_schema = "default"
+        target_schema = self.__schema
         target_table = "dw_dim_org"
 
         result: Result = self.__runner.invoke(
@@ -86,6 +99,7 @@ class TemplateRegressionTests(unittest.TestCase):
 
         cli_assert_equal(0, result)
 
+        # refactor below to use vdk-trino-query
         actual_rs: Result = self.__runner.invoke(
             [
                 "trino-query",
@@ -112,10 +126,17 @@ class TemplateRegressionTests(unittest.TestCase):
             actual_rs.output == expected_rs.output
         ), f"Elements in {source_view} and {target_table} differ."
 
+    def test_scd1_template_using_rename_strategy(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {VDK_TRINO_TEMPLATES_DATA_TO_TARGET_STRATEGY: "RENAME"},
+        ):
+            self.test_scd1_template()
+
     def test_scd1_template_reserved_args(self) -> None:
-        source_schema = "default"
+        source_schema = self.__schema
         source_view = "alter"
-        target_schema = "default"
+        target_schema = self.__schema
         target_table = "table"
 
         result: Result = self.__runner.invoke(
@@ -166,10 +187,10 @@ class TemplateRegressionTests(unittest.TestCase):
         ), f"Elements in {source_view} and {target_table} differ."
 
     def test_scd2_template(self) -> None:
-        test_schema = "default"
-        source_view = "vw_scmdb_people"
-        target_table = "dw_scmdb_people"
-        expect_table = "ex_scmdb_people"
+        test_schema = self.__schema
+        source_view = "vw_people_scd2"
+        target_table = "dw_people_scd2"
+        expect_table = "ex_people_scd2"
 
         result: Result = self.__scd2_template_execute(
             test_schema, source_view, target_table, expect_table
@@ -182,8 +203,15 @@ class TemplateRegressionTests(unittest.TestCase):
             1, self.__template_table_exists(test_schema, "backup_" + target_table)
         )
 
+    def test_scd2_template_using_rename_strategy(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {VDK_TRINO_TEMPLATES_DATA_TO_TARGET_STRATEGY: "RENAME"},
+        ):
+            self.test_scd2_template()
+
     def test_scd2_template_reserved_args(self) -> None:
-        test_schema = "default"
+        test_schema = self.__schema
         source_view = "alter"
         target_table = "table"
         expect_table = "between"
@@ -202,10 +230,10 @@ class TemplateRegressionTests(unittest.TestCase):
         )
 
     def test_scd2_template_restore_target_from_backup_on_start(self) -> None:
-        test_schema = "default"
-        source_view = "vw_scmdb_people"
-        target_table = "dw_scmdb_people"
-        expect_table = "ex_scmdb_people"
+        test_schema = self.__schema
+        source_view = "vw_people_scd2_restore"
+        target_table = "dw_people_scd2_restore"
+        expect_table = "ex_people_scd2_restore"
 
         result: Result = self.__scd2_template_execute(
             test_schema, source_view, target_table, expect_table, True
@@ -224,10 +252,10 @@ class TemplateRegressionTests(unittest.TestCase):
         new=trino_move_data_to_table_break_tmp_to_target,
     )
     def test_scd2_template_fail_last_step_and_restore_target(self):
-        test_schema = "default"
-        source_view = "vw_scmdb_people"
-        target_table = "dw_scmdb_people"
-        expect_table = "ex_scmdb_people"
+        test_schema = self.__schema
+        source_view = "vw_people"
+        target_table = "dw_people_scd2_fail_restore"
+        expect_table = "ex_people_scd2_fail_restore"
 
         result: Result = self.__scd2_template_execute(
             test_schema, source_view, target_table, expect_table
@@ -243,10 +271,10 @@ class TemplateRegressionTests(unittest.TestCase):
         new=trino_move_data_to_table_break_tmp_to_target_and_restore,
     )
     def test_scd2_template_fail_last_step_and_fail_restore_target(self):
-        test_schema = "default"
-        source_view = "vw_scmdb_people"
-        target_table = "dw_scmdb_people"
-        expect_table = "ex_scmdb_people"
+        test_schema = self.__schema
+        source_view = "vw_people_scd2_fail_fail_restore"
+        target_table = "dw_people_scd2_fail_fail_restore"
+        expect_table = "ex_people_scd2_fail_fail_restore"
 
         result: Result = self.__scd2_template_execute(
             test_schema, source_view, target_table, expect_table
@@ -261,7 +289,7 @@ class TemplateRegressionTests(unittest.TestCase):
         ), "Missing log for losing target schema."
 
     def test_fact_periodic_snapshot_template(self) -> None:
-        test_schema = "default"
+        test_schema = self.__schema
         source_view = "vw_fact_sddc_daily"
         target_table = "dw_fact_sddc_daily"
         expect_table = "ex_fact_sddc_daily"
@@ -275,8 +303,15 @@ class TemplateRegressionTests(unittest.TestCase):
             test_schema, target_table, expect_table
         )
 
+    def test_fact_periodic_snapshot_template_using_rename_strategy(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {VDK_TRINO_TEMPLATES_DATA_TO_TARGET_STRATEGY: "RENAME"},
+        ):
+            self.test_fact_periodic_snapshot_template()
+
     def test_fact_periodic_snapshot_template_reserved_args(self) -> None:
-        test_schema = "default"
+        test_schema = self.__schema
         source_view = "alter"
         target_table = "table"
         expect_table = "between"
@@ -291,10 +326,10 @@ class TemplateRegressionTests(unittest.TestCase):
         )
 
     def test_fact_periodic_snapshot_empty_source(self) -> None:
-        test_schema = "default"
-        source_view = "vw_fact_sddc_daily"
-        target_table = "dw_fact_sddc_daily"
-        expect_table = "ex_fact_sddc_daily"
+        test_schema = self.__schema
+        source_view = "vw_fact_sddc_daily_empty_source"
+        target_table = "dw_fact_sddc_daily_empty_source"
+        expect_table = "ex_fact_sddc_daily_empty_source"
 
         result: Result = self.__runner.invoke(
             [
@@ -331,10 +366,10 @@ class TemplateRegressionTests(unittest.TestCase):
     def test_fact_periodic_snapshot_template_restore_target_from_backup_on_start(
         self,
     ) -> None:
-        test_schema = "default"
-        source_view = "vw_scmdb_people"
-        target_table = "dw_scmdb_people"
-        expect_table = "ex_scmdb_people"
+        test_schema = self.__schema
+        source_view = "vw_people_fact_restore"
+        target_table = "dw_people_fact_restore"
+        expect_table = "ex_people_fact_restore"
 
         result: Result = self.__fact_periodic_snapshot_template_execute(
             test_schema, source_view, target_table, expect_table, True
@@ -355,10 +390,10 @@ class TemplateRegressionTests(unittest.TestCase):
         new=trino_move_data_to_table_break_tmp_to_target,
     )
     def test_fact_periodic_snapshot_template_fail_last_step_and_restore_target(self):
-        test_schema = "default"
-        source_view = "vw_scmdb_people"
-        target_table = "dw_scmdb_people"
-        expect_table = "ex_scmdb_people"
+        test_schema = self.__schema
+        source_view = "vw_people_fact_fail_restore"
+        target_table = "dw_people_fact_fail_restore"
+        expect_table = "ex_people_fact_fail_restore"
 
         result: Result = self.__fact_periodic_snapshot_template_execute(
             test_schema, source_view, target_table, expect_table
@@ -376,10 +411,10 @@ class TemplateRegressionTests(unittest.TestCase):
     def test_fact_periodic_snapshot_template_fail_last_step_and_fail_restore_target(
         self,
     ):
-        test_schema = "default"
-        source_view = "vw_scmdb_people"
-        target_table = "dw_scmdb_people"
-        expect_table = "ex_scmdb_people"
+        test_schema = self.__schema
+        source_view = "vw_people_fact_fail_fail_restore"
+        target_table = "dw_people_fact_fail_fail_restore"
+        expect_table = "ex_people_fact_fail_fail_restore"
 
         result: Result = self.__fact_periodic_snapshot_template_execute(
             test_schema, source_view, target_table, expect_table
@@ -570,15 +605,11 @@ class TemplateRegressionTests(unittest.TestCase):
             ]
         )
 
-
-@mock.patch.dict(
-    os.environ,
-    {
-        VDK_DB_DEFAULT_TYPE: "TRINO",
-        VDK_TRINO_PORT: "8080",
-        VDK_TRINO_USE_SSL: "False",
-        VDK_TRINO_TEMPLATES_DATA_TO_TARGET_STRATEGY: "RENAME",
-    },
-)
-class TemplateRegressionTestsRenameStrategy(TemplateRegressionTests):
-    pass
+    def __trino_query(self, query: str) -> Result:
+        return self.__runner.invoke(
+            [
+                "trino-query",
+                "--query",
+                query,
+            ]
+        )


### PR DESCRIPTION
This change is fixing vdk-trino tests which are failing regularly in the nightly builds . See
https://github.com/vmware/versatile-data-kit/issues/1559

The tests were failing intermittently for two main reasons 
* Docker failures which are being fixed by adopting testcontainers  (in favour of pytest-docker)
* Hidden dependencies between  test cases (because different test use same schema and tables on shared db instance)

Until now we used pytest-docker to start service container, this is switching it to testcontainers-python.

There are multiple advantages of using it.

* Supposedly Testcontainers is built with performance in mind and uses a variety of techniques to minimize container startup time and resource usage like image reuse, container reuse, asynchronous operations.
* It is far more popular lately - https://hugovk.github.io/top-pypi-packages/  is a site I frequently use to decide which library is likely to be more stable/used . It is showing testcontainers is 2000 places ahead of pytest-docker
* Testcontainers provides a wider range of features for managing containers, such as starting and stopping them, waiting for them to become available, and exposing their ports to the host system
* Testcontainers-Python allows you to define and configure containers using Python code instead of yaml which pytest-docker required.

Testing Done: ran the test suite of vdk-trino a few times and it was more stable and quick. I have not run actual benchmarks and recorded times but it seems about twice faster possibly. We will verify this as part of the nightly builds.