### PR TITLE
vdk-cicd: set ephemeral storage request/limits

### DIFF
--- a/support/gitlab-runners/values.yaml
+++ b/support/gitlab-runners/values.yaml
@@ -99,9 +99,18 @@ runners:
   ## You can specify helm values inside the config.
   ## tpl: https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function
   ## runner configuration: https://docs.gitlab.com/runner/configuration/advanced-configuration.html
+  ## executor configuration: https://docs.gitlab.com/runner/executors/kubernetes.html
   config: |
     [[runners]]
       [runners.kubernetes]
+        helper_ephemeral_storage_request_overwrite_max_allowed = "1Gi"
+        helper_ephemeral_storage_limit_overwrite_max_allowed = "3Gi"
+        ephemeral_storage_limit = "3Gi"
+        ephemeral_storage_request = "1Gi"
+        ephemeral_storage_limit_overwrite_max_allowed = "5Gi"
+        ephemeral_storage_request_overwrite_max_allowed = "4Gi"
+        service_ephemeral_storage_request = "100Mi"
+        service_ephemeral_storage_limit = "1Gi"
         [[runners.kubernetes.host_aliases]]
           ip = "127.0.0.1"
           hostnames = ["localhost.vmware.com"]


### PR DESCRIPTION
Frontend tests are being killed/evicited by Kubernetes Noticeable are following errors from kubectl get events in cicd namespace:

```
41m         Warning   Evicted
pod/runner-xpbjijbb-project-28359933-concurrent-3qnpql
 The node was low on resource: ephemeral-storage.
Container build was using 32Ki, which exceeds its request of 0.
 Container helper was using 16Ki, which exceeds its request of 0.
49m         Warning   Evicted
 pod/test-prom-node-exporter-9cpmq
  The node had condition: [DiskPressure].

```

I am asetting some limits and requests in
to try to fix it.