### PR TITLE
frontend: bump data-pipelines dependency versions

### DIFF
--- a/projects/frontend/data-pipelines/gui/package.json
+++ b/projects/frontend/data-pipelines/gui/package.json
@@ -71,7 +71,7 @@
     "lodash": "4.17.21",
     "lottie-web": "5.9.4",
     "lz-string": "1.4.4",
-    "moment": "2.29.3",
+    "moment": "2.29.4",
     "ng2-date-picker": "12.0.4",
     "ngx-clipboard": "15.1.0",
     "ngx-cookie-service": "13.2.1",
@@ -82,7 +82,7 @@
     "striptags": "3.2.0",
     "superagent": "5.3.1",
     "tslib": "2.3.1",
-    "ua-parser-js": "1.0.2",
+    "ua-parser-js": "1.0.33",
     "zone.js": "0.11.5"
   },
   "optionalDependencies": {

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/package.json
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/package.json
@@ -53,7 +53,7 @@
     "lodash": "~4.17.21",
     "lottie-web": "~5.9.4",
     "lz-string": "~1.4.4",
-    "moment": "~2.29.3",
+    "moment": "~2.29.4",
     "ng2-date-picker": "~12.0.4",
     "ngx-clipboard": "~15.1.0",
     "ngx-cookie-service": "~13.2.1",
@@ -63,7 +63,7 @@
     "rxjs": "~7.5.5",
     "striptags": "~3.2.0",
     "superagent": "~5.3.1",
-    "ua-parser-js": "~1.0.2",
+    "ua-parser-js": "~1.0.33",
     "zone.js": "~0.11.5"
   },
   "dependencies": {


### PR DESCRIPTION
#### Why

Fixes following vulnerabilities

https://github.com/vmware/versatile-data-kit/security/dependabot/6 https://github.com/vmware/versatile-data-kit/security/dependabot/7

#### What

Bump patch versions for moment.js and ua-parser-js

#### How has this been tested?

Manual build data-pipelines and run tests

#### What type of change are you making?

Bugfix