### PR TITLE
vdk-plugins: test only oldest and newest supported python version

### DIFF
--- a/projects/vdk-plugins/quickstart-vdk/.plugin-ci.yml
+++ b/projects/vdk-plugins/quickstart-vdk/.plugin-ci.yml
@@ -31,18 +31,6 @@ build-py37-quickstart-vdk:
   extends: .build-quickstart-vdk
   image: "python:3.7"
 
-build-py38-quickstart-vdk:
-  extends: .build-quickstart-vdk
-  image: "python:3.8"
-
-build-py39-quickstart-vdk:
-  extends: .build-quickstart-vdk
-  image: "python:3.9"
-
-build-py310-quickstart-vdk:
-  extends: .build-quickstart-vdk
-  image: "python:3.10"
-
 build-py311-quickstart-vdk:
   extends: .build-quickstart-vdk
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-audit/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-audit/.plugin-ci.yml
@@ -10,14 +10,6 @@ build-py38-vdk-audit:
   extends: .build-vdk-audit
   image: "python:3.8"
 
-build-py39-vdk-audit:
-  extends: .build-vdk-audit
-  image: "python:3.9"
-
-build-py310-vdk-audit:
-  extends: .build-vdk-audit
-  image: "python:3.10"
-
 build-py311-vdk-audit:
   extends: .build-vdk-audit
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-control-api-auth/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-control-api-auth/.plugin-ci.yml
@@ -12,20 +12,6 @@ build-py37-vdk-control-api-auth:
   extends: .build-vdk-control-api-auth
   image: "python:3.7"
 
-
-build-py38-vdk-control-api-auth:
-  extends: .build-vdk-control-api-auth
-  image: "python:3.8"
-
-
-build-py39-vdk-control-api-auth:
-  extends: .build-vdk-control-api-auth
-  image: "python:3.9"
-
-build-py310-vdk-control-api-auth:
-  extends: .build-vdk-control-api-auth
-  image: "python:3.10"
-
 build-py311-vdk-control-api-auth:
   extends: .build-vdk-control-api-auth
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-csv/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-csv/.plugin-ci.yml
@@ -12,20 +12,6 @@ build-py37-vdk-csv:
   extends: .build-vdk-csv
   image: "python:3.7"
 
-
-build-py38-vdk-csv:
-  extends: .build-vdk-csv
-  image: "python:3.8"
-
-
-build-py39-vdk-csv:
-  extends: .build-vdk-csv
-  image: "python:3.9"
-
-build-py310-vdk-csv:
-  extends: .build-vdk-csv
-  image: "python:3.10"
-
 build-py311-vdk-csv:
   extends: .build-vdk-csv
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-greenplum/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-greenplum/.plugin-ci.yml
@@ -12,20 +12,6 @@ build-py37-vdk-greenplum:
   extends: .build-vdk-greenplum
   image: "python:3.7"
 
-
-build-py38-vdk-greenplum:
-  extends: .build-vdk-greenplum
-  image: "python:3.8"
-
-
-build-py39-vdk-greenplum:
-  extends: .build-vdk-greenplum
-  image: "python:3.9"
-
-build-py310-vdk-greenplum:
-  extends: .build-vdk-greenplum
-  image: "python:3.10"
-
 build-py311-vdk-greenplum:
   extends: .build-vdk-greenplum
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-impala/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-impala/.plugin-ci.yml
@@ -12,20 +12,6 @@ build-py37-vdk-impala:
   extends: .build-vdk-impala
   image: "python:3.7"
 
-
-build-py38-vdk-impala:
-  extends: .build-vdk-impala
-  image: "python:3.8"
-
-
-build-py39-vdk-impala:
-  extends: .build-vdk-impala
-  image: "python:3.9"
-
-build-py310-vdk-impala:
-  extends: .build-vdk-impala
-  image: "python:3.10"
-
 build-py311-vdk-impala:
   extends: .build-vdk-impala
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-ingest-file/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-ingest-file/.plugin-ci.yml
@@ -12,20 +12,6 @@ build-py37-vdk-ingest-file:
   extends: .build-vdk-ingest-file
   image: "python:3.7"
 
