### PR TITLE
control-service: don't include needless service token

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/k8s-data-job-template.yaml
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/k8s-data-job-template.yaml
@@ -37,4 +37,5 @@ spec:
             runAsUser: 1000
             runAsGroup: 1000
             fsGroup: 1000
+          automountServiceAccountToken: false
       ttlSecondsAfterFinished: 600

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/v1-k8s-data-job-template.yaml
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/v1-k8s-data-job-template.yaml
@@ -37,4 +37,5 @@ spec:
             runAsUser: 1000
             runAsGroup: 1000
             fsGroup: 1000
+          automountServiceAccountToken: false
       ttlSecondsAfterFinished: 600


### PR DESCRIPTION
Kubernetes, service accounts are used by pods to authenticate with the Kubernetes API server and access resources in the cluster. Each pod is assigned a service account, and by default, the service account token is mounted in the pod's file system and used for authentication.

However, not all pods need to access the Kubernetes API server or cluster resources, and in some cases, including the service account token can pose a security risk. For example, if a pod is compromised or runs untrusted code (which data job generally do), an attacker could use the service account token to escalate privileges and access sensitive resources in the cluster.

To mitigate this risk, Kubernetes provides the
`automountServiceAccountToken` property, which can be used to disable the automatic mounting of the service account token in pods. By setting this property to false, the service account token is not included by default, and the pod does not have access to the token unless it is manually mounted in a volume.

It is a best practice to follow the principle of least privilege when designing and configuring Kubernetes workloads. By disabling the automatic mounting of the service account token, we can reduce the attack surface of our pods (and hence data jobs) and minimize the risk of compromise or data breaches.

Testing Done: existing integration tests cover that the main functionality will not be broken by setting automountServiceAccountToken to false.