### PR TITLE
frontend: Fix shebang in build_shared.sh

### DIFF
--- a/projects/frontend/cicd/install_shared.sh
+++ b/projects/frontend/cicd/install_shared.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash -e
 # Copyright 2023-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/projects/frontend/data-pipelines/gui/.npmrc
+++ b/projects/frontend/data-pipelines/gui/.npmrc
@@ -1,1 +1,2 @@
 legacy-peer-deps=true
+verbose=true

--- a/projects/frontend/shared-components/gui/.npmrc
+++ b/projects/frontend/shared-components/gui/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps=true
 engine-strict=true
+verbose=true


### PR DESCRIPTION
Change shebang in build_shared.sh to !/bin/bash -e

This points to the correct execution shell for build scripts and passes the -e flag, which makes the script fail on the first error exit code