-
-build-py38-vdk-ingest-file:
-  extends: .build-vdk-ingest-file
-  image: "python:3.8"
-
-
-build-py39-vdk-ingest-file:
-  extends: .build-vdk-ingest-file
-  image: "python:3.9"
-
-build-py310-vdk-ingest-file:
-  extends: .build-vdk-ingest-file
-  image: "python:3.10"
-
 build-py311-vdk-ingest-file:
   extends: .build-vdk-ingest-file
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-ingest-http/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-ingest-http/.plugin-ci.yml
@@ -12,20 +12,6 @@ build-py37-vdk-ingest-http:
   extends: .build-vdk-ingest-http
   image: "python:3.7"
 
-
-build-py38-vdk-ingest-http:
-  extends: .build-vdk-ingest-http
-  image: "python:3.8"
-
-
-build-py39-vdk-ingest-http:
-  extends: .build-vdk-ingest-http
-  image: "python:3.9"
-
-build-py310-vdk-ingest-http:
-  extends: .build-vdk-ingest-http
-  image: "python:3.10"
-
 build-py311-vdk-ingest-http:
   extends: .build-vdk-ingest-http
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-ipython/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-ipython/.plugin-ci.yml
@@ -12,19 +12,6 @@ build-py37-vdk-ipython:
   extends: .build-vdk-ipython
   image: "python:3.7"
 
-
-build-py38-vdk-ipython:
-  extends: .build-vdk-ipython
-  image: "python:3.8"
-
-build-py39-vdk-ipython:
-  extends: .build-vdk-ipython
-  image: "python:3.9"
-
-build-py310-vdk-ipython:
-  extends: .build-vdk-ipython
-  image: "python:3.10"
-
 build-py311-vdk-ipython:
   extends: .build-vdk-ipython
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-jobs-troubleshooting/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jobs-troubleshooting/.plugin-ci.yml
@@ -12,20 +12,6 @@ build-py37-vdk-jobs-troubleshooting:
   extends: .build-vdk-jobs-troubleshooting
   image: "python:3.7"
 
-
-build-py38-vdk-jobs-troubleshooting:
-  extends: .build-vdk-jobs-troubleshooting
-  image: "python:3.8"
-
-
-build-py39-vdk-jobs-troubleshooting:
-  extends: .build-vdk-jobs-troubleshooting
-  image: "python:3.9"
-
-build-py310-vdk-jobs-troubleshooting:
-  extends: .build-vdk-jobs-troubleshooting
-  image: "python:3.10"
-
 build-py311-vdk-jobs-troubleshooting:
   extends: .build-vdk-jobs-troubleshooting
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-kerberos-auth/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-kerberos-auth/.plugin-ci.yml
@@ -18,18 +18,6 @@ build-py37-vdk-kerberos-auth:
   extends: .build-vdk-kerberos-auth
   image: "python:3.7"
 
-build-py38-vdk-kerberos-auth:
-  extends: .build-vdk-kerberos-auth
-  image: "python:3.8"
-
-build-py39-vdk-kerberos-auth:
-  extends: .build-vdk-kerberos-auth
-  image: "python:3.9"
-
-build-py310-vdk-kerberos-auth:
-  extends: .build-vdk-kerberos-auth
-  image: "python:3.10"
-
 build-py311-vdk-kerberos-auth:
   extends: .build-vdk-kerberos-auth
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-lineage-model/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-lineage-model/.plugin-ci.yml
@@ -12,20 +12,6 @@ build-py37-vdk-lineage-model:
   extends: .build-vdk-lineage-model
   image: "python:3.7"
 
-
-build-py38-vdk-lineage-model:
-  extends: .build-vdk-lineage-model
-  image: "python:3.8"
-
-
-build-py39-vdk-lineage-model:
-  extends: .build-vdk-lineage-model
-  image: "python:3.9"
-
-build-py310-vdk-lineage-model:
-  extends: .build-vdk-lineage-model
-  image: "python:3.10"
-
 build-py311-vdk-lineage-model:
   extends: .build-vdk-lineage-model
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-lineage/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-lineage/.plugin-ci.yml
@@ -12,20 +12,6 @@ build-py37-vdk-lineage:
   extends: .build-vdk-lineage
   image: "python:3.7"
 
