### PR TITLE
vdk-server: upgrade minimum k8s cluster version and upgrade vdk-quickstart k8s version

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/README.md
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/README.md
@@ -2,7 +2,7 @@
 Versatile Data Kit is a platform that enables Data Engineers to implement automated pull ingestion (E in ELT) and batch data transformation into a database (T in ELT).
 
 ## Prerequisites
-- Kubernetes 1.19<=x>1.25 works with no config changes
+- Kubernetes 1.21<=x>1.25 works with no config changes
 - for kubernetes 1.25+ the datajob template needs to be changed in the [values.yaml](./values.yaml). Specifically `enabled` needs to be set to `true` and `apiVersion` needs to be set to `batch/v1`
 - Helm 3.0
 - PV provisioner support in the underlying infrastructure if using the embedded database.

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/README.md
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/README.md
@@ -4,7 +4,7 @@ The goal of the tests is to validate that the functionality of the service
 works in combination with other dependant components (KDC, Kubernetes, DB, Git repo, etc).
 
 # Prerequisites
-* Kubernetes 1.15+ (E.g. minikube, kubernetes-in-docker, etc.)
+* Kubernetes 1.21+ (E.g. minikube, kubernetes-in-docker, etc.)
 * Valid kubeconfig.yaml in ```${HOME}/.kube/config``` or set the ```datajobs.deployment.k8s.kubeconfig``` and ```datajobs.control.k8s.kubeconfig``` property
   in [integration-test/resources/application-test.properties](./resources/application-test.properties)
 * Git server and Git repo for storing the jobs, using public github as the git server is the most straight forward approach

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/README.md
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/README.md
@@ -4,7 +4,7 @@ The goal of the tests is to validate that the functionality of the service
 works in combination with other dependant components (KDC, Kubernetes, DB, Git repo, etc).
 
 # Prerequisites
-* Kubernetes 1.21+ (E.g. minikube, kubernetes-in-docker, etc.)
+* Kubernetes 1.21+<=x>1.25 (E.g. minikube, kubernetes-in-docker, etc.)
 * Valid kubeconfig.yaml in ```${HOME}/.kube/config``` or set the ```datajobs.deployment.k8s.kubeconfig``` and ```datajobs.control.k8s.kubeconfig``` property
   in [integration-test/resources/application-test.properties](./resources/application-test.properties)
 * Git server and Git repo for storing the jobs, using public github as the git server is the most straight forward approach

--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/installer.py
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/installer.py
@@ -481,7 +481,7 @@ class Installer:
                         "--name",
                         self.kind_cluster_name,
                         "--image",
-                        "kindest/node:v1.20.15",
+                        "kindest/node:v1.24.7",
                     ],
                     capture_output=True,
                 )

--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/server_plugin.py
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/server_plugin.py
@@ -63,3 +63,7 @@ def server(install, uninstall, status):
 @hookimpl
 def vdk_command_line(root_command: click.Group):
     root_command.add_command(server)
+
+
+if __name__ == "__main__":
+    Installer().install()

--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/server_plugin.py
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/server_plugin.py
@@ -63,7 +63,3 @@ def server(install, uninstall, status):
 @hookimpl
 def vdk_command_line(root_command: click.Group):
     root_command.add_command(server)
-
-
-if __name__ == "__main__":
-    Installer().install()


### PR DESCRIPTION
# Why
When we merged this PR https://github.com/vmware/versatile-data-kit/pull/1580/files we unintentionally changed the minimum required version from 1.19 to 1.21. 

We always check for v1 versions of batch jobs. checking for that version on clusters <1.21 will result in errors.

# What
Change the docs to state that 1.21 is a minimum requirement and vdk server --install now uses a newer version of k8s. 

# How has this been tested
installed locally and tested locally


# Not handled in this PR
How do we prevent issues like this in the future? 
Maybe integration tests run against many versions of k8s?


