### PR TITLE
vdk-jupyter: add py-to-ts-interfaces to build

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package.json
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package.json
@@ -35,6 +35,7 @@
     "build:labextension": "jupyter labextension build .",
     "build:labextension:dev": "jupyter labextension build --development True .",
     "build:lib": "tsc",
+    "build:interfaces": "npx py-to-ts-interfaces vdk-jupyterlab-extension/vdk_options/ src/vdkOptions",
     "clean": "jlpm clean:lib",
     "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
     "clean:lintcache": "rimraf .eslintcache .stylelintcache",
@@ -59,7 +60,8 @@
     "@jupyterlab/application": "^3.1.0",
     "@jupyterlab/coreutils": "^5.1.0",
     "@jupyterlab/services": "^6.1.0",
-    "@jupyterlab/settingregistry": "^3.1.0"
+    "@jupyterlab/settingregistry": "^3.1.0",
+    "py-to-ts-interfaces": "git+https://github.com/Syndallic/py-to-ts-interfaces#main"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",


### PR DESCRIPTION
What:
Added py-to-ts-interfaces to build. 

What the changes do:
 - Instruct npm to download the py-to-ts-interfaces package from the main branch of the repository located at https://github.com/Syndallic/py-to-ts-interfaces
 - build script by updating the "build:interfaces" script in the package.json (the npx command is used to run the installed py-to-ts-interfaces package)

Why: linked to the issue https://github.com/vmware/versatile-data-kit/issues/1690

Tests: tested manually the build by adding new options to VdkOptions in the python project

Signed-off-by: Duygu Hasan [hduygu@vmware.com](mailto:hduygu@vmware.com)