### PR TITLE
control-service: Add support for Python 3.11

### DIFF
--- a/projects/control-service/projects/job-base-image/publish-job-base.sh
+++ b/projects/control-service/projects/job-base-image/publish-job-base.sh
@@ -39,3 +39,8 @@ build_and_push_image \
     "data-job-base-python-3.10" \
     Dockerfile-data-job-base \
     "--build-arg base_image=python:3.10-slim"
+
+build_and_push_image \
+    "data-job-base-python-3.11" \
+    Dockerfile-data-job-base \
+    "--build-arg base_image=python:3.11-slim"


### PR DESCRIPTION
Why:
As part of the initiative to add support for multiple Python versions, we need to provide the ability to specify Python 3.11.

What:
Added step for producing a base job image for Python 3.11.

Testing done:
Manually executed the script.

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com