-
-build-py38-vdk-lineage:
-  extends: .build-vdk-lineage
-  image: "python:3.8"
-
-
-build-py39-vdk-lineage:
-  extends: .build-vdk-lineage
-  image: "python:3.9"
-
-build-py310-vdk-lineage:
-  extends: .build-vdk-lineage
-  image: "python:3.10"
-
 build-py311-vdk-lineage:
   extends: .build-vdk-lineage
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-logging-format/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-logging-format/.plugin-ci.yml
@@ -12,20 +12,6 @@ build-py37-vdk-logging-format:
   extends: .build-vdk-logging-format
   image: "python:3.7"
 
-
-build-py38-vdk-logging-format:
-  extends: .build-vdk-logging-format
-  image: "python:3.8"
-
-
-build-py39-vdk-logging-format:
-  extends: .build-vdk-logging-format
-  image: "python:3.9"
-
-build-py310-vdk-logging-format:
-  extends: .build-vdk-logging-format
-  image: "python:3.10"
-
 build-py311-vdk-logging-format:
   extends: .build-vdk-logging-format
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-meta-jobs/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-meta-jobs/.plugin-ci.yml
@@ -12,19 +12,6 @@ build-py37-vdk-meta-jobs:
   extends: .build-vdk-meta-jobs
   image: "python:3.7"
 
-
-build-py38-vdk-meta-jobs:
-  extends: .build-vdk-meta-jobs
-  image: "python:3.8"
-
-build-py39-vdk-meta-jobs:
-  extends: .build-vdk-meta-jobs
-  image: "python:3.9"
-
-build-py310-vdk-meta-jobs:
-  extends: .build-vdk-meta-jobs
-  image: "python:3.10"
-
 build-py311-vdk-meta-jobs:
   extends: .build-vdk-meta-jobs
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-notebook/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-notebook/.plugin-ci.yml
@@ -12,19 +12,6 @@ build-py37-vdk-notebook:
   extends: .build-vdk-notebook
   image: "python:3.7"
 
-
-build-py38-vdk-notebook:
-  extends: .build-vdk-notebook
-  image: "python:3.8"
-
-build-py39-vdk-notebook:
-  extends: .build-vdk-notebook
-  image: "python:3.9"
-
-build-py310-vdk-notebook:
-  extends: .build-vdk-notebook
-  image: "python:3.10"
-
 build-py311-vdk-notebook:
   extends: .build-vdk-notebook
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-plugin-control-cli/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-plugin-control-cli/.plugin-ci.yml
@@ -12,20 +12,6 @@ build-py37-vdk-plugin-control-cli:
   extends: .build-vdk-plugin-control-cli
   image: "python:3.7"
 
-
-build-py38-vdk-plugin-control-cli:
-  extends: .build-vdk-plugin-control-cli
-  image: "python:3.8"
-
-
-build-py39-vdk-plugin-control-cli:
-  extends: .build-vdk-plugin-control-cli
-  image: "python:3.9"
-
-build-py310-vdk-plugin-control-cli:
-  extends: .build-vdk-plugin-control-cli
-  image: "python:3.10"
-
 build-py311-vdk-plugin-control-cli:
   extends: .build-vdk-plugin-control-cli
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-postgres/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-postgres/.plugin-ci.yml
@@ -12,20 +12,6 @@ build-py37-vdk-postgres:
   extends: .build-vdk-postgres
   image: "python:3.7"
 
-
-build-py38-vdk-postgres:
-  extends: .build-vdk-postgres
-  image: "python:3.8"
-
-
-build-py39-vdk-postgres:
-  extends: .build-vdk-postgres
-  image: "python:3.9"
-
-build-py310-vdk-postgres:
-  extends: .build-vdk-postgres
-  image: "python:3.10"
-
 build-py311-vdk-postgres:
   extends: .build-vdk-postgres
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-properties-fs/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-properties-fs/.plugin-ci.yml
@@ -12,18 +12,6 @@ build-py37-vdk-properties-fs:
   extends: .build-vdk-properties-fs
   image: "python:3.7"
 
