### PR TITLE
versatile-data-kit: dependabot auto-merge fix

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ahmadnassri/action-dependabot-auto-merge@v2
         with:
-          github-token: ${{ secrets.mytoken || github.token }}
+          token: ${{ secrets.mytoken || github.token }}

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ahmadnassri/action-dependabot-auto-merge@v2
         with:
-          github-token: ${{ secrets.mytoken }}
+          github-token: ${{ secrets.mytoken || github.token }}


### PR DESCRIPTION
The auto-merge fails due
`Error: Input required and not supplied: github-token` See https://github.com/vmware/versatile-data-kit/actions/runs/4295507705/jobs/7486018753

Applying the fix suggested:
https://github.com/actions/checkout/issues/298#issuecomment-820748989

Testing done: ci/cd