### PR TITLE
versatile-data-kit: automate merging of dependabot PRs

### DIFF
--- a/.github/workflows/dependabot.autoapprove.yml
+++ b/.github/workflows/dependabot.autoapprove.yml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 name: Auto approve
 on: pull_request_target
 

--- a/.github/workflows/dependabot.autoapprove.yml
+++ b/.github/workflows/dependabot.autoapprove.yml
@@ -1,0 +1,11 @@
+name: Auto approve
+on: pull_request_target
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: hmarr/auto-approve-action@v3

--- a/.github/workflows/dependabot.automerge.yml
+++ b/.github/workflows/dependabot.automerge.yml
@@ -1,3 +1,6 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 name: automerge
 on:
   pull_request:

--- a/.github/workflows/dependabot.automerge.yml
+++ b/.github/workflows/dependabot.automerge.yml
@@ -1,0 +1,32 @@
+name: automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - id: automerge
+        name: automerge
+        uses: "pascalgn/automerge-action@v0.15.6"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_METHOD: "rebase"
+          MERGE_LABELS: "dependencies"
+          UPDATE_METHOD: "rebase"
+          UPDATE_LABELS: "dependencies"


### PR DESCRIPTION
Dependabot is creating PR. This is helping to automate them by
1. Automatically approving them
2. Automatically trying to merge them (only if all tests have passed)
3. Automatically updating them with latest changes

Testing Done: created a fork and tested the flow there.
using custom labels (as a proxy for dependabot)