-build-py38-vdk-properties-fs:
-  extends: .build-vdk-properties-fs
-  image: "python:3.8"
-
-build-py39-vdk-properties-fs:
-  extends: .build-vdk-properties-fs
-  image: "python:3.9"
-
-build-py310-vdk-properties-fs:
-  extends: .build-vdk-properties-fs
-  image: "python:3.10"
-
 build-py311-vdk-properties-fs:
   extends: .build-vdk-properties-fs
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-server/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-server/.plugin-ci.yml
@@ -12,20 +12,6 @@ build-py37-vdk-server:
   extends: .build-vdk-server
   image: "python:3.7"
 
-
-build-py38-vdk-server:
-  extends: .build-vdk-server
-  image: "python:3.8"
-
-
-build-py39-vdk-server:
-  extends: .build-vdk-server
-  image: "python:3.9"
-
-build-py310-vdk-server:
-  extends: .build-vdk-server
-  image: "python:3.10"
-
 build-py311-vdk-server:
   extends: .build-vdk-server
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-snowflake/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-snowflake/.plugin-ci.yml
@@ -11,18 +11,6 @@ build-py37-vdk-snowflake:
   extends: .build-vdk-snowflake
   image: "python:3.7"
 
-build-py38-vdk-snowflake:
-  extends: .build-vdk-snowflake
-  image: "python:3.8"
-
-build-py39-vdk-snowflake:
-  extends: .build-vdk-snowflake
-  image: "python:3.9"
-
-build-py310-vdk-snowflake:
-  extends: .build-vdk-snowflake
-  image: "python:3.10"
-
 build-py311-vdk-snowflake:
   extends: .build-vdk-snowflake
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-sqlite/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-sqlite/.plugin-ci.yml
@@ -13,20 +13,6 @@ build-py37-vdk-sqlite:
   extends: .build-vdk-sqlite
   image: "python:3.7"
 
-
-build-py38-vdk-sqlite:
-  extends: .build-vdk-sqlite
-  image: "python:3.8"
-
-
-build-py39-vdk-sqlite:
-  extends: .build-vdk-sqlite
-  image: "python:3.9"
-
-build-py310-vdk-sqlite:
-  extends: .build-vdk-sqlite
-  image: "python:3.10"
-
 build-py311-vdk-sqlite:
   extends: .build-vdk-sqlite
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-test-utils/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-test-utils/.plugin-ci.yml
@@ -12,20 +12,6 @@ build-py37-vdk-test-utils:
   extends: .build-vdk-test-utils
   image: "python:3.7"
 
-
-build-py38-vdk-test-utils:
-  extends: .build-vdk-test-utils
-  image: "python:3.8"
-
-
-build-py39-vdk-test-utils:
-  extends: .build-vdk-test-utils
-  image: "python:3.9"
-
-build-py310-vdk-test-utils:
-  extends: .build-vdk-test-utils
-  image: "python:3.10"
-
 build-py311-vdk-test-utils:
   extends: .build-vdk-test-utils
   image: "python:3.11"

--- a/projects/vdk-plugins/vdk-trino/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-trino/.plugin-ci.yml
@@ -12,20 +12,6 @@ build-py37-vdk-trino:
   extends: .build-vdk-trino
   image: "python:3.7"
 
-
-build-py38-vdk-trino:
-  extends: .build-vdk-trino
-  image: "python:3.8"
-
-
-build-py39-vdk-trino:
-  extends: .build-vdk-trino
-  image: "python:3.9"
-
-build-py310-vdk-trino:
-  extends: .build-vdk-trino
-  image: "python:3.10"
-
 build-py311-vdk-trino:
   extends: .build-vdk-trino
   image: "python:3.11"


### PR DESCRIPTION
As part of my effort to stabilize our Nightly builds and the CICD cluster I am removing testing middle versions.

We test with the oldest supported version to make sure we do not use a new feature added lately which would break compatability.

We test with newest version to make sure that it runs with newest version. Although the python itself is very likely to be backwords compatible (for minor release), there are sometimes small changes that are not and same cannot be told for 3th party dependecies we may use which may not support latest version fully.

Testing Done: this CI