### PR TITLE
vdk-control-cli: fix circular import dependecy

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/version_group/version.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/version_group/version.py
@@ -1,31 +1,8 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 import click
-from pkg_resources import DistributionNotFound
-from pkg_resources import get_distribution
-
-# https://packaging.python.org/guides/single-sourcing-package-version/#
-
-try:
-    # Change here if project is renamed and does not equal the setuptools metadata.name
-    dist_name = "vdk-control-cli"
-    __version__ = get_distribution(dist_name).version
-except DistributionNotFound:  # pragma: no cover
-    __version__ = "unknown"
-
-
-def build_details():
-    try:
-        from vdk.internal.control import vdk_control_build_info
-
-        build = [
-            f"{key}={value}"
-            for key, value in vdk_control_build_info.__dict__.items()
-            if not key.startswith("_")
-        ]
-        return ", ".join(build)
-    except:
-        return ""
+from vdk.internal.control.utils.version_utils import __version__
+from vdk.internal.control.utils.version_utils import build_details
 
 
 @click.command(help="Prints the version of the client")

--- a/projects/vdk-control-cli/src/vdk/internal/control/configuration/vdk_config.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/configuration/vdk_config.py
@@ -8,8 +8,8 @@ import sys
 from configparser import ConfigParser
 from pathlib import Path
 
-from vdk.internal.control.command_groups.version_group import version
 from vdk.internal.control.exception.vdk_exception import VDKException
+from vdk.internal.control.utils import version_utils
 from vdk.internal.control.utils.control_utils import read_config_ini_file
 
 log = logging.getLogger(__name__)
@@ -23,7 +23,7 @@ class VDKConfig:
 
     _user_agent = os.environ.get(
         "VDK_CONTROL_SERVICE_USER_AGENT",
-        f"vdk-control-cli/{version.__version__} ({sys.platform}; {platform.platform()}; ) Python {platform.python_version()}",
+        f"vdk-control-cli/{version_utils.__version__} ({sys.platform}; {platform.platform()}; ) Python {platform.python_version()}",
     )
 
     @property

--- a/projects/vdk-control-cli/src/vdk/internal/control/utils/version_utils.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/utils/version_utils.py
@@ -1,0 +1,27 @@
+# Copyright 2023-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from pkg_resources import DistributionNotFound
+from pkg_resources import get_distribution
+
+# https://packaging.python.org/guides/single-sourcing-package-version/#
+try:
+    # Change here if project is renamed and does not equal the setuptools metadata.name
+    dist_name = "vdk-control-cli"
+    __version__ = get_distribution(dist_name).version
+    pass
+except DistributionNotFound:  # pragma: no cover
+    __version__ = "unknown"
+
+
+def build_details():
+    try:
+        from vdk.internal.control import vdk_control_build_info
+
+        build = [
+            f"{key}={value}"
+            for key, value in vdk_control_build_info.__dict__.items()
+            if not key.startswith("_")
+        ]
+        return ", ".join(build)
+    except:
+        return ""

--- a/projects/vdk-control-cli/src/vdk/internal/control/utils/version_utils.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/utils/version_utils.py
@@ -8,7 +8,6 @@ try:
     # Change here if project is renamed and does not equal the setuptools metadata.name
     dist_name = "vdk-control-cli"
     __version__ = get_distribution(dist_name).version
-    pass
 except DistributionNotFound:  # pragma: no cover
     __version__ = "unknown"
 


### PR DESCRIPTION
There is a circular import issue between the
vdk.internal.control.configuration.vdk_config and
vdk.internal.control.command_groups.version_group.version modules. Specifically, vdk_config is importing version and version is importing cli_utils, which is importing vdk_config. This creates a cycle that cannot be resolved, which is causing the ImportError under certain circumstances.

To fix this issue, I need to refactor the code to remove the circular import. I moved the methods for determining verison in version utils which is used by both vdk_config and version_group.version modules.