### PR TITLE
versatile-data-kit: add hosts entry to gitlab runners

### DIFF
--- a/support/gitlab-runners/values.yaml
+++ b/support/gitlab-runners/values.yaml
@@ -95,6 +95,17 @@ runners:
     cpuRequests: 100m
     memoryRequests: 128Mi
 
+  ## Runner configuration, where the multi line strings is evaluated as template.
+  ## You can specify helm values inside the config.
+  ## tpl: https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function
+  ## runner configuration: https://docs.gitlab.com/runner/configuration/advanced-configuration.html
+  config: |
+    [[runners]]
+      [runners.kubernetes]
+        [[runners.kubernetes.host_aliases]]
+          ip = "127.0.0.1"
+          hostnames = ["localhost.vmware.com"]
+
 # Resources for the runner itself. It is very lean.
 resources:
   limits:


### PR DESCRIPTION
To resolve VDK Frontend e2e tests blocked by a host hard requirement, we need to add localhost.vmware.com alias entry to /etc/hosts file of the containers. See:
https://gitlab.com/vmware-analytics/versatile-data-kit/-/jobs/3886157064

Patching the gitlab runners config.

Testing done: upon approval before merge, I intend to update the gitlab runners and verify.