### PR TITLE
Fix CICD build for control service

### DIFF
--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -10,8 +10,8 @@
 .images:dind:
   image: docker:23.0.1
   variables:
-    DOCKER_HOST: tcp://localhost:2375
-    DOCKER_DRIVER: overlay2
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_TLS_CERTDIR: ""
   services:
     - docker:23.0.1-dind
 

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -45,10 +45,11 @@ control_service_build_image:
     - .images:dind
   stage: build
   script:
-    - docker info
     - apk --no-cache add git openjdk17-jdk
     - export TAG=$(git rev-parse --short HEAD)
     - cd projects/control-service/projects
+    - ./gradlew -p ./model build publishToMavenLocal --info --stacktrace
+    - ./gradlew build jacocoTestReport -x integrationTest --info --stacktrace
     - ./gradlew :pipelines_control_service:docker --info --stacktrace -Pversion=$TAG
   retry: !reference [.control_service_retry, retry_options]
   coverage: "/    - Line Coverage: ([0-9.]+)%/"
@@ -64,6 +65,45 @@ control_service_build_image:
       - external_pull_requests
     changes: *control_service_code_change_locations
 
+control_service_integration_test:
+  extends: .control_service_base_build
+  stage: build
+  variables:
+    DEPLOYMENT_K8S_KUBECONFIG: "~/.kube/config"
+    DEPLOYMENT_K8S_NAMESPACE: $CICD_KUBERNETES_NAMESPACE
+    CONTROL_K8S_KUBECONFIG: "~/.kube/config"
+    CONTROL_K8S_NAMESPACE: $CICD_KUBERNETES_NAMESPACE
+    DOCKER_REGISTRY_URL: $CICD_CONTAINER_REGISTRY_URI
+    DOCKER_REGISTRY_USERNAME: $CICD_CONTAINER_REGISTRY_USER_NAME
+    DOCKER_REGISTRY_PASSWORD: $CICD_CONTAINER_REGISTRY_USER_PASSWORD
+    GIT_URL: $CICD_GIT_URI
+    GIT_USERNAME: $CICD_GIT_USER
+    GIT_PASSWORD: $CICD_GIT_PASSWORD
+    GIT_USERNAME_READ_WRITE: $CICD_GIT_USER
+    GIT_PASSWORD_READ_WRITE: $CICD_GIT_PASSWORD
+  script:
+    - cd projects/control-service/projects
+    - ./gradlew -p ./model build publishToMavenLocal
+    - mkdir -p ~/.kube
+    - cp $KUBECONFIG ~/.kube/config
+    - ./gradlew -v
+    - ./gradlew projects --info
+    - ./gradlew -Djdk.tls.client.protocols=TLSv1.2 :pipelines_control_service:integrationTest --info --stacktrace
+  retry: !reference [.control_service_retry, retry_options]
+  artifacts:
+    when: always
+    paths:
+      - ./projects/control-service/projects/*/build/reports/**
+    expire_in: 1 week
+    reports:
+      junit: ./projects/control-service/projects/**/build/test-results/integrationTest/TEST-*.xml
+  only:
+    refs:
+      - external_pull_requests
+    changes: *control_service_code_change_locations
+  except:
+    changes:
+      - projects/control-service/projects/helm_charts/pipelines-control-service/version.txt
 
 control_service_test_helm_chart:
   stage: build
@@ -198,7 +238,7 @@ control_service_publish_image:
       changes: *control_service_helm_change_locations
 
 control_service_publish_api_client:
-  image: docker:20.10.22
+  image: docker:23.0.1
   stage: publish_artifacts
   script:
     - apk add --no-cache py-pip openjdk17-jdk git python
@@ -221,7 +261,7 @@ control_service_publish_api_client:
 # Go to the namespace -> StorageClass
 control_service_deploy_testing_data_pipelines:
   stage: pre_release
-  image: docker:20.10.22
+  image: docker:23.0.1
   script:
     - apk --no-cache add bash openssl curl git gettext zip py-pip
     - pip install --upgrade pip && pip install awscli
@@ -261,7 +301,7 @@ control_service_post_deployment_test:
       changes: *control_service_helm_change_locations
 
 control_service_release:
-  image: docker:20.10.22
+  image: docker:23.0.1
   stage: release
   script:
     - apk --no-cache add bash openssl curl git
@@ -284,15 +324,8 @@ control_service_release:
       changes: *control_service_helm_change_locations
 
 # TODO: automatically rebuild image on vdk-heartbeat change
-# We are using an old version of docker here because we get error on the newest version which at the time was tag=20.10.22
 control_service_vdk_heartbeat_release:
