### PR TITLE
frontend: Omit optional dependencies when testing

### DIFF
--- a/projects/frontend/cicd/install_data_pipelines.sh
+++ b/projects/frontend/cicd/install_data_pipelines.sh
@@ -9,6 +9,19 @@
 # lints them to verify format, builds the UI application and runs the unit tests.
 ###
 
+link_shared () {
+  shared_dist_dir="../../shared-components/gui/dist/shared"
+  if [ -d "$shared_dist_dir" ]
+  then
+    echo "Linking the shared-components dist rebuild found..."
+    npm link $shared_dist_dir
+    npm link @versatiledatakit/shared
+  else
+    echo "No shared-components dist rebuild found."
+    exit 1
+  fi
+}
+
 if ! which npm >/dev/null 2>&1 ; then
   echo "ERROR:"
   echo "Please install npm 8.5.5+. Install cannot continue without it."
@@ -23,20 +36,15 @@ cd "../data-pipelines/gui"
 echo "Removing package lock if available..."
 rm -f "package-lock.json"
 
-shared_dist_dir="../../shared-components/gui/dist/shared"
-if [ -d "$shared_dist_dir" ]
-then
-  echo "Linking the shared-components dist rebuild found..."
-  npm link "$shared_dist_dir"
-else
-  echo "No shared-components dist rebuild found."
-fi
-
 echo "Install Dependencies..."
-npm install
+npm install --omit=optional
+
+link_shared
 
 echo "Running linking script..."
 sh "../../cicd/build_data_pipelines.sh"
+
+link_shared
 
 echo "Linting all projects & sub-projects..."
 npm run lint

--- a/projects/frontend/cicd/install_shared.sh
+++ b/projects/frontend/cicd/install_shared.sh
@@ -5,7 +5,7 @@
 echo "Logging npm engines version..."
 npm version
 echo "Installing dependencies..."
-npm install
+npm install --omit=optional
 echo "Building package..."
 npm run build
 echo "Linking package..."

--- a/projects/frontend/data-pipelines/gui/package.json
+++ b/projects/frontend/data-pipelines/gui/package.json
@@ -46,7 +46,6 @@
     "@ngrx/store": "13.2.0",
     "@swimlane/ngx-charts": "16.0.0",
     "@swimlane/ngx-graph": "8.0.0",
-    "@versatiledatakit/shared": ">=0.0.0",
     "@webcomponents/custom-elements": "1.5.0",
     "@yellowspot/ng-truncate": "2.0.1",
     "angular-ng-autocomplete": "2.0.8",
@@ -86,6 +85,7 @@
     "zone.js": "0.11.5"
   },
   "optionalDependencies": {
+    "@versatiledatakit/shared": "0.0.0",
     "@versatiledatakit/data-pipelines": "0.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Why?

The CICD scripts pull data-pipelines and shared packages from registry instead of using the linked packages. This happens because optional dependencies are not omitted on running npm install

What?

Add the omit flag to npm install for both scripts

How was this tested?

1. Ran tests locally
2. CI/CD

What type of change are you making?

Bugfix, non-breaking