### PR TITLE
vdk-plugins: remove global "variables" in CI

### DIFF
--- a/projects/vdk-plugins/.plugin-common.yml
+++ b/projects/vdk-plugins/.plugin-common.yml
@@ -27,7 +27,7 @@
   artifacts:
     when: always
     reports:
-      junit: tests.xml
+      junit: "projects/vdk-plugins/$PLUGIN_NAME/tests.xml"
 
 .build-plugin-on-vdk-core-release:
   stage: pre_release_test

--- a/projects/vdk-plugins/vdk-impala/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-impala/.plugin-ci.yml
@@ -1,7 +1,6 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
 
 .build-vdk-impala:
   variables:

--- a/projects/vdk-plugins/vdk-ingest-http/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-ingest-http/.plugin-ci.yml
@@ -1,8 +1,6 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
-
 .build-vdk-ingest-http:
   variables:
     PLUGIN_NAME: vdk-ingest-http

--- a/projects/vdk-plugins/vdk-plugin-control-cli/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-plugin-control-cli/.plugin-ci.yml
@@ -1,7 +1,6 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
 
 .build-vdk-plugin-control-cli:
   variables:


### PR DESCRIPTION
As part of effort to stabilize builds -
https://github.com/vmware/versatile-data-kit/issues/1559

I am removing global variables and names since they can be overwriten by accident across differnet projects.