### PR TITLE
vdk-lineage: support for latest version sqllineage library

### DIFF
--- a/projects/vdk-plugins/vdk-lineage/src/vdk/plugin/lineage/sql_lineage_parser.py
+++ b/projects/vdk-plugins/vdk-lineage/src/vdk/plugin/lineage/sql_lineage_parser.py
@@ -45,11 +45,11 @@ def get_table_lineage_from_query(
 
     runner = LineageRunner(query)
 
-    if len(runner.statements_parsed) == 0:
+    if len(runner.statements()) == 0:
         # log.debug("No statement passed")
         return None
 
-    if len(runner.statements_parsed) > 1:
+    if len(runner.statements()) > 1:
         raise RuntimeError(
             "Query with more than one statement is passed. "
             "Make sure that multiple query statements (separated) are not passed to this method."
@@ -74,7 +74,7 @@ def get_table_lineage_from_query(
 
     return LineageData(
         query=query,
-        query_type=runner.statements_parsed[0].get_type(),
+        query_type="not implemented",
         query_status="",
         input_tables=input_tables,
         output_table=output_table,


### PR DESCRIPTION
latest version of sqllineage is removing `statements_parsed` method We are adopting our vdk-lineage plugin to support the latest release. This means we won't detect query type but that property was never used anywhere by vdk-lineage.

Testing Done: existing unit tests