-  image: docker:19.03.15
-  services:
-    - docker:19.03.15-dind
-  variables:
-    DOCKER_HOST: tcp://localhost:2375
-    DOCKER_DRIVER: overlay2
-    DOCKER_TLS_CERTDIR: ""
+  extends: .images:dind
   stage: release
   script:
     - export CHART_NAME=pipelines-control-service

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -48,7 +48,6 @@ control_service_build_image:
     - apk --no-cache add git openjdk17-jdk
     - export TAG=$(git rev-parse --short HEAD)
     - cd projects/control-service/projects
-    - ./gradlew -p ./model build publishToMavenLocal --info --stacktrace
     - ./gradlew :pipelines_control_service:docker --info --stacktrace -Pversion=$TAG
   retry: !reference [.control_service_retry, retry_options]
   coverage: "/    - Line Coverage: ([0-9.]+)%/"

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -8,12 +8,12 @@
       - always
 
 .images:dind:
-  image: docker:20.10.22
+  image: docker:23.0.1
   variables:
     DOCKER_HOST: tcp://localhost:2375
     DOCKER_DRIVER: overlay2
   services:
-    - docker:20.10.22-dind
+    - docker:23.0.1-dind
 
 # This grouping listens on changes to all code of control service
 # Changes to this group should trigger runs of runs of unit and integration tests.
@@ -49,7 +49,6 @@ control_service_build_image:
     - export TAG=$(git rev-parse --short HEAD)
     - cd projects/control-service/projects
     - ./gradlew -p ./model build publishToMavenLocal --info --stacktrace
-    - ./gradlew build jacocoTestReport -x integrationTest --info --stacktrace
     - ./gradlew :pipelines_control_service:docker --info --stacktrace -Pversion=$TAG
   retry: !reference [.control_service_retry, retry_options]
   coverage: "/    - Line Coverage: ([0-9.]+)%/"

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -64,45 +64,6 @@ control_service_build_image:
       - external_pull_requests
     changes: *control_service_code_change_locations
 
-control_service_integration_test:
-  extends: .control_service_base_build
-  stage: build
-  variables:
-    DEPLOYMENT_K8S_KUBECONFIG: "~/.kube/config"
-    DEPLOYMENT_K8S_NAMESPACE: $CICD_KUBERNETES_NAMESPACE
-    CONTROL_K8S_KUBECONFIG: "~/.kube/config"
-    CONTROL_K8S_NAMESPACE: $CICD_KUBERNETES_NAMESPACE
-    DOCKER_REGISTRY_URL: $CICD_CONTAINER_REGISTRY_URI
-    DOCKER_REGISTRY_USERNAME: $CICD_CONTAINER_REGISTRY_USER_NAME
-    DOCKER_REGISTRY_PASSWORD: $CICD_CONTAINER_REGISTRY_USER_PASSWORD
-    GIT_URL: $CICD_GIT_URI
-    GIT_USERNAME: $CICD_GIT_USER
-    GIT_PASSWORD: $CICD_GIT_PASSWORD
-    GIT_USERNAME_READ_WRITE: $CICD_GIT_USER
-    GIT_PASSWORD_READ_WRITE: $CICD_GIT_PASSWORD
-  script:
-    - cd projects/control-service/projects
-    - ./gradlew -p ./model build publishToMavenLocal
-    - mkdir -p ~/.kube
-    - cp $KUBECONFIG ~/.kube/config
-    - ./gradlew -v
-    - ./gradlew projects --info
-    - ./gradlew -Djdk.tls.client.protocols=TLSv1.2 :pipelines_control_service:integrationTest --info --stacktrace
-  retry: !reference [.control_service_retry, retry_options]
-  artifacts:
-    when: always
-    paths:
-      - ./projects/control-service/projects/*/build/reports/**
-    expire_in: 1 week
-    reports:
-      junit: ./projects/control-service/projects/**/build/test-results/integrationTest/TEST-*.xml
-  only:
-    refs:
-      - external_pull_requests
-    changes: *control_service_code_change_locations
-  except:
-    changes:
-      - projects/control-service/projects/helm_charts/pipelines-control-service/version.txt
 
 control_service_test_helm_chart:
   stage: build

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -32,7 +32,7 @@
   - projects/control-service/projects/helm_charts/pipelines-control-service/**/*
 
 .control_service_base_build:
-  image: docker:20.10.22
+  image: docker:23.0.1
   variables:
     _JAVA_OPTIONS: "-Xms2048m -Xmx4096m"
   before_script:
@@ -45,6 +45,7 @@ control_service_build_image:
     - .images:dind
   stage: build
   script:
+    - docker info
     - apk --no-cache add git openjdk17-jdk
     - export TAG=$(git rev-parse --short HEAD)
     - cd projects/control-service/projects


### PR DESCRIPTION
# Why 
We are seeing job builds fail.
For full details see here:
https://cloud-native.slack.com/archives/C033PSLKCPR/p1680003501501429

# What
we were failing to connect to the daemon in an old version of docker in docker.
Upgrading to the latest version fixes all the issues.  

# How has this been tested?
CICD
