### PR TITLE
frontend: Align code formatting in frontend projects

### DIFF
--- a/projects/frontend/data-pipelines/gui/.editorconfig
+++ b/projects/frontend/data-pipelines/gui/.editorconfig
@@ -9,7 +9,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 [*.{ts, html}]
-max_line_length = 80
+max_line_length = 140
 
 [*.{ts, js}]
 quote_type = single

--- a/projects/frontend/data-pipelines/gui/.eslintrc.json
+++ b/projects/frontend/data-pipelines/gui/.eslintrc.json
@@ -12,7 +12,16 @@
       ]
     },
     "import/resolver": {
-      "typescript": {}
+      "typescript": {
+        "project": [
+          "tsconfig.json"
+        ]
+      },
+      "node": {
+        "project": [
+          "tsconfig.json"
+        ]
+      }
     }
   },
   "overrides": [

--- a/projects/frontend/data-pipelines/gui/.prettierrc.json
+++ b/projects/frontend/data-pipelines/gui/.prettierrc.json
@@ -3,7 +3,7 @@
   "semi": true,
   "singleQuote": true,
   "quoteProps": "as-needed",
-  "trailingComma": "all",
+  "trailingComma": "none",
   "bracketSpacing": true,
   "jsxBracketSameLine": true,
   "arrowParens": "always",

--- a/projects/frontend/data-pipelines/gui/e2e/integration/app/getting-started/getting-started.spec.js
+++ b/projects/frontend/data-pipelines/gui/e2e/integration/app/getting-started/getting-started.spec.js
@@ -27,7 +27,7 @@ describe('Getting Started Page', { tags: ['@dataPipelines'] }, () => {
 
                 return cy.wrap({
                     context: 'getting-started.spec::before()',
-                    action: 'continue',
+                    action: 'continue'
                 });
             });
     });
@@ -47,8 +47,8 @@ describe('Getting Started Page', { tags: ['@dataPipelines'] }, () => {
             .getMainTitle()
             .should(($el) =>
                 expect($el.text().trim()).to.equal(
-                    'Get Started with Data Pipelines',
-                ),
+                    'Get Started with Data Pipelines'
+                )
             );
     });
 
@@ -113,7 +113,7 @@ describe('Getting Started Page', { tags: ['@dataPipelines'] }, () => {
 
             // navigate to most recent failing job executions
             dataJobsHealthPanel.navigateToMostRecentFailingJobExecutions(
-                testJob.job_name,
+                testJob.job_name
             );
 
             const dataJobManageExecutionsPage =

--- a/projects/frontend/data-pipelines/gui/e2e/integration/lib/explore/data-job-details.spec.js
+++ b/projects/frontend/data-pipelines/gui/e2e/integration/lib/explore/data-job-details.spec.js
@@ -18,7 +18,7 @@ describe(
         before(() => {
             return DataJobExploreDetailsPage.recordHarIfSupported()
                 .then(() =>
-                    cy.clearLocalStorageSnapshot('data-job-explore-details'),
+                    cy.clearLocalStorageSnapshot('data-job-explore-details')
                 )
                 .then(() => DataJobExploreDetailsPage.login())
                 .then(() => cy.saveLocalStorage('data-job-explore-details'))
@@ -30,7 +30,7 @@ describe(
 
                     return cy.wrap({
                         context: 'explore::data-job-details.spec::before()',
-                        action: 'continue',
+                        action: 'continue'
                     });
                 });
         });
@@ -54,7 +54,7 @@ describe(
 
             dataJobsExplorePage.openJobDetails(
                 testJobs[0].team,
-                testJobs[0].job_name,
+                testJobs[0].job_name
             );
 
             dataJobExploreDetailsPage = DataJobExploreDetailsPage.getPage();
@@ -86,7 +86,7 @@ describe(
                 .should('be.visible')
                 .should(
                     'contains.text',
-                    'At 12:00 AM, on day 01 of the month, and on Friday',
+                    'At 12:00 AM, on day 01 of the month, and on Friday'
                 );
 
             // DISABLED Because there is no Source at the moment.
@@ -101,7 +101,7 @@ describe(
                 .should('be.visible')
                 .should(
                     'contains.text',
-                    testJobs[0].config.contacts.notified_on_job_deploy,
+                    testJobs[0].config.contacts.notified_on_job_deploy
                 );
 
             dataJobExploreDetailsPage
@@ -110,7 +110,7 @@ describe(
                 .should(
                     'contains.text',
                     testJobs[0].config.contacts
-                        .notified_on_job_failure_platform_error,
+                        .notified_on_job_failure_platform_error
                 );
 
             dataJobExploreDetailsPage
@@ -119,7 +119,7 @@ describe(
                 .should(
                     'contains.text',
                     testJobs[0].config.contacts
-                        .notified_on_job_failure_user_error,
+                        .notified_on_job_failure_user_error
                 );
 
             dataJobExploreDetailsPage
@@ -127,7 +127,7 @@ describe(
                 .should('be.visible')
                 .should(
                     'contains.text',
-                    testJobs[0].config.contacts.notified_on_job_success,
+                    testJobs[0].config.contacts.notified_on_job_success
                 );
         });
 
@@ -138,7 +138,7 @@ describe(
 
             dataJobsExplorePage.openJobDetails(
                 testJobs[0].team,
-                testJobs[0].job_name,
+                testJobs[0].job_name
             );
 
             const dataJobExploreDetailsPage =
@@ -162,7 +162,7 @@ describe(
 
             dataJobsExplorePage.openJobDetails(
                 testJobs[0].team,
-                testJobs[0].job_name,
+                testJobs[0].job_name
             );
 
             const dataJobExploreDetailsPage =
@@ -179,5 +179,5 @@ describe(
                 .getActionDropdownBtn()
                 .should('not.exist');
         });
-    },
+    }
 );

--- a/projects/frontend/data-pipelines/gui/e2e/integration/lib/explore/data-job-executions.spec.js
+++ b/projects/frontend/data-pipelines/gui/e2e/integration/lib/explore/data-job-executions.spec.js
@@ -18,7 +18,7 @@ describe(
         before(() => {
             return DataJobBasePO.recordHarIfSupported()
                 .then(() =>
-                    cy.clearLocalStorageSnapshot('data-job-explore-executions'),
+                    cy.clearLocalStorageSnapshot('data-job-explore-executions')
                 )
                 .then(() => DataJobBasePO.login())
                 .then(() => cy.saveLocalStorage('data-job-explore-executions'))
@@ -30,7 +30,7 @@ describe(
 
                     return cy.wrap({
                         context: 'explore::data-job-executions.spec::before()',
-                        action: 'continue',
+                        action: 'continue'
                     });
                 });
         });
@@ -54,7 +54,7 @@ describe(
 
             dataJobsExplorePage.openJobDetails(
                 testJobs[0].team,
-                testJobs[0].job_name,
+                testJobs[0].job_name
             );
 
             const dataJobBasePage = DataJobBasePO.getPage();
@@ -71,7 +71,7 @@ describe(
 
         it('Data Job Explore Executions Page - should verify on URL navigate to Executions will redirect to Details', () => {
             const dataJobBasePage = DataJobBasePO.navigateToUrl(
-                `/explore/data-jobs/${testJobs[0].team}/${testJobs[0].job_name}/executions`,
+                `/explore/data-jobs/${testJobs[0].team}/${testJobs[0].job_name}/executions`
             );
 
             dataJobBasePage
@@ -84,11 +84,11 @@ describe(
                 .should(
                     'match',
                     new RegExp(
-                        `\\/explore\\/data-jobs\\/${testJobs[0].team}\\/${testJobs[0].job_name}\\/details$`,
-                    ),
+                        `\\/explore\\/data-jobs\\/${testJobs[0].team}\\/${testJobs[0].job_name}\\/details$`
+                    )
                 );
 
             dataJobBasePage.getDetailsTab().should('have.class', 'active');
         });
-    },
+    }
 );

--- a/projects/frontend/data-pipelines/gui/e2e/integration/lib/explore/data-jobs.spec.js
+++ b/projects/frontend/data-pipelines/gui/e2e/integration/lib/explore/data-jobs.spec.js
@@ -28,7 +28,7 @@ describe(
 
                     return cy.wrap({
                         context: 'explore::data-jobs.spec::before()',
-                        action: 'continue',
+                        action: 'continue'
                     });
                 });
         });
@@ -52,7 +52,7 @@ describe(
                 .getMainTitle()
                 .should('be.visible')
                 .should(($el) =>
-                    expect($el.text().trim()).to.equal('Explore Data Jobs'),
+                    expect($el.text().trim()).to.equal('Explore Data Jobs')
                 );
         });
 
@@ -114,13 +114,13 @@ describe(
                     dataJobsExplorePage.refreshDataGrid();
 
                     dataJobsExplorePage.filterByJobName(
-                        normalizedTestJob.job_name,
+                        normalizedTestJob.job_name
                     );
 
                     dataJobsExplorePage
                         .getDataGridCell(normalizedTestJob.job_name)
                         .should('have.text', normalizedTestJob.job_name);
-                },
+                }
             );
         });
 
@@ -251,7 +251,7 @@ describe(
                 .invoke('join', ',')
                 .should(
                     'eq',
-                    'Description,Deployment Status,Last Execution Duration,Success rate,Next run (UTC),Last Deployed (UTC),Last Deployed By,Source,Logs',
+                    'Description,Deployment Status,Last Execution Duration,Success rate,Next run (UTC),Last Deployed (UTC),Last Deployed By,Source,Logs'
                 );
 
             // verify column is not checked in toggling menu
@@ -267,7 +267,7 @@ describe(
 
             // toggle column to render
             dataJobsExplorePage.checkColumnShowHideOption(
-                'Last Execution Duration',
+                'Last Execution Duration'
             );
 
             // verify column is checked in toggling menu
@@ -283,7 +283,7 @@ describe(
 
             // toggle column to hide
             dataJobsExplorePage.uncheckColumnShowHideOption(
-                'Last Execution Duration',
+                'Last Execution Duration'
             );
 
             // verify column is not checked in toggling menu
@@ -308,7 +308,7 @@ describe(
 
             dataJobsExplorePage.openJobDetails(
                 testJobs[0].team,
-                testJobs[0].job_name,
+                testJobs[0].job_name
             );
 
             const dataJobExploreDetailsPage =
@@ -324,5 +324,5 @@ describe(
                 .should('be.visible')
                 .should('contain.text', testJobs[0].description);
         });
-    },
+    }
 );

--- a/projects/frontend/data-pipelines/gui/e2e/integration/lib/manage/data-job-details.int.spec.js
+++ b/projects/frontend/data-pipelines/gui/e2e/integration/lib/manage/data-job-details.int.spec.js
@@ -25,7 +25,7 @@ describe(
         before(() => {
             return DataJobManageDetailsPage.recordHarIfSupported()
                 .then(() =>
-                    cy.clearLocalStorageSnapshot('data-job-manage-details'),
+                    cy.clearLocalStorageSnapshot('data-job-manage-details')
                 )
                 .then(() => DataJobManageDetailsPage.login())
                 .then(() => cy.saveLocalStorage('data-job-manage-details'))
@@ -39,7 +39,7 @@ describe(
 
                     return cy.wrap({
                         context: 'manage::data-job-details.spec::1::before()',
-                        action: 'continue',
+                        action: 'continue'
                     });
                 })
                 .then(() => cy.fixture('lib/manage/e2e-cypress-dp-test.json'))
@@ -48,7 +48,7 @@ describe(
 
                     return cy.wrap({
                         context: 'manage::data-job-details.spec::2::before()',
-                        action: 'continue',
+                        action: 'continue'
                     });
                 });
         });
@@ -72,19 +72,19 @@ describe(
             () => {
                 dataJobManageDetailsPage = DataJobManageDetailsPage.navigateTo(
                     longLivedTestJob.team,
-                    longLivedTestJob.job_name,
+                    longLivedTestJob.job_name
                 );
 
                 dataJobManageDetailsPage.clickOnContentContainer();
 
                 //Toggle job status twice, enable to disable and vice versa.
                 dataJobManageDetailsPage.toggleJobStatus(
-                    longLivedTestJob.job_name,
+                    longLivedTestJob.job_name
                 );
                 dataJobManageDetailsPage.toggleJobStatus(
-                    longLivedTestJob.job_name,
+                    longLivedTestJob.job_name
                 );
-            },
+            }
         );
 
         it(
@@ -96,7 +96,7 @@ describe(
 
                 dataJobManageDetailsPage = DataJobManageDetailsPage.navigateTo(
                     testJobs[0].team,
-                    testJobs[0].job_name,
+                    testJobs[0].job_name
                 );
 
                 dataJobManageDetailsPage.clickOnContentContainer();
@@ -104,7 +104,7 @@ describe(
                 dataJobManageDetailsPage.openDescription();
 
                 dataJobManageDetailsPage.enterDescriptionDetails(
-                    newDescription,
+                    newDescription
                 );
 
                 dataJobManageDetailsPage.saveDescription();
@@ -117,15 +117,15 @@ describe(
                         newDescription
                             .split(' ')
                             .slice(0, descriptionWordsBeforeTruncate)
-                            .join(' '),
+                            .join(' ')
                     );
-            },
+            }
         );
 
         it('Data Job Manage Details Page - execute now', () => {
             dataJobManageDetailsPage = DataJobManageDetailsPage.navigateTo(
                 longLivedTestJob.team,
-                longLivedTestJob.job_name,
+                longLivedTestJob.job_name
             );
 
             dataJobManageDetailsPage.waitForTestJobExecutionCompletion();
@@ -140,14 +140,14 @@ describe(
                 .getToastTitle(10000)
                 .should('exist')
                 .contains(
-                    /Data job Queued for execution|Failed, Data job is already executing/,
+                    /Data job Queued for execution|Failed, Data job is already executing/
                 );
         });
 
         it('Data Job Manage Details Page - download job key', () => {
             dataJobManageDetailsPage = DataJobManageDetailsPage.navigateTo(
                 longLivedTestJob.team,
-                longLivedTestJob.job_name,
+                longLivedTestJob.job_name
             );
 
             dataJobManageDetailsPage.openActionDropdown();
@@ -157,7 +157,7 @@ describe(
             dataJobManageDetailsPage
                 .readFile(
                     'downloadsFolder',
-                    `${longLivedTestJob.job_name}.keytab`,
+                    `${longLivedTestJob.job_name}.keytab`
                 )
                 .should('exist');
         });
@@ -176,7 +176,7 @@ describe(
                         dataJobManageDetailsPage =
                             DataJobManageDetailsPage.navigateTo(
                                 normalizedTestJob.team,
-                                normalizedTestJob.job_name,
+                                normalizedTestJob.job_name
                             );
 
                         dataJobManageDetailsPage.clickOnContentContainer();
@@ -191,7 +191,7 @@ describe(
                             .getToastTitle(20000) // Wait up to 20 seconds for the job to be deleted.
                             .should(
                                 'contain.text',
-                                'Data job delete completed',
+                                'Data job delete completed'
                             );
 
                         dataJobManageDetailsPage.waitForBackendRequestCompletion();
@@ -201,9 +201,9 @@ describe(
                         dataJobsManagePage
                             .getDataGridCell(normalizedTestJob.job_name, 10000) // Wait up to 10 seconds for the jobs list to show.
                             .should('not.exist');
-                    },
+                    }
                 );
-            },
+            }
         );
 
         //TODO: Double-check and enable this test
@@ -213,12 +213,12 @@ describe(
 
             cy.intercept({
                 method: 'GET',
-                url: `/data-jobs/for-team/${team}/jobs/${jobName}/executions`,
+                url: `/data-jobs/for-team/${team}/jobs/${jobName}/executions`
             }).as('executionApiCall');
 
             dataJobManageDetailsPage = DataJobManageDetailsPage.navigateTo(
                 team,
-                jobName,
+                jobName
             );
 
             cy.wait('@executionApiCall').then((interception) => {
@@ -232,7 +232,7 @@ describe(
 
                 cy.get('.clr-timeline-step').should(
                     'have.length',
-                    lastExecutionsSize + 1,
+                    lastExecutionsSize + 1
                 ); // +1 next execution
 
                 cy.get(`[data-cy=${lastExecution.id}]`).as('lastExecution');
@@ -271,5 +271,5 @@ describe(
                 }
             });
         });
-    },
+    }
 );

--- a/projects/frontend/data-pipelines/gui/e2e/integration/lib/manage/data-job-executions.int.spec.js
+++ b/projects/frontend/data-pipelines/gui/e2e/integration/lib/manage/data-job-executions.int.spec.js
@@ -19,7 +19,7 @@ describe(
         before(() => {
             return DataJobManageExecutionsPage.recordHarIfSupported()
                 .then(() =>
-                    cy.clearLocalStorageSnapshot('data-job-manage-executions'),
+                    cy.clearLocalStorageSnapshot('data-job-manage-executions')
                 )
                 .then(() => DataJobManageExecutionsPage.login())
                 .then(() => cy.saveLocalStorage('data-job-manage-executions'))
@@ -31,7 +31,7 @@ describe(
 
                     return cy.wrap({
                         context: 'manage::data-job-executions.spec::before()',
-                        action: 'continue',
+                        action: 'continue'
                     });
                 });
         });
@@ -58,7 +58,7 @@ describe(
 
                 dataJobsManagePage.openJobDetails(
                     longLivedTestJob.team,
-                    longLivedTestJob.job_name,
+                    longLivedTestJob.job_name
                 );
 
                 const dataJobBasePage = DataJobBasePO.getPage();
@@ -95,7 +95,7 @@ describe(
                 const dataJobExecutionsPage =
                     DataJobManageExecutionsPage.navigateTo(
                         longLivedTestJob.team,
-                        longLivedTestJob.job_name,
+                        longLivedTestJob.job_name
                     );
 
                 dataJobExecutionsPage
@@ -103,8 +103,8 @@ describe(
                     .should(
                         'match',
                         new RegExp(
-                            `\\/manage\\/data-jobs\\/${longLivedTestJob.team}\\/${longLivedTestJob.job_name}\\/executions$`,
-                        ),
+                            `\\/manage\\/data-jobs\\/${longLivedTestJob.team}\\/${longLivedTestJob.job_name}\\/executions$`
+                        )
                     );
 
                 dataJobExecutionsPage
@@ -124,7 +124,7 @@ describe(
                 const dataJobExecutionsPage =
                     DataJobManageExecutionsPage.navigateTo(
                         longLivedTestJob.team,
-                        longLivedTestJob.job_name,
+                        longLivedTestJob.job_name
                     );
 
                 dataJobExecutionsPage
@@ -171,7 +171,7 @@ describe(
                 const dataJobExecutionsPage =
                     DataJobManageExecutionsPage.navigateTo(
                         longLivedTestJob.team,
-                        longLivedTestJob.job_name,
+                        longLivedTestJob.job_name
                     );
 
                 DataJobManageExecutionsPage.initPostExecutionInterceptor();
@@ -226,7 +226,7 @@ describe(
             const dataJobExecutionsPage =
                 DataJobManageExecutionsPage.navigateTo(
                     longLivedTestJob.team,
-                    longLivedTestJob.job_name,
+                    longLivedTestJob.job_name
                 );
 
             dataJobExecutionsPage
@@ -236,8 +236,8 @@ describe(
                 .should(
                     'match',
                     new RegExp(
-                        `^\\w+\\s\\d+,\\s\\d+,\\s\\d+:\\d+:\\d+\\s(AM|PM)\\sto\\s\\w+\\s\\d+,\\s\\d+,\\s\\d+:\\d+:\\d+\\s(AM|PM)$`,
-                    ),
+                        `^\\w+\\s\\d+,\\s\\d+,\\s\\d+:\\d+:\\d+\\s(AM|PM)\\sto\\s\\w+\\s\\d+,\\s\\d+,\\s\\d+:\\d+:\\d+\\s(AM|PM)$`
+                    )
                 );
         });
 
@@ -245,7 +245,7 @@ describe(
             const dataJobExecutionsPage =
                 DataJobManageExecutionsPage.navigateTo(
                     longLivedTestJob.team,
-                    longLivedTestJob.job_name,
+                    longLivedTestJob.job_name
                 );
 
             dataJobExecutionsPage.getDataGrid().should('exist');
@@ -280,7 +280,7 @@ describe(
                 const dataJobExecutionsPage =
                     DataJobManageExecutionsPage.navigateTo(
                         longLivedTestJob.team,
-                        longLivedTestJob.job_name,
+                        longLivedTestJob.job_name
                     );
 
                 dataJobExecutionsPage.openStatusFilter();
@@ -290,7 +290,7 @@ describe(
                 dataJobExecutionsPage
                     .getDataGridExecStatusFilters()
                     .then((elements) =>
-                        Array.from(elements).map((el) => el.innerText),
+                        Array.from(elements).map((el) => el.innerText)
                     )
                     .should('deep.equal', [
                         'Success',
@@ -299,7 +299,7 @@ describe(
                         'Running',
                         'Submitted',
                         'Skipped',
-                        'Canceled',
+                        'Canceled'
                     ]);
 
                 dataJobExecutionsPage.closeFilter();
@@ -313,7 +313,7 @@ describe(
                 const dataJobExecutionsPage =
                     DataJobManageExecutionsPage.navigateTo(
                         longLivedTestJob.team,
-                        longLivedTestJob.job_name,
+                        longLivedTestJob.job_name
                     );
 
                 dataJobExecutionsPage.openTypeFilter();
@@ -323,7 +323,7 @@ describe(
                 dataJobExecutionsPage
                     .getDataGridExecTypeFilters()
                     .then((elements) =>
-                        Array.from(elements).map((el) => el.innerText),
+                        Array.from(elements).map((el) => el.innerText)
                     )
                     .should('deep.equal', ['Manual', 'Scheduled']);
 
@@ -338,7 +338,7 @@ describe(
                 const dataJobExecutionsPage =
                     DataJobManageExecutionsPage.navigateTo(
                         longLivedTestJob.team,
-                        longLivedTestJob.job_name,
+                        longLivedTestJob.job_name
                     );
 
                 dataJobExecutionsPage
@@ -372,7 +372,7 @@ describe(
                 const dataJobExecutionsPage =
                     DataJobManageExecutionsPage.navigateTo(
                         longLivedTestJob.team,
-                        longLivedTestJob.job_name,
+                        longLivedTestJob.job_name
                     );
 
                 dataJobExecutionsPage
@@ -408,7 +408,7 @@ describe(
                 const dataJobExecutionsPage =
                     DataJobManageExecutionsPage.navigateTo(
                         longLivedTestJob.team,
-                        longLivedTestJob.job_name,
+                        longLivedTestJob.job_name
                     );
 
                 dataJobExecutionsPage
@@ -445,10 +445,10 @@ describe(
                             .then((elText2) => {
                                 return (
                                     dataJobExecutionsPage.convertStringContentToSeconds(
-                                        elText1,
+                                        elText1
                                     ) -
                                     dataJobExecutionsPage.convertStringContentToSeconds(
-                                        elText2,
+                                        elText2
                                     )
                                 );
                             });
@@ -479,10 +479,10 @@ describe(
                             .then((elText2) => {
                                 return (
                                     dataJobExecutionsPage.convertStringContentToSeconds(
-                                        elText1,
+                                        elText1
                                     ) -
                                     dataJobExecutionsPage.convertStringContentToSeconds(
-                                        elText2,
+                                        elText2
                                     )
                                 );
                             });
@@ -494,7 +494,7 @@ describe(
                 const dataJobExecutionsPage =
                     DataJobManageExecutionsPage.navigateTo(
                         longLivedTestJob.team,
-                        longLivedTestJob.job_name,
+                        longLivedTestJob.job_name
                     );
 
                 dataJobExecutionsPage
@@ -554,7 +554,7 @@ describe(
                 const dataJobExecutionsPage =
                     DataJobManageExecutionsPage.navigateTo(
                         longLivedTestJob.team,
-                        longLivedTestJob.job_name,
+                        longLivedTestJob.job_name
                     );
 
                 dataJobExecutionsPage
@@ -636,5 +636,5 @@ describe(
                     .should('be.gte', 0);
             });
         });
-    },
+    }
 );

--- a/projects/frontend/data-pipelines/gui/e2e/integration/lib/manage/data-jobs.int.spec.js
+++ b/projects/frontend/data-pipelines/gui/e2e/integration/lib/manage/data-jobs.int.spec.js
@@ -45,9 +45,9 @@ describe(
                             return cy.wrap({
                                 context:
                                     'manage::1::data-jobs.int.spec::before()',
-                                action: 'continue',
+                                action: 'continue'
                             });
-                        }),
+                        })
                 )
                 .then(() =>
                     cy
@@ -59,9 +59,9 @@ describe(
                             return cy.wrap({
                                 context:
                                     'manage::2::data-jobs.int.spec::before()',
-                                action: 'continue',
+                                action: 'continue'
                             });
-                        }),
+                        })
                 )
                 .then(() =>
                     cy
@@ -73,17 +73,17 @@ describe(
                             return cy.wrap({
                                 context:
                                     'manage::3::data-jobs.int.spec::before()',
-                                action: 'continue',
+                                action: 'continue'
                             });
-                        }),
+                        })
                 )
                 .then(() =>
                     // Enable data job after job end
                     DataJobsManagePage.changeJobStatus(
                         longLivedTestJob.team,
                         longLivedTestJob.job_name,
-                        true,
-                    ),
+                        true
+                    )
                 );
         });
 
@@ -103,7 +103,7 @@ describe(
             DataJobsManagePage.changeJobStatus(
                 longLivedTestJob.team,
                 longLivedTestJob.job_name,
-                true,
+                true
             );
 
             DataJobsManagePage.saveHarIfSupported();
@@ -145,7 +145,7 @@ describe(
                 dataJobsManagePage
                     .getDataGridCell(testJobs[1].job_name)
                     .should('not.exist');
-            },
+            }
         );
 
         it(
@@ -165,7 +165,7 @@ describe(
                 dataJobsManagePage
                     .getDataGridCell(testJobs[1].job_name)
                     .should('be.visible');
-            },
+            }
         );
 
         it('Data Jobs Manage Page - grid search parameter goes into URL', () => {
@@ -203,8 +203,8 @@ describe(
                 .should(
                     'match',
                     new RegExp(
-                        `\\/manage\\/data-jobs\\?search=${testJobs[0].job_name}$`,
-                    ),
+                        `\\/manage\\/data-jobs\\?search=${testJobs[0].job_name}$`
+                    )
                 );
 
             // clear search with clear() method
@@ -231,7 +231,7 @@ describe(
         it('Data Jobs Manage Page - grid search perform search when URL contains search parameter', () => {
             // navigate with search value in URL
             dataJobsManagePage = DataJobsManagePage.navigateToUrl(
-                `/manage/data-jobs?search=${testJobs[1].job_name}`,
+                `/manage/data-jobs?search=${testJobs[1].job_name}`
             );
 
             dataJobsManagePage.chooseQuickFilter(0);
@@ -244,8 +244,8 @@ describe(
                 .should(
                     'match',
                     new RegExp(
-                        `\\/manage\\/data-jobs\\?search=${testJobs[1].job_name}$`,
-                    ),
+                        `\\/manage\\/data-jobs\\?search=${testJobs[1].job_name}$`
+                    )
                 );
 
             // verify 1 test row visible
@@ -301,13 +301,13 @@ describe(
                     dataJobsManagePage.refreshDataGrid();
 
                     dataJobsManagePage.filterByJobName(
-                        normalizedTestJob.job_name,
+                        normalizedTestJob.job_name
                     );
 
                     dataJobsManagePage
                         .getDataGridCell(normalizedTestJob.job_name)
                         .should('have.text', normalizedTestJob.job_name);
-                },
+                }
             );
         });
 
@@ -323,7 +323,7 @@ describe(
 
                 dataJobsManagePage.openJobDetails(
                     testJobs[0].team,
-                    testJobs[0].job_name,
+                    testJobs[0].job_name
                 );
 
                 const dataJobManageDetailsPage =
@@ -342,7 +342,7 @@ describe(
                         testJobs[0].description
                             .split(' ')
                             .slice(0, descriptionWordsBeforeTruncate)
-                            .join(' '),
+                            .join(' ')
                     );
 
                 dataJobManageDetailsPage.getSchedule().should('be.visible');
@@ -351,7 +351,7 @@ describe(
                     .getDeploymentStatus('not-deployed')
                     .should('be.visible')
                     .should('have.text', 'Not Deployed');
-            },
+            }
         );
 
         it(
@@ -372,7 +372,7 @@ describe(
                 //Toggle job status twice, enable to disable and vice versa.
                 dataJobsManagePage.toggleJobStatus(longLivedTestJob.job_name);
                 dataJobsManagePage.toggleJobStatus(longLivedTestJob.job_name);
-            },
+            }
         );
 
         it(
@@ -383,14 +383,14 @@ describe(
                 DataJobsManagePage.changeJobStatus(
                     longLivedFailingTestJob.team,
                     longLivedFailingTestJob.job_name,
-                    true,
+                    true
                 )
                     .then(() =>
                         DataJobsManagePage.changeJobStatus(
                             longLivedTestJob.team,
                             longLivedTestJob.job_name,
-                            false,
-                        ),
+                            false
+                        )
                     )
                     .then(() => {
                         dataJobsManagePage.clickOnContentContainer();
@@ -408,8 +408,8 @@ describe(
                                         .should(
                                             'match',
                                             new RegExp(
-                                                'data-pipelines-job-(enabled|disabled|not-deployed)',
-                                            ),
+                                                'data-pipelines-job-(enabled|disabled|not-deployed)'
+                                            )
                                         );
                                 }
                             });
@@ -425,7 +425,7 @@ describe(
                                     cy.wrap(icon).should(
                                         'have.attr',
                                         'data-cy',
-                                        'data-pipelines-job-enabled',
+                                        'data-pipelines-job-enabled'
                                     );
                                 }
                             });
@@ -441,7 +441,7 @@ describe(
                                     cy.wrap(icon).should(
                                         'have.attr',
                                         'data-cy',
-                                        'data-pipelines-job-disabled',
+                                        'data-pipelines-job-disabled'
                                     );
                                 }
                             });
@@ -457,7 +457,7 @@ describe(
                                     cy.wrap(icon).should(
                                         'have.attr',
                                         'data-cy',
-                                        'data-pipelines-job-not-deployed',
+                                        'data-pipelines-job-not-deployed'
                                     );
                                 }
                             });
@@ -466,10 +466,10 @@ describe(
                         DataJobsManagePage.changeJobStatus(
                             longLivedTestJob.team,
                             longLivedTestJob.job_name,
-                            true,
+                            true
                         );
                     });
-            },
+            }
         );
 
         it('Data Jobs Manage Page - show/hide column when toggling from menu', () => {
@@ -483,7 +483,7 @@ describe(
                 .invoke('join', ',')
                 .should(
                     'eq',
-                    'Description,Deployment Status,Last Execution Duration,Success rate,Next run (UTC),Last Deployed (UTC),Last Deployed By,Notifications,Source,Logs',
+                    'Description,Deployment Status,Last Execution Duration,Success rate,Next run (UTC),Last Deployed (UTC),Last Deployed By,Notifications,Source,Logs'
                 );
 
             // verify column is not checked in toggling menu
@@ -548,9 +548,9 @@ describe(
                     .getToastTitle(10000) // Wait up to 10 seconds for Toast to show.
                     .should('exist')
                     .contains(
-                        /Data job Queued for execution|Failed, Data job is already executing/,
+                        /Data job Queued for execution|Failed, Data job is already executing/
                     );
-            },
+            }
         );
-    },
+    }
 );

--- a/projects/frontend/data-pipelines/gui/e2e/plugins/index.js
+++ b/projects/frontend/data-pipelines/gui/e2e/plugins/index.js
@@ -19,7 +19,7 @@
 
 const {
     install,
-    ensureBrowserFlags,
+    ensureBrowserFlags
 } = require('@neuralegion/cypress-har-generator');
 const path = require('path');
 
@@ -33,15 +33,15 @@ module.exports = (on, config) => {
         // generated output directory.
         specRoot: path.relative(
             config.fileServerFolder,
-            config.integrationFolder,
+            config.integrationFolder
         ),
         outputTarget: {
-            'cypress-logs|json': 'json',
+            'cypress-logs|json': 'json'
         },
         printLogsToConsole: 'always',
         printLogsToFile: 'always',
         includeSuccessfulHookLogs: true,
-        logToFilesOnAfterRun: true,
+        logToFilesOnAfterRun: true
     };
 
     require('cypress-terminal-report/src/installLogsPrinter')(on, options);

--- a/projects/frontend/data-pipelines/gui/e2e/support/application/data-job-details-base.po.js
+++ b/projects/frontend/data-pipelines/gui/e2e/support/application/data-job-details-base.po.js
@@ -12,7 +12,7 @@ export class DataJobDetailsBasePO extends DataJobBasePO {
 
     static navigateTo(context, teamName, jobName) {
         return this.navigateToUrl(
-            `/${context}/data-jobs/${teamName}/${jobName}`,
+            `/${context}/data-jobs/${teamName}/${jobName}`
         );
     }
 

--- a/projects/frontend/data-pipelines/gui/e2e/support/application/data-jobs-base.po.js
+++ b/projects/frontend/data-pipelines/gui/e2e/support/application/data-jobs-base.po.js
@@ -91,7 +91,7 @@ export class DataJobsBasePO extends DataPipelinesBasePO {
         return this.getDataGrid()
             .should('exist')
             .find(
-                '[data-cy=data-pipelines-manage-grid-status-cell] clr-icon[data-cy*=data-pipelines-job]',
+                '[data-cy=data-pipelines-manage-grid-status-cell] clr-icon[data-cy*=data-pipelines-job]'
             );
     }
 
@@ -122,7 +122,7 @@ export class DataJobsBasePO extends DataPipelinesBasePO {
         return this.getDataGridColumnShowHideOptions()
             .should('have.length.gt', 0)
             .then((elements) =>
-                Array.from(elements).find((el) => el.innerText === option),
+                Array.from(elements).find((el) => el.innerText === option)
             )
             .find('input');
     }

--- a/projects/frontend/data-pipelines/gui/e2e/support/application/data-pipelines-base.po.js
+++ b/projects/frontend/data-pipelines/gui/e2e/support/application/data-pipelines-base.po.js
@@ -146,7 +146,7 @@ export class DataPipelinesBasePO {
 
     getToast(timeout) {
         return cy.get('vdk-toast-container vdk-toast', {
-            timeout: this.resolveTimeout(timeout),
+            timeout: this.resolveTimeout(timeout)
         });
     }
 

--- a/projects/frontend/data-pipelines/gui/e2e/support/commands.js
+++ b/projects/frontend/data-pipelines/gui/e2e/support/commands.js
@@ -11,7 +11,7 @@ import {
     createTestJob,
     deleteTestJobIfExists,
     deployTestJobIfNotExists,
-    waitForJobExecutionCompletion,
+    waitForJobExecutionCompletion
 } from './helpers/commands.helpers';
 
 Cypress.Commands.add('login', () => {
@@ -23,10 +23,10 @@ Cypress.Commands.add('login', () => {
             form: true,
             body: {
                 // See project README.md how to set this token
-                api_token: Cypress.env('OAUTH2_API_TOKEN'),
+                api_token: Cypress.env('OAUTH2_API_TOKEN')
             },
             followRedirect: false,
-            failOnStatusCode: false,
+            failOnStatusCode: false
         })
         .its('body')
         .then((body) => {
@@ -46,7 +46,7 @@ Cypress.Commands.add('login', () => {
 
             return cy.wrap({
                 context: 'commands::login()',
-                action: 'continue',
+                action: 'continue'
             });
         });
 });
@@ -54,7 +54,7 @@ Cypress.Commands.add('login', () => {
 Cypress.Commands.add('initBackendRequestInterceptor', () => {
     cy.intercept({
         method: 'GET',
-        url: '**/data-jobs/for-team/**',
+        url: '**/data-jobs/for-team/**'
     }).as('getJobsRequest');
 });
 
@@ -76,7 +76,7 @@ Cypress.Commands.add('initGetExecutionsInterceptor', () => {
 Cypress.Commands.add('initGetExecutionInterceptor', () => {
     cy.intercept({
         method: 'GET',
-        url: '**/data-jobs/for-team/**/executions/**',
+        url: '**/data-jobs/for-team/**/executions/**'
     }).as('getExecutionRequest');
 });
 
@@ -96,7 +96,7 @@ Cypress.Commands.add('waitForInterceptor', (aliasName, retries, predicate) => {
 
 Cypress.Commands.add('initPatchDetailsReqInterceptor', () => {
     cy.intercept('PATCH', '**/data-jobs/for-team/**/jobs/**/deployments/**').as(
-        'patchJobDetails',
+        'patchJobDetails'
     );
 });
 
@@ -107,7 +107,7 @@ Cypress.Commands.add('waitForPatchDetailsReqInterceptor', () => {
 Cypress.Commands.add('initPostExecutionInterceptor', () => {
     cy.intercept({
         method: 'POST',
-        url: '**/data-jobs/for-team/**/executions',
+        url: '**/data-jobs/for-team/**/executions'
     }).as('postExecuteNow');
 });
 
@@ -118,7 +118,7 @@ Cypress.Commands.add('waitForPostExecutionCompletion', () => {
 Cypress.Commands.add('initDeleteExecutionInterceptor', () => {
     cy.intercept({
         method: 'DELETE',
-        url: '**/data-jobs/for-team/**/executions/**',
+        url: '**/data-jobs/for-team/**/executions/**'
     }).as('deleteExecution');
 });
 
@@ -133,14 +133,14 @@ Cypress.Commands.add('recordHarIfSupported', () => {
                 'vendor.js$',
                 'clr-ui.min.css$',
                 'scripts.js$',
-                'polyfills.js$',
-            ],
+                'polyfills.js$'
+            ]
         });
     }
 
     return cy.wrap({
         context: 'commands::recordHarIfSupported()',
-        action: 'continue',
+        action: 'continue'
     });
 });
 
@@ -151,7 +151,7 @@ Cypress.Commands.add('saveHarIfSupported', () => {
 
     return cy.wrap({
         context: 'commands::saveHarIfSupported()',
-        action: 'continue',
+        action: 'continue'
     });
 });
 
@@ -162,7 +162,7 @@ Cypress.Commands.add('prepareBaseTestJobs', () => {
                 const normalizedTestJob = applyGlobalEnvSettings(testJob);
 
                 return createTestJob(normalizedTestJob);
-            }),
+            })
         );
     });
 });
@@ -180,14 +180,14 @@ Cypress.Commands.add('prepareAdditionalTestJobs', () => {
 Cypress.Commands.add('prepareLongLivedTestJob', () => {
     return deployTestJobIfNotExists(
         'lib/manage/e2e-cypress-dp-test.json',
-        'lib/manage/e2e-cypress-dp-test.zip',
+        'lib/manage/e2e-cypress-dp-test.zip'
     );
 });
 
 Cypress.Commands.add('prepareLongLivedFailingTestJob', () => {
     return deployTestJobIfNotExists(
         'e2e-cy-dp-failing.job.json',
-        'e2e-cy-dp-failing.job.zip',
+        'e2e-cy-dp-failing.job.zip'
     );
 });
 
@@ -200,7 +200,7 @@ Cypress.Commands.add('cleanTestJobs', () => {
                     const normalizedTestJob = applyGlobalEnvSettings(testJob);
 
                     return deleteTestJobIfExists(normalizedTestJob);
-                }),
+                })
             );
         })
         .then(() => {
@@ -223,7 +223,7 @@ Cypress.Commands.add('waitForTestJobExecutionCompletion', () => {
         return waitForJobExecutionCompletion(
             normalizedTestJob.team,
             normalizedTestJob.job_name,
-            waitForJobExecutionTimeout,
+            waitForJobExecutionTimeout
         );
     });
 });
@@ -238,7 +238,7 @@ Cypress.Commands.add('createTwoExecutionsLongLivedTestJob', () => {
             normalizedTestJob.team,
             normalizedTestJob.job_name,
             waitForJobExecutionTimeout,
-            2,
+            2
         );
     });
 });
@@ -253,7 +253,7 @@ Cypress.Commands.add('createExecutionsLongLivedFailingTestJob', () => {
             normalizedTestJob.team,
             normalizedTestJob.job_name,
             waitForJobExecutionTimeout,
-            2,
+            2
         );
     });
 });
@@ -268,9 +268,9 @@ Cypress.Commands.add(
                     `/data-jobs/for-team/${teamName}/jobs/${jobName}/deployments`,
                 method: 'get',
                 auth: {
-                    bearer: window.localStorage.getItem('access_token'),
+                    bearer: window.localStorage.getItem('access_token')
                 },
-                failOnStatusCode: false,
+                failOnStatusCode: false
             })
             .then((outerResponse) => {
                 if (outerResponse.status === 200) {
@@ -287,10 +287,10 @@ Cypress.Commands.add(
                             body: { enabled: status },
                             auth: {
                                 bearer: window.localStorage.getItem(
-                                    'access_token',
-                                ),
+                                    'access_token'
+                                )
                             },
-                            failOnStatusCode: false,
+                            failOnStatusCode: false
                         })
                         .then((innerResponse) => {
                             if (
@@ -298,11 +298,11 @@ Cypress.Commands.add(
                                 innerResponse.status < 300
                             ) {
                                 cy.log(
-                                    `Change enable status to [${status}] for data job [${jobName}]`,
+                                    `Change enable status to [${status}] for data job [${jobName}]`
                                 );
                             } else {
                                 cy.log(
-                                    `Cannot change enabled status to [${status}] for data job [${jobName}]`,
+                                    `Cannot change enabled status to [${status}] for data job [${jobName}]`
                                 );
 
                                 console.log(`Http request:`, innerResponse);
@@ -311,21 +311,21 @@ Cypress.Commands.add(
                             return cy.wrap({
                                 context:
                                     'commands::1::changeDataJobEnabledStatus()',
-                                action: 'continue',
+                                action: 'continue'
                             });
                         });
                 } else {
                     cy.log(
-                        `Cannot change enabled status to [${status}] for data job [${jobName}]`,
+                        `Cannot change enabled status to [${status}] for data job [${jobName}]`
                     );
 
                     console.log(`Http request:`, outerResponse);
 
                     return cy.wrap({
                         context: 'commands::2::changeDataJobEnabledStatus()',
-                        action: 'continue',
+                        action: 'continue'
                     });
                 }
             });
-    },
+    }
 );

--- a/projects/frontend/data-pipelines/gui/e2e/support/helpers/commands.helpers.js
+++ b/projects/frontend/data-pipelines/gui/e2e/support/helpers/commands.helpers.js
@@ -35,32 +35,32 @@ const createExecutionsForJob = (
     teamName,
     jobName,
     waitForJobExecutionTimeout,
-    numberOfExecutions = 2,
+    numberOfExecutions = 2
 ) => {
     cy.log(
-        `Trying to provide at least ${numberOfExecutions} executions for Job "${jobName}"`,
+        `Trying to provide at least ${numberOfExecutions} executions for Job "${jobName}"`
     );
 
     return _getJobExecutions(teamName, jobName).then((executions) => {
         cy.log(
-            `Found ${executions.length} executions for Job "${jobName}" and target is ${numberOfExecutions} executions`,
+            `Found ${executions.length} executions for Job "${jobName}" and target is ${numberOfExecutions} executions`
         );
 
         if (executions.length >= numberOfExecutions) {
             cy.log(
-                `Skipping manual execution, expected number of executions found`,
+                `Skipping manual execution, expected number of executions found`
             );
 
             return cy.wrap({
                 context: 'commands.helpers::1::createExecutionsForJob()',
-                action: 'continue',
+                action: 'continue'
             });
         }
 
         return waitForJobExecutionCompletion(
             teamName,
             jobName,
-            waitForJobExecutionTimeout,
+            waitForJobExecutionTimeout
         ).then(() => {
             return _getJobLastDeployment(teamName, jobName).then(
                 (lastDeployment) => {
@@ -71,16 +71,16 @@ const createExecutionsForJob = (
                             waitForJobExecutionTimeout,
                             lastDeployment,
                             executions,
-                            numberOfExecutions,
+                            numberOfExecutions
                         );
                     }
 
                     return cy.wrap({
                         context:
                             'commands.helpers::2::createExecutionsForJob()',
-                        action: 'continue',
+                        action: 'continue'
                     });
-                },
+                }
             );
         });
     });
@@ -90,7 +90,7 @@ const waitForJobExecutionCompletion = (
     teamName,
     jobName,
     jobExecutionTimeout,
-    loopStep = 0,
+    loopStep = 0
 ) => {
     const pollInterval = 5000;
 
@@ -101,19 +101,19 @@ const waitForJobExecutionCompletion = (
                 `/data-jobs/for-team/${teamName}/jobs/${jobName}/executions`,
             method: 'get',
             auth: {
-                bearer: window.localStorage.getItem('access_token'),
-            },
+                bearer: window.localStorage.getItem('access_token')
+            }
         })
         .then((response) => {
             if (response.status !== 200) {
                 cy.log(
-                    `Job execution poll failed. Status: ${response.status}; Message: ${response.body}`,
+                    `Job execution poll failed. Status: ${response.status}; Message: ${response.body}`
                 );
 
                 return cy.wrap({
                     context:
                         'commands.helpers::1::waitForJobExecutionCompletion()',
-                    action: 'continue',
+                    action: 'continue'
                 });
             }
 
@@ -127,7 +127,7 @@ const waitForJobExecutionCompletion = (
                 return cy.wrap({
                     context:
                         'commands.helpers::2::waitForJobExecutionCompletion()',
-                    action: 'continue',
+                    action: 'continue'
                 });
             }
 
@@ -144,37 +144,37 @@ const waitForJobExecutionCompletion = (
                         : cy.wrap({
                               context:
                                   'commands.helpers::3::waitForJobExecutionCompletion()',
-                              action: 'continue',
+                              action: 'continue'
                           })
                 ).then(() => {
                     cy.log(
-                        `Job "${jobName}" executed successfully, polling completed!`,
+                        `Job "${jobName}" executed successfully, polling completed!`
                     );
 
                     return cy.wrap({
                         context:
                             'commands.helpers::4::waitForJobExecutionCompletion()',
-                        action: 'continue',
+                        action: 'continue'
                     });
                 });
             }
 
             if (jobExecutionTimeout <= 0) {
                 cy.log(
-                    'Time to wait exceeded! Will not wait for job execution to finish any longer.',
+                    'Time to wait exceeded! Will not wait for job execution to finish any longer.'
                 );
 
                 return cy.wrap({
                     context:
                         'commands.helpers::5::waitForJobExecutionCompletion()',
-                    action: 'continue',
+                    action: 'continue'
                 });
             }
 
             cy.log(
                 `Job ${jobName}, still executing... Retrying after: ${
                     pollInterval / 1000
-                } seconds`,
+                } seconds`
             );
 
             return cy
@@ -184,8 +184,8 @@ const waitForJobExecutionCompletion = (
                         teamName,
                         jobName,
                         jobExecutionTimeout - pollInterval,
-                        jobExecutionTimeout++,
-                    ),
+                        jobExecutionTimeout++
+                    )
                 );
         });
 };
@@ -202,15 +202,15 @@ const createTestJob = (testJob) => {
             method: 'post',
             body: testJob,
             auth: {
-                bearer: window.localStorage.getItem('access_token'),
+                bearer: window.localStorage.getItem('access_token')
             },
-            failOnStatusCode: false,
+            failOnStatusCode: false
         })
         .then((response) => {
             if (response.status >= 400) {
                 cy.log(
                     `Http request fail for url:`,
-                    `/data-jobs/for-team/${teamName}/jobs`,
+                    `/data-jobs/for-team/${teamName}/jobs`
                 );
 
                 console.log(`Http request error:`, response);
@@ -231,9 +231,9 @@ const deleteTestJobIfExists = (testJob) => {
                 `/data-jobs/for-team/${teamName}/jobs/${jobName}`,
             method: 'get',
             auth: {
-                bearer: window.localStorage.getItem('access_token'),
+                bearer: window.localStorage.getItem('access_token')
             },
-            failOnStatusCode: false,
+            failOnStatusCode: false
         })
         .then((outerResponse) => {
             if (outerResponse.status === 200) {
@@ -244,15 +244,15 @@ const deleteTestJobIfExists = (testJob) => {
                             `/data-jobs/for-team/${teamName}/jobs/${jobName}`,
                         method: 'delete',
                         auth: {
-                            bearer: window.localStorage.getItem('access_token'),
+                            bearer: window.localStorage.getItem('access_token')
                         },
-                        failOnStatusCode: false,
+                        failOnStatusCode: false
                     })
                     .then((innerResponse) => {
                         if (innerResponse.status >= 400) {
                             cy.log(
                                 `Http request fail for url:`,
-                                `/data-jobs/for-team/${teamName}/jobs/${jobName}`,
+                                `/data-jobs/for-team/${teamName}/jobs/${jobName}`
                             );
 
                             console.log(`Http request error:`, innerResponse);
@@ -261,13 +261,13 @@ const deleteTestJobIfExists = (testJob) => {
                         return cy.wrap({
                             context:
                                 'commands.helpers::1::deleteTestJobIfExists()',
-                            action: 'continue',
+                            action: 'continue'
                         });
                     });
             } else if (outerResponse.status >= 400) {
                 cy.log(
                     `Http request fail for url:`,
-                    `/data-jobs/for-team/${teamName}/jobs/${jobName}`,
+                    `/data-jobs/for-team/${teamName}/jobs/${jobName}`
                 );
 
                 console.log(`Http request error:`, outerResponse);
@@ -275,7 +275,7 @@ const deleteTestJobIfExists = (testJob) => {
 
             return cy.wrap({
                 context: 'commands.helpers::2::deleteTestJobIfExists()',
-                action: 'continue',
+                action: 'continue'
             });
         });
 };
@@ -294,9 +294,9 @@ const deployTestJobIfNotExists = (pathToJobData, pathToJobBinary) => {
                     `/data-jobs/for-team/${teamName}/jobs/${jobName}/deployments`,
                 method: 'get',
                 auth: {
-                    bearer: window.localStorage.getItem('access_token'),
+                    bearer: window.localStorage.getItem('access_token')
                 },
-                failOnStatusCode: false,
+                failOnStatusCode: false
             })
             .then((outerResponse) => {
                 if (
@@ -305,7 +305,7 @@ const deployTestJobIfNotExists = (pathToJobData, pathToJobBinary) => {
                 ) {
                     cy.log(
                         jobName +
-                            ' is already existing, therefore skipping creation and deployment.',
+                            ' is already existing, therefore skipping creation and deployment.'
                     );
                 } else if (
                     outerResponse.status === 200 &&
@@ -313,12 +313,12 @@ const deployTestJobIfNotExists = (pathToJobData, pathToJobBinary) => {
                 ) {
                     cy.log(
                         jobName +
-                            ' exists, but it is not deployed. Deploying...',
+                            ' exists, but it is not deployed. Deploying...'
                     );
 
                     return _deployTestDataJob(
                         normalizedTestJob,
-                        pathToJobBinary,
+                        pathToJobBinary
                     );
                 } else if (outerResponse.status === 404) {
                     return createTestJob(normalizedTestJob).then(
@@ -326,19 +326,19 @@ const deployTestJobIfNotExists = (pathToJobData, pathToJobBinary) => {
                             if (innerResponse.status === 201) {
                                 return _deployTestDataJob(
                                     normalizedTestJob,
-                                    pathToJobBinary,
+                                    pathToJobBinary
                                 );
                             } else {
                                 throw new Error(
-                                    'Failed to create job: ' + jobName,
+                                    'Failed to create job: ' + jobName
                                 );
                             }
-                        },
+                        }
                     );
                 } else if (outerResponse.status >= 400) {
                     cy.log(
                         `Http request fail for url:`,
-                        `/data-jobs/for-team/${teamName}/jobs/${jobName}/deployments`,
+                        `/data-jobs/for-team/${teamName}/jobs/${jobName}/deployments`
                     );
 
                     console.log(`Http request error:`, outerResponse);
@@ -346,7 +346,7 @@ const deployTestJobIfNotExists = (pathToJobData, pathToJobBinary) => {
 
                 return cy.wrap({
                     context: 'commands.helpers::deployTestJobIfNotExists()',
-                    action: 'continue',
+                    action: 'continue'
                 });
             });
     });
@@ -357,7 +357,7 @@ function _loadTestEnvironmentVar() {
 
     if (!testEnv) {
         console.log(
-            `DataPipelines test_environment is not set. Using default: ${DEFAULT_TEST_ENV_VAR}`,
+            `DataPipelines test_environment is not set. Using default: ${DEFAULT_TEST_ENV_VAR}`
         );
         testEnv = DEFAULT_TEST_ENV_VAR;
     }
@@ -372,7 +372,7 @@ function _executeCreateExecutionsForJob(
     lastDeployment,
     executions,
     numberOfExecutions,
-    counterOfExecutions = 0,
+    counterOfExecutions = 0
 ) {
     const neededExecutions = numberOfExecutions - executions.length;
 
@@ -382,14 +382,14 @@ function _executeCreateExecutionsForJob(
         cy.log(
             `${
                 neededExecutions - counterOfExecutions
-            } more executions left for executing`,
+            } more executions left for executing`
         );
     }
 
     if (neededExecutions === counterOfExecutions) {
         return cy.wrap({
             context: 'commands.helpers::1::_executeCreateExecutionsForJob()',
-            action: 'continue',
+            action: 'continue'
         });
     }
 
@@ -399,15 +399,15 @@ function _executeCreateExecutionsForJob(
                 cy.wrap({
                     context:
                         'commands.helpers::2::_executeCreateExecutionsForJob()',
-                    action: 'continue',
-                }),
+                    action: 'continue'
+                })
             );
         })
         .then(() => {
             return waitForJobExecutionCompletion(
                 teamName,
                 jobName,
-                waitForJobExecutionTimeout,
+                waitForJobExecutionTimeout
             );
         })
         .then(() => {
@@ -418,7 +418,7 @@ function _executeCreateExecutionsForJob(
                 lastDeployment,
                 executions,
                 numberOfExecutions,
-                counterOfExecutions + 1,
+                counterOfExecutions + 1
             );
         });
 }
@@ -431,20 +431,20 @@ function _getJobExecutions(teamName, jobName) {
             url: `/data-jobs/for-team/${teamName}/jobs/${jobName}/executions`,
             method: 'get',
             auth: {
-                bearer: window.localStorage.getItem('access_token'),
-            },
+                bearer: window.localStorage.getItem('access_token')
+            }
         })
         .then((response) => {
             if (response.status !== 200) {
                 cy.log(
-                    `Getting Job executions failed. Status: ${response.status}; Message: ${response.body}`,
+                    `Getting Job executions failed. Status: ${response.status}; Message: ${response.body}`
                 );
 
                 return cy.wrap([]);
             }
 
             return cy.wrap(
-                response.body && response.body.length ? response.body : [],
+                response.body && response.body.length ? response.body : []
             );
         });
 }
@@ -459,13 +459,13 @@ function _getJobLastDeployment(teamName, jobName) {
                 `/data-jobs/for-team/${teamName}/jobs/${jobName}/deployments`,
             method: 'get',
             auth: {
-                bearer: window.localStorage.getItem('access_token'),
-            },
+                bearer: window.localStorage.getItem('access_token')
+            }
         })
         .then((response) => {
             if (response.status !== 200) {
                 cy.log(
-                    `Getting Job deployments failed. Status: ${response.status}; Message: ${response.body}`,
+                    `Getting Job deployments failed. Status: ${response.status}; Message: ${response.body}`
                 );
 
                 return cy.wrap(null);
@@ -474,7 +474,7 @@ function _getJobLastDeployment(teamName, jobName) {
             return cy.wrap(
                 response.body && response.body.length
                     ? response.body[response.body.length - 1]
-                    : null,
+                    : null
             );
         });
 }
@@ -489,20 +489,20 @@ function _executeJob(teamName, jobName, deploymentId) {
                 `/data-jobs/for-team/${teamName}/jobs/${jobName}/deployments/${deploymentId}/executions`,
             method: 'post',
             auth: {
-                bearer: window.localStorage.getItem('access_token'),
+                bearer: window.localStorage.getItem('access_token')
             },
-            body: {},
+            body: {}
         })
         .then((response) => {
             if (response.status >= 400) {
                 cy.log(
-                    `Executing Job failed. Status: ${response.status}; Message: ${response.body}`,
+                    `Executing Job failed. Status: ${response.status}; Message: ${response.body}`
                 );
             }
 
             return cy.wrap({
                 context: 'commands.helpers::_executeJob()',
-                action: 'continue',
+                action: 'continue'
             });
         });
 }
@@ -536,13 +536,13 @@ function _deployTestDataJob(testJob, pathToJobBinary) {
                     '/sources',
                 method: 'post',
                 auth: {
-                    bearer: window.localStorage.getItem('access_token'),
+                    bearer: window.localStorage.getItem('access_token')
                 },
-                body: Cypress.Blob.binaryStringToBlob(zippedDataJob),
+                body: Cypress.Blob.binaryStringToBlob(zippedDataJob)
             })
             .then((response1) => {
                 let jsonResponse = JSON.parse(
-                    Cypress.Blob.arrayBufferToBinaryString(response1.body),
+                    Cypress.Blob.arrayBufferToBinaryString(response1.body)
                 );
 
                 // Deploy data job
@@ -557,29 +557,29 @@ function _deployTestDataJob(testJob, pathToJobBinary) {
                             '/deployments',
                         method: 'post',
                         auth: {
-                            bearer: window.localStorage.getItem('access_token'),
+                            bearer: window.localStorage.getItem('access_token')
                         },
                         body: {
                             job_version: jsonResponse.version_sha,
                             mode: 'release',
-                            enabled: true,
-                        },
+                            enabled: true
+                        }
                     })
                     .then((response2) => {
                         if (response2.status === 202) {
                             cy.log(
-                                `Job: ${jobName} deployment in progress. Waiting for deployment to complete`,
+                                `Job: ${jobName} deployment in progress. Waiting for deployment to complete`
                             );
 
                             return _waitForDeploymentToFinish(
                                 testJob,
-                                waitForJobDeploymentTimeout,
+                                waitForJobDeploymentTimeout
                             );
                         }
 
                         return cy.wrap({
                             context: 'commands.helpers::_deployTestDataJob()',
-                            action: 'continue',
+                            action: 'continue'
                         });
                     });
             });
@@ -602,8 +602,8 @@ function _waitForDeploymentToFinish(testJob, timeout) {
                 '/deployments',
             method: 'get',
             auth: {
-                bearer: window.localStorage.getItem('access_token'),
-            },
+                bearer: window.localStorage.getItem('access_token')
+            }
         })
         .then((resp) => {
             if (resp.status === 200 && resp.body.length > 0) {
@@ -612,32 +612,32 @@ function _waitForDeploymentToFinish(testJob, timeout) {
                 return cy.wrap({
                     context:
                         'commands.helpers::1::_waitForDeploymentToFinish()',
-                    action: 'continue',
+                    action: 'continue'
                 });
             }
 
             if (timeout <= 0) {
                 cy.log(
-                    'Time to wait exceeded! Will not wait for job deployment to finish any longer.',
+                    'Time to wait exceeded! Will not wait for job deployment to finish any longer.'
                 );
 
                 return cy.wrap({
                     context:
                         'commands.helpers::2::_waitForDeploymentToFinish()',
-                    action: 'continue',
+                    action: 'continue'
                 });
             }
 
             cy.log(
                 `Job ${jobName}, still not deployed.. retrying after: ${
                     waitInterval / 1000
-                } seconds`,
+                } seconds`
             );
 
             return cy
                 .wait(waitInterval)
                 .then(() =>
-                    _waitForDeploymentToFinish(testJob, timeout - waitInterval),
+                    _waitForDeploymentToFinish(testJob, timeout - waitInterval)
                 );
         });
 }
@@ -648,5 +648,5 @@ module.exports = {
     waitForJobExecutionCompletion,
     createTestJob,
     deleteTestJobIfExists,
-    deployTestJobIfNotExists,
+    deployTestJobIfNotExists
 };

--- a/projects/frontend/data-pipelines/gui/e2e/support/index.js
+++ b/projects/frontend/data-pipelines/gui/e2e/support/index.js
@@ -14,5 +14,5 @@ Cypress.Server.defaults({
     force404: false,
     ignore: (xhr) => {
         return true;
-    },
+    }
 });

--- a/projects/frontend/data-pipelines/gui/e2e/support/pages/app/getting-started/data-jobs-health-panel-component.po.js
+++ b/projects/frontend/data-pipelines/gui/e2e/support/pages/app/getting-started/data-jobs-health-panel-component.po.js
@@ -107,7 +107,7 @@ export class DataJobsHealthPanelComponentPO extends GettingStartedPage {
         return this.getMostRecentFailingJobsExecutionsWidget()
             .should('exist')
             .find(
-                '[data-cy=dp-failed-data-jobs-executions-widget-job-name-link]',
+                '[data-cy=dp-failed-data-jobs-executions-widget-job-name-link]'
             );
     }
 
@@ -121,7 +121,7 @@ export class DataJobsHealthPanelComponentPO extends GettingStartedPage {
         this._navigateToDataJob(
             this.getAllMostRecentFailingJobsExecutions(),
             jobName,
-            2,
+            2
         );
     }
 

--- a/projects/frontend/data-pipelines/gui/e2e/support/pages/app/lib/explore/data-jobs.po.js
+++ b/projects/frontend/data-pipelines/gui/e2e/support/pages/app/lib/explore/data-jobs.po.js
@@ -27,7 +27,7 @@ export class DataJobsExplorePage extends DataJobsBasePO {
     getDataGridCell(content) {
         return cy
             .get(
-                '[id^="clr-dg-row"] > .datagrid-row-scrollable > .datagrid-scrolling-cells > .ng-star-inserted',
+                '[id^="clr-dg-row"] > .datagrid-row-scrollable > .datagrid-scrolling-cells > .ng-star-inserted'
             )
             .contains(new RegExp(`^\\s*${content}\\s*$`));
     }
@@ -38,7 +38,7 @@ export class DataJobsExplorePage extends DataJobsBasePO {
                 team +
                 ';' +
                 job +
-                '"]',
+                '"]'
         );
     }
 

--- a/projects/frontend/data-pipelines/gui/e2e/support/pages/app/lib/manage/data-job-details.po.js
+++ b/projects/frontend/data-pipelines/gui/e2e/support/pages/app/lib/manage/data-job-details.po.js
@@ -19,7 +19,7 @@ export class DataJobManageDetailsPage extends DataJobDetailsBasePO {
     // Acceptable values are "not-deployed", "enabled", "disabled"
     getDeploymentStatus(status) {
         return cy.get(
-            '[data-cy=data-pipelines-job-details-status-' + status + ']',
+            '[data-cy=data-pipelines-job-details-status-' + status + ']'
         );
     }
 
@@ -27,25 +27,25 @@ export class DataJobManageDetailsPage extends DataJobDetailsBasePO {
 
     getDescription() {
         return cy.get(
-            '[data-cy=data-pipelines-data-job-details-description] .form-section-readonly',
+            '[data-cy=data-pipelines-data-job-details-description] .form-section-readonly'
         );
     }
 
     getDescriptionEditButton() {
         return cy.get(
-            '[data-cy=data-pipelines-data-job-details-description] .form-section-header > .btn',
+            '[data-cy=data-pipelines-data-job-details-description] .form-section-header > .btn'
         );
     }
 
     getDescriptionEditTextarea() {
         return cy.get(
-            '[data-cy=data-pipelines-data-job-details-description] textarea',
+            '[data-cy=data-pipelines-data-job-details-description] textarea'
         );
     }
 
     getDescriptionSaveButton() {
         return cy.get(
-            '[data-cy=data-pipelines-data-job-details-description] button:contains(Save)',
+            '[data-cy=data-pipelines-data-job-details-description] button:contains(Save)'
         );
     }
 
@@ -67,7 +67,7 @@ export class DataJobManageDetailsPage extends DataJobDetailsBasePO {
 
     getSchedule() {
         return cy.get(
-            '[data-cy=data-pipelines-data-job-details-schedule] .form-section-readonly',
+            '[data-cy=data-pipelines-data-job-details-schedule] .form-section-readonly'
         );
     }
 
@@ -75,13 +75,13 @@ export class DataJobManageDetailsPage extends DataJobDetailsBasePO {
 
     getStatusEditButton() {
         return cy.get(
-            '[data-cy=data-pipelines-data-job-details-status] .form-section-header > .btn',
+            '[data-cy=data-pipelines-data-job-details-status] .form-section-header > .btn'
         );
     }
 
     getStatusSaveButton() {
         return cy.get(
-            '[data-cy=data-pipelines-data-job-details-status] button:contains(Save)',
+            '[data-cy=data-pipelines-data-job-details-status] button:contains(Save)'
         );
     }
 
@@ -93,7 +93,7 @@ export class DataJobManageDetailsPage extends DataJobDetailsBasePO {
 
         return cy
             .get(
-                `[data-cy=data-pipelines-data-job-details-status-${newStatus}]`,
+                `[data-cy=data-pipelines-data-job-details-status-${newStatus}]`
             )
             .should('exist')
             .check({ force: true });

--- a/projects/frontend/data-pipelines/gui/e2e/support/pages/app/lib/manage/data-job-executions.po.js
+++ b/projects/frontend/data-pipelines/gui/e2e/support/pages/app/lib/manage/data-job-executions.po.js
@@ -12,7 +12,7 @@ export class DataJobManageExecutionsPage extends DataJobBasePO {
 
     static navigateTo(teamName, jobName) {
         return super.navigateToUrl(
-            `/manage/data-jobs/${teamName}/${jobName}/executions`,
+            `/manage/data-jobs/${teamName}/${jobName}/executions`
         );
     }
 
@@ -47,7 +47,7 @@ export class DataJobManageExecutionsPage extends DataJobBasePO {
 
     getExecLoadingSpinner() {
         return cy.get(
-            '[data-cy=data-pipelines-job-executions-loading-spinner]',
+            '[data-cy=data-pipelines-job-executions-loading-spinner]'
         );
     }
 
@@ -217,7 +217,7 @@ export class DataJobManageExecutionsPage extends DataJobBasePO {
             .then(($rows) => {
                 const _rows = $rows.reduce((accumulator, row) => {
                     const _cells = Array.from(
-                        row.querySelectorAll('clr-dg-cell.datagrid-cell'),
+                        row.querySelectorAll('clr-dg-cell.datagrid-cell')
                     );
 
                     if (_cells[cellIndex - 1]) {
@@ -238,7 +238,7 @@ export class DataJobManageExecutionsPage extends DataJobBasePO {
     getDataGridExecTypeCell(rowIndex) {
         return this.getDataGridCellByIdentifier(
             rowIndex,
-            '[data-cy=data-pipelines-job-executions-type-cell]',
+            '[data-cy=data-pipelines-job-executions-type-cell]'
         );
     }
 
@@ -251,21 +251,21 @@ export class DataJobManageExecutionsPage extends DataJobBasePO {
     getDataGridExecDurationCell(rowIndex) {
         return this.getDataGridCellByIdentifier(
             rowIndex,
-            '[data-cy=data-pipelines-job-executions-duration-cell]',
+            '[data-cy=data-pipelines-job-executions-duration-cell]'
         );
     }
 
     getDataGridExecStartCell(rowIndex) {
         return this.getDataGridCellByIdentifier(
             rowIndex,
-            '[data-cy=data-pipelines-job-executions-start-cell]',
+            '[data-cy=data-pipelines-job-executions-start-cell]'
         );
     }
 
     getDataGridExecEndCell(rowIndex) {
         return this.getDataGridCellByIdentifier(
             rowIndex,
-            '[data-cy=data-pipelines-job-executions-end-cell]',
+            '[data-cy=data-pipelines-job-executions-end-cell]'
         );
     }
 
@@ -275,7 +275,7 @@ export class DataJobManageExecutionsPage extends DataJobBasePO {
         return this.getDataGrid()
             .should('exist')
             .find(
-                '[data-cy=data-pipelines-job-executions-datagrid-pagination]',
+                '[data-cy=data-pipelines-job-executions-datagrid-pagination]'
             );
     }
 

--- a/projects/frontend/data-pipelines/gui/e2e/support/pages/app/lib/manage/data-jobs.po.js
+++ b/projects/frontend/data-pipelines/gui/e2e/support/pages/app/lib/manage/data-jobs.po.js
@@ -12,7 +12,7 @@ export class DataJobsManagePage extends DataJobsBasePO {
 
     static navigateTo() {
         const page = super.navigateTo(
-            '[data-cy=navigation-link-manage-datajobs]',
+            '[data-cy=navigation-link-manage-datajobs]'
         );
 
         // this is temporary fix for test to pass
@@ -33,10 +33,10 @@ export class DataJobsManagePage extends DataJobsBasePO {
     getDataGridCell(content, timeout) {
         return cy
             .get(
-                '[id^="clr-dg-row"] > .datagrid-row-scrollable > .datagrid-scrolling-cells > .ng-star-inserted',
+                '[id^="clr-dg-row"] > .datagrid-row-scrollable > .datagrid-scrolling-cells > .ng-star-inserted'
             )
             .contains(new RegExp(`^\\s*${content}\\s*$`), {
-                timeout: this.resolveTimeout(timeout),
+                timeout: this.resolveTimeout(timeout)
             });
     }
 
@@ -52,7 +52,7 @@ export class DataJobsManagePage extends DataJobsBasePO {
                 team +
                 ';' +
                 job +
-                '"]',
+                '"]'
         );
     }
 
@@ -92,7 +92,7 @@ export class DataJobsManagePage extends DataJobsBasePO {
 
     refreshDataGrid() {
         cy.get('[data-cy=data-pipelines-manage-refresh-btn]').click({
-            force: true,
+            force: true
         });
 
         this.waitForBackendRequestCompletion();
@@ -155,7 +155,7 @@ export class DataJobsManagePage extends DataJobsBasePO {
             const newStatus = currentStatus === 'enable' ? 'disable' : 'enable';
 
             cy.log(
-                `Current status: ${currentStatus}, new status: ${newStatus}`,
+                `Current status: ${currentStatus}, new status: ${newStatus}`
             );
 
             this.changeStatus(newStatus);
@@ -182,7 +182,7 @@ export class DataJobsManagePage extends DataJobsBasePO {
 
     filterByJobName(jobName) {
         cy.get(
-            '[data-cy=data-pipelines-jobs-name-column] > .datagrid-column-flex > clr-dg-string-filter.ng-star-inserted > clr-dg-filter > .datagrid-filter-toggle > cds-icon',
+            '[data-cy=data-pipelines-jobs-name-column] > .datagrid-column-flex > clr-dg-string-filter.ng-star-inserted > clr-dg-filter > .datagrid-filter-toggle > cds-icon'
         ).click({ force: true });
 
         cy.get('div.datagrid-filter > input')

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/.eslintrc.json
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/.eslintrc.json
@@ -40,7 +40,6 @@
             ],
             "leadingUnderscore": "allow",
             "filter": {
-              // you can expand this regex to add more allowed names
               "regex": "^((\\$\\..+))$",
               "match": false
             }
@@ -80,7 +79,6 @@
             ],
             "leadingUnderscore": "allow",
             "filter": {
-              // you can expand this regex to add more allowed names
               "regex": "^((\\$\\..+)|(test_)|(data-)|(aria-))",
               "match": false
             }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/karma.conf.js
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function (config) {
             require('karma-jasmine-html-reporter'),
             require('karma-junit-reporter'),
             require('karma-coverage'),
-            require('@angular-devkit/build-angular/plugins/karma'),
+            require('@angular-devkit/build-angular/plugins/karma')
         ],
         client: {
             jasmine: {
@@ -25,37 +25,37 @@ module.exports = function (config) {
                 // for example, you can disable the random execution with `random: false`
                 // or set a specific seed with `seed: 4321`
             },
-            clearContext: false, // leave Jasmine Spec Runner output visible in browser
+            clearContext: false // leave Jasmine Spec Runner output visible in browser
         },
         jasmineHtmlReporter: {
-            suppressAll: true, // removes the duplicated traces
+            suppressAll: true // removes the duplicated traces
         },
         coverageReporter: {
             dir: require('path').join(
                 __dirname,
-                '../../reports/coverage/data-pipelines-lib',
+                '../../reports/coverage/data-pipelines-lib'
             ),
             subdir: '.',
             reporters: [
                 //Code coverage - output in HTML file and Console(to be parsed in the CI/CD badge)
                 { type: 'html' },
                 { type: 'text-summary' },
-                { type: 'lcovonly' },
+                { type: 'lcovonly' }
             ],
             check: {
                 global: {
-                    lines: 80,
-                },
-            },
+                    lines: 80
+                }
+            }
         },
         reporters: ['progress', 'junit', 'coverage'],
         junitReporter: {
             outputDir: require('path').join(
                 __dirname,
-                '../../reports/test-results/data-pipelines-lib',
+                '../../reports/test-results/data-pipelines-lib'
             ),
             outputFile: 'unit-tests.xml',
-            useBrowserName: false,
+            useBrowserName: false
         },
         port: 9876,
         colors: true,
@@ -65,10 +65,10 @@ module.exports = function (config) {
         customLaunchers: {
             ChromeHeadless_No_Sandbox: {
                 base: 'ChromeHeadless',
-                flags: ['--no-sandbox'],
-            },
+                flags: ['--no-sandbox']
+            }
         },
         singleRun: false,
-        restartOnFileChange: true,
+        restartOnFileChange: true
     });
 };

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/base-grid/data-jobs-base-grid.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/base-grid/data-jobs-base-grid.component.ts
@@ -33,7 +33,7 @@ import {
     RouterState,
     RouteState,
     TaurusBaseComponent,
-    URLStateManager,
+    URLStateManager
 } from '@versatiledatakit/shared';
 
 import { ErrorUtil } from '../../shared/utils';
@@ -47,7 +47,7 @@ import {
     DataPipelinesConfig,
     DataPipelinesRestoreUI,
     DisplayMode,
-    JOBS_DATA_KEY,
+    JOBS_DATA_KEY
 } from '../../model';
 
 import { TASK_LOAD_JOBS_STATE } from '../../state/tasks';
@@ -75,13 +75,7 @@ export type DataJobsLocalStorageUserConfig = {
 @Directive()
 export abstract class DataJobsBaseGridComponent
     extends TaurusBaseComponent
-    implements
-        OnInit,
-        OnTaurusModelInit,
-        OnTaurusModelInitialLoad,
-        OnTaurusModelLoad,
-        OnTaurusModelChange,
-        OnTaurusModelError
+    implements OnInit, OnTaurusModelInit, OnTaurusModelInitialLoad, OnTaurusModelLoad, OnTaurusModelChange, OnTaurusModelError
 {
     /**
      * @inheritDoc
@@ -91,8 +85,7 @@ export abstract class DataJobsBaseGridComponent
     /**
      * @inheritDoc
      */
-    static override readonly PUBLIC_NAME: string =
-        'DataJobs-BaseGrid-Component';
+    static override readonly PUBLIC_NAME: string = 'DataJobs-BaseGrid-Component';
 
     static readonly UI_KEY_PAGE_OFFSET = 'pageOffset';
     static readonly UI_KEY_GRID_OFFSET = 'gridOffset';
@@ -101,8 +94,7 @@ export abstract class DataJobsBaseGridComponent
     static readonly CONTENT_AREA_SELECTOR = '.content-area';
     static readonly DATA_GRID_SELECTOR = '.datagrid';
 
-    @Input() urlUpdateStrategy: 'updateLocation' | 'updateRouter' =
-        'updateRouter';
+    @Input() urlUpdateStrategy: 'updateLocation' | 'updateRouter' = 'updateRouter';
     @Input() searchParam: string = QUERY_PARAM_SEARCH;
 
     @Input() set urlStateManager(value: URLStateManager) {
@@ -130,17 +122,13 @@ export abstract class DataJobsBaseGridComponent
     totalJobs = 0;
     loadDataDebouncer = new Subject<'normal' | 'forced'>();
 
-    deploymentStatuses = [
-        DataJobStatus.ENABLED,
-        DataJobStatus.DISABLED,
-        DataJobStatus.NOT_DEPLOYED,
-    ];
+    deploymentStatuses = [DataJobStatus.ENABLED, DataJobStatus.DISABLED, DataJobStatus.NOT_DEPLOYED];
     executionStatuses = [
         DataJobExecutionStatus.SUCCEEDED,
         DataJobExecutionStatus.PLATFORM_ERROR,
         DataJobExecutionStatus.USER_ERROR,
         DataJobExecutionStatus.SKIPPED,
-        DataJobExecutionStatus.CANCELLED,
+        DataJobExecutionStatus.CANCELLED
     ];
 
     clrGridCurrentPage = 1;
@@ -156,9 +144,7 @@ export abstract class DataJobsBaseGridComponent
     /**
      * ** Array of error code patterns that component should listen for in errors store.
      */
-    listenForErrorPatterns: string[] = [
-        LOAD_JOBS_ERROR_CODES[TASK_LOAD_JOBS_STATE].All,
-    ];
+    listenForErrorPatterns: string[] = [LOAD_JOBS_ERROR_CODES[TASK_LOAD_JOBS_STATE].All];
 
     /**
      * ** Flag that indicates actionable elements should be disabled.
@@ -186,19 +172,11 @@ export abstract class DataJobsBaseGridComponent
         protected dataPipelinesModuleConfig: DataPipelinesConfig,
         protected readonly localStorageConfigKey: string,
         public localStorageUserConfig: DataJobsLocalStorageUserConfig,
-        className: string = null,
+        className: string = null
     ) {
-        super(
-            componentService,
-            navigationService,
-            activatedRoute,
-            className ?? DataJobsBaseGridComponent.CLASS_NAME,
-        );
+        super(componentService, navigationService, activatedRoute, className ?? DataJobsBaseGridComponent.CLASS_NAME);
 
-        this._urlStateManager = new URLStateManager(
-            router.url.split('?')[0],
-            location,
-        );
+        this._urlStateManager = new URLStateManager(router.url.split('?')[0], location);
     }
 
     /**
@@ -209,10 +187,7 @@ export abstract class DataJobsBaseGridComponent
     }
 
     resolveLogsUrl(job: DataJob): string {
-        if (
-            CollectionsUtil.isNil(job) ||
-            CollectionsUtil.isArrayEmpty(job.deployments)
-        ) {
+        if (CollectionsUtil.isNil(job) || CollectionsUtil.isArrayEmpty(job.deployments)) {
             return null;
         }
 
@@ -225,10 +200,7 @@ export abstract class DataJobsBaseGridComponent
 
     showOrHideColumnChange(columnName: string, hidden: boolean): void {
         this.localStorageUserConfig.hiddenColumns[columnName] = hidden;
-        localStorage.setItem(
-            this.localStorageConfigKey,
-            JSON.stringify(this.localStorageUserConfig),
-        );
+        localStorage.setItem(this.localStorageConfigKey, JSON.stringify(this.localStorageUserConfig));
     }
 
     getJobStatus(job: DataJob): DataJobExecutionStatus {
@@ -242,8 +214,7 @@ export abstract class DataJobsBaseGridComponent
     getJobSuccessRateTitle(job: DataJob): string {
         if (job.deployments) {
             return `${job.deployments[0]?.successfulExecutions} successful / ${
-                job.deployments[0]?.failedExecutions +
-                job.deployments[0]?.successfulExecutions
+                job.deployments[0]?.failedExecutions + job.deployments[0]?.successfulExecutions
             } total`;
         }
 
@@ -279,9 +250,7 @@ export abstract class DataJobsBaseGridComponent
 
         if (this.filterByTeamName && !this.teamNameFilter) {
             //While the teamNameFilter is empty, no refresh requests will be executed.
-            console.log(
-                'Refresh operation will be skipped. teamNameFilter is empty.',
-            );
+            console.log('Refresh operation will be skipped. teamNameFilter is empty.');
 
             return;
         }
@@ -311,7 +280,7 @@ export abstract class DataJobsBaseGridComponent
 
             this.navigateTo({
                 '$.team': job.config?.team,
-                '$.job': job.jobName,
+                '$.job': job.jobName
             }).finally(() => {
                 this.navigationInProgress = false;
             });
@@ -330,11 +299,9 @@ export abstract class DataJobsBaseGridComponent
                 .pipe(
                     distinctUntilChanged(
                         (a, b) =>
-                            a.state.absoluteConfigPath !==
-                                b.state.absoluteConfigPath ||
-                            a.state.absoluteRoutePath ===
-                                b.state.absoluteRoutePath,
-                    ),
+                            a.state.absoluteConfigPath !== b.state.absoluteConfigPath ||
+                            a.state.absoluteRoutePath === b.state.absoluteRoutePath
+                    )
                 )
                 .subscribe((routerState) => {
                     if (initializationFinished) {
@@ -352,10 +319,7 @@ export abstract class DataJobsBaseGridComponent
                         if (this._shouldRestoreUIState(routerState)) {
                             this.restoreUIStateInProgress = true;
 
-                            const clrGridUIState =
-                                this.model.getUiState<ClrGridUIState>(
-                                    DataJobsBaseGridComponent.UI_KEY_GRID_UI_STATE,
-                                );
+                            const clrGridUIState = this.model.getUiState<ClrGridUIState>(DataJobsBaseGridComponent.UI_KEY_GRID_UI_STATE);
                             if (clrGridUIState) {
                                 this.clrGridUIState = clrGridUIState;
                             }
@@ -371,7 +335,7 @@ export abstract class DataJobsBaseGridComponent
                     if (this.gridState) {
                         this.refresh();
                     }
-                }),
+                })
         );
     }
 
@@ -408,11 +372,7 @@ export abstract class DataJobsBaseGridComponent
     /**
      * @inheritDoc
      */
-    onModelError(
-        model: ComponentModel,
-        _task: string,
-        newErrorRecords: ErrorRecord[],
-    ): void {
+    onModelError(model: ComponentModel, _task: string, newErrorRecords: ErrorRecord[]): void {
         this._extractData(model);
 
         newErrorRecords.forEach((errorRecord) => {
@@ -432,23 +392,19 @@ export abstract class DataJobsBaseGridComponent
         // attach listener to ErrorStore and listen for Errors change
         this.errors.onChange((store) => {
             // if there is record for listened error code patterns disable actionable elements
-            this.disableActionableElements = store.hasCodePattern(
-                ...this.listenForErrorPatterns,
-            );
+            this.disableActionableElements = store.hasCodePattern(...this.listenForErrorPatterns);
         });
 
         this.subscriptions.push(
-            this.loadDataDebouncer
-                .pipe(debounceTime(300))
-                .subscribe((handling) => {
-                    if (this.isLoadDataAllowed() || handling === 'forced') {
-                        this._doLoadData();
-                    }
+            this.loadDataDebouncer.pipe(debounceTime(300)).subscribe((handling) => {
+                if (this.isLoadDataAllowed() || handling === 'forced') {
+                    this._doLoadData();
+                }
 
-                    if (this.isUrlUpdateAllowed() || handling === 'forced') {
-                        this._doUrlUpdate();
-                    }
-                }),
+                if (this.isUrlUpdateAllowed() || handling === 'forced') {
+                    this._doUrlUpdate();
+                }
+            })
         );
 
         super.ngOnInit();
@@ -458,19 +414,12 @@ export abstract class DataJobsBaseGridComponent
         try {
             this._loadLocalStorageUserConfig();
         } catch (e1) {
-            console.error(
-                'Failed to read config from localStorage',
-                e1,
-                'Will attempt to re-create it.',
-            );
+            console.error('Failed to read config from localStorage', e1, 'Will attempt to re-create it.');
             try {
                 localStorage.removeItem(this.localStorageConfigKey);
                 this._loadLocalStorageUserConfig();
             } catch (e2) {
-                console.error(
-                    'Was unable to re-initialize localStorage user config',
-                    e2,
-                );
+                console.error('Was unable to re-initialize localStorage user config', e2);
             }
         }
     }
@@ -478,9 +427,7 @@ export abstract class DataJobsBaseGridComponent
     protected isLoadDataAllowed(): boolean {
         if (!this.gridState) {
             //While the gridState is empty, no refresh requests will be executed.
-            console.log(
-                'Load data will be skipped. gridState is empty. operation not allowed.',
-            );
+            console.log('Load data will be skipped. gridState is empty. operation not allowed.');
 
             return false;
         }
@@ -489,50 +436,31 @@ export abstract class DataJobsBaseGridComponent
     }
 
     protected isUrlUpdateAllowed(): boolean {
-        return (
-            !this.navigationInProgress &&
-            this.urlStateManager.isQueryParamsStateMutated
-        );
+        return !this.navigationInProgress && this.urlStateManager.isQueryParamsStateMutated;
     }
 
     protected saveUIState() {
-        const dataGrid = this.elementRef.nativeElement.querySelector(
-            DataJobsBaseGridComponent.DATA_GRID_SELECTOR,
-        );
+        const dataGrid = this.elementRef.nativeElement.querySelector(DataJobsBaseGridComponent.DATA_GRID_SELECTOR);
         if (dataGrid) {
-            this.model.withUiState(
-                DataJobsBaseGridComponent.UI_KEY_GRID_OFFSET,
-                {
-                    x: dataGrid.scrollLeft,
-                    y: dataGrid.scrollTop,
-                },
-            );
+            this.model.withUiState(DataJobsBaseGridComponent.UI_KEY_GRID_OFFSET, {
+                x: dataGrid.scrollLeft,
+                y: dataGrid.scrollTop
+            });
         }
 
-        const contentArea = this.document.querySelector(
-            DataJobsBaseGridComponent.CONTENT_AREA_SELECTOR,
-        );
+        const contentArea = this.document.querySelector(DataJobsBaseGridComponent.CONTENT_AREA_SELECTOR);
         if (contentArea) {
-            this.model.withUiState(
-                DataJobsBaseGridComponent.UI_KEY_PAGE_OFFSET,
-                {
-                    x: contentArea.scrollLeft,
-                    y: contentArea.scrollTop,
-                },
-            );
+            this.model.withUiState(DataJobsBaseGridComponent.UI_KEY_PAGE_OFFSET, {
+                x: contentArea.scrollLeft,
+                y: contentArea.scrollTop
+            });
         }
 
-        const clrGridUIStateDeepCloned = CollectionsUtil.cloneDeep(
-            this.clrGridUIState,
-        );
-        clrGridUIStateDeepCloned.pageSize =
-            this.model.getComponentState()?.page?.size;
+        const clrGridUIStateDeepCloned = CollectionsUtil.cloneDeep(this.clrGridUIState);
+        clrGridUIStateDeepCloned.pageSize = this.model.getComponentState()?.page?.size;
         clrGridUIStateDeepCloned.lastPage = this.clrGridCurrentPage;
 
-        this.model.withUiState(
-            DataJobsBaseGridComponent.UI_KEY_GRID_UI_STATE,
-            clrGridUIStateDeepCloned,
-        );
+        this.model.withUiState(DataJobsBaseGridComponent.UI_KEY_GRID_UI_STATE, clrGridUIStateDeepCloned);
 
         this.componentService.update(this.model.getComponentState());
     }
@@ -543,22 +471,14 @@ export abstract class DataJobsBaseGridComponent
         }
 
         setTimeout(() => {
-            const gridOffset = this.model.getUiState<UIElementOffset>(
-                DataJobsBaseGridComponent.UI_KEY_GRID_OFFSET,
-            );
-            const dataGrid = this.elementRef.nativeElement.querySelector(
-                DataJobsBaseGridComponent.DATA_GRID_SELECTOR,
-            );
+            const gridOffset = this.model.getUiState<UIElementOffset>(DataJobsBaseGridComponent.UI_KEY_GRID_OFFSET);
+            const dataGrid = this.elementRef.nativeElement.querySelector(DataJobsBaseGridComponent.DATA_GRID_SELECTOR);
             if (dataGrid) {
                 dataGrid.scrollTo(gridOffset.x, gridOffset.y);
             }
 
-            const pageOffset = this.model.getUiState<UIElementOffset>(
-                DataJobsBaseGridComponent.UI_KEY_PAGE_OFFSET,
-            );
-            const contentArea = this.document.querySelector(
-                DataJobsBaseGridComponent.CONTENT_AREA_SELECTOR,
-            );
+            const pageOffset = this.model.getUiState<UIElementOffset>(DataJobsBaseGridComponent.UI_KEY_PAGE_OFFSET);
+            const contentArea = this.document.querySelector(DataJobsBaseGridComponent.CONTENT_AREA_SELECTOR);
             if (contentArea) {
                 contentArea.scrollTo(pageOffset.x, pageOffset.y);
             }
@@ -568,8 +488,7 @@ export abstract class DataJobsBaseGridComponent
     }
 
     private _shouldRestoreUIState(routerState: RouterState): boolean {
-        const restoreUiWhen =
-            routerState.state.getData<DataPipelinesRestoreUI>('restoreUiWhen');
+        const restoreUiWhen = routerState.state.getData<DataPipelinesRestoreUI>('restoreUiWhen');
         if (CollectionsUtil.isNil(restoreUiWhen)) {
             return true;
         }
@@ -578,34 +497,20 @@ export abstract class DataJobsBaseGridComponent
             return true;
         }
 
-        return routerState
-            .getPrevious()
-            .state.absoluteConfigPath.includes(
-                restoreUiWhen.previousConfigPathLike,
-            );
+        return routerState.getPrevious().state.absoluteConfigPath.includes(restoreUiWhen.previousConfigPathLike);
     }
 
     private _doesRestoreUIStateExist(): boolean {
         return (
             CollectionsUtil.isDefined(this.model) &&
-            CollectionsUtil.isDefined(
-                this.model.getUiState<ClrGridUIState>(
-                    DataJobsBaseGridComponent.UI_KEY_GRID_UI_STATE,
-                ),
-            )
+            CollectionsUtil.isDefined(this.model.getUiState<ClrGridUIState>(DataJobsBaseGridComponent.UI_KEY_GRID_UI_STATE))
         );
     }
 
     private _clearUiPageState() {
-        this.model
-            .getComponentState()
-            .uiState.delete(DataJobsBaseGridComponent.UI_KEY_GRID_OFFSET);
-        this.model
-            .getComponentState()
-            .uiState.delete(DataJobsBaseGridComponent.UI_KEY_PAGE_OFFSET);
-        this.model
-            .getComponentState()
-            .uiState.delete(DataJobsBaseGridComponent.UI_KEY_GRID_UI_STATE);
+        this.model.getComponentState().uiState.delete(DataJobsBaseGridComponent.UI_KEY_GRID_OFFSET);
+        this.model.getComponentState().uiState.delete(DataJobsBaseGridComponent.UI_KEY_PAGE_OFFSET);
+        this.model.getComponentState().uiState.delete(DataJobsBaseGridComponent.UI_KEY_GRID_UI_STATE);
 
         this.componentService.update(this.model.getComponentState());
     }
@@ -620,10 +525,7 @@ export abstract class DataJobsBaseGridComponent
             this.model
                 .withFilter(this._buildRefreshFilters())
                 .withSearch(this.searchQueryValue)
-                .withPage(
-                    this.gridState?.page?.current,
-                    this.gridState?.page?.size,
-                );
+                .withPage(this.gridState?.page?.current, this.gridState?.page?.size);
         }
 
         this.dataJobsService.loadJobs(this.model);
@@ -631,22 +533,16 @@ export abstract class DataJobsBaseGridComponent
 
     private _extractData(model: ComponentModel): void {
         const componentState = model.getComponentState();
-        const dataJobsData: { content?: DataJob[]; totalItems?: number } =
-            componentState.data.get(JOBS_DATA_KEY) ?? {};
+        const dataJobsData: { content?: DataJob[]; totalItems?: number } = componentState.data.get(JOBS_DATA_KEY) ?? {};
 
-        this.dataJobs = CollectionsUtil.isArray(dataJobsData?.content)
-            ? [...dataJobsData?.content]
-            : [];
+        this.dataJobs = CollectionsUtil.isArray(dataJobsData?.content) ? [...dataJobsData?.content] : [];
 
         this.clrGridUIState.totalItems = dataJobsData?.totalItems ?? 0;
     }
 
     private _initUrlStateManager(routeState: RouteState): void {
         if (!this._isUrlStateManagerExternalDependency) {
-            this._urlStateManager = new URLStateManager(
-                routeState.absoluteRoutePath,
-                this.location,
-            );
+            this._urlStateManager = new URLStateManager(routeState.absoluteRoutePath, this.location);
         }
     }
 
@@ -667,10 +563,7 @@ export abstract class DataJobsBaseGridComponent
             this.urlStateManager.baseURL = routeState.absoluteRoutePath;
         }
 
-        this.urlStateManager.setQueryParam(
-            this.searchParam,
-            this.searchQueryValue,
-        );
+        this.urlStateManager.setQueryParam(this.searchParam, this.searchQueryValue);
     }
 
     private _doUrlUpdate(): void {
@@ -686,32 +579,22 @@ export abstract class DataJobsBaseGridComponent
         const userConfig = localStorage.getItem(this.localStorageConfigKey);
         if (userConfig) {
             let newColumnProvided = false;
-            const parsedUserConfig: DataJobsLocalStorageUserConfig =
-                JSON.parse(userConfig);
+            const parsedUserConfig: DataJobsLocalStorageUserConfig = JSON.parse(userConfig);
 
-            CollectionsUtil.iterateObject(
-                this.localStorageUserConfig.hiddenColumns,
-                (value, key) => {
-                    if (!parsedUserConfig.hiddenColumns.hasOwnProperty(key)) {
-                        newColumnProvided = true;
-                        parsedUserConfig.hiddenColumns[key] = value;
-                    }
-                },
-            );
+            CollectionsUtil.iterateObject(this.localStorageUserConfig.hiddenColumns, (value, key) => {
+                if (!parsedUserConfig.hiddenColumns.hasOwnProperty(key)) {
+                    newColumnProvided = true;
+                    parsedUserConfig.hiddenColumns[key] = value;
+                }
+            });
 
             if (newColumnProvided) {
-                localStorage.setItem(
-                    this.localStorageConfigKey,
-                    JSON.stringify(parsedUserConfig),
-                );
+                localStorage.setItem(this.localStorageConfigKey, JSON.stringify(parsedUserConfig));
             }
 
             this.localStorageUserConfig = parsedUserConfig;
         } else {
-            localStorage.setItem(
-                this.localStorageConfigKey,
-                JSON.stringify(this.localStorageUserConfig),
-            );
+            localStorage.setItem(this.localStorageConfigKey, JSON.stringify(this.localStorageUserConfig));
         }
     }
 
@@ -727,7 +610,7 @@ export abstract class DataJobsBaseGridComponent
             filters.push({
                 property: 'config.team',
                 pattern: this.teamNameFilter,
-                sort: null,
+                sort: null
             });
         }
 
@@ -741,7 +624,7 @@ export abstract class DataJobsBaseGridComponent
                 filters.push({
                     property,
                     pattern: this._getFilterPattern(property, value),
-                    sort: null,
+                    sort: null
                 });
             }
         }
@@ -752,7 +635,7 @@ export abstract class DataJobsBaseGridComponent
             filters.push({
                 property: this.gridState.sort.by as string,
                 pattern: null,
-                sort: direction,
+                sort: direction
             });
         }
 
@@ -791,7 +674,7 @@ export abstract class DataJobsBaseGridComponent
                 suppressCancel: true,
                 onActivate: () => {
                     this.clrGridUIState.filter = {};
-                },
+                }
             },
             {
                 label: 'Enabled',
@@ -801,8 +684,8 @@ export abstract class DataJobsBaseGridComponent
                     title: 'Enabled - This job is deployed and executed by schedule',
                     class: 'is-solid status-icon-enabled',
                     shape: 'check-circle',
-                    size: 20,
-                },
+                    size: 20
+                }
             },
             {
                 label: 'Disabled',
@@ -812,8 +695,8 @@ export abstract class DataJobsBaseGridComponent
                     title: 'Disabled - This job is deployed but not executing by schedule',
                     class: 'is-solid status-icon-disabled',
                     shape: 'times-circle',
-                    size: 15,
-                },
+                    size: 15
+                }
             },
             {
                 label: 'Not Deployed',
@@ -822,16 +705,14 @@ export abstract class DataJobsBaseGridComponent
                 icon: {
                     title: 'Not Deployed - This job is created but still not deployed',
                     shape: 'circle',
-                    size: 15,
-                },
-            },
+                    size: 15
+                }
+            }
         ];
 
         if (
             CollectionsUtil.isNumber(this.quickFiltersDefaultActiveIndex) &&
-            CollectionsUtil.isDefined(
-                filters[this.quickFiltersDefaultActiveIndex],
-            )
+            CollectionsUtil.isDefined(filters[this.quickFiltersDefaultActiveIndex])
         ) {
             filters[this.quickFiltersDefaultActiveIndex].active = true;
         }
@@ -845,11 +726,11 @@ export abstract class DataJobsBaseGridComponent
             lastPage: 1,
             pageSize: 25,
             filter: {
-                ...(this.clrGridDefaultFilter ?? {}),
+                ...(this.clrGridDefaultFilter ?? {})
             },
             sort: {
-                ...(this.clrGridDefaultSort ?? {}),
-            },
+                ...(this.clrGridDefaultSort ?? {})
+            }
         };
     }
 }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/data-job-page.component.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/data-job-page.component.spec.ts
@@ -20,7 +20,7 @@ import {
     RouterService,
     RouterState,
     RouteState,
-    ToastService,
+    ToastService
 } from '@versatiledatakit/shared';
 
 import {
@@ -30,7 +30,7 @@ import {
     DataJobDetails,
     DataJobExecution,
     DataJobExecutionStatus,
-    DataJobExecutionType,
+    DataJobExecutionType
 } from '../../model';
 
 import { DataJobsApiService, DataJobsService } from '../../services';
@@ -70,13 +70,13 @@ describe('DataJobsDetailsComponent', () => {
                 memoryLimit: 1000,
                 memoryRequest: 1000,
                 cpuLimit: 0.5,
-                cpuRequest: 0.5,
+                cpuRequest: 0.5
             },
             executions: [],
             deployedDate: '2020-11-11T10:10:10Z',
             deployedBy: 'pmitev',
-            status: DataJobDeploymentStatus.SUCCESS,
-        },
+            status: DataJobDeploymentStatus.SUCCESS
+        }
     } as DataJobExecution;
 
     const TEST_JOB_DEPLOYMENT = {
@@ -97,85 +97,55 @@ describe('DataJobsDetailsComponent', () => {
             memory_limit: 1000,
             memory_request: 1000,
             cpu_limit: 0.5,
-            cpu_request: 0.5,
-        },
+            cpu_request: 0.5
+        }
         /* eslint-enable @typescript-eslint/naming-convention */
     } as DataJobDeploymentDetails;
 
     beforeEach(() => {
-        componentServiceStub = jasmine.createSpyObj<ComponentService>(
-            'componentService',
-            ['init', 'getModel', 'idle'],
-        );
-        navigationServiceStub = jasmine.createSpyObj<NavigationService>(
-            'navigationService',
-            ['navigate', 'navigateTo', 'navigateBack'],
-        );
-        routerServiceStub = jasmine.createSpyObj<RouterService>(
-            'routerService',
-            ['getState'],
-        );
-        toastServiceStub = jasmine.createSpyObj<ToastService>('toastService', [
-            'show',
+        componentServiceStub = jasmine.createSpyObj<ComponentService>('componentService', ['init', 'getModel', 'idle']);
+        navigationServiceStub = jasmine.createSpyObj<NavigationService>('navigationService', ['navigate', 'navigateTo', 'navigateBack']);
+        routerServiceStub = jasmine.createSpyObj<RouterService>('routerService', ['getState']);
+        toastServiceStub = jasmine.createSpyObj<ToastService>('toastService', ['show']);
+        dataJobsApiServiceStub = jasmine.createSpyObj<DataJobsApiService>('dataJobsApiService', [
+            'getJobDetails',
+            'getJobExecutions',
+            'getJobDeployments',
+            'removeJob',
+            'downloadFile',
+            'executeDataJob',
+            'getJob'
         ]);
-        dataJobsApiServiceStub = jasmine.createSpyObj<DataJobsApiService>(
-            'dataJobsApiService',
-            [
-                'getJobDetails',
-                'getJobExecutions',
-                'getJobDeployments',
-                'removeJob',
-                'downloadFile',
-                'executeDataJob',
-                'getJob',
-            ],
-        );
-        dataJobsServiceStub = jasmine.createSpyObj<DataJobsService>(
-            'dataJobsService',
-            [
-                'loadJobs',
-                'notifyForRunningJobExecutionId',
-                'notifyForJobExecutions',
-                'notifyForTeamImplicitly',
-                'getNotifiedForRunningJobExecutionId',
-                'getNotifiedForJobExecutions',
-                'getNotifiedForTeamImplicitly',
-            ],
-        );
-        errorHandlerServiceStub = jasmine.createSpyObj<ErrorHandlerService>(
-            'errorHandlerService',
-            ['processError', 'handleError'],
-        );
+        dataJobsServiceStub = jasmine.createSpyObj<DataJobsService>('dataJobsService', [
+            'loadJobs',
+            'notifyForRunningJobExecutionId',
+            'notifyForJobExecutions',
+            'notifyForTeamImplicitly',
+            'getNotifiedForRunningJobExecutionId',
+            'getNotifiedForJobExecutions',
+            'getNotifiedForTeamImplicitly'
+        ]);
+        errorHandlerServiceStub = jasmine.createSpyObj<ErrorHandlerService>('errorHandlerService', ['processError', 'handleError']);
 
         const activatedRouteStub = () => ({
             snapshot: createRouteSnapshot({
                 data: {
-                    activateSubpageNavigation: true,
-                },
-            }),
+                    activateSubpageNavigation: true
+                }
+            })
         });
 
         dataJobsApiServiceStub.executeDataJob.and.returnValue(new Subject());
         dataJobsApiServiceStub.getJob.and.returnValue(new Subject());
         dataJobsApiServiceStub.getJobDetails.and.returnValue(new Subject());
-        dataJobsApiServiceStub.getJobExecutions.and.returnValue(
-            of({ content: [TEST_JOB_EXECUTION], totalItems: 1, totalPages: 1 }),
-        );
-        dataJobsApiServiceStub.getJobDeployments.and.returnValue(
-            of([TEST_JOB_DEPLOYMENT]),
-        );
+        dataJobsApiServiceStub.getJobExecutions.and.returnValue(of({ content: [TEST_JOB_EXECUTION], totalItems: 1, totalPages: 1 }));
+        dataJobsApiServiceStub.getJobDeployments.and.returnValue(of([TEST_JOB_DEPLOYMENT]));
         dataJobsApiServiceStub.removeJob.and.returnValue(new Subject());
         dataJobsApiServiceStub.downloadFile.and.returnValue(new Subject());
 
-        dataJobsServiceStub.getNotifiedForRunningJobExecutionId.and.returnValue(
-            new Subject(),
-        );
-        dataJobsServiceStub.getNotifiedForJobExecutions.and.returnValue(
-            new Subject(),
-        );
-        dataJobsServiceStub.getNotifiedForTeamImplicitly.and.returnValue(
-            new BehaviorSubject('taurus'),
-        );
+        dataJobsServiceStub.getNotifiedForRunningJobExecutionId.and.returnValue(new Subject());
+        dataJobsServiceStub.getNotifiedForJobExecutions.and.returnValue(new Subject());
+        dataJobsServiceStub.getNotifiedForTeamImplicitly.and.returnValue(new BehaviorSubject('taurus'));
 
         TestBed.configureTestingModule({
             imports: [RouterTestingModule.withRoutes([])],
@@ -189,12 +159,12 @@ describe('DataJobsDetailsComponent', () => {
                 { provide: ToastService, useValue: toastServiceStub },
                 {
                     provide: DataJobsApiService,
-                    useValue: dataJobsApiServiceStub,
+                    useValue: dataJobsApiServiceStub
                 },
                 { provide: DataJobsService, useValue: dataJobsServiceStub },
                 {
                     provide: ErrorHandlerService,
-                    useValue: errorHandlerServiceStub,
+                    useValue: errorHandlerServiceStub
                 },
                 {
                     provide: DATA_PIPELINES_CONFIGS,
@@ -202,17 +172,14 @@ describe('DataJobsDetailsComponent', () => {
                         defaultOwnerTeamName: 'all',
                         manageConfig: {
                             allowKeyTabDownloads: true,
-                            allowExecuteNow: true,
-                        },
-                    }),
-                },
-            ],
+                            allowExecuteNow: true
+                        }
+                    })
+                }
+            ]
         });
 
-        componentModelStub = ComponentModel.of(
-            ComponentStateImpl.of({}),
-            RouterState.of(RouteState.empty(), 1),
-        );
+        componentModelStub = ComponentModel.of(ComponentStateImpl.of({}), RouterState.of(RouteState.empty(), 1));
         componentServiceStub.init.and.returnValue(of(componentModelStub));
         componentServiceStub.getModel.and.returnValue(of(componentModelStub));
         routerServiceStub.getState.and.returnValue(of(RouteState.empty()));
@@ -251,7 +218,7 @@ describe('DataJobsDetailsComponent', () => {
             spyOn(component, '_submitOperationStarted').and.callThrough();
             // @ts-ignore
             spyOn(component, '_extractJobDeployment').and.returnValue({
-                id: '10',
+                id: '10'
             } as DataJobDetails);
 
             // When

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/data-job-page.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/data-job-page.component.ts
@@ -10,17 +10,7 @@ import { ActivatedRoute, Params } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 
 import { interval, of, Subject, timer } from 'rxjs';
-import {
-    catchError,
-    filter,
-    finalize,
-    map,
-    switchMap,
-    take,
-    takeUntil,
-    takeWhile,
-    tap,
-} from 'rxjs/operators';
+import { catchError, filter, finalize, map, switchMap, take, takeUntil, takeWhile, tap } from 'rxjs/operators';
 
 import { ClrLoadingState } from '@clr/angular';
 
@@ -40,16 +30,12 @@ import {
     RouteState,
     TaurusBaseComponent,
     ToastService,
-    VmwToastType,
+    VmwToastType
 } from '@versatiledatakit/shared';
 
 import { DataJobUtil, ErrorUtil } from '../../shared/utils';
 import { ExtractJobStatusPipe } from '../../shared/pipes';
-import {
-    ConfirmationModalOptions,
-    DeleteModalOptions,
-    ModalOptions,
-} from '../../shared/model';
+import { ConfirmationModalOptions, DeleteModalOptions, ModalOptions } from '../../shared/model';
 
 import {
     DATA_PIPELINES_CONFIGS,
@@ -60,7 +46,7 @@ import {
     DataJobExecutionsPage,
     DataJobStatus,
     DataPipelinesConfig,
-    ToastDefinitions,
+    ToastDefinitions
 } from '../../model';
 
 import { DataJobsApiService, DataJobsService } from '../../services';
@@ -73,18 +59,15 @@ enum TypeButtonState {
     /* eslint-disable-next-line @typescript-eslint/naming-convention */
     DELETE,
     /* eslint-disabe-next-line @typescript-eslint/naming-convention */
-    STOP,
+    STOP
 }
 
 @Component({
     selector: 'lib-data-job-page',
     templateUrl: './data-job-page.component.html',
-    styleUrls: ['./data-job-page.component.scss'],
+    styleUrls: ['./data-job-page.component.scss']
 })
-export class DataJobPageComponent
-    extends TaurusBaseComponent
-    implements OnInit, OnTaurusModelInit, OnTaurusModelError
-{
+export class DataJobPageComponent extends TaurusBaseComponent implements OnInit, OnTaurusModelInit, OnTaurusModelError {
     readonly uuid = 'DataJobPageComponent';
 
     teamName = '';
@@ -130,12 +113,11 @@ export class DataJobPageComponent
         private readonly toastService: ToastService,
         private readonly errorHandlerService: ErrorHandlerService,
         @Inject(DATA_PIPELINES_CONFIGS)
-        public readonly dataPipelinesModuleConfig: DataPipelinesConfig,
+        public readonly dataPipelinesModuleConfig: DataPipelinesConfig
     ) {
         super(componentService, navigationService, activatedRoute);
 
-        this.isSubpageNavigation =
-            !!activatedRoute.snapshot.data['activateSubpageNavigation'];
+        this.isSubpageNavigation = !!activatedRoute.snapshot.data['activateSubpageNavigation'];
 
         this.deleteOptions = new DeleteModalOptions();
         this.executeNowOptions = new ConfirmationModalOptions();
@@ -177,21 +159,15 @@ export class DataJobPageComponent
 
         this.subscriptions.push(
             this.dataJobsApiService
-                .executeDataJob(
-                    this.teamName,
-                    this.jobName,
-                    this._extractJobDeployment()?.id,
-                )
+                .executeDataJob(this.teamName, this.jobName, this._extractJobDeployment()?.id)
                 .pipe(
                     finalize(() => {
                         this._submitOperationEnded();
-                    }),
+                    })
                 )
                 .subscribe({
                     next: () => {
-                        this.toastService.show(
-                            ToastDefinitions.successfullyRanJob(this.jobName),
-                        );
+                        this.toastService.show(ToastDefinitions.successfullyRanJob(this.jobName));
 
                         let previousReqFinished = true;
 
@@ -206,44 +182,24 @@ export class DataJobPageComponent
                                     tap(() => (previousReqFinished = false)),
                                     switchMap(() =>
                                         this.dataJobsApiService
-                                            .getJobExecutions(
-                                                this.teamName,
-                                                this.jobName,
-                                                true,
-                                                null,
-                                                {
-                                                    property: 'startTime',
-                                                    direction: ASC,
-                                                },
-                                            )
+                                            .getJobExecutions(this.teamName, this.jobName, true, null, {
+                                                property: 'startTime',
+                                                direction: ASC
+                                            })
                                             .pipe(
                                                 catchError((error: unknown) => {
-                                                    this.errorHandlerService.processError(
-                                                        ErrorUtil.extractError(
-                                                            error as Error,
-                                                        ),
-                                                    );
+                                                    this.errorHandlerService.processError(ErrorUtil.extractError(error as Error));
 
                                                     return of([]);
                                                 }),
                                                 finalize(() => {
                                                     previousReqFinished = true;
-                                                }),
-                                            ),
+                                                })
+                                            )
                                     ),
-                                    map((executions: DataJobExecutionsPage) =>
-                                        executions.content
-                                            ? [...executions.content]
-                                            : [],
-                                    ),
+                                    map((executions: DataJobExecutionsPage) => (executions.content ? [...executions.content] : [])),
                                     takeWhile((executions) => {
-                                        if (
-                                            CollectionsUtil.isArrayEmpty(
-                                                executions,
-                                            ) ||
-                                            executions.length <=
-                                                this.jobExecutions.length
-                                        ) {
+                                        if (CollectionsUtil.isArrayEmpty(executions) || executions.length <= this.jobExecutions.length) {
                                             return true;
                                         }
 
@@ -251,41 +207,29 @@ export class DataJobPageComponent
 
                                         this.areJobExecutionsLoaded = true;
 
-                                        const lastExecution =
-                                            executions[executions.length - 1];
-                                        if (
-                                            !DataJobUtil.isJobRunningPredicate(
-                                                lastExecution,
-                                            )
-                                        ) {
+                                        const lastExecution = executions[executions.length - 1];
+                                        if (!DataJobUtil.isJobRunningPredicate(lastExecution)) {
                                             return true;
                                         }
 
-                                        this.dataJobsService.notifyForJobExecutions(
-                                            executions,
-                                        );
-                                        this.dataJobsService.notifyForRunningJobExecutionId(
-                                            lastExecution.id,
-                                        );
+                                        this.dataJobsService.notifyForJobExecutions(executions);
+                                        this.dataJobsService.notifyForRunningJobExecutionId(lastExecution.id);
 
                                         return false; // Stop polling if above condition is met.
-                                    }),
+                                    })
                                 )
-                                .subscribe(), // eslint-disable-line rxjs/no-nested-subscribe
+                                .subscribe() // eslint-disable-line rxjs/no-nested-subscribe
                         );
                     },
                     error: (error: unknown) => {
-                        this.errorHandlerService.processError(
-                            ErrorUtil.extractError(error as Error),
-                            {
-                                title:
-                                    (error as HttpErrorResponse)?.status === 409
-                                        ? 'Failed, Data job is already executing'
-                                        : 'Failed to queue Data job for execution',
-                            },
-                        );
-                    },
-                }),
+                        this.errorHandlerService.processError(ErrorUtil.extractError(error as Error), {
+                            title:
+                                (error as HttpErrorResponse)?.status === 409
+                                    ? 'Failed, Data job is already executing'
+                                    : 'Failed to queue Data job for execution'
+                        });
+                    }
+                })
         );
     }
 
@@ -300,12 +244,12 @@ export class DataJobPageComponent
             .pipe(
                 finalize(() => {
                     this._submitOperationEnded();
-                }),
+                })
             )
             .subscribe({
                 next: (response: Blob) => {
                     const blob: Blob = new Blob([response], {
-                        type: 'application/octet-stream',
+                        type: 'application/octet-stream'
                     });
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
                     fileSaver.saveAs(blob, `${this.jobName}.keytab`);
@@ -313,7 +257,7 @@ export class DataJobPageComponent
                     this.toastService.show({
                         type: VmwToastType.INFO,
                         title: `Download completed`,
-                        description: `Data job keytab "${this.jobName}.keytab" successfully downloaded`,
+                        description: `Data job keytab "${this.jobName}.keytab" successfully downloaded`
                     });
                 },
                 error: (error: unknown) => {
@@ -322,13 +266,10 @@ export class DataJobPageComponent
                             ? `Download failed. Keytab file doesn't exist for this job.`
                             : `Download failed. Keytab file failed to download.`;
 
-                    this.errorHandlerService.processError(
-                        ErrorUtil.extractError(error as Error),
-                        {
-                            description: errorDescription,
-                        },
-                    );
-                },
+                    this.errorHandlerService.processError(ErrorUtil.extractError(error as Error), {
+                        description: errorDescription
+                    });
+                }
             });
     }
 
@@ -356,41 +297,34 @@ export class DataJobPageComponent
             .pipe(
                 finalize(() => {
                     this._submitOperationEnded();
-                }),
+                })
             )
             .subscribe({
                 next: () => {
                     this.toastService.show({
                         type: VmwToastType.INFO,
                         title: `Data job delete completed`,
-                        description: `Data job "${this.jobName}" successfully deleted`,
+                        description: `Data job "${this.jobName}" successfully deleted`
                     });
 
                     this.doNavigateBack();
                 },
                 error: (error: unknown) => {
-                    this.errorHandlerService.processError(
-                        ErrorUtil.extractError(error as Error),
-                        {
-                            title: `Data job delete failed`,
-                        },
-                    );
-                },
+                    this.errorHandlerService.processError(ErrorUtil.extractError(error as Error), {
+                        title: `Data job delete failed`
+                    });
+                }
             });
     }
 
     confirmCancelDataJob() {
         this._submitOperationStarted(TypeButtonState.STOP);
         this.dataJobsApiService
-            .cancelDataJobExecution(
-                this.teamName,
-                this.jobName,
-                this.lastExecution()?.id,
-            )
+            .cancelDataJobExecution(this.teamName, this.jobName, this.lastExecution()?.id)
             .pipe(
                 finalize(() => {
                     this._submitOperationEnded();
-                }),
+                })
             )
             .subscribe({
                 next: () => {
@@ -398,17 +332,14 @@ export class DataJobPageComponent
                     this.toastService.show({
                         type: VmwToastType.INFO,
                         title: `Data job execution cancellation completed`,
-                        description: `Data job "${this.jobName}" successfully canceled`,
+                        description: `Data job "${this.jobName}" successfully canceled`
                     });
                 },
                 error: (error: unknown) => {
-                    this.errorHandlerService.processError(
-                        ErrorUtil.extractError(error as Error),
-                        {
-                            title: `Data job cancellation failed`,
-                        },
-                    );
-                },
+                    this.errorHandlerService.processError(ErrorUtil.extractError(error as Error), {
+                        title: `Data job cancellation failed`
+                    });
+                }
             });
     }
 
@@ -417,8 +348,7 @@ export class DataJobPageComponent
      */
     cancelExecution() {
         this.cancelNowOptions.title = `Cancel ${this.lastExecution()?.id} now?`;
-        this.cancelNowOptions.message = `Execution <strong>${this.lastExecution()
-            ?.id}</strong> will be canceled.`;
+        this.cancelNowOptions.message = `Execution <strong>${this.lastExecution()?.id}</strong> will be canceled.`;
         this.cancelNowOptions.infoText = `Confirming will result in immediate data job execution cancellation.`;
         this.cancelNowOptions.opened = true;
     }
@@ -444,11 +374,7 @@ export class DataJobPageComponent
     /**
      * @inheritDoc
      */
-    onModelError(
-        model: ComponentModel,
-        _task: string,
-        newErrorRecords: ErrorRecord[],
-    ) {
+    onModelError(model: ComponentModel, _task: string, newErrorRecords: ErrorRecord[]) {
         newErrorRecords.forEach((errorRecord) => {
             const error = ErrorUtil.extractError(errorRecord.error);
 
@@ -460,10 +386,7 @@ export class DataJobPageComponent
         const teamParamKey = state.getData<string>('teamParamKey');
         this.teamName = state.getParam(teamParamKey);
 
-        if (
-            CollectionsUtil.isNil(teamParamKey) ||
-            CollectionsUtil.isNil(this.teamName)
-        ) {
+        if (CollectionsUtil.isNil(teamParamKey) || CollectionsUtil.isNil(this.teamName)) {
             this._subscribeForImplicitTeam();
         }
 
@@ -474,9 +397,7 @@ export class DataJobPageComponent
 
         this.queryParams = state.queryParams;
 
-        this.isDownloadJobKeyAllowed =
-            this.dataPipelinesModuleConfig.manageConfig?.allowKeyTabDownloads &&
-            this.isJobEditable;
+        this.isDownloadJobKeyAllowed = this.dataPipelinesModuleConfig.manageConfig?.allowKeyTabDownloads && this.isJobEditable;
 
         this._subscribeForTeamChange(state);
         this._subscribeForExecutionsChange();
@@ -493,36 +414,26 @@ export class DataJobPageComponent
     }
 
     private _subscribeForTeamChange(state: RouteState): void {
-        const shouldActivateListener = !!state.getData<boolean>(
-            'activateListenerForTeamChange',
-        );
+        const shouldActivateListener = !!state.getData<boolean>('activateListenerForTeamChange');
 
-        if (
-            shouldActivateListener &&
-            this.dataPipelinesModuleConfig?.manageConfig
-                ?.selectedTeamNameObservable
-        ) {
+        if (shouldActivateListener && this.dataPipelinesModuleConfig?.manageConfig?.selectedTeamNameObservable) {
             this.subscriptions.push(
-                this.dataPipelinesModuleConfig.manageConfig.selectedTeamNameObservable.subscribe(
-                    (newTeam) => {
-                        if (this.teamName !== newTeam) {
-                            this.teamName = newTeam;
+                this.dataPipelinesModuleConfig.manageConfig.selectedTeamNameObservable.subscribe((newTeam) => {
+                    if (this.teamName !== newTeam) {
+                        this.teamName = newTeam;
 
-                            this.doNavigateBack();
-                        }
-                    },
-                ),
+                        this.doNavigateBack();
+                    }
+                })
             );
         }
     }
 
     private _subscribeForExecutionsChange(): void {
         this.subscriptions.push(
-            this.dataJobsService
-                .getNotifiedForJobExecutions()
-                .subscribe((executions) => {
-                    this.jobExecutions = [...executions];
-                }),
+            this.dataJobsService.getNotifiedForJobExecutions().subscribe((executions) => {
+                this.jobExecutions = [...executions];
+            })
         );
     }
 
@@ -535,45 +446,27 @@ export class DataJobPageComponent
                     switchMap((id) =>
                         interval(5000).pipe(
                             switchMap(() =>
-                                this.dataJobsApiService
-                                    .getJobExecution(
-                                        this.teamName,
-                                        this.jobName,
-                                        id,
-                                    )
-                                    .pipe(
-                                        map((execution) => {
-                                            return {
-                                                execution,
-                                                error: null as Error,
-                                            };
-                                        }),
-                                        catchError((error: unknown) => {
-                                            this.errorHandlerService.processError(
-                                                ErrorUtil.extractError(
-                                                    error as Error,
-                                                ),
-                                            );
+                                this.dataJobsApiService.getJobExecution(this.teamName, this.jobName, id).pipe(
+                                    map((execution) => {
+                                        return {
+                                            execution,
+                                            error: null as Error
+                                        };
+                                    }),
+                                    catchError((error: unknown) => {
+                                        this.errorHandlerService.processError(ErrorUtil.extractError(error as Error));
 
-                                            return of({
-                                                execution:
-                                                    null as DataJobExecutionDetails,
-                                                error: error as Error,
-                                            });
-                                        }),
-                                    ),
+                                        return of({
+                                            execution: null as DataJobExecutionDetails,
+                                            error: error as Error
+                                        });
+                                    })
+                                )
                             ),
-                            tap((data) =>
-                                this._replaceRunningExecutionAndNotify(
-                                    data.execution,
-                                ),
-                            ),
+                            tap((data) => this._replaceRunningExecutionAndNotify(data.execution)),
                             takeWhile((data) => {
                                 if (data.error instanceof HttpErrorResponse) {
-                                    if (
-                                        data.error.status === 404 ||
-                                        data.error.status >= 500
-                                    ) {
+                                    if (data.error.status === 404 || data.error.status >= 500) {
                                         this.isDataJobRunning = false;
 
                                         return false;
@@ -581,20 +474,17 @@ export class DataJobPageComponent
                                 }
 
                                 const isRunning =
-                                    CollectionsUtil.isNil(data.execution) ||
-                                    DataJobUtil.isJobRunningPredicate(
-                                        data.execution,
-                                    );
+                                    CollectionsUtil.isNil(data.execution) || DataJobUtil.isJobRunningPredicate(data.execution);
 
                                 if (!isRunning) {
                                     this.isDataJobRunning = false;
                                 }
                                 return isRunning;
-                            }),
-                        ),
-                    ),
+                            })
+                        )
+                    )
                 )
-                .subscribe(),
+                .subscribe()
         );
 
         this.subscriptions.push(
@@ -602,89 +492,61 @@ export class DataJobPageComponent
                 .getNotifiedForRunningJobExecutionId()
                 .pipe(
                     switchMap((executionId: string) =>
-                        this.dataJobsApiService
-                            .getJobExecution(
-                                this.teamName,
-                                this.jobName,
-                                executionId,
-                            )
-                            .pipe(
-                                map((executionDetails) => [
-                                    executionId,
-                                    executionDetails,
-                                ]),
-                                catchError((error: unknown) => {
-                                    this.errorHandlerService.processError(
-                                        ErrorUtil.extractError(error as Error),
-                                    );
+                        this.dataJobsApiService.getJobExecution(this.teamName, this.jobName, executionId).pipe(
+                            map((executionDetails) => [executionId, executionDetails]),
+                            catchError((error: unknown) => {
+                                this.errorHandlerService.processError(ErrorUtil.extractError(error as Error));
 
-                                    return of([executionId]);
-                                }),
-                            ),
-                    ),
+                                return of([executionId]);
+                            })
+                        )
+                    )
                 )
-                .subscribe(
-                    ([executionId, executionDetails]: [
-                        string,
-                        DataJobExecutionDetails,
-                    ]) => {
-                        this.isDataJobRunning = true;
-                        this.cancelDataJobDisabled = false;
-                        this._replaceRunningExecutionAndNotify(
-                            executionDetails,
-                        );
-                        scheduleLastExecutionPolling.next(executionId);
-                    },
-                ),
+                .subscribe(([executionId, executionDetails]: [string, DataJobExecutionDetails]) => {
+                    this.isDataJobRunning = true;
+                    this.cancelDataJobDisabled = false;
+                    this._replaceRunningExecutionAndNotify(executionDetails);
+                    scheduleLastExecutionPolling.next(executionId);
+                })
         );
     }
 
     private _loadJobDetails(): void {
         this.subscriptions.push(
-            this.dataJobsApiService
-                .getJobDetails(this.teamName, this.jobName)
-                .subscribe({
-                    error: (error: unknown) => {
-                        if (error instanceof HttpErrorResponse) {
-                            if (error.status === 404) {
-                                this._showMessageJobNotExist();
-                                this.doNavigateBack();
-                            }
-
-                            console.error('Error loading jobDetails', error);
+            this.dataJobsApiService.getJobDetails(this.teamName, this.jobName).subscribe({
+                error: (error: unknown) => {
+                    if (error instanceof HttpErrorResponse) {
+                        if (error.status === 404) {
+                            this._showMessageJobNotExist();
+                            this.doNavigateBack();
                         }
-                    },
-                }),
+
+                        console.error('Error loading jobDetails', error);
+                    }
+                }
+            })
         );
         this.subscriptions.push(
-            this.dataJobsApiService
-                .getJob(this.teamName, this.jobName)
-                .subscribe({
-                    next: (job) => {
-                        if (CollectionsUtil.isDefined(job)) {
-                            this.isJobAvailable = true;
+            this.dataJobsApiService.getJob(this.teamName, this.jobName).subscribe({
+                next: (job) => {
+                    if (CollectionsUtil.isDefined(job)) {
+                        this.isJobAvailable = true;
 
-                            this.jobDeployments = job.deployments;
-                            this.isExecuteJobAllowed =
-                                ExtractJobStatusPipe.transform(
-                                    this.jobDeployments,
-                                ) !== DataJobStatus.NOT_DEPLOYED;
+                        this.jobDeployments = job.deployments;
+                        this.isExecuteJobAllowed = ExtractJobStatusPipe.transform(this.jobDeployments) !== DataJobStatus.NOT_DEPLOYED;
 
-                            return;
-                        }
+                        return;
+                    }
 
-                        this._showMessageJobNotExist();
-                        this.doNavigateBack();
-                    },
-                    error: (error: unknown) => {
-                        this.errorHandlerService.processError(
-                            ErrorUtil.extractError(error as Error),
-                            {
-                                title: `Loading Data job "${this.jobName}" failed`,
-                            },
-                        );
-                    },
-                }),
+                    this._showMessageJobNotExist();
+                    this.doNavigateBack();
+                },
+                error: (error: unknown) => {
+                    this.errorHandlerService.processError(ErrorUtil.extractError(error as Error), {
+                        title: `Loading Data job "${this.jobName}" failed`
+                    });
+                }
+            })
         );
     }
 
@@ -693,51 +555,36 @@ export class DataJobPageComponent
             this.dataJobsApiService
                 .getJobExecutions(this.teamName, this.jobName, true, null, {
                     property: 'startTime',
-                    direction: ASC,
+                    direction: ASC
                 })
                 .subscribe({
                     next: (value) => {
                         if (value?.content) {
-                            this.dataJobsService.notifyForJobExecutions([
-                                ...value.content,
-                            ]);
+                            this.dataJobsService.notifyForJobExecutions([...value.content]);
 
                             // eslint-disable-next-line @typescript-eslint/unbound-method
-                            const runningExecution = value.content.find(
-                                DataJobUtil.isJobRunningPredicate,
-                            );
+                            const runningExecution = value.content.find(DataJobUtil.isJobRunningPredicate);
                             if (runningExecution) {
-                                this.dataJobsService.notifyForRunningJobExecutionId(
-                                    runningExecution.id,
-                                );
+                                this.dataJobsService.notifyForRunningJobExecutionId(runningExecution.id);
                             }
                         }
 
                         this.areJobExecutionsLoaded = true;
                     },
                     error: (error: unknown) => {
-                        this.errorHandlerService.processError(
-                            ErrorUtil.extractError(error as Error),
-                        );
-                    },
-                }),
+                        this.errorHandlerService.processError(ErrorUtil.extractError(error as Error));
+                    }
+                })
         );
     }
 
-    private _replaceRunningExecutionAndNotify(
-        executionDetails: DataJobExecutionDetails,
-    ): void {
+    private _replaceRunningExecutionAndNotify(executionDetails: DataJobExecutionDetails): void {
         if (CollectionsUtil.isNil(executionDetails)) {
             return;
         }
 
-        const convertedExecution =
-            DataJobUtil.convertFromExecutionDetailsToExecutionState(
-                executionDetails,
-            );
-        const foundIndex = this.jobExecutions.findIndex(
-            (ex) => ex.id === convertedExecution.id,
-        );
+        const convertedExecution = DataJobUtil.convertFromExecutionDetailsToExecutionState(executionDetails);
+        const foundIndex = this.jobExecutions.findIndex((ex) => ex.id === convertedExecution.id);
 
         if (foundIndex !== -1) {
             this.jobExecutions.splice(foundIndex, 1, convertedExecution);
@@ -791,7 +638,7 @@ export class DataJobPageComponent
             this.toastService.show({
                 type: VmwToastType.FAILURE,
                 title: `Job "${this.jobName}" doesn't exist`,
-                description: `Data Job "${this.jobName}" for Team "${this.teamName}" doesn't exist, will load Data Jobs list`,
+                description: `Data Job "${this.jobName}" for Team "${this.teamName}" doesn't exist, will load Data Jobs list`
             });
         }
     }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/details/data-job-details-page.component.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/details/data-job-details-page.component.spec.ts
@@ -23,16 +23,12 @@ import {
     RouterState,
     RouteState,
     ToastService,
-    VdkFormState,
+    VdkFormState
 } from '@versatiledatakit/shared';
 
 import { DataJobsApiService, DataJobsService } from '../../../../services';
 
-import {
-    ExtractContactsPipe,
-    ExtractJobStatusPipe,
-    FormatSchedulePipe,
-} from '../../../../shared/pipes';
+import { ExtractContactsPipe, ExtractJobStatusPipe, FormatSchedulePipe } from '../../../../shared/pipes';
 
 import {
     DATA_PIPELINES_CONFIGS,
@@ -43,15 +39,12 @@ import {
     DataJobExecution,
     DataJobExecutionsPage,
     DataJobExecutionStatus,
-    DataJobExecutionType,
+    DataJobExecutionType
 } from '../../../../model';
 
 import { LOAD_JOB_ERROR_CODES } from '../../../../state/error-codes';
 
-import {
-    TASK_LOAD_JOB_DETAILS,
-    TASK_LOAD_JOB_STATE,
-} from '../../../../state/tasks';
+import { TASK_LOAD_JOB_DETAILS, TASK_LOAD_JOB_STATE } from '../../../../state/tasks';
 
 import { DataJobDetailsPageComponent } from './data-job-details-page.component';
 
@@ -75,13 +68,13 @@ const TEST_JOB_EXECUTION = {
             memoryLimit: 1000,
             memoryRequest: 1000,
             cpuLimit: 0.5,
-            cpuRequest: 0.5,
+            cpuRequest: 0.5
         },
         executions: [],
         deployedDate: '2020-11-11T10:10:10Z',
         deployedBy: 'pmitev',
-        status: DataJobDeploymentStatus.SUCCESS,
-    },
+        status: DataJobDeploymentStatus.SUCCESS
+    }
 } as DataJobExecution;
 
 const TEST_JOB_DEPLOYMENT = {
@@ -91,14 +84,14 @@ const TEST_JOB_DEPLOYMENT = {
     job_version: '001',
     mode: 'test_mode',
     /* eslint-disable-next-line @typescript-eslint/naming-convention */
-    vdk_version: '001',
+    vdk_version: '001'
 } as DataJobDeploymentDetails;
 
 const TEST_JOB_DETAILS = {
     /* eslint-disable-next-line @typescript-eslint/naming-convention */
     job_name: 'job001',
     team: 'taurus',
-    description: 'description',
+    description: 'description'
 };
 
 describe('DataJobsDetailsModalComponent', () => {
@@ -116,131 +109,74 @@ describe('DataJobsDetailsModalComponent', () => {
     let fixture: ComponentFixture<DataJobDetailsPageComponent>;
 
     beforeEach(() => {
-        componentServiceStub = jasmine.createSpyObj<ComponentService>(
-            'componentService',
-            ['init', 'getModel', 'idle', 'update'],
-        );
-        navigationServiceStub = jasmine.createSpyObj<NavigationService>(
-            'navigationService',
-            ['navigateTo', 'navigateBack'],
-        );
+        componentServiceStub = jasmine.createSpyObj<ComponentService>('componentService', ['init', 'getModel', 'idle', 'update']);
+        navigationServiceStub = jasmine.createSpyObj<NavigationService>('navigationService', ['navigateTo', 'navigateBack']);
         activatedRouteStub = { snapshot: null } as any;
-        routerServiceStub = jasmine.createSpyObj<RouterService>(
-            'routerService',
-            ['getState'],
-        );
-        toastServiceStub = jasmine.createSpyObj<ToastService>('toastService', [
-            'show',
+        routerServiceStub = jasmine.createSpyObj<RouterService>('routerService', ['getState']);
+        toastServiceStub = jasmine.createSpyObj<ToastService>('toastService', ['show']);
+        dataJobsApiServiceStub = jasmine.createSpyObj<DataJobsApiService>('dataJobsApiService', [
+            'getJobDetails',
+            'getJobExecutions',
+            'getJobDeployments',
+            'downloadFile',
+            'updateDataJobStatus',
+            'updateDataJob',
+            'executeDataJob',
+            'removeJob',
+            'getJob'
         ]);
-        dataJobsApiServiceStub = jasmine.createSpyObj<DataJobsApiService>(
-            'dataJobsApiService',
-            [
-                'getJobDetails',
-                'getJobExecutions',
-                'getJobDeployments',
-                'downloadFile',
-                'updateDataJobStatus',
-                'updateDataJob',
-                'executeDataJob',
-                'removeJob',
-                'getJob',
-            ],
-        );
-        dataJobsServiceStub = jasmine.createSpyObj<DataJobsService>(
-            'dataJobsService',
-            [
-                'loadJobs',
-                'loadJob',
-                'notifyForRunningJobExecutionId',
-                'notifyForJobExecutions',
-                'notifyForTeamImplicitly',
-                'getNotifiedForRunningJobExecutionId',
-                'getNotifiedForJobExecutions',
-                'getNotifiedForTeamImplicitly',
-            ],
-        );
-        errorHandlerServiceStub = jasmine.createSpyObj<ErrorHandlerService>(
-            'errorHandlerService',
-            ['processError', 'handleError'],
-        );
+        dataJobsServiceStub = jasmine.createSpyObj<DataJobsService>('dataJobsService', [
+            'loadJobs',
+            'loadJob',
+            'notifyForRunningJobExecutionId',
+            'notifyForJobExecutions',
+            'notifyForTeamImplicitly',
+            'getNotifiedForRunningJobExecutionId',
+            'getNotifiedForJobExecutions',
+            'getNotifiedForTeamImplicitly'
+        ]);
+        errorHandlerServiceStub = jasmine.createSpyObj<ErrorHandlerService>('errorHandlerService', ['processError', 'handleError']);
 
-        dataJobsApiServiceStub.getJobDetails.and.returnValue(
-            new BehaviorSubject<DataJobDetails>(
-                TEST_JOB_DETAILS,
-            ).asObservable(),
-        );
+        dataJobsApiServiceStub.getJobDetails.and.returnValue(new BehaviorSubject<DataJobDetails>(TEST_JOB_DETAILS).asObservable());
         dataJobsApiServiceStub.getJobExecutions.and.returnValue(
             new BehaviorSubject<DataJobExecutionsPage>({
                 content: [TEST_JOB_EXECUTION],
                 totalItems: 1,
-                totalPages: 1,
-            }).asObservable(),
+                totalPages: 1
+            }).asObservable()
         );
         dataJobsApiServiceStub.getJobDeployments.and.returnValue(
-            new BehaviorSubject<DataJobDeploymentDetails[]>([
-                TEST_JOB_DEPLOYMENT,
-            ]).asObservable(),
+            new BehaviorSubject<DataJobDeploymentDetails[]>([TEST_JOB_DEPLOYMENT]).asObservable()
         );
-        dataJobsApiServiceStub.downloadFile.and.returnValue(
-            new BehaviorSubject<Blob>({} as never).asObservable(),
-        );
+        dataJobsApiServiceStub.downloadFile.and.returnValue(new BehaviorSubject<Blob>({} as never).asObservable());
         dataJobsApiServiceStub.updateDataJobStatus.and.returnValue(
             new BehaviorSubject<{ enabled: boolean }>({
-                enabled: true,
-            }).asObservable(),
+                enabled: true
+            }).asObservable()
         );
-        dataJobsApiServiceStub.updateDataJob.and.returnValue(
-            new BehaviorSubject<DataJobDetails>({}).asObservable(),
-        );
-        dataJobsApiServiceStub.executeDataJob.and.returnValue(
-            new BehaviorSubject<undefined>(undefined).asObservable(),
-        );
-        dataJobsApiServiceStub.removeJob.and.returnValue(
-            new BehaviorSubject<DataJobDetails>(
-                TEST_JOB_DETAILS,
-            ).asObservable(),
-        );
-        dataJobsApiServiceStub.getJob.and.returnValue(
-            of({ data: { content: [TEST_JOB_DETAILS] } } as DataJob),
-        );
+        dataJobsApiServiceStub.updateDataJob.and.returnValue(new BehaviorSubject<DataJobDetails>({}).asObservable());
+        dataJobsApiServiceStub.executeDataJob.and.returnValue(new BehaviorSubject<undefined>(undefined).asObservable());
+        dataJobsApiServiceStub.removeJob.and.returnValue(new BehaviorSubject<DataJobDetails>(TEST_JOB_DETAILS).asObservable());
+        dataJobsApiServiceStub.getJob.and.returnValue(of({ data: { content: [TEST_JOB_DETAILS] } } as DataJob));
 
-        dataJobsServiceStub.getNotifiedForJobExecutions.and.returnValue(
-            new Subject(),
-        );
-        dataJobsServiceStub.getNotifiedForTeamImplicitly.and.returnValue(
-            new BehaviorSubject(TEST_JOB_DETAILS.team),
-        );
+        dataJobsServiceStub.getNotifiedForJobExecutions.and.returnValue(new Subject());
+        dataJobsServiceStub.getNotifiedForTeamImplicitly.and.returnValue(new BehaviorSubject(TEST_JOB_DETAILS.team));
 
-        componentModelStub = ComponentModel.of(
-            ComponentStateImpl.of({}),
-            RouterState.of(RouteState.empty(), 1),
-        );
+        componentModelStub = ComponentModel.of(ComponentStateImpl.of({}), RouterState.of(RouteState.empty(), 1));
         routerServiceStub.getState.and.returnValue(new Subject());
         componentServiceStub.init.and.returnValue(of(componentModelStub));
         componentServiceStub.getModel.and.returnValue(of(componentModelStub));
 
-        navigationServiceStub.navigateBack.and.returnValue(
-            Promise.resolve(true),
-        );
+        navigationServiceStub.navigateBack.and.returnValue(Promise.resolve(true));
 
-        generateErrorCodes<DataJobsApiService>(dataJobsApiServiceStub, [
-            'getJob',
-            'getJobDetails',
-        ]);
+        generateErrorCodes<DataJobsApiService>(dataJobsApiServiceStub, ['getJob', 'getJobDetails']);
 
-        LOAD_JOB_ERROR_CODES[TASK_LOAD_JOB_STATE] =
-            dataJobsApiServiceStub.errorCodes.getJob;
-        LOAD_JOB_ERROR_CODES[TASK_LOAD_JOB_DETAILS] =
-            dataJobsApiServiceStub.errorCodes.getJobDetails;
+        LOAD_JOB_ERROR_CODES[TASK_LOAD_JOB_STATE] = dataJobsApiServiceStub.errorCodes.getJob;
+        LOAD_JOB_ERROR_CODES[TASK_LOAD_JOB_DETAILS] = dataJobsApiServiceStub.errorCodes.getJobDetails;
 
         TestBed.configureTestingModule({
             schemas: [NO_ERRORS_SCHEMA],
-            declarations: [
-                DataJobDetailsPageComponent,
-                FormatSchedulePipe,
-                ExtractJobStatusPipe,
-                ExtractContactsPipe,
-            ],
+            declarations: [DataJobDetailsPageComponent, FormatSchedulePipe, ExtractJobStatusPipe, ExtractContactsPipe],
             imports: [RouterTestingModule],
             providers: [
                 FormBuilder,
@@ -250,13 +186,13 @@ describe('DataJobsDetailsModalComponent', () => {
                 { provide: ActivatedRoute, useValue: activatedRouteStub },
                 {
                     provide: DataJobsApiService,
-                    useValue: dataJobsApiServiceStub,
+                    useValue: dataJobsApiServiceStub
                 },
                 { provide: ToastService, useValue: toastServiceStub },
                 { provide: DataJobsService, useValue: dataJobsServiceStub },
                 {
                     provide: ErrorHandlerService,
-                    useValue: errorHandlerServiceStub,
+                    useValue: errorHandlerServiceStub
                 },
                 {
                     provide: DATA_PIPELINES_CONFIGS,
@@ -264,11 +200,11 @@ describe('DataJobsDetailsModalComponent', () => {
                         defaultOwnerTeamName: 'all',
                         manageConfig: {
                             allowKeyTabDownloads: true,
-                            allowExecuteNow: true,
-                        },
-                    }),
-                },
-            ],
+                            allowExecuteNow: true
+                        }
+                    })
+                }
+            ]
         });
 
         fixture = TestBed.createComponent(DataJobDetailsPageComponent);

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/details/data-job-details-page.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/details/data-job-details-page.component.ts
@@ -28,20 +28,11 @@ import {
     TaurusBaseComponent,
     ToastService,
     VdkFormState,
-    VmwToastType,
+    VmwToastType
 } from '@versatiledatakit/shared';
 
-import {
-    ConfirmationModalOptions,
-    DeleteModalOptions,
-    ModalOptions,
-} from '../../../../shared/model';
-import {
-    CronUtil,
-    DataJobUtil,
-    ErrorUtil,
-    StringUtil,
-} from '../../../../shared/utils';
+import { ConfirmationModalOptions, DeleteModalOptions, ModalOptions } from '../../../../shared/model';
+import { CronUtil, DataJobUtil, ErrorUtil, StringUtil } from '../../../../shared/utils';
 import { ExtractJobStatusPipe, ParseEpochPipe } from '../../../../shared/pipes';
 
 import {
@@ -62,7 +53,7 @@ import {
     JOB_STATE_REQ_PARAM,
     JOB_STATUS_REQ_PARAM,
     ORDER_REQ_PARAM,
-    TEAM_NAME_REQ_PARAM,
+    TEAM_NAME_REQ_PARAM
 } from '../../../../model';
 
 import {
@@ -70,7 +61,7 @@ import {
     TASK_LOAD_JOB_EXECUTIONS,
     TASK_LOAD_JOB_STATE,
     TASK_UPDATE_JOB_DESCRIPTION,
-    TASK_UPDATE_JOB_STATUS,
+    TASK_UPDATE_JOB_STATUS
 } from '../../../../state/tasks';
 
 import { LOAD_JOB_ERROR_CODES } from '../../../../state/error-codes';
@@ -80,16 +71,11 @@ import { DataJobsApiService, DataJobsService } from '../../../../services';
 @Component({
     selector: 'lib-data-job-details-page',
     templateUrl: './data-job-details-page.component.html',
-    styleUrls: ['./data-job-details-page.component.scss'],
+    styleUrls: ['./data-job-details-page.component.scss']
 })
 export class DataJobDetailsPageComponent
     extends TaurusBaseComponent
-    implements
-        OnInit,
-        OnTaurusModelInit,
-        OnTaurusModelLoad,
-        OnTaurusModelChange,
-        OnTaurusModelError
+    implements OnInit, OnTaurusModelInit, OnTaurusModelLoad, OnTaurusModelChange, OnTaurusModelError
 {
     readonly uuid = 'DataJobDetailsPageComponent';
 
@@ -148,10 +134,7 @@ export class DataJobDetailsPageComponent
     /**
      * ** Array of error code patterns that component should listen for in errors store.
      */
-    listenForErrorPatterns: string[] = [
-        LOAD_JOB_ERROR_CODES[TASK_LOAD_JOB_STATE].All,
-        LOAD_JOB_ERROR_CODES[TASK_LOAD_JOB_DETAILS].All,
-    ];
+    listenForErrorPatterns: string[] = [LOAD_JOB_ERROR_CODES[TASK_LOAD_JOB_STATE].All, LOAD_JOB_ERROR_CODES[TASK_LOAD_JOB_DETAILS].All];
 
     /**
      * ** Flag that indicates there is jobs executions load error.
@@ -170,7 +153,7 @@ export class DataJobDetailsPageComponent
         private readonly toastService: ToastService,
         private readonly errorHandlerService: ErrorHandlerService,
         @Inject(DATA_PIPELINES_CONFIGS)
-        public readonly dataPipelinesModuleConfig: DataPipelinesConfig,
+        public readonly dataPipelinesModuleConfig: DataPipelinesConfig
     ) {
         super(componentService, navigationService, activatedRoute);
 
@@ -186,18 +169,11 @@ export class DataJobDetailsPageComponent
     }
 
     isDescriptionSubmitEnabled(): boolean {
-        return (
-            this._isFormSubmitEnabled() &&
-            this.description.value !== this.jobDetails.description
-        );
+        return this._isFormSubmitEnabled() && this.description.value !== this.jobDetails.description;
     }
 
     isStatusSubmitEnabled(): boolean {
-        return (
-            this._isFormSubmitEnabled() &&
-            this.status.value !==
-                ExtractJobStatusPipe.transform(this.jobState?.deployments)
-        );
+        return this._isFormSubmitEnabled() && this.status.value !== ExtractJobStatusPipe.transform(this.jobState?.deployments);
     }
 
     isJobRunning(): boolean {
@@ -212,11 +188,7 @@ export class DataJobDetailsPageComponent
         if (sectionState.state === FORM_STATE.CAN_EDIT) {
             switch (sectionState.emittingSection) {
                 case 'status':
-                    this.status.setValue(
-                        ExtractJobStatusPipe.transform(
-                            this.jobState?.deployments,
-                        ),
-                    );
+                    this.status.setValue(ExtractJobStatusPipe.transform(this.jobState?.deployments));
                     break;
                 case 'description':
                     this.description.setValue(this.jobDetails.description);
@@ -233,17 +205,11 @@ export class DataJobDetailsPageComponent
     }
 
     submitForm(event: VdkFormState) {
-        if (
-            event.emittingSection === 'description' &&
-            this.isDescriptionSubmitEnabled()
-        ) {
+        if (event.emittingSection === 'description' && this.isDescriptionSubmitEnabled()) {
             this._doSubmitDescriptionUpdate();
         }
 
-        if (
-            event.emittingSection === 'status' &&
-            this.isStatusSubmitEnabled()
-        ) {
+        if (event.emittingSection === 'status' && this.isStatusSubmitEnabled()) {
             this._doSubmitStatusUpdate();
         }
     }
@@ -259,14 +225,7 @@ export class DataJobDetailsPageComponent
 
     redirectToHealthStatus() {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.router
-            .navigateByUrl(
-                StringUtil.stringFormat(
-                    this.dataPipelinesModuleConfig.healthStatusUrl,
-                    this.jobDetails.job_name,
-                ),
-            )
-            .then();
+        this.router.navigateByUrl(StringUtil.stringFormat(this.dataPipelinesModuleConfig.healthStatusUrl, this.jobDetails.job_name)).then();
     }
 
     /**
@@ -295,45 +254,31 @@ export class DataJobDetailsPageComponent
      */
     onModelChange(model: ComponentModel, task: string): void {
         if (task === TASK_LOAD_JOB_STATE) {
-            this.jobState = model
-                .getComponentState()
-                .data.get(JOB_STATE_DATA_KEY);
+            this.jobState = model.getComponentState().data.get(JOB_STATE_DATA_KEY);
             this._initializeNextRunDate();
-            this.allowExecutionsByDeployment =
-                ExtractJobStatusPipe.transform(this.jobState?.deployments) !==
-                DataJobStatus.NOT_DEPLOYED;
-            this.cronError = CronUtil.getNextExecutionErrors(
-                this.jobState?.config?.schedule?.scheduleCron,
-            );
+            this.allowExecutionsByDeployment = ExtractJobStatusPipe.transform(this.jobState?.deployments) !== DataJobStatus.NOT_DEPLOYED;
+            this.cronError = CronUtil.getNextExecutionErrors(this.jobState?.config?.schedule?.scheduleCron);
 
             return;
         }
 
         if (task === TASK_LOAD_JOB_DETAILS) {
-            this.jobDetails = model
-                .getComponentState()
-                .data.get(JOB_DETAILS_DATA_KEY);
+            this.jobDetails = model.getComponentState().data.get(JOB_DETAILS_DATA_KEY);
             this._updateForm();
 
             return;
         }
 
         if (task === TASK_LOAD_JOB_EXECUTIONS) {
-            const executions: DataJobExecutions = model
-                .getComponentState()
-                .data.get(JOB_EXECUTIONS_DATA_KEY);
+            const executions: DataJobExecutions = model.getComponentState().data.get(JOB_EXECUTIONS_DATA_KEY);
 
             if (executions) {
                 this.dataJobsService.notifyForJobExecutions([...executions]);
 
                 // eslint-disable-next-line @typescript-eslint/unbound-method
-                const runningExecution = executions.find(
-                    DataJobUtil.isJobRunningPredicate,
-                );
+                const runningExecution = executions.find(DataJobUtil.isJobRunningPredicate);
                 if (runningExecution) {
-                    this.dataJobsService.notifyForRunningJobExecutionId(
-                        runningExecution.id,
-                    );
+                    this.dataJobsService.notifyForRunningJobExecutionId(runningExecution.id);
                 }
             }
 
@@ -344,12 +289,10 @@ export class DataJobDetailsPageComponent
             this.toastService.show({
                 type: VmwToastType.INFO,
                 title: `Description update completed`,
-                description: `Data job "${this.jobName}" description successfully updated`,
+                description: `Data job "${this.jobName}" description successfully updated`
             });
 
-            this.jobDetails = model
-                .getComponentState()
-                .data.get(JOB_DETAILS_DATA_KEY);
+            this.jobDetails = model.getComponentState().data.get(JOB_DETAILS_DATA_KEY);
 
             this.editOperationEnded();
 
@@ -361,17 +304,10 @@ export class DataJobDetailsPageComponent
                 type: VmwToastType.INFO,
                 title: `Status update completed`,
                 description:
-                    `Data job "${this.jobName}" successfully ` +
-                    `${
-                        !this._extractJobDeployment()?.enabled
-                            ? 'enabled'
-                            : 'disabled'
-                    }`,
+                    `Data job "${this.jobName}" successfully ` + `${!this._extractJobDeployment()?.enabled ? 'enabled' : 'disabled'}`
             });
 
-            this.jobState = model
-                .getComponentState()
-                .data.get(JOB_STATE_DATA_KEY);
+            this.jobState = model.getComponentState().data.get(JOB_STATE_DATA_KEY);
 
             this.editOperationEnded();
         }
@@ -380,11 +316,7 @@ export class DataJobDetailsPageComponent
     /**
      * @inheritDoc
      */
-    onModelError(
-        model: ComponentModel,
-        task: string,
-        newErrorRecords: ErrorRecord[],
-    ): void {
+    onModelError(model: ComponentModel, task: string, newErrorRecords: ErrorRecord[]): void {
         newErrorRecords.forEach((errorRecord) => {
             const error = ErrorUtil.extractError(errorRecord.error);
 
@@ -402,13 +334,13 @@ export class DataJobDetailsPageComponent
                     break;
                 case TASK_UPDATE_JOB_DESCRIPTION:
                     errorHandlerConfig = {
-                        title: 'Description update failed',
+                        title: 'Description update failed'
                     };
                     this.editOperationEnded();
                     break;
                 case TASK_UPDATE_JOB_STATUS:
                     errorHandlerConfig = {
-                        title: 'Status update failed',
+                        title: 'Status update failed'
                     };
                     this.editOperationEnded();
                     break;
@@ -427,27 +359,21 @@ export class DataJobDetailsPageComponent
         // attach listener to ErrorStore and listen for Errors change
         this.errors.onChange((store) => {
             // if there is record for listened error code patterns set component in error state
-            this.isComponentInErrorState = store.hasCodePattern(
-                ...this.listenForErrorPatterns,
-            );
+            this.isComponentInErrorState = store.hasCodePattern(...this.listenForErrorPatterns);
         });
 
         super.ngOnInit();
 
         this._initializeNextRunDate();
 
-        this.shouldShowTeamsSection =
-            this.dataPipelinesModuleConfig?.exploreConfig?.showTeamsColumn;
+        this.shouldShowTeamsSection = this.dataPipelinesModuleConfig?.exploreConfig?.showTeamsColumn;
     }
 
     private _initialize(state: RouteState): void {
         const teamParamKey = state.getData<string>('teamParamKey');
         this.teamName = state.getParam(teamParamKey);
 
-        if (
-            CollectionsUtil.isNil(teamParamKey) ||
-            CollectionsUtil.isNil(this.teamName)
-        ) {
+        if (CollectionsUtil.isNil(teamParamKey) || CollectionsUtil.isNil(this.teamName)) {
             this._subscribeForImplicitTeam();
         }
 
@@ -468,8 +394,8 @@ export class DataJobDetailsPageComponent
                 .withRequestParam(JOB_NAME_REQ_PARAM, this.jobName)
                 .withRequestParam(ORDER_REQ_PARAM, {
                     property: 'startTime',
-                    direction: ASC,
-                } as DataJobExecutionOrder),
+                    direction: ASC
+                } as DataJobExecutionOrder)
         );
     }
 
@@ -484,9 +410,7 @@ export class DataJobDetailsPageComponent
         if (!this.jobState?.deployments) {
             return null;
         }
-        return this.jobState?.deployments[
-            this.jobState?.deployments.length - 1
-        ];
+        return this.jobState?.deployments[this.jobState?.deployments.length - 1];
     }
 
     private _isFormSubmitEnabled(): boolean {
@@ -498,7 +422,7 @@ export class DataJobDetailsPageComponent
             name: '',
             team: '',
             status: '',
-            description: '',
+            description: ''
         });
     }
 
@@ -507,25 +431,22 @@ export class DataJobDetailsPageComponent
             name: this.jobDetails.job_name,
             team: this.jobDetails.team,
             status: ExtractJobStatusPipe.transform(this.jobState?.deployments),
-            description: this.jobDetails.description,
+            description: this.jobDetails.description
         });
     }
 
     private _doSubmitDescriptionUpdate(): void {
         const jobDetailsUpdated: DataJobDetails = {
             ...this.jobDetails,
-            description: this.description.value as string,
+            description: this.description.value as string
         };
 
         this.dataJobsService.updateJob(
             this.model
                 .withRequestParam(TEAM_NAME_REQ_PARAM, jobDetailsUpdated.team)
-                .withRequestParam(
-                    JOB_NAME_REQ_PARAM,
-                    jobDetailsUpdated.job_name,
-                )
+                .withRequestParam(JOB_NAME_REQ_PARAM, jobDetailsUpdated.job_name)
                 .withRequestParam(JOB_DETAILS_REQ_PARAM, jobDetailsUpdated),
-            TASK_UPDATE_JOB_DESCRIPTION,
+            TASK_UPDATE_JOB_DESCRIPTION
         );
     }
 
@@ -533,9 +454,7 @@ export class DataJobDetailsPageComponent
         const jobDeployment = this._extractJobDeployment();
 
         if (!jobDeployment) {
-            console.log(
-                'Status update will not be performed for job with no deployments.',
-            );
+            console.log('Status update will not be performed for job with no deployments.');
 
             return;
         }
@@ -545,10 +464,10 @@ export class DataJobDetailsPageComponent
             deployments: [
                 {
                     ...this.jobState.deployments[0],
-                    enabled: this.status.value === DataJobStatus.ENABLED,
+                    enabled: this.status.value === DataJobStatus.ENABLED
                 },
-                ...this.jobState.deployments.slice(1),
-            ],
+                ...this.jobState.deployments.slice(1)
+            ]
         };
 
         this.dataJobsService.updateJob(
@@ -556,28 +475,21 @@ export class DataJobDetailsPageComponent
                 .withRequestParam(TEAM_NAME_REQ_PARAM, this.jobDetails.team)
                 .withRequestParam(JOB_NAME_REQ_PARAM, this.jobDetails.job_name)
                 .withRequestParam(JOB_DEPLOYMENT_ID_REQ_PARAM, jobDeployment.id)
-                .withRequestParam(
-                    JOB_STATUS_REQ_PARAM,
-                    this.status.value === DataJobStatus.ENABLED,
-                )
+                .withRequestParam(JOB_STATUS_REQ_PARAM, this.status.value === DataJobStatus.ENABLED)
                 .withRequestParam(JOB_STATE_REQ_PARAM, jobState),
-            TASK_UPDATE_JOB_STATUS,
+            TASK_UPDATE_JOB_STATUS
         );
     }
 
     private _initializeNextRunDate(): void {
-        this.next = ParseEpochPipe.transform(
-            this.jobState?.config?.schedule?.nextRunEpochSeconds,
-        );
+        this.next = ParseEpochPipe.transform(this.jobState?.config?.schedule?.nextRunEpochSeconds);
     }
 
     private _subscribeForExecutions(): void {
         this.subscriptions.push(
-            this.dataJobsService
-                .getNotifiedForJobExecutions()
-                .subscribe((executions) => {
-                    this.jobExecutions = executions;
-                }),
+            this.dataJobsService.getNotifiedForJobExecutions().subscribe((executions) => {
+                this.jobExecutions = executions;
+            })
         );
     }
 

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/data-job-deployment-details-modal/data-job-deployment-details-modal.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/data-job-deployment-details-modal/data-job-deployment-details-modal.component.ts
@@ -9,7 +9,7 @@ import { DataJobDeployment } from '../../../../../model';
 @Component({
     selector: 'lib-data-job-deployment-details-modal',
     templateUrl: './data-job-deployment-details-modal.component.html',
-    styleUrls: ['./data-job-deployment-details-modal.component.scss'],
+    styleUrls: ['./data-job-deployment-details-modal.component.scss']
 })
 export class DataJobDeploymentDetailsModalComponent {
     @Output() openModalChange = new EventEmitter<boolean>();

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/data-job-execution-status-filter/data-job-execution-status-filter.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/data-job-execution-status-filter/data-job-execution-status-filter.component.ts
@@ -15,11 +15,9 @@ import { GridDataJobExecution } from '../model';
 
 @Component({
     selector: 'lib-data-job-execution-status-filter',
-    templateUrl: './data-job-execution-status-filter.component.html',
+    templateUrl: './data-job-execution-status-filter.component.html'
 })
-export class DataJobExecutionStatusFilterComponent
-    implements ClrDatagridFilterInterface<GridDataJobExecution>
-{
+export class DataJobExecutionStatusFilterComponent implements ClrDatagridFilterInterface<GridDataJobExecution> {
     allStatuses = [
         DataJobExecutionStatus.SUCCEEDED,
         DataJobExecutionStatus.PLATFORM_ERROR,
@@ -27,7 +25,7 @@ export class DataJobExecutionStatusFilterComponent
         DataJobExecutionStatus.RUNNING,
         DataJobExecutionStatus.SUBMITTED,
         DataJobExecutionStatus.SKIPPED,
-        DataJobExecutionStatus.CANCELLED,
+        DataJobExecutionStatus.CANCELLED
     ];
 
     selectedStatuses: string[] = [];
@@ -48,9 +46,7 @@ export class DataJobExecutionStatusFilterComponent
         if (checkbox.checked) {
             this.selectedStatuses.push(checkbox.value);
         } else {
-            const statusToRemoveIndex = this.selectedStatuses.indexOf(
-                checkbox.value,
-            );
+            const statusToRemoveIndex = this.selectedStatuses.indexOf(checkbox.value);
             if (statusToRemoveIndex > -1) {
                 this.selectedStatuses.splice(statusToRemoveIndex, 1);
             }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/data-job-execution-status/data-job-execution-status.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/data-job-execution-status/data-job-execution-status.component.ts
@@ -17,7 +17,7 @@ type StatusPropertiesMapping = {
 @Component({
     selector: 'lib-data-job-execution-status',
     templateUrl: './data-job-execution-status.component.html',
-    styleUrls: ['./data-job-execution-status.component.scss'],
+    styleUrls: ['./data-job-execution-status.component.scss']
 })
 export class DataJobExecutionStatusComponent {
     @HostListener('mouseenter') onMouseEnter(): void {
@@ -38,57 +38,54 @@ export class DataJobExecutionStatusComponent {
             shape: 'hourglass',
             status: '',
             direction: '',
-            text: 'Submitted',
+            text: 'Submitted'
         },
         [DataJobExecutionStatus.RUNNING]: {
             shape: 'play',
             status: '',
             direction: '',
-            text: 'Running',
+            text: 'Running'
         },
         [DataJobExecutionStatus.SUCCEEDED]: {
             shape: 'success-standard',
             status: 'is-success',
             direction: '',
-            text: 'Success',
+            text: 'Success'
         },
         [DataJobExecutionStatus.CANCELLED]: {
             shape: 'ban',
             status: '',
             direction: '',
-            text: 'Canceled',
+            text: 'Canceled'
         },
         [DataJobExecutionStatus.SKIPPED]: {
             shape: 'angle-double',
             status: '',
             direction: 'right',
-            text: 'Skipped',
+            text: 'Skipped'
         },
         [DataJobExecutionStatus.USER_ERROR]: {
             shape: 'error-standard',
             status: 'is-danger',
             direction: '',
-            text: 'User Error',
+            text: 'User Error'
         },
         [DataJobExecutionStatus.PLATFORM_ERROR]: {
             shape: 'error-standard',
             status: 'is-warning',
             direction: '',
-            text: 'Platform Error',
+            text: 'Platform Error'
         },
         [DataJobExecutionStatus.FAILED]: {
             shape: 'error-standard',
             status: 'is-danger',
             direction: '',
-            text: 'Error',
-        },
+            text: 'Error'
+        }
     };
 
     get executionStatusProperties(): StatusPropertiesMapping {
-        return (
-            this.statusPropertiesMapping[this.jobStatus] ??
-            ({} as StatusPropertiesMapping)
-        );
+        return this.statusPropertiesMapping[this.jobStatus] ?? ({} as StatusPropertiesMapping);
     }
 
     isJobStatusSuitableForMessageTooltip(): boolean {
@@ -101,11 +98,6 @@ export class DataJobExecutionStatusComponent {
 
     isJobMessageDifferentFromStatus(): boolean {
         const message = this.jobMessage?.toLowerCase();
-        return (
-            message !== 'user error' &&
-            message !== 'platform error' &&
-            message !== 'skipped' &&
-            message !== ''
-        );
+        return message !== 'user error' && message !== 'platform error' && message !== 'skipped' && message !== '';
     }
 }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/data-job-execution-type-filter/data-job-execution-type-filter.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/data-job-execution-type-filter/data-job-execution-type-filter.component.ts
@@ -15,11 +15,9 @@ import { GridDataJobExecution } from '../model/data-job-execution';
 
 @Component({
     selector: 'lib-data-job-execution-type-filter',
-    templateUrl: './data-job-execution-type-filter.component.html',
+    templateUrl: './data-job-execution-type-filter.component.html'
 })
-export class DataJobExecutionTypeFilterComponent
-    implements ClrDatagridFilterInterface<GridDataJobExecution>
-{
+export class DataJobExecutionTypeFilterComponent implements ClrDatagridFilterInterface<GridDataJobExecution> {
     allTypes = [DataJobExecutionType.MANUAL, DataJobExecutionType.SCHEDULED];
     selectedTypes: string[] = [];
     changes: Subject<boolean> = new Subject<boolean>();
@@ -38,9 +36,7 @@ export class DataJobExecutionTypeFilterComponent
         if (checkbox.checked) {
             this.selectedTypes.push(checkbox.value);
         } else {
-            const statusToRemoveIndex = this.selectedTypes.indexOf(
-                checkbox.value,
-            );
+            const statusToRemoveIndex = this.selectedTypes.indexOf(checkbox.value);
             if (statusToRemoveIndex > -1) {
                 this.selectedTypes.splice(statusToRemoveIndex, 1);
             }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/data-job-execution-type/data-job-execution-type.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/data-job-execution-type/data-job-execution-type.component.ts
@@ -11,7 +11,7 @@ import { GridDataJobExecution } from '../model/data-job-execution';
 
 @Component({
     selector: 'lib-data-job-execution-type',
-    templateUrl: './data-job-execution-type.component.html',
+    templateUrl: './data-job-execution-type.component.html'
 })
 export class DataJobExecutionTypeComponent {
     @Input() jobExecution: GridDataJobExecution;
@@ -19,9 +19,9 @@ export class DataJobExecutionTypeComponent {
     executionTypePropertiesMapping = {
         [DataJobExecutionType.MANUAL]: {
             shape: 'cursor-hand-open',
-            status: 'is-info',
+            status: 'is-info'
         },
-        [DataJobExecutionType.SCHEDULED]: { shape: 'clock', status: '' },
+        [DataJobExecutionType.SCHEDULED]: { shape: 'clock', status: '' }
     };
 
     get executionTypeProperties() {

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/data-job-executions-grid/comparators/execution-duration-comparator.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/data-job-executions-grid/comparators/execution-duration-comparator.spec.ts
@@ -23,15 +23,15 @@ describe('DataJobExecutionDurationComparator', () => {
                         startTime: aStartTime.toISOString(),
                         endTime: aEndTime.toISOString(),
                         duration: '100',
-                        jobVersion: '',
+                        jobVersion: ''
                     },
                     {
                         id: 'bJob',
                         startTime: bStartTime.toISOString(),
                         endTime: bEndTime.toISOString(),
                         duration: '110',
-                        jobVersion: '',
-                    },
+                        jobVersion: ''
+                    }
                 );
 
                 // Then

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/data-job-executions-grid/comparators/execution-duration-comparator.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/data-job-executions-grid/comparators/execution-duration-comparator.ts
@@ -7,9 +7,7 @@ import { ClrDatagridComparatorInterface } from '@clr/angular';
 
 import { GridDataJobExecution } from '../../model/data-job-execution';
 
-export class DataJobExecutionDurationComparator
-    implements ClrDatagridComparatorInterface<GridDataJobExecution>
-{
+export class DataJobExecutionDurationComparator implements ClrDatagridComparatorInterface<GridDataJobExecution> {
     /**
      * @inheritDoc
      */

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/data-job-executions-grid/data-job-executions-grid.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/data-job-executions-grid/data-job-executions-grid.component.ts
@@ -3,12 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-    ChangeDetectionStrategy,
-    ChangeDetectorRef,
-    Component,
-    Input,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input } from '@angular/core';
 
 import { ClrDatagridSortOrder } from '@clr/angular';
 
@@ -22,7 +17,7 @@ import { DataJobExecutionDurationComparator } from './comparators/execution-dura
     selector: 'lib-data-job-executions-grid',
     templateUrl: './data-job-executions-grid.component.html',
     styleUrls: ['./data-job-executions-grid.component.scss'],
-    changeDetection: ChangeDetectionStrategy.OnPush,
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DataJobExecutionsGridComponent {
     @Input() jobExecutions: GridDataJobExecution[];

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/data-job-executions-page/data-job-executions-page.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/data-job-executions-page/data-job-executions-page.component.ts
@@ -22,7 +22,7 @@ import {
     OnTaurusModelLoad,
     RouterService,
     RouteState,
-    TaurusBaseComponent,
+    TaurusBaseComponent
 } from '@versatiledatakit/shared';
 
 import { DataJobUtil, ErrorUtil } from '../../../../../shared/utils';
@@ -36,7 +36,7 @@ import {
     JOB_EXECUTIONS_DATA_KEY,
     JOB_NAME_REQ_PARAM,
     ORDER_REQ_PARAM,
-    TEAM_NAME_REQ_PARAM,
+    TEAM_NAME_REQ_PARAM
 } from '../../../../../model';
 
 import { TASK_LOAD_JOB_EXECUTIONS } from '../../../../../state/tasks';
@@ -45,24 +45,16 @@ import { LOAD_JOB_ERROR_CODES } from '../../../../../state/error-codes';
 
 import { DataJobsService } from '../../../../../services';
 
-import {
-    DataJobExecutionToGridDataJobExecution,
-    GridDataJobExecution,
-} from '../model/data-job-execution';
+import { DataJobExecutionToGridDataJobExecution, GridDataJobExecution } from '../model/data-job-execution';
 
 @Component({
     selector: 'lib-data-job-executions-page',
     templateUrl: './data-job-executions-page.component.html',
-    styleUrls: ['./data-job-executions-page.component.scss'],
+    styleUrls: ['./data-job-executions-page.component.scss']
 })
 export class DataJobExecutionsPageComponent
     extends TaurusBaseComponent
-    implements
-        OnTaurusModelInit,
-        OnTaurusModelLoad,
-        OnTaurusModelChange,
-        OnTaurusModelError,
-        OnInit
+    implements OnTaurusModelInit, OnTaurusModelLoad, OnTaurusModelChange, OnTaurusModelError, OnInit
 {
     readonly uuid = 'DataJobExecutionsPageComponent';
 
@@ -77,15 +69,13 @@ export class DataJobExecutionsPageComponent
 
     dateTimeFilter: { fromTime: Date; toTime: Date } = {
         fromTime: null,
-        toTime: null,
+        toTime: null
     };
 
     /**
      * ** Array of error code patterns that component should listen for in errors store.
      */
-    listenForErrorPatterns: string[] = [
-        LOAD_JOB_ERROR_CODES[TASK_LOAD_JOB_EXECUTIONS].All,
-    ];
+    listenForErrorPatterns: string[] = [LOAD_JOB_ERROR_CODES[TASK_LOAD_JOB_EXECUTIONS].All];
 
     /**
      * ** Flag that indicates there is jobs executions load error.
@@ -98,7 +88,7 @@ export class DataJobExecutionsPageComponent
         activatedRoute: ActivatedRoute,
         private readonly routerService: RouterService,
         private readonly dataJobsService: DataJobsService,
-        private readonly errorHandlerService: ErrorHandlerService,
+        private readonly errorHandlerService: ErrorHandlerService
     ) {
         super(componentService, navigationService, activatedRoute);
     }
@@ -111,26 +101,20 @@ export class DataJobExecutionsPageComponent
     onTimeFilterChange(dateTimeFilter: { fromTime: Date; toTime: Date }): void {
         this.dateTimeFilter = dateTimeFilter;
 
-        const modelFilter: DataJobExecutionFilter =
-            this.model
-                .getComponentState()
-                .requestParams.get(FILTER_REQ_PARAM) ?? {};
+        const modelFilter: DataJobExecutionFilter = this.model.getComponentState().requestParams.get(FILTER_REQ_PARAM) ?? {};
 
-        if (
-            CollectionsUtil.isNil(dateTimeFilter.fromTime) ||
-            CollectionsUtil.isNil(dateTimeFilter.toTime)
-        ) {
+        if (CollectionsUtil.isNil(dateTimeFilter.fromTime) || CollectionsUtil.isNil(dateTimeFilter.toTime)) {
             delete modelFilter.startTimeGte;
             delete modelFilter.startTimeLte;
 
             this.model.withRequestParam(FILTER_REQ_PARAM, {
-                ...modelFilter,
+                ...modelFilter
             } as DataJobExecutionFilter);
         } else {
             this.model.withRequestParam(FILTER_REQ_PARAM, {
                 ...modelFilter,
                 startTimeGte: dateTimeFilter.fromTime,
-                startTimeLte: dateTimeFilter.toTime,
+                startTimeLte: dateTimeFilter.toTime
             } as DataJobExecutionFilter);
         }
 
@@ -146,8 +130,8 @@ export class DataJobExecutionsPageComponent
                 .withRequestParam(JOB_NAME_REQ_PARAM, this.jobName)
                 .withRequestParam(ORDER_REQ_PARAM, {
                     property: 'startTime',
-                    direction: ASC,
-                } as DataJobExecutionOrder),
+                    direction: ASC
+                } as DataJobExecutionOrder)
         );
     }
 
@@ -174,20 +158,14 @@ export class DataJobExecutionsPageComponent
      */
     onModelChange(model: ComponentModel, task: string): void {
         if (task === TASK_LOAD_JOB_EXECUTIONS) {
-            const executions: DataJobExecutions = model
-                .getComponentState()
-                .data.get(JOB_EXECUTIONS_DATA_KEY);
+            const executions: DataJobExecutions = model.getComponentState().data.get(JOB_EXECUTIONS_DATA_KEY);
             if (executions) {
                 this.dataJobsService.notifyForJobExecutions([...executions]);
 
                 // eslint-disable-next-line @typescript-eslint/unbound-method
-                const runningExecution = executions.find(
-                    DataJobUtil.isJobRunningPredicate,
-                );
+                const runningExecution = executions.find(DataJobUtil.isJobRunningPredicate);
                 if (runningExecution) {
-                    this.dataJobsService.notifyForRunningJobExecutionId(
-                        runningExecution.id,
-                    );
+                    this.dataJobsService.notifyForRunningJobExecutionId(runningExecution.id);
                 }
             }
         }
@@ -196,11 +174,7 @@ export class DataJobExecutionsPageComponent
     /**
      * @inheritDoc
      */
-    onModelError(
-        model: ComponentModel,
-        _task: string,
-        newErrorRecords: ErrorRecord[],
-    ): void {
+    onModelError(model: ComponentModel, _task: string, newErrorRecords: ErrorRecord[]): void {
         newErrorRecords.forEach((errorRecord) => {
             const error = ErrorUtil.extractError(errorRecord.error);
 
@@ -215,27 +189,20 @@ export class DataJobExecutionsPageComponent
         // attach listener to ErrorStore and listen for Errors change
         this.errors.onChange((store) => {
             // if there is record for listened error code patterns set component in error state
-            this.isComponentInErrorState = store.hasCodePattern(
-                ...this.listenForErrorPatterns,
-            );
+            this.isComponentInErrorState = store.hasCodePattern(...this.listenForErrorPatterns);
         });
 
         super.ngOnInit();
     }
 
     private _initialize(state: RouteState): void {
-        const teamParamKey =
-            state.getData<DataPipelinesRouteData['teamParamKey']>(
-                'teamParamKey',
-            );
+        const teamParamKey = state.getData<DataPipelinesRouteData['teamParamKey']>('teamParamKey');
         this.teamName = state.getParam(teamParamKey);
 
-        const jobParamKey =
-            state.getData<DataPipelinesRouteData['jobParamKey']>('jobParamKey');
+        const jobParamKey = state.getData<DataPipelinesRouteData['jobParamKey']>('jobParamKey');
         this.jobName = state.getParam(jobParamKey);
 
-        this.isJobEditable =
-            !!state.getData<DataPipelinesRouteData['editable']>('editable');
+        this.isJobEditable = !!state.getData<DataPipelinesRouteData['editable']>('editable');
 
         this._subscribeForExecutions();
 
@@ -248,21 +215,12 @@ export class DataJobExecutionsPageComponent
                 .getNotifiedForJobExecutions()
                 .pipe(
                     // eslint-disable-next-line @typescript-eslint/unbound-method
-                    map(
-                        DataJobExecutionToGridDataJobExecution.convertToDataJobExecution,
-                    ),
+                    map(DataJobExecutionToGridDataJobExecution.convertToDataJobExecution)
                 )
                 .subscribe({
                     next: (values) => {
                         this.jobExecutions = values.filter((ex) => {
-                            if (
-                                CollectionsUtil.isNil(
-                                    this.dateTimeFilter.fromTime,
-                                ) ||
-                                CollectionsUtil.isNil(
-                                    this.dateTimeFilter.toTime,
-                                )
-                            ) {
+                            if (CollectionsUtil.isNil(this.dateTimeFilter.fromTime) || CollectionsUtil.isNil(this.dateTimeFilter.toTime)) {
                                 return true;
                             }
 
@@ -272,38 +230,26 @@ export class DataJobExecutionsPageComponent
 
                             const startTime = new Date(ex.startTime);
 
-                            return (
-                                startTime > this.dateTimeFilter.fromTime &&
-                                startTime < this.dateTimeFilter.toTime
-                            );
+                            return startTime > this.dateTimeFilter.fromTime && startTime < this.dateTimeFilter.toTime;
                         });
 
                         if (this.jobExecutions.length > 0) {
                             const newMinJobExecutionsTime = new Date(
-                                this.jobExecutions.reduce((prev, curr) =>
-                                    prev.startTime < curr.startTime
-                                        ? prev
-                                        : curr,
-                                ).startTime,
+                                this.jobExecutions.reduce((prev, curr) => (prev.startTime < curr.startTime ? prev : curr)).startTime
                             );
 
                             if (
-                                CollectionsUtil.isNil(
-                                    this.minJobExecutionTime,
-                                ) ||
-                                newMinJobExecutionsTime.getTime() -
-                                    this.minJobExecutionTime.getTime() !==
-                                    0
+                                CollectionsUtil.isNil(this.minJobExecutionTime) ||
+                                newMinJobExecutionsTime.getTime() - this.minJobExecutionTime.getTime() !== 0
                             ) {
-                                this.minJobExecutionTime =
-                                    newMinJobExecutionsTime;
+                                this.minJobExecutionTime = newMinJobExecutionsTime;
                             }
                         }
                     },
                     error: (error: unknown) => {
                         console.error(error);
-                    },
-                }),
+                    }
+                })
         );
     }
 }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/execution-duration-chart/execution-duration-chart.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/execution-duration-chart/execution-duration-chart.component.ts
@@ -4,21 +4,9 @@
  */
 
 import { DatePipe, formatDate } from '@angular/common';
-import {
-    Component,
-    Input,
-    OnChanges,
-    OnInit,
-    SimpleChanges,
-} from '@angular/core';
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 
-import {
-    Chart,
-    ChartData,
-    registerables,
-    ScatterDataPoint,
-    TimeUnit,
-} from 'chart.js';
+import { Chart, ChartData, registerables, ScatterDataPoint, TimeUnit } from 'chart.js';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 import zoomPlugin from 'chartjs-plugin-zoom';
 import 'chartjs-adapter-date-fns';
@@ -29,10 +17,7 @@ import { DateUtil } from '../../../../../shared/utils';
 
 import { DataJobExecutionStatus } from '../../../../../model';
 
-import {
-    DataJobExecutionToGridDataJobExecution,
-    GridDataJobExecution,
-} from '../model';
+import { DataJobExecutionToGridDataJobExecution, GridDataJobExecution } from '../model';
 
 type CustomChartData = ScatterDataPoint & {
     startTime: number;
@@ -46,7 +31,7 @@ type CustomChartData = ScatterDataPoint & {
     selector: 'lib-execution-duration-chart',
     templateUrl: './execution-duration-chart.component.html',
     styleUrls: ['./execution-duration-chart.component.scss'],
-    providers: [DatePipe],
+    providers: [DatePipe]
 })
 export class ExecutionDurationChartComponent implements OnInit, OnChanges {
     @Input() jobExecutions: GridDataJobExecution[] = [];
@@ -61,18 +46,14 @@ export class ExecutionDurationChartComponent implements OnInit, OnChanges {
     }
 
     getChartLabels(): number[] {
-        return this.jobExecutions.map((execution) =>
-            DateUtil.normalizeToUTC(execution.startTime).getTime(),
-        );
+        return this.jobExecutions.map((execution) => DateUtil.normalizeToUTC(execution.startTime).getTime());
     }
 
     getData(min?: number, max?: number): CustomChartData[] {
         const divider = this.getDurationUnit().divider;
         const executions = CollectionsUtil.isDefined(min)
             ? this.jobExecutions.filter((ex) => {
-                  const startTime = DateUtil.normalizeToUTC(
-                      ex.startTime,
-                  ).getTime();
+                  const startTime = DateUtil.normalizeToUTC(ex.startTime).getTime();
 
                   return startTime >= min && startTime <= max;
               })
@@ -80,18 +61,11 @@ export class ExecutionDurationChartComponent implements OnInit, OnChanges {
 
         return executions.map((execution) => {
             return {
-                startTime: DateUtil.normalizeToUTC(
-                    execution.startTime,
-                ).getTime(),
-                duration:
-                    Math.round(
-                        (this.getJobDurationSeconds(execution) / divider) * 100,
-                    ) / 100,
-                endTime: execution.endTime
-                    ? new Date(execution.endTime)
-                    : undefined,
+                startTime: DateUtil.normalizeToUTC(execution.startTime).getTime(),
+                duration: Math.round((this.getJobDurationSeconds(execution) / divider) * 100) / 100,
+                endTime: execution.endTime ? new Date(execution.endTime) : undefined,
                 status: execution.status,
-                opId: execution.opId,
+                opId: execution.opId
             } as unknown as CustomChartData;
         });
     }
@@ -104,9 +78,7 @@ export class ExecutionDurationChartComponent implements OnInit, OnChanges {
 
     getJobDurationSeconds(execution: GridDataJobExecution) {
         return (
-            ((execution.endTime
-                ? new Date(execution.endTime).getTime()
-                : new Date(Date.now()).getTime()) -
+            ((execution.endTime ? new Date(execution.endTime).getTime() : new Date(Date.now()).getTime()) -
                 new Date(execution.startTime).getTime()) /
             1000
         );
@@ -116,9 +88,7 @@ export class ExecutionDurationChartComponent implements OnInit, OnChanges {
         const maxDurationSeconds = this.getMaxDurationSeconds();
 
         if (maxDurationSeconds > 60) {
-            return maxDurationSeconds > 3600
-                ? { name: 'hours', divider: 3600 }
-                : { name: 'minutes', divider: 60 };
+            return maxDurationSeconds > 3600 ? { name: 'hours', divider: 3600 } : { name: 'minutes', divider: 60 };
         } else {
             return { name: 'seconds', divider: 1 };
         }
@@ -157,20 +127,16 @@ export class ExecutionDurationChartComponent implements OnInit, OnChanges {
                     fill: false,
                     pointRadius: 3,
                     pointBorderColor: (context) =>
-                        DataJobExecutionToGridDataJobExecution.resolveColor(
-                            (context.raw as { status: string }).status,
-                        ),
+                        DataJobExecutionToGridDataJobExecution.resolveColor((context.raw as { status: string }).status),
                     pointBackgroundColor: (context) =>
-                        DataJobExecutionToGridDataJobExecution.resolveColor(
-                            (context.raw as { status: string }).status,
-                        ),
+                        DataJobExecutionToGridDataJobExecution.resolveColor((context.raw as { status: string }).status),
                     pointBorderWidth: 3,
                     parsing: {
                         xAxisKey: 'startTime',
-                        yAxisKey: 'duration',
-                    },
-                },
-            ],
+                        yAxisKey: 'duration'
+                    }
+                }
+            ]
         };
 
         this.chart = new Chart<'line'>('durationChart', {
@@ -182,37 +148,35 @@ export class ExecutionDurationChartComponent implements OnInit, OnChanges {
                     x: {
                         type: 'time',
                         time: {
-                            unit: this._getTimeScaleUnit(
-                                ...this._getMinMaxExecutionTuple(),
-                            ),
-                        },
+                            unit: this._getTimeScaleUnit(...this._getMinMaxExecutionTuple())
+                        }
                     },
                     y: {
                         title: {
                             display: true,
-                            text: `Duration ${this.getDurationUnit().name}`,
-                        },
-                    },
+                            text: `Duration ${this.getDurationUnit().name}`
+                        }
+                    }
                 },
                 maintainAspectRatio: false,
                 plugins: {
                     zoom: {
                         zoom: {
                             drag: {
-                                enabled: true,
+                                enabled: true
                             },
                             mode: 'x',
                             onZoomComplete: (context) => {
                                 this._adjustTimeScaleUnit(context.chart);
                                 this.chartZoomed = true;
-                            },
-                        },
+                            }
+                        }
                     },
                     datalabels: {
-                        display: false,
+                        display: false
                     },
                     legend: {
-                        display: false,
+                        display: false
                     },
                     tooltip: {
                         callbacks: {
@@ -226,19 +190,14 @@ export class ExecutionDurationChartComponent implements OnInit, OnChanges {
                                 return (
                                     `Duration: ${context.parsed.y}|${rawValues.status}` +
                                     (rawValues.endTime
-                                        ? `|End: ${formatDate(
-                                              rawValues.endTime,
-                                              'MMM d, y, hh:mm:ss a',
-                                              'en-US',
-                                              'UTC',
-                                          )}`
+                                        ? `|End: ${formatDate(rawValues.endTime, 'MMM d, y, hh:mm:ss a', 'en-US', 'UTC')}`
                                         : '')
                                 );
-                            },
-                        },
-                    },
-                },
-            },
+                            }
+                        }
+                    }
+                }
+            }
         });
     }
 
@@ -259,10 +218,10 @@ export class ExecutionDurationChartComponent implements OnInit, OnChanges {
         this.chart.options.scales['x'] = {
             type: 'time',
             time: {
-                unit,
+                unit
             },
             min,
-            max,
+            max
         };
 
         this.chart.data.datasets[0].data = this.getData(min, max);
@@ -277,41 +236,23 @@ export class ExecutionDurationChartComponent implements OnInit, OnChanges {
             return [null, null];
         }
 
-        return [
-            executions[0].startTime,
-            executions[executions.length - 1].startTime,
-        ];
+        return [executions[0].startTime, executions[executions.length - 1].startTime];
     }
 
-    private _getTimeScaleUnit(
-        min: number | string,
-        max: number | string,
-    ): TimeUnit {
+    private _getTimeScaleUnit(min: number | string, max: number | string): TimeUnit {
         if (CollectionsUtil.isNil(min) || CollectionsUtil.isNil(max)) {
             return 'day';
         }
 
-        const _min = CollectionsUtil.isNumber(min)
-            ? min
-            : new Date(min).getTime();
-        const _max = CollectionsUtil.isNumber(max)
-            ? max
-            : new Date(max).getTime();
+        const _min = CollectionsUtil.isNumber(min) ? min : new Date(min).getTime();
+        const _max = CollectionsUtil.isNumber(max) ? max : new Date(max).getTime();
         const diff = _max - _min;
 
-        if (
-            diff >
-            this._getTimeUnitMilliseconds('year') +
-                this._getTimeUnitMilliseconds('second')
-        ) {
+        if (diff > this._getTimeUnitMilliseconds('year') + this._getTimeUnitMilliseconds('second')) {
             return 'year';
         }
 
-        if (
-            diff >
-            this._getTimeUnitMilliseconds('month') +
-                this._getTimeUnitMilliseconds('second')
-        ) {
+        if (diff > this._getTimeUnitMilliseconds('month') + this._getTimeUnitMilliseconds('second')) {
             return 'month';
         }
 
@@ -319,52 +260,26 @@ export class ExecutionDurationChartComponent implements OnInit, OnChanges {
             return 'week';
         }
 
-        if (
-            diff >
-            this._getTimeUnitMilliseconds('day') +
-                this._getTimeUnitMilliseconds('second')
-        ) {
+        if (diff > this._getTimeUnitMilliseconds('day') + this._getTimeUnitMilliseconds('second')) {
             return 'day';
         }
 
-        if (
-            diff >
-            this._getTimeUnitMilliseconds('hour') +
-                this._getTimeUnitMilliseconds('second')
-        ) {
+        if (diff > this._getTimeUnitMilliseconds('hour') + this._getTimeUnitMilliseconds('second')) {
             return 'hour';
         }
 
-        if (
-            diff >
-            this._getTimeUnitMilliseconds('minute') +
-                this._getTimeUnitMilliseconds('millisecond')
-        ) {
+        if (diff > this._getTimeUnitMilliseconds('minute') + this._getTimeUnitMilliseconds('millisecond')) {
             return 'minute';
         }
 
-        if (
-            diff >
-            this._getTimeUnitMilliseconds('second') +
-                this._getTimeUnitMilliseconds('millisecond')
-        ) {
+        if (diff > this._getTimeUnitMilliseconds('second') + this._getTimeUnitMilliseconds('millisecond')) {
             return 'second';
         }
 
         return 'millisecond';
     }
 
-    private _getTimeUnitMilliseconds(
-        unit:
-            | 'millisecond'
-            | 'second'
-            | 'minute'
-            | 'hour'
-            | 'day'
-            | 'week'
-            | 'month'
-            | 'year',
-    ): number {
+    private _getTimeUnitMilliseconds(unit: 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year'): number {
         switch (unit) {
             case 'millisecond':
                 return 1;
@@ -385,7 +300,7 @@ export class ExecutionDurationChartComponent implements OnInit, OnChanges {
             default:
                 console.error(
                     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-                    `Taurus DataPipelines ExecutionDurationChartComponent unsupported time format unit ${unit}`,
+                    `Taurus DataPipelines ExecutionDurationChartComponent unsupported time format unit ${unit}`
                 );
 
                 return 0;

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/execution-status-chart/execution-status-chart.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/execution-status-chart/execution-status-chart.component.ts
@@ -3,26 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-    Component,
-    Input,
-    OnChanges,
-    OnInit,
-    SimpleChanges,
-} from '@angular/core';
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 
 import { Chart, registerables } from 'chart.js';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 
-import {
-    DataJobExecutionToGridDataJobExecution,
-    GridDataJobExecution,
-} from '../model/data-job-execution';
+import { DataJobExecutionToGridDataJobExecution, GridDataJobExecution } from '../model/data-job-execution';
 
 @Component({
     selector: 'lib-execution-status-chart',
     templateUrl: './execution-status-chart.component.html',
-    styleUrls: ['./execution-status-chart.component.scss'],
+    styleUrls: ['./execution-status-chart.component.scss']
 })
 export class ExecutionStatusChartComponent implements OnInit, OnChanges {
     @Input() jobExecutions: GridDataJobExecution[];
@@ -35,20 +26,14 @@ export class ExecutionStatusChartComponent implements OnInit, OnChanges {
     }
 
     getDoughnutLabels(): string[] {
-        return this.jobExecutions
-            .map((execution) => execution.status as string)
-            .filter((item, i, ar) => ar.indexOf(item) === i);
+        return this.jobExecutions.map((execution) => execution.status as string).filter((item, i, ar) => ar.indexOf(item) === i);
     }
 
     getDoughnutData(): number[] {
         const data: number[] = [];
 
         this.getDoughnutLabels().forEach((label) =>
-            data.push(
-                this.jobExecutions.filter(
-                    (execution) => (execution.status as string) === label,
-                ).length,
-            ),
+            data.push(this.jobExecutions.filter((execution) => (execution.status as string) === label).length)
         );
 
         return data;
@@ -56,8 +41,7 @@ export class ExecutionStatusChartComponent implements OnInit, OnChanges {
 
     getDoughnutLabelColors(): string[] {
         const colors: string[] = [];
-        const statusColorMap =
-            DataJobExecutionToGridDataJobExecution.getStatusColorsMap();
+        const statusColorMap = DataJobExecutionToGridDataJobExecution.getStatusColorsMap();
 
         this.getDoughnutLabels().forEach((label) => {
             colors.push(statusColorMap[label] as string);
@@ -70,8 +54,7 @@ export class ExecutionStatusChartComponent implements OnInit, OnChanges {
         if (!changes['jobExecutions'].isFirstChange()) {
             this.totalExecutions = this.jobExecutions.length;
             this.chart.data.labels = this.getDoughnutLabels();
-            this.chart.data.datasets[0].backgroundColor =
-                this.getDoughnutLabelColors();
+            this.chart.data.datasets[0].backgroundColor = this.getDoughnutLabelColors();
             this.chart.data.datasets[0].data = this.getDoughnutData();
             this.chart.update();
         }
@@ -86,9 +69,9 @@ export class ExecutionStatusChartComponent implements OnInit, OnChanges {
                 {
                     data: this.getDoughnutData(),
                     backgroundColor: this.getDoughnutLabelColors(),
-                    hoverOffset: 4,
-                },
-            ],
+                    hoverOffset: 4
+                }
+            ]
         };
 
         this.chart = new Chart('statusChart', {
@@ -98,28 +81,28 @@ export class ExecutionStatusChartComponent implements OnInit, OnChanges {
                 spacing: 1,
                 elements: {
                     arc: {
-                        borderWidth: 0,
-                    },
+                        borderWidth: 0
+                    }
                 },
                 cutout: 70,
                 maintainAspectRatio: false,
                 plugins: {
                     legend: {
                         display: false,
-                        position: 'left',
+                        position: 'left'
                     },
                     datalabels: {
                         color: 'black',
                         font: {
-                            size: 16,
-                        },
+                            size: 16
+                        }
                     },
                     tooltip: {
                         xAlign: 'center',
-                        yAlign: 'center',
-                    },
-                },
-            },
+                        yAlign: 'center'
+                    }
+                }
+            }
         });
     }
 }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/model/data-job-execution.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/model/data-job-execution.spec.ts
@@ -3,63 +3,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-    DataJobExecution,
-    DataJobExecutionStatus,
-    DataJobExecutionType,
-} from '../../../../../model';
-import {
-    DataJobExecutionToGridDataJobExecution,
-    GridDataJobExecution,
-} from './data-job-execution';
+import { DataJobExecution, DataJobExecutionStatus, DataJobExecutionType } from '../../../../../model';
+import { DataJobExecutionToGridDataJobExecution, GridDataJobExecution } from './data-job-execution';
 
 describe('DataJobExecutionToGridDataJobExecution', () => {
     describe('Statics::', () => {
         describe('Methods::', () => {
             describe('|convertStatus|', () => {
-                const params: Array<[string, string, DataJobExecutionStatus]> =
-                    [
-                        [
-                            `${DataJobExecutionStatus.SUCCEEDED}`,
-                            null,
-                            DataJobExecutionStatus.SUCCEEDED,
-                        ],
-                        [
-                            `${DataJobExecutionStatus.FINISHED}`,
-                            null,
-                            DataJobExecutionStatus.SUCCEEDED,
-                        ],
-                        [
-                            `${DataJobExecutionStatus.FAILED}`,
-                            'Platform error',
-                            DataJobExecutionStatus.PLATFORM_ERROR,
-                        ],
-                        [
-                            `${DataJobExecutionStatus.FAILED}`,
-                            'Some exception message',
-                            DataJobExecutionStatus.USER_ERROR,
-                        ],
-                        [
-                            `${DataJobExecutionStatus.FAILED}`,
-                            null,
-                            DataJobExecutionStatus.FAILED,
-                        ],
-                        [
-                            `Some new execution status`,
-                            null,
-                            `Some new execution status` as any,
-                        ],
-                    ];
+                const params: Array<[string, string, DataJobExecutionStatus]> = [
+                    [`${DataJobExecutionStatus.SUCCEEDED}`, null, DataJobExecutionStatus.SUCCEEDED],
+                    [`${DataJobExecutionStatus.FINISHED}`, null, DataJobExecutionStatus.SUCCEEDED],
+                    [`${DataJobExecutionStatus.FAILED}`, 'Platform error', DataJobExecutionStatus.PLATFORM_ERROR],
+                    [`${DataJobExecutionStatus.FAILED}`, 'Some exception message', DataJobExecutionStatus.USER_ERROR],
+                    [`${DataJobExecutionStatus.FAILED}`, null, DataJobExecutionStatus.FAILED],
+                    [`Some new execution status`, null, `Some new execution status` as any]
+                ];
 
                 for (const [status, message, assertion] of params) {
                     it(`should verify for provided status "${status}" will return "${assertion}"`, () => {
                         // When
                         const returnedStatus =
                             /* eslint-disable @typescript-eslint/no-unsafe-argument */
-                            DataJobExecutionToGridDataJobExecution.convertStatus(
-                                status as any,
-                                message,
-                            );
+                            DataJobExecutionToGridDataJobExecution.convertStatus(status as any, message);
 
                         // Then
                         expect(returnedStatus).toEqual(assertion);
@@ -95,11 +60,11 @@ describe('DataJobExecutionToGridDataJobExecution', () => {
                                 memoryLimit: 1000,
                                 memoryRequest: 1000,
                                 cpuLimit: 0.5,
-                                cpuRequest: 0.5,
+                                cpuRequest: 0.5
                             },
                             enabled: true,
-                            schedule: { scheduleCron: '12 * * * *' },
-                        },
+                            schedule: { scheduleCron: '12 * * * *' }
+                        }
                     };
                     const expectedObject: GridDataJobExecution = {
                         jobName: 'test-job',
@@ -125,38 +90,31 @@ describe('DataJobExecutionToGridDataJobExecution', () => {
                                 memoryLimit: 1000,
                                 memoryRequest: 1000,
                                 cpuLimit: 0.5,
-                                cpuRequest: 0.5,
+                                cpuRequest: 0.5
                             },
                             enabled: true,
-                            schedule: { scheduleCron: '12 * * * *' },
-                        },
+                            schedule: { scheduleCron: '12 * * * *' }
+                        }
                     };
                     /* eslint-enable @typescript-eslint/naming-convention */
 
-                    const convertedJobExecution =
-                        DataJobExecutionToGridDataJobExecution.convertToDataJobExecution(
-                            [
-                                dataJobExecution,
-                                {
-                                    ...dataJobExecution,
-                                    endTime: null,
-                                },
-                            ],
-                        );
+                    const convertedJobExecution = DataJobExecutionToGridDataJobExecution.convertToDataJobExecution([
+                        dataJobExecution,
+                        {
+                            ...dataJobExecution,
+                            endTime: null
+                        }
+                    ]);
 
                     expect(convertedJobExecution.length).toEqual(2);
-                    expect(convertedJobExecution).toEqual([
-                        expectedObject,
-                        { ...expectedObject, endTime: null, duration: '3d 2h' },
-                    ]);
+                    expect(convertedJobExecution).toEqual([expectedObject, { ...expectedObject, endTime: null, duration: '3d 2h' }]);
                 });
             });
 
             describe('|getStatusColorsMap|', () => {
                 it('should verify will return correct values', () => {
                     // When
-                    const value =
-                        DataJobExecutionToGridDataJobExecution.getStatusColorsMap();
+                    const value = DataJobExecutionToGridDataJobExecution.getStatusColorsMap();
 
                     // Then
                     expect(value).toEqual({
@@ -166,7 +124,7 @@ describe('DataJobExecutionToGridDataJobExecution', () => {
                         [DataJobExecutionStatus.CANCELLED]: '#CCCCCC',
                         [DataJobExecutionStatus.SKIPPED]: '#CCCCCC',
                         [DataJobExecutionStatus.USER_ERROR]: '#F27963',
-                        [DataJobExecutionStatus.PLATFORM_ERROR]: '#F8CF2A',
+                        [DataJobExecutionStatus.PLATFORM_ERROR]: '#F8CF2A'
                     });
                 });
             });
@@ -174,10 +132,7 @@ describe('DataJobExecutionToGridDataJobExecution', () => {
             describe('|resolveColor|', () => {
                 it('should verify will resolve color from map', () => {
                     // When
-                    const color =
-                        DataJobExecutionToGridDataJobExecution.resolveColor(
-                            DataJobExecutionStatus.SUCCEEDED,
-                        );
+                    const color = DataJobExecutionToGridDataJobExecution.resolveColor(DataJobExecutionStatus.SUCCEEDED);
 
                     // Then
                     expect(color).toEqual('#5EB715');

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/model/data-job-execution.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/model/data-job-execution.ts
@@ -5,11 +5,7 @@
 
 import { FormatDeltaPipe } from '../../../../../shared/pipes';
 
-import {
-    DataJobExecution,
-    DataJobExecutions,
-    DataJobExecutionStatus,
-} from '../../../../../model';
+import { DataJobExecution, DataJobExecutions, DataJobExecutionStatus } from '../../../../../model';
 
 export interface GridDataJobExecution extends DataJobExecution {
     duration: string;
@@ -17,19 +13,14 @@ export interface GridDataJobExecution extends DataJobExecution {
 }
 
 export class DataJobExecutionToGridDataJobExecution {
-    static convertStatus(
-        jobStatus: DataJobExecutionStatus,
-        message: string,
-    ): DataJobExecutionStatus {
+    static convertStatus(jobStatus: DataJobExecutionStatus, message: string): DataJobExecutionStatus {
         switch (`${jobStatus}`.toUpperCase()) {
             case DataJobExecutionStatus.SUCCEEDED:
             case DataJobExecutionStatus.FINISHED:
                 return DataJobExecutionStatus.SUCCEEDED;
             case DataJobExecutionStatus.FAILED:
                 if (message) {
-                    return message === 'Platform error'
-                        ? DataJobExecutionStatus.PLATFORM_ERROR
-                        : DataJobExecutionStatus.USER_ERROR;
+                    return message === 'Platform error' ? DataJobExecutionStatus.PLATFORM_ERROR : DataJobExecutionStatus.USER_ERROR;
                 } else {
                     return DataJobExecutionStatus.FAILED;
                 }
@@ -38,17 +29,12 @@ export class DataJobExecutionToGridDataJobExecution {
         }
     }
 
-    static convertToDataJobExecution = (
-        dataJobExecution: DataJobExecutions,
-    ): GridDataJobExecution[] => {
+    static convertToDataJobExecution = (dataJobExecution: DataJobExecutions): GridDataJobExecution[] => {
         const formatDeltaPipe = new FormatDeltaPipe();
 
         return dataJobExecution.reduce((accumulator, execution) => {
             accumulator.push({
-                status: DataJobExecutionToGridDataJobExecution.convertStatus(
-                    execution.status,
-                    execution.message,
-                ),
+                status: DataJobExecutionToGridDataJobExecution.convertStatus(execution.status, execution.message),
                 type: execution.type,
                 duration: formatDeltaPipe.transform(execution),
                 startTime: execution.startTime,
@@ -60,7 +46,7 @@ export class DataJobExecutionToGridDataJobExecution {
                 opId: execution.opId,
                 jobVersion: execution.deployment.jobVersion,
                 deployment: execution.deployment,
-                message: execution.message,
+                message: execution.message
             });
 
             return accumulator;
@@ -75,13 +61,11 @@ export class DataJobExecutionToGridDataJobExecution {
             [DataJobExecutionStatus.CANCELLED]: '#CCCCCC',
             [DataJobExecutionStatus.SKIPPED]: '#CCCCCC',
             [DataJobExecutionStatus.USER_ERROR]: '#F27963',
-            [DataJobExecutionStatus.PLATFORM_ERROR]: '#F8CF2A',
+            [DataJobExecutionStatus.PLATFORM_ERROR]: '#F8CF2A'
         };
     }
 
     static resolveColor(key: string): string {
-        return DataJobExecutionToGridDataJobExecution.getStatusColorsMap()[
-            key
-        ] as string;
+        return DataJobExecutionToGridDataJobExecution.getStatusColorsMap()[key] as string;
     }
 }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/time-period-filter/time-period-filter.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/time-period-filter/time-period-filter.component.ts
@@ -3,22 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-    Component,
-    EventEmitter,
-    Input,
-    OnDestroy,
-    OnInit,
-    Output,
-    ViewChild,
-} from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
 
-import {
-    CalendarValue,
-    DatePickerDirective,
-    IDatePickerDirectiveConfig,
-} from 'ng2-date-picker';
+import { CalendarValue, DatePickerDirective, IDatePickerDirectiveConfig } from 'ng2-date-picker';
 
 // TODO [import dayjs from 'dayjs'] used in ng2-date-picker v13+ instead of moment
 import moment from 'moment';
@@ -30,7 +18,7 @@ type CustomFormGroup = FormGroup & { controls: { [key: string]: FormControl } };
 @Component({
     selector: 'lib-time-period-filter',
     templateUrl: './time-period-filter.component.html',
-    styleUrls: ['./time-period-filter.component.scss'],
+    styleUrls: ['./time-period-filter.component.scss']
 })
 export class TimePeriodFilterComponent implements OnInit, OnDestroy {
     @ViewChild('fromPicker') fromPicker: DatePickerDirective;
@@ -49,8 +37,7 @@ export class TimePeriodFilterComponent implements OnInit, OnDestroy {
      */
     @Input() isComponentInErrorState = false;
 
-    @Output() filterChanged: EventEmitter<{ fromTime: Date; toTime: Date }> =
-        new EventEmitter<{ fromTime: Date; toTime: Date }>();
+    @Output() filterChanged: EventEmitter<{ fromTime: Date; toTime: Date }> = new EventEmitter<{ fromTime: Date; toTime: Date }>();
 
     pickerConfig: IDatePickerDirectiveConfig = {
         // TODO [format: 'MMM DD, YYYY, hh:mm:ss A',] dayjs
@@ -60,13 +47,13 @@ export class TimePeriodFilterComponent implements OnInit, OnDestroy {
         showSeconds: true,
         weekDayFormat: 'dd',
         numOfMonthRows: 6,
-        monthBtnFormat: 'MMMM',
+        monthBtnFormat: 'MMMM'
     };
     fromPickerConfig: IDatePickerDirectiveConfig = {
-        ...this.pickerConfig,
+        ...this.pickerConfig
     };
     toPickerConfig: IDatePickerDirectiveConfig = {
-        ...this.pickerConfig,
+        ...this.pickerConfig
     };
 
     fromTime: Date;
@@ -96,23 +83,17 @@ export class TimePeriodFilterComponent implements OnInit, OnDestroy {
             this.fromTimeMin = minDateTime;
             this.fromPickerConfig = {
                 ...this.fromPickerConfig,
-                min: this.fromTimeMin,
+                min: this.fromTimeMin
             };
 
             this.toTimeMin = minDateTime;
             this.toPickerConfig = {
                 ...this.toPickerConfig,
-                min: this.toTimeMin,
+                min: this.toTimeMin
             };
 
             if (!this._isFromPickerOpened) {
-                this.tmForm
-                    .get('fromDate')
-                    .patchValue(
-                        this._normalizeDateTime(date, 'from', 'utc').format(
-                            this.fromPickerConfig.format,
-                        ),
-                    );
+                this.tmForm.get('fromDate').patchValue(this._normalizeDateTime(date, 'from', 'utc').format(this.fromPickerConfig.format));
             }
         }
 
@@ -135,7 +116,7 @@ export class TimePeriodFilterComponent implements OnInit, OnDestroy {
     constructor(private readonly formBuilder: FormBuilder) {
         this.tmForm = this.formBuilder.group({
             fromDate: '',
-            toDate: '',
+            toDate: ''
         }) as CustomFormGroup;
     }
 
@@ -147,51 +128,29 @@ export class TimePeriodFilterComponent implements OnInit, OnDestroy {
         const emittedDate = $event as moment.Moment;
 
         if (type === 'from') {
-            const origMinTimeUtc = this._normalizeDateTime(
-                this._minTimeOrig,
-                'from',
-                'utc',
-            );
-            if (
-                emittedDate.isBefore(origMinTimeUtc) ||
-                emittedDate.isAfter(this.fromTimeMax)
-            ) {
+            const origMinTimeUtc = this._normalizeDateTime(this._minTimeOrig, 'from', 'utc');
+            if (emittedDate.isBefore(origMinTimeUtc) || emittedDate.isAfter(this.fromTimeMax)) {
                 return;
             }
 
-            this.fromTime = new Date(
-                this._normalizeDateTime(
-                    emittedDate,
-                    'from',
-                    'timezone',
-                ).valueOf(),
-            );
+            this.fromTime = new Date(this._normalizeDateTime(emittedDate, 'from', 'timezone').valueOf());
 
             this.toTimeMin = this._normalizeDateTime(emittedDate, 'min');
             this.toPickerConfig = {
                 ...this.toPickerConfig,
-                min: this.toTimeMin,
+                min: this.toTimeMin
             };
         } else {
-            if (
-                emittedDate.isBefore(this.toTimeMin) ||
-                emittedDate.isAfter(this.toTimeMax)
-            ) {
+            if (emittedDate.isBefore(this.toTimeMin) || emittedDate.isAfter(this.toTimeMax)) {
                 return;
             }
 
-            this.toTime = new Date(
-                this._normalizeDateTime(
-                    emittedDate,
-                    'to',
-                    'timezone',
-                ).valueOf(),
-            );
+            this.toTime = new Date(this._normalizeDateTime(emittedDate, 'to', 'timezone').valueOf());
 
             this.fromTimeMax = this._normalizeDateTime(emittedDate, 'max');
             this.fromPickerConfig = {
                 ...this.fromPickerConfig,
-                max: this.fromTimeMax,
+                max: this.fromTimeMax
             };
         }
     }
@@ -249,7 +208,7 @@ export class TimePeriodFilterComponent implements OnInit, OnDestroy {
         this._refreshIntervalRef = setInterval(
             // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             this._refreshMaxTime.bind(this),
-            15 * 1000,
+            15 * 1000
         ); // Update max time every 15s
     }
 
@@ -268,7 +227,7 @@ export class TimePeriodFilterComponent implements OnInit, OnDestroy {
         this.toTimeMax = this._normalizeDateTime(date, 'max', 'utc');
         this.toPickerConfig = {
             ...this.toPickerConfig,
-            max: this.toTimeMax,
+            max: this.toTimeMax
         };
 
         if (!this._initiallySetMax) {
@@ -279,17 +238,11 @@ export class TimePeriodFilterComponent implements OnInit, OnDestroy {
             this.fromTimeMax = this._normalizeDateTime(date, 'max', 'utc');
             this.fromPickerConfig = {
                 ...this.fromPickerConfig,
-                max: this.fromTimeMax,
+                max: this.fromTimeMax
             };
 
             if (!this._isToPickerOpened) {
-                this.tmForm
-                    .get('toDate')
-                    .patchValue(
-                        this._normalizeDateTime(date, 'to', 'utc').format(
-                            this.toPickerConfig.format,
-                        ),
-                    );
+                this.tmForm.get('toDate').patchValue(this._normalizeDateTime(date, 'to', 'utc').format(this.toPickerConfig.format));
             }
         }
     }
@@ -297,7 +250,7 @@ export class TimePeriodFilterComponent implements OnInit, OnDestroy {
     private _normalizeDateTime(
         date: Date | moment.Moment,
         type: 'min' | 'max' | 'from' | 'to',
-        travel: 'utc' | 'timezone' = null,
+        travel: 'utc' | 'timezone' = null
     ): moment.Moment {
         const offset = moment().utcOffset();
 
@@ -305,15 +258,9 @@ export class TimePeriodFilterComponent implements OnInit, OnDestroy {
 
         if (travel) {
             if (offset > 0) {
-                dtInstance =
-                    travel === 'utc'
-                        ? dtInstance.subtract(offset, 'm')
-                        : dtInstance.add(offset, 'm');
+                dtInstance = travel === 'utc' ? dtInstance.subtract(offset, 'm') : dtInstance.add(offset, 'm');
             } else if (offset < 0) {
-                dtInstance =
-                    travel === 'utc'
-                        ? dtInstance.add(-offset, 'm')
-                        : dtInstance.subtract(-offset, 'm');
+                dtInstance = travel === 'utc' ? dtInstance.add(-offset, 'm') : dtInstance.subtract(-offset, 'm');
             }
         }
 
@@ -331,7 +278,7 @@ export class TimePeriodFilterComponent implements OnInit, OnDestroy {
     private _emitChanges(): void {
         this.filterChanged.emit({
             fromTime: this.fromTime,
-            toTime: this.toTime,
+            toTime: this.toTime
         });
     }
 }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-explore/components/grid/data-jobs-explore-grid.component.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-explore/components/grid/data-jobs-explore-grid.component.spec.ts
@@ -26,15 +26,10 @@ import {
     RouterService,
     RouterState,
     SystemEventDispatcher,
-    URLStateManager,
+    URLStateManager
 } from '@versatiledatakit/shared';
 
-import {
-    DATA_PIPELINES_CONFIGS,
-    DataJobDetails,
-    DataJobPage,
-    DisplayMode,
-} from '../../../../model';
+import { DATA_PIPELINES_CONFIGS, DataJobDetails, DataJobPage, DisplayMode } from '../../../../model';
 
 import { DataJobsApiService, DataJobsService } from '../../../../services';
 
@@ -59,7 +54,7 @@ describe('DataJobsExploreGridComponent', () => {
     let fixture: ComponentFixture<DataJobsExploreGridComponent>;
 
     const TEST_JOB = {
-        jobName: 'job001',
+        jobName: 'job001'
     };
 
     beforeAll(() => {
@@ -71,75 +66,46 @@ describe('DataJobsExploreGridComponent', () => {
     beforeEach(() => {
         const activatedRouteStub = () => ({
             queryParams: {
-                subscribe: CallFake,
+                subscribe: CallFake
             },
-            snapshot: null,
+            snapshot: null
         });
         const routerStub = () => ({
-            url: '/explore/data-jobs',
+            url: '/explore/data-jobs'
         });
 
-        componentServiceStub = jasmine.createSpyObj<ComponentService>(
-            'componentService',
-            ['init', 'getModel', 'idle', 'update'],
-        );
-        navigationServiceStub = jasmine.createSpyObj<NavigationService>(
-            'navigationService',
-            ['navigate', 'navigateTo', 'navigateBack'],
-        );
-        dataJobsApiServiceStub = jasmine.createSpyObj<DataJobsApiService>(
-            'dataJobsService',
-            ['getJobs', 'getJobDetails', 'getJobExecutions'],
-        );
-        dataJobsServiceStub = jasmine.createSpyObj<DataJobsService>(
-            'dataJobsService',
-            [
-                'loadJobs',
-                'notifyForRunningJobExecutionId',
-                'notifyForJobExecutions',
-                'notifyForTeamImplicitly',
-                'getNotifiedForRunningJobExecutionId',
-                'getNotifiedForJobExecutions',
-                'getNotifiedForTeamImplicitly',
-            ],
-        );
-        locationStub = jasmine.createSpyObj<Location>('location', [
-            'path',
-            'go',
+        componentServiceStub = jasmine.createSpyObj<ComponentService>('componentService', ['init', 'getModel', 'idle', 'update']);
+        navigationServiceStub = jasmine.createSpyObj<NavigationService>('navigationService', ['navigate', 'navigateTo', 'navigateBack']);
+        dataJobsApiServiceStub = jasmine.createSpyObj<DataJobsApiService>('dataJobsService', [
+            'getJobs',
+            'getJobDetails',
+            'getJobExecutions'
         ]);
-        routerServiceStub = jasmine.createSpyObj<RouterService>(
-            'routerService',
-            ['getState', 'get'],
-        );
-        errorHandlerServiceStub = jasmine.createSpyObj<ErrorHandlerService>(
-            'errorHandlerService',
-            ['processError', 'handleError'],
-        );
+        dataJobsServiceStub = jasmine.createSpyObj<DataJobsService>('dataJobsService', [
+            'loadJobs',
+            'notifyForRunningJobExecutionId',
+            'notifyForJobExecutions',
+            'notifyForTeamImplicitly',
+            'getNotifiedForRunningJobExecutionId',
+            'getNotifiedForJobExecutions',
+            'getNotifiedForTeamImplicitly'
+        ]);
+        locationStub = jasmine.createSpyObj<Location>('location', ['path', 'go']);
+        routerServiceStub = jasmine.createSpyObj<RouterService>('routerService', ['getState', 'get']);
+        errorHandlerServiceStub = jasmine.createSpyObj<ErrorHandlerService>('errorHandlerService', ['processError', 'handleError']);
 
-        dataJobsServiceStub.getNotifiedForJobExecutions.and.returnValue(
-            new Subject(),
-        );
-        dataJobsServiceStub.getNotifiedForTeamImplicitly.and.returnValue(
-            new BehaviorSubject('taurus'),
-        );
+        dataJobsServiceStub.getNotifiedForJobExecutions.and.returnValue(new Subject());
+        dataJobsServiceStub.getNotifiedForTeamImplicitly.and.returnValue(new BehaviorSubject('taurus'));
 
-        componentModelStub = ComponentModel.of(
-            ComponentStateImpl.of({}),
-            RouterState.empty(),
-        );
+        componentModelStub = ComponentModel.of(ComponentStateImpl.of({}), RouterState.empty());
         routerServiceStub.getState.and.returnValue(new Subject());
         routerServiceStub.get.and.returnValue(new Subject());
         componentServiceStub.init.and.returnValue(of(componentModelStub));
         componentServiceStub.getModel.and.returnValue(of(componentModelStub));
 
-        generateErrorCodes<DataJobsApiService>(dataJobsApiServiceStub, [
-            'getJobs',
-            'getJobDetails',
-            'getJobExecutions',
-        ]);
+        generateErrorCodes<DataJobsApiService>(dataJobsApiServiceStub, ['getJobs', 'getJobDetails', 'getJobExecutions']);
 
-        LOAD_JOBS_ERROR_CODES[TASK_LOAD_JOBS_STATE] =
-            dataJobsApiServiceStub.errorCodes.getJobs;
+        LOAD_JOBS_ERROR_CODES[TASK_LOAD_JOBS_STATE] = dataJobsApiServiceStub.errorCodes.getJobs;
 
         TestBed.configureTestingModule({
             schemas: [NO_ERRORS_SCHEMA],
@@ -148,8 +114,8 @@ describe('DataJobsExploreGridComponent', () => {
                 {
                     provide: DATA_PIPELINES_CONFIGS,
                     useFactory: () => ({
-                        defaultOwnerTeamName: 'all',
-                    }),
+                        defaultOwnerTeamName: 'all'
+                    })
                 },
                 { provide: RouterService, useValue: routerServiceStub },
                 { provide: ComponentService, useValue: componentServiceStub },
@@ -157,16 +123,16 @@ describe('DataJobsExploreGridComponent', () => {
                 { provide: ActivatedRoute, useFactory: activatedRouteStub },
                 {
                     provide: DataJobsApiService,
-                    useValue: dataJobsApiServiceStub,
+                    useValue: dataJobsApiServiceStub
                 },
                 { provide: DataJobsService, useValue: dataJobsServiceStub },
                 { provide: Location, useValue: locationStub },
                 { provide: Router, useFactory: routerStub },
                 {
                     provide: ErrorHandlerService,
-                    useValue: errorHandlerServiceStub,
-                },
-            ],
+                    useValue: errorHandlerServiceStub
+                }
+            ]
         });
 
         fixture = TestBed.createComponent(DataJobsExploreGridComponent);
@@ -178,22 +144,16 @@ describe('DataJobsExploreGridComponent', () => {
             of({
                 data: {
                     content: [],
-                    totalItems: 0,
-                },
-            } as ApolloQueryResult<DataJobPage>),
+                    totalItems: 0
+                }
+            } as ApolloQueryResult<DataJobPage>)
         );
-        dataJobsApiServiceStub.getJobDetails.and.returnValue(
-            of(null) as Observable<DataJobDetails>,
-        );
-        dataJobsApiServiceStub.getJobExecutions.and.returnValue(
-            of({ content: [], totalItems: 0, totalPages: 0 }),
-        );
+        dataJobsApiServiceStub.getJobDetails.and.returnValue(of(null) as Observable<DataJobDetails>);
+        dataJobsApiServiceStub.getJobExecutions.and.returnValue(of({ content: [], totalItems: 0, totalPages: 0 }));
 
         locationStub.path.and.returnValue('/explore/data-jobs');
 
-        spyOn(SystemEventDispatcher, 'send').and.returnValue(
-            Promise.resolve(true),
-        );
+        spyOn(SystemEventDispatcher, 'send').and.returnValue(Promise.resolve(true));
     });
 
     it('can load instance', () => {
@@ -218,10 +178,7 @@ describe('DataJobsExploreGridComponent', () => {
 
     describe('urlUpdateStrategy', () => {
         it('should verify the behaviour of _doUrlUpdate when urlUpdateStrategy is default (updateRouter)', () => {
-            const navigateToUrlSpy = spyOn(
-                component.urlStateManager,
-                'navigateToUrl',
-            ).and.returnValue(Promise.resolve(true));
+            const navigateToUrlSpy = spyOn(component.urlStateManager, 'navigateToUrl').and.returnValue(Promise.resolve(true));
 
             // @ts-ignore
             component._doUrlUpdate();
@@ -230,10 +187,7 @@ describe('DataJobsExploreGridComponent', () => {
         });
 
         it('should verify the behaviour of _doUrlUpdate when urlUpdateStrategy is changed (updateLocation)', () => {
-            const locationToURLSpy = spyOn(
-                component.urlStateManager,
-                'locationToURL',
-            ).and.callFake(CallFake);
+            const locationToURLSpy = spyOn(component.urlStateManager, 'locationToURL').and.callFake(CallFake);
             component.urlUpdateStrategy = 'updateLocation';
 
             // @ts-ignore
@@ -246,49 +200,31 @@ describe('DataJobsExploreGridComponent', () => {
     describe('urlStateManager', () => {
         it('should verify will invoke default urlStateManager (locally created)', () => {
             // Given
-            const setQueryParamSpy = spyOn(
-                component.urlStateManager,
-                'setQueryParam',
-            ).and.callFake(CallFake);
+            const setQueryParamSpy = spyOn(component.urlStateManager, 'setQueryParam').and.callFake(CallFake);
 
             // When
             component.search('search');
 
             // Then
-            expect(setQueryParamSpy).toHaveBeenCalledWith(
-                QUERY_PARAM_SEARCH,
-                'search',
-            );
+            expect(setQueryParamSpy).toHaveBeenCalledWith(QUERY_PARAM_SEARCH, 'search');
         });
 
         it('should verify will invoke external urlStateManager (dependency injected)', () => {
             // Given
-            const urlStateManagerStub = new URLStateManager(
-                'baseUrl',
-                locationStub,
-            );
-            const setQueryParamSpy = spyOn(
-                urlStateManagerStub,
-                'setQueryParam',
-            ).and.callFake(CallFake);
+            const urlStateManagerStub = new URLStateManager('baseUrl', locationStub);
+            const setQueryParamSpy = spyOn(urlStateManagerStub, 'setQueryParam').and.callFake(CallFake);
 
             // When
             component.urlStateManager = urlStateManagerStub;
             component.search('search');
 
             // Then
-            expect(setQueryParamSpy).toHaveBeenCalledWith(
-                QUERY_PARAM_SEARCH,
-                'search',
-            );
+            expect(setQueryParamSpy).toHaveBeenCalledWith(QUERY_PARAM_SEARCH, 'search');
         });
 
         it('should verify will invoke default urlStateManager (dependency injection is null or undefined)', () => {
             // Given
-            const setQueryParamSpy = spyOn(
-                component.urlStateManager,
-                'setQueryParam',
-            ).and.callFake(CallFake);
+            const setQueryParamSpy = spyOn(component.urlStateManager, 'setQueryParam').and.callFake(CallFake);
 
             // When
             component.urlStateManager = null;
@@ -297,26 +233,20 @@ describe('DataJobsExploreGridComponent', () => {
             component.search('search test value 2');
 
             // Then
-            expect(setQueryParamSpy.calls.argsFor(0)).toEqual([
-                QUERY_PARAM_SEARCH,
-                'search test value 1',
-            ]);
-            expect(setQueryParamSpy.calls.argsFor(1)).toEqual([
-                QUERY_PARAM_SEARCH,
-                'search test value 2',
-            ]);
+            expect(setQueryParamSpy.calls.argsFor(0)).toEqual([QUERY_PARAM_SEARCH, 'search test value 1']);
+            expect(setQueryParamSpy.calls.argsFor(1)).toEqual([QUERY_PARAM_SEARCH, 'search test value 2']);
         });
     });
 
     describe('handleStateChange', () => {
         it('makes expected calls', () => {
             const clrDatagridStateInterfaceStub = {
-                filters: [],
+                filters: []
             } as ClrDatagridStateInterface;
             clrDatagridStateInterfaceStub.filters.push({
                 property: 'search_prop',
                 pattern: '%search%',
-                sort: ASC,
+                sort: ASC
             });
             component.gridState = clrDatagridStateInterfaceStub;
 
@@ -333,9 +263,7 @@ describe('DataJobsExploreGridComponent', () => {
     describe('viewJobDetails', () => {
         it('skips viewJobDetails for undefined job', () => {
             // Given
-            const navigateToSpy = spyOn(component, 'navigateTo').and.callFake(
-                CallFake,
-            );
+            const navigateToSpy = spyOn(component, 'navigateTo').and.callFake(CallFake);
 
             // When
             component.navigateToJobDetails();
@@ -347,23 +275,20 @@ describe('DataJobsExploreGridComponent', () => {
 
         it('opens viewJobDetails for valid job', () => {
             // Given
-            const navigateToSpy = spyOn(
-                component,
-                'navigateTo',
-            ).and.returnValue(Promise.resolve(true));
+            const navigateToSpy = spyOn(component, 'navigateTo').and.returnValue(Promise.resolve(true));
             component.ngOnInit();
 
             // When
             component.navigateToJobDetails({
                 jobName: 'job001',
-                config: { team: 'team007' },
+                config: { team: 'team007' }
             });
 
             // Then
             expect(component.selectedJob).toBeDefined();
             expect(navigateToSpy).toHaveBeenCalledWith({
                 '$.team': 'team007',
-                '$.job': 'job001',
+                '$.job': 'job001'
             });
         });
     });

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-explore/components/grid/data-jobs-explore-grid.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-explore/components/grid/data-jobs-explore-grid.component.ts
@@ -3,29 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-    Component,
-    ElementRef,
-    HostBinding,
-    Inject,
-    Input,
-    OnInit,
-} from '@angular/core';
+import { Component, ElementRef, HostBinding, Inject, Input, OnInit } from '@angular/core';
 import { DOCUMENT, Location } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 
-import {
-    ComponentService,
-    ErrorHandlerService,
-    NavigationService,
-    RouterService,
-} from '@versatiledatakit/shared';
+import { ComponentService, ErrorHandlerService, NavigationService, RouterService } from '@versatiledatakit/shared';
 
-import {
-    DATA_PIPELINES_CONFIGS,
-    DataPipelinesConfig,
-    DisplayMode,
-} from '../../../../model';
+import { DATA_PIPELINES_CONFIGS, DataPipelinesConfig, DisplayMode } from '../../../../model';
 import { DataJobsApiService, DataJobsService } from '../../../../services';
 
 import { DataJobsBaseGridComponent } from '../../../base-grid/data-jobs-base-grid.component';
@@ -33,30 +17,24 @@ import { DataJobsBaseGridComponent } from '../../../base-grid/data-jobs-base-gri
 @Component({
     selector: 'lib-data-jobs-explore-grid',
     templateUrl: './data-jobs-explore-grid.component.html',
-    styleUrls: ['./data-jobs-explore-grid.component.scss'],
+    styleUrls: ['./data-jobs-explore-grid.component.scss']
 })
-export class DataJobsExploreGridComponent
-    extends DataJobsBaseGridComponent
-    implements OnInit
-{
+export class DataJobsExploreGridComponent extends DataJobsBaseGridComponent implements OnInit {
     /**
      * @inheritDoc
      */
-    static override readonly CLASS_NAME: string =
-        'DataJobsExploreGridComponent';
+    static override readonly CLASS_NAME: string = 'DataJobsExploreGridComponent';
 
     /**
      * @inheritDoc
      */
-    static override readonly PUBLIC_NAME: string =
-        'DataJobs-ExploreGrid-Component';
+    static override readonly PUBLIC_NAME: string = 'DataJobs-ExploreGrid-Component';
 
     //Decorators are not inherited in Angular. If we need @Input() we need to declare it here
     @Input() override teamNameFilter: string;
     @Input() override displayMode: DisplayMode;
 
-    @HostBinding('attr.data-cy') attributeDataCy =
-        'data-pipelines-explore-data-jobs';
+    @HostBinding('attr.data-cy') attributeDataCy = 'data-pipelines-explore-data-jobs';
 
     readonly uuid = 'DataJobsExploreGridComponent';
 
@@ -73,7 +51,7 @@ export class DataJobsExploreGridComponent
         elementRef: ElementRef<HTMLElement>,
         @Inject(DOCUMENT) document: Document,
         @Inject(DATA_PIPELINES_CONFIGS)
-        dataPipelinesModuleConfig: DataPipelinesConfig,
+        dataPipelinesModuleConfig: DataPipelinesConfig
     ) {
         super(
             componentService,
@@ -98,10 +76,10 @@ export class DataJobsExploreGridComponent
                     lastDeployedDate: true,
                     lastDeployedBy: true,
                     source: true,
-                    logsUrl: true,
-                },
+                    logsUrl: true
+                }
             },
-            DataJobsExploreGridComponent.CLASS_NAME,
+            DataJobsExploreGridComponent.CLASS_NAME
         );
     }
 

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-explore/data-jobs-explore-page.component.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-explore/data-jobs-explore-page.component.spec.ts
@@ -14,7 +14,7 @@ describe('DataJobsExploreComponent', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             schemas: [NO_ERRORS_SCHEMA],
-            declarations: [DataJobsExplorePageComponent],
+            declarations: [DataJobsExplorePageComponent]
         });
         fixture = TestBed.createComponent(DataJobsExplorePageComponent);
         component = fixture.componentInstance;

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-explore/data-jobs-explore-page.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-explore/data-jobs-explore-page.component.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 @Component({
     selector: 'lib-data-jobs-explore',
     templateUrl: './data-jobs-explore-page.component.html',
-    styleUrls: ['./data-jobs-explore-page.component.css'],
+    styleUrls: ['./data-jobs-explore-page.component.css']
 })
 export class DataJobsExplorePageComponent {}

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-manage/components/grid/data-jobs-manage-grid.component.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-manage/components/grid/data-jobs-manage-grid.component.spec.ts
@@ -6,12 +6,7 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Location } from '@angular/common';
-import {
-    ComponentFixture,
-    fakeAsync,
-    TestBed,
-    tick,
-} from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { of, Subject } from 'rxjs';
 
@@ -30,7 +25,7 @@ import {
     RouterService,
     RouterState,
     RouteState,
-    ToastService,
+    ToastService
 } from '@versatiledatakit/shared';
 
 import { ExtractJobStatusPipe } from '../../../../shared/pipes';
@@ -58,16 +53,16 @@ describe('DataJobsManageGridComponent', () => {
 
     const TEST_DEPLOYMENT = {
         id: 'id001',
-        enabled: true,
+        enabled: true
     };
 
     const TEST_JOB = {
         jobName: 'job001',
         config: {
             description: 'description001',
-            team: 'testTeam',
+            team: 'testTeam'
         },
-        deployments: [TEST_DEPLOYMENT],
+        deployments: [TEST_DEPLOYMENT]
     };
 
     let teamSubject: Subject<string>;
@@ -82,92 +77,64 @@ describe('DataJobsManageGridComponent', () => {
     });
 
     beforeEach(() => {
-        componentServiceStub = jasmine.createSpyObj<ComponentService>(
-            'componentService',
-            ['init', 'getModel', 'idle', 'update'],
-        );
-        navigationServiceStub = jasmine.createSpyObj<NavigationService>(
-            'navigationService',
-            ['navigateTo', 'navigateBack'],
-        );
-        routerServiceStub = jasmine.createSpyObj<RouterService>(
-            'routerService',
-            ['getState', 'get'],
-        );
-        dataJobsServiceStub = jasmine.createSpyObj<DataJobsService>(
-            'dataJobsService',
-            [
-                'loadJobs',
-                'notifyForRunningJobExecutionId',
-                'notifyForJobExecutions',
-                'notifyForTeamImplicitly',
-                'getNotifiedForRunningJobExecutionId',
-                'getNotifiedForJobExecutions',
-                'getNotifiedForTeamImplicitly',
-            ],
-        );
-        toastServiceStub = jasmine.createSpyObj<ToastService>('toastService', [
-            'show',
+        componentServiceStub = jasmine.createSpyObj<ComponentService>('componentService', ['init', 'getModel', 'idle', 'update']);
+        navigationServiceStub = jasmine.createSpyObj<NavigationService>('navigationService', ['navigateTo', 'navigateBack']);
+        routerServiceStub = jasmine.createSpyObj<RouterService>('routerService', ['getState', 'get']);
+        dataJobsServiceStub = jasmine.createSpyObj<DataJobsService>('dataJobsService', [
+            'loadJobs',
+            'notifyForRunningJobExecutionId',
+            'notifyForJobExecutions',
+            'notifyForTeamImplicitly',
+            'getNotifiedForRunningJobExecutionId',
+            'getNotifiedForJobExecutions',
+            'getNotifiedForTeamImplicitly'
         ]);
-        errorHandlerServiceStub = jasmine.createSpyObj<ErrorHandlerService>(
-            'errorHandlerService',
-            ['processError', 'handleError'],
-        );
+        toastServiceStub = jasmine.createSpyObj<ToastService>('toastService', ['show']);
+        errorHandlerServiceStub = jasmine.createSpyObj<ErrorHandlerService>('errorHandlerService', ['processError', 'handleError']);
 
         teamSubject = new Subject<string>();
-        teamSubjectSubscribeSpy = spyOn(
-            teamSubject,
-            'subscribe',
-        ).and.callThrough();
+        teamSubjectSubscribeSpy = spyOn(teamSubject, 'subscribe').and.callThrough();
 
         const activatedRouteStub = () => ({
             queryParams: {
-                subscribe: CallFake,
+                subscribe: CallFake
             },
-            snapshot: null,
+            snapshot: null
         });
         const dataJobsApiServiceStub = () => ({
             getAllJobs: () => ({
-                subscribe: CallFake,
+                subscribe: CallFake
             }),
             getJobDetails: () => ({
-                subscribe: () => CallFake,
+                subscribe: () => CallFake
             }),
             getJobExecutions: () => ({
-                subscribe: () => CallFake,
+                subscribe: () => CallFake
             }),
             updateDataJobStatus: () => ({
                 subscribe: () => {
                     return new Subject();
-                },
+                }
             }),
             executeDataJob: () => ({
                 subscribe: () => {
                     return new Subject();
-                },
-            }),
+                }
+            })
         });
         const locationStub = () => ({
             path: () => 'Test',
-            go: () => CallFake,
+            go: () => CallFake
         });
         const routerStub = () => ({
-            url: '/explore/data-jobs',
+            url: '/explore/data-jobs'
         });
 
-        const dataJobsApiServiceStubTemp =
-            jasmine.createSpyObj<DataJobsApiService>('dataJobsApiServiceStub', [
-                'getJobs',
-            ]);
+        const dataJobsApiServiceStubTemp = jasmine.createSpyObj<DataJobsApiService>('dataJobsApiServiceStub', ['getJobs']);
 
-        generateErrorCodes<DataJobsApiService>(dataJobsApiServiceStubTemp, [
-            'getJobs',
-            'getJobDetails',
-            'getJobExecutions',
-        ]);
+        generateErrorCodes<DataJobsApiService>(dataJobsApiServiceStubTemp, ['getJobs', 'getJobDetails', 'getJobExecutions']);
 
-        LOAD_JOBS_ERROR_CODES[TASK_LOAD_JOBS_STATE] =
-            dataJobsApiServiceStubTemp.errorCodes.getJobs;
+        LOAD_JOBS_ERROR_CODES[TASK_LOAD_JOBS_STATE] = dataJobsApiServiceStubTemp.errorCodes.getJobs;
 
         TestBed.configureTestingModule({
             schemas: [NO_ERRORS_SCHEMA],
@@ -182,9 +149,9 @@ describe('DataJobsManageGridComponent', () => {
                             showTeamsColumn: true,
                             allowExecuteNow: true,
                             displayMode: DisplayMode.COMPACT,
-                            selectedTeamNameObservable: teamSubject,
-                        },
-                    }),
+                            selectedTeamNameObservable: teamSubject
+                        }
+                    })
                 },
                 { provide: RouterService, useValue: routerServiceStub },
                 { provide: ComponentService, useValue: componentServiceStub },
@@ -194,21 +161,18 @@ describe('DataJobsManageGridComponent', () => {
                 { provide: ToastService, useValue: toastServiceStub },
                 {
                     provide: DataJobsApiService,
-                    useFactory: dataJobsApiServiceStub,
+                    useFactory: dataJobsApiServiceStub
                 },
                 { provide: Location, useFactory: locationStub },
                 { provide: Router, useFactory: routerStub },
                 {
                     provide: ErrorHandlerService,
-                    useValue: errorHandlerServiceStub,
-                },
-            ],
+                    useValue: errorHandlerServiceStub
+                }
+            ]
         });
 
-        componentModelStub = ComponentModel.of(
-            ComponentStateImpl.of({}),
-            RouterState.of(RouteState.empty(), 1),
-        );
+        componentModelStub = ComponentModel.of(ComponentStateImpl.of({}), RouterState.of(RouteState.empty(), 1));
         componentServiceStub.init.and.returnValue(of(componentModelStub));
         componentServiceStub.getModel.and.returnValue(of(componentModelStub));
         routerServiceStub.getState.and.returnValue(new Subject());
@@ -227,9 +191,7 @@ describe('DataJobsManageGridComponent', () => {
     describe('editJob', () => {
         it('skips editJob for undefined job', () => {
             // Given
-            const navigateToSpy = spyOn(component, 'navigateTo').and.callFake(
-                CallFake,
-            );
+            const navigateToSpy = spyOn(component, 'navigateTo').and.callFake(CallFake);
             component.selectedJob = null;
 
             // When
@@ -242,10 +204,7 @@ describe('DataJobsManageGridComponent', () => {
 
         it('opens editJob for valid job', () => {
             // Given
-            const navigateToSpy = spyOn(
-                component,
-                'navigateTo',
-            ).and.returnValue(Promise.resolve(true));
+            const navigateToSpy = spyOn(component, 'navigateTo').and.returnValue(Promise.resolve(true));
             component.selectedJob = null;
             component.ngOnInit();
 
@@ -256,7 +215,7 @@ describe('DataJobsManageGridComponent', () => {
             expect(component.selectedJob).toBeDefined();
             expect(navigateToSpy).toHaveBeenCalledWith({
                 '$.team': 'testTeam',
-                '$.job': 'job001',
+                '$.job': 'job001'
             });
         });
     });
@@ -287,8 +246,7 @@ describe('DataJobsManageGridComponent', () => {
 
         it('makes expected calls for valid SelectedJobDeployment', () => {
             component.selectedJob.deployments = [TEST_DEPLOYMENT];
-            const dataJobSServiceStub: DataJobsApiService =
-                fixture.debugElement.injector.get(DataJobsApiService);
+            const dataJobSServiceStub: DataJobsApiService = fixture.debugElement.injector.get(DataJobsApiService);
             spyOn(component, 'extractSelectedJobDeployment').and.callThrough();
             spyOn(dataJobSServiceStub, 'updateDataJobStatus').and.callThrough();
             component.onJobStatusChange();
@@ -301,8 +259,7 @@ describe('DataJobsManageGridComponent', () => {
         it('makes expected calls', () => {
             component.selectedJob = TEST_JOB;
             component.selectedJob.deployments = [TEST_DEPLOYMENT];
-            const dataJobSServiceStub: DataJobsApiService =
-                fixture.debugElement.injector.get(DataJobsApiService);
+            const dataJobSServiceStub: DataJobsApiService = fixture.debugElement.injector.get(DataJobsApiService);
             spyOn(component, 'extractSelectedJobDeployment').and.callThrough();
             spyOn(dataJobSServiceStub, 'executeDataJob').and.callThrough();
             component.onExecuteDataJob();
@@ -368,8 +325,8 @@ describe('DataJobsManageGridComponent', () => {
                     sort: null,
                     page: {
                         size: 10,
-                        current: 2,
-                    },
+                        current: 2
+                    }
                 };
                 component.ngOnInit();
                 teamSubject.next('teamA');
@@ -387,21 +344,19 @@ describe('DataJobsManageGridComponent', () => {
                 expect(filter.criteria[0]).toEqual({
                     property: 'config.team',
                     pattern: 'teamA',
-                    sort: null,
+                    sort: null
                 });
             }));
 
             it('should verify will append on model filter and sorting and default team filter', fakeAsync(() => {
                 // Given
                 const state: ClrDatagridStateInterface = {
-                    filters: [
-                        { property: 'deployments.enabled', value: 'true' },
-                    ],
+                    filters: [{ property: 'deployments.enabled', value: 'true' }],
                     sort: { by: 'jobName', reverse: false },
                     page: {
                         size: 10,
-                        current: 2,
-                    },
+                        current: 2
+                    }
                 };
                 component.ngOnInit();
                 teamSubject.next('teamB');
@@ -420,23 +375,21 @@ describe('DataJobsManageGridComponent', () => {
                     {
                         property: 'deployments.enabled',
                         pattern: 'true',
-                        sort: null,
+                        sort: null
                     },
-                    { property: 'jobName', pattern: null, sort: ASC },
+                    { property: 'jobName', pattern: null, sort: ASC }
                 ]);
             }));
 
             it('should verify will append on model filter and sorting and no default team filter', fakeAsync(() => {
                 // Given
                 const state: ClrDatagridStateInterface = {
-                    filters: [
-                        { property: 'deployments.enabled', value: 'false' },
-                    ],
+                    filters: [{ property: 'deployments.enabled', value: 'false' }],
                     sort: { by: 'config.description', reverse: true },
                     page: {
                         size: 10,
-                        current: 2,
-                    },
+                        current: 2
+                    }
                 };
                 component.filterByTeamName = false;
                 component.ngOnInit();
@@ -455,13 +408,13 @@ describe('DataJobsManageGridComponent', () => {
                     {
                         property: 'deployments.enabled',
                         pattern: 'false',
-                        sort: null,
+                        sort: null
                     },
                     {
                         property: 'config.description',
                         pattern: null,
-                        sort: DESC,
-                    },
+                        sort: DESC
+                    }
                 ]);
             }));
         });

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-manage/components/grid/data-jobs-manage-grid.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-manage/components/grid/data-jobs-manage-grid.component.ts
@@ -3,13 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-    Component,
-    ElementRef,
-    HostBinding,
-    Inject,
-    OnInit,
-} from '@angular/core';
+import { Component, ElementRef, HostBinding, Inject, OnInit } from '@angular/core';
 import { DOCUMENT, Location } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -20,38 +14,24 @@ import {
     NavigationService,
     RouterService,
     ToastService,
-    VmwToastType,
+    VmwToastType
 } from '@versatiledatakit/shared';
 
 import { ErrorUtil } from '../../../../shared/utils';
 
-import {
-    ConfirmationModalOptions,
-    ModalOptions,
-} from '../../../../shared/model';
+import { ConfirmationModalOptions, ModalOptions } from '../../../../shared/model';
 
-import {
-    DATA_PIPELINES_CONFIGS,
-    DataJobStatus,
-    DataPipelinesConfig,
-    ToastDefinitions,
-} from '../../../../model';
+import { DATA_PIPELINES_CONFIGS, DataJobStatus, DataPipelinesConfig, ToastDefinitions } from '../../../../model';
 import { DataJobsApiService, DataJobsService } from '../../../../services';
 
-import {
-    ClrGridUIState,
-    DataJobsBaseGridComponent,
-} from '../../../base-grid/data-jobs-base-grid.component';
+import { ClrGridUIState, DataJobsBaseGridComponent } from '../../../base-grid/data-jobs-base-grid.component';
 
 @Component({
     selector: 'lib-data-jobs-manage-grid',
     templateUrl: './data-jobs-manage-grid.component.html',
-    styleUrls: ['./data-jobs-manage-grid.component.scss'],
+    styleUrls: ['./data-jobs-manage-grid.component.scss']
 })
-export class DataJobsManageGridComponent
-    extends DataJobsBaseGridComponent
-    implements OnInit
-{
+export class DataJobsManageGridComponent extends DataJobsBaseGridComponent implements OnInit {
     /**
      * @inheritDoc
      */
@@ -60,11 +40,9 @@ export class DataJobsManageGridComponent
     /**
      * @inheritDoc
      */
-    static override readonly PUBLIC_NAME: string =
-        'DataJobs-ManageGrid-Component';
+    static override readonly PUBLIC_NAME: string = 'DataJobs-ManageGrid-Component';
 
-    @HostBinding('attr.data-cy') attributeDataCy =
-        'data-pipelines-manage-data-jobs';
+    @HostBinding('attr.data-cy') attributeDataCy = 'data-pipelines-manage-data-jobs';
 
     readonly uuid = 'DataJobsManageGridComponent';
 
@@ -73,11 +51,11 @@ export class DataJobsManageGridComponent
 
     override clrGridDefaultFilter: ClrGridUIState['filter'] = {
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        'deployments.enabled': DataJobStatus.ENABLED,
+        'deployments.enabled': DataJobStatus.ENABLED
     };
     override clrGridDefaultSort: ClrGridUIState['sort'] = {
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        'deployments.lastExecutionTime': -1,
+        'deployments.lastExecutionTime': -1
     };
 
     override quickFiltersDefaultActiveIndex = 1;
@@ -98,7 +76,7 @@ export class DataJobsManageGridComponent
         @Inject(DOCUMENT) document: Document,
         @Inject(DATA_PIPELINES_CONFIGS)
         dataPipelinesModuleConfig: DataPipelinesConfig,
-        private readonly toastService: ToastService,
+        private readonly toastService: ToastService
     ) {
         super(
             componentService,
@@ -121,10 +99,10 @@ export class DataJobsManageGridComponent
                     lastDeployedDate: true,
                     lastDeployedBy: true,
                     notifications: true,
-                    source: true,
-                },
+                    source: true
+                }
             },
-            DataJobsManageGridComponent.CLASS_NAME,
+            DataJobsManageGridComponent.CLASS_NAME
         );
 
         this.confirmStatusOptions = new ConfirmationModalOptions();
@@ -149,9 +127,7 @@ export class DataJobsManageGridComponent
     onJobStatusChange() {
         const selectedJobDeployment = this.extractSelectedJobDeployment();
         if (!selectedJobDeployment) {
-            console.log(
-                'Status update action will not be performed for job with no deployments.',
-            );
+            console.log('Status update action will not be performed for job with no deployments.');
             return;
         }
 
@@ -161,32 +137,26 @@ export class DataJobsManageGridComponent
                     this.selectedJob.config?.team,
                     this.selectedJob.jobName,
                     selectedJobDeployment.id,
-                    !selectedJobDeployment.enabled,
+                    !selectedJobDeployment.enabled
                 )
                 .subscribe({
                     next: () => {
-                        selectedJobDeployment.enabled =
-                            !selectedJobDeployment.enabled;
+                        selectedJobDeployment.enabled = !selectedJobDeployment.enabled;
 
-                        const state = selectedJobDeployment.enabled
-                            ? 'enabled'
-                            : 'disabled';
+                        const state = selectedJobDeployment.enabled ? 'enabled' : 'disabled';
 
                         this.toastService.show({
                             type: VmwToastType.INFO,
                             title: `Status update completed`,
-                            description: `Data job "${this.selectedJob.jobName}" successfully ${state}`,
+                            description: `Data job "${this.selectedJob.jobName}" successfully ${state}`
                         });
                     },
                     error: (error: unknown) => {
-                        this.errorHandlerService.processError(
-                            ErrorUtil.extractError(error as Error),
-                            {
-                                title: `Updating status for Data job "${this.selectedJob?.jobName}" failed`,
-                            },
-                        );
-                    },
-                }),
+                        this.errorHandlerService.processError(ErrorUtil.extractError(error as Error), {
+                            title: `Updating status for Data job "${this.selectedJob?.jobName}" failed`
+                        });
+                    }
+                })
         );
     }
 
@@ -199,31 +169,20 @@ export class DataJobsManageGridComponent
     onExecuteDataJob() {
         this.subscriptions.push(
             this.dataJobsApiService
-                .executeDataJob(
-                    this.selectedJob.config?.team,
-                    this.selectedJob.jobName,
-                    this.extractSelectedJobDeployment().id,
-                )
+                .executeDataJob(this.selectedJob.config?.team, this.selectedJob.jobName, this.extractSelectedJobDeployment().id)
                 .subscribe({
                     next: () => {
-                        this.toastService.show(
-                            ToastDefinitions.successfullyRanJob(
-                                this.selectedJob.jobName,
-                            ),
-                        );
+                        this.toastService.show(ToastDefinitions.successfullyRanJob(this.selectedJob.jobName));
                     },
                     error: (error: unknown) => {
-                        this.errorHandlerService.processError(
-                            ErrorUtil.extractError(error as Error),
-                            {
-                                title:
-                                    (error as HttpErrorResponse)?.status === 409
-                                        ? 'Failed, Data job is already executing'
-                                        : 'Failed to queue Data job for execution',
-                            },
-                        );
-                    },
-                }),
+                        this.errorHandlerService.processError(ErrorUtil.extractError(error as Error), {
+                            title:
+                                (error as HttpErrorResponse)?.status === 409
+                                    ? 'Failed, Data job is already executing'
+                                    : 'Failed to queue Data job for execution'
+                        });
+                    }
+                })
         );
     }
 
@@ -236,46 +195,37 @@ export class DataJobsManageGridComponent
     }
 
     extractSelectedJobDeployment() {
-        return this.selectedJob?.deployments[
-            this.selectedJob?.deployments?.length - 1
-        ];
+        return this.selectedJob?.deployments[this.selectedJob?.deployments?.length - 1];
     }
 
     private _inputConfig(dataPipelinesModuleConfig: DataPipelinesConfig) {
         if (dataPipelinesModuleConfig.manageConfig?.filterByTeamName) {
-            this.filterByTeamName =
-                dataPipelinesModuleConfig.manageConfig?.filterByTeamName;
+            this.filterByTeamName = dataPipelinesModuleConfig.manageConfig?.filterByTeamName;
         }
 
         if (dataPipelinesModuleConfig.manageConfig?.displayMode) {
-            this.displayMode =
-                dataPipelinesModuleConfig.manageConfig?.displayMode;
+            this.displayMode = dataPipelinesModuleConfig.manageConfig?.displayMode;
         }
 
-        if (
-            dataPipelinesModuleConfig.manageConfig?.selectedTeamNameObservable
-        ) {
+        if (dataPipelinesModuleConfig.manageConfig?.selectedTeamNameObservable) {
             this.subscriptions.push(
-                dataPipelinesModuleConfig.manageConfig?.selectedTeamNameObservable.subscribe(
-                    {
-                        next: (newTeam) => {
-                            if (newTeam !== this.teamNameFilter) {
-                                this.teamNameFilter = newTeam;
-                                this.refresh();
-                            }
-                        },
-                        error: (error: unknown) => {
-                            this.resetTeamNameFilter();
-                            console.error('Error loading selected team', error);
-                        },
+                dataPipelinesModuleConfig.manageConfig?.selectedTeamNameObservable.subscribe({
+                    next: (newTeam) => {
+                        if (newTeam !== this.teamNameFilter) {
+                            this.teamNameFilter = newTeam;
+                            this.refresh();
+                        }
                     },
-                ),
+                    error: (error: unknown) => {
+                        this.resetTeamNameFilter();
+                        console.error('Error loading selected team', error);
+                    }
+                })
             );
         }
 
         if (dataPipelinesModuleConfig?.dataPipelinesDocumentationUrl) {
-            this.dataPipelinesDocumentationUrl =
-                dataPipelinesModuleConfig.dataPipelinesDocumentationUrl;
+            this.dataPipelinesDocumentationUrl = dataPipelinesModuleConfig.dataPipelinesDocumentationUrl;
         }
     }
 }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-manage/data-jobs-manage-page.component.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-manage/data-jobs-manage-page.component.spec.ts
@@ -14,7 +14,7 @@ describe('DataJobsManageComponent', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             schemas: [NO_ERRORS_SCHEMA],
-            declarations: [DataJobsManagePageComponent],
+            declarations: [DataJobsManagePageComponent]
         });
         fixture = TestBed.createComponent(DataJobsManagePageComponent);
         component = fixture.componentInstance;

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-manage/data-jobs-manage-page.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-manage/data-jobs-manage-page.component.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 @Component({
     selector: 'lib-data-jobs-manage',
     templateUrl: './data-jobs-manage-page.component.html',
-    styleUrls: ['./data-jobs-manage-page.component.css'],
+    styleUrls: ['./data-jobs-manage-page.component.css']
 })
 export class DataJobsManagePageComponent {}

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/widgets/data-jobs-executions-widget/data-jobs-executions-widget.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/widgets/data-jobs-executions-widget/data-jobs-executions-widget.component.ts
@@ -3,13 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-    ChangeDetectionStrategy,
-    Component,
-    Input,
-    OnChanges,
-    SimpleChanges,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 
 import { NavigationService } from '@versatiledatakit/shared';
 
@@ -19,7 +13,7 @@ import { DataJob, DataJobExecution, DataJobExecutions } from '../../../model';
     selector: 'lib-data-jobs-executions-widget',
     templateUrl: './data-jobs-executions-widget.component.html',
     styleUrls: ['./data-jobs-executions-widget.component.scss'],
-    changeDetection: ChangeDetectionStrategy.OnPush,
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DataJobsExecutionsWidgetComponent implements OnChanges {
     @Input() manageLink: string;
@@ -43,10 +37,7 @@ export class DataJobsExecutionsWidgetComponent implements OnChanges {
      * @inheritDoc
      */
     ngOnChanges(changes: SimpleChanges) {
-        if (
-            changes['jobExecutions'] !== undefined &&
-            changes['jobExecutions'].currentValue !== undefined
-        ) {
+        if (changes['jobExecutions'] !== undefined && changes['jobExecutions'].currentValue !== undefined) {
             this.loading = false;
         }
     }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/widgets/data-jobs-failed-widget/data-jobs-failed-widget.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/widgets/data-jobs-failed-widget/data-jobs-failed-widget.component.ts
@@ -3,13 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-    ChangeDetectionStrategy,
-    Component,
-    Input,
-    OnChanges,
-    SimpleChanges,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 
 import { NavigationService } from '@versatiledatakit/shared';
 
@@ -23,7 +17,7 @@ interface DataJobGrid extends DataJob {
     selector: 'lib-data-jobs-failed-widget',
     templateUrl: './data-jobs-failed-widget.component.html',
     styleUrls: ['./data-jobs-failed-widget.component.scss'],
-    changeDetection: ChangeDetectionStrategy.OnPush,
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DataJobsFailedWidgetComponent implements OnChanges {
     @Input() manageLink: string;
@@ -50,16 +44,12 @@ export class DataJobsFailedWidgetComponent implements OnChanges {
     ngOnChanges(changes: SimpleChanges) {
         if (changes['jobExecutions'] !== undefined) {
             this.dataJobs = [];
-            (
-                changes['jobExecutions'].currentValue as DataJobExecutions
-            ).forEach((element) => {
-                const temp = this.dataJobs.find(
-                    (i) => i.jobName === element.jobName,
-                );
+            (changes['jobExecutions'].currentValue as DataJobExecutions).forEach((element) => {
+                const temp = this.dataJobs.find((i) => i.jobName === element.jobName);
                 if (!temp) {
                     this.dataJobs.push({
                         jobName: element.jobName,
-                        failedTotal: 1,
+                        failedTotal: 1
                     } as DataJobGrid);
                 } else {
                     temp.failedTotal++;

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/widgets/data-jobs-health-panel/data-jobs-health-panel.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/widgets/data-jobs-health-panel/data-jobs-health-panel.component.ts
@@ -3,14 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-    Component,
-    EventEmitter,
-    Inject,
-    Input,
-    OnInit,
-    Output,
-} from '@angular/core';
+import { Component, EventEmitter, Inject, Input, OnInit, Output } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 import {
@@ -26,7 +19,7 @@ import {
     OnTaurusModelInit,
     OnTaurusModelLoad,
     RouterService,
-    TaurusBaseComponent,
+    TaurusBaseComponent
 } from '@versatiledatakit/shared';
 
 import { ErrorUtil } from '../../../shared/utils';
@@ -46,17 +39,11 @@ import {
     JOB_NAME_REQ_PARAM,
     JOBS_DATA_KEY,
     ORDER_REQ_PARAM,
-    TEAM_NAME_REQ_PARAM,
+    TEAM_NAME_REQ_PARAM
 } from '../../../model';
 
-import {
-    TASK_LOAD_JOB_EXECUTIONS,
-    TASK_LOAD_JOBS_STATE,
-} from '../../../state/tasks';
-import {
-    LOAD_JOB_ERROR_CODES,
-    LOAD_JOBS_ERROR_CODES,
-} from '../../../state/error-codes';
+import { TASK_LOAD_JOB_EXECUTIONS, TASK_LOAD_JOBS_STATE } from '../../../state/tasks';
+import { LOAD_JOB_ERROR_CODES, LOAD_JOBS_ERROR_CODES } from '../../../state/error-codes';
 
 import { DataJobExecutionToGridDataJobExecution } from '../../data-job/pages/executions';
 
@@ -64,22 +51,17 @@ enum State {
     loading = 'loading',
     ready = 'ready',
     empty = 'empty',
-    error = 'error',
+    error = 'error'
 }
 
 @Component({
     selector: 'lib-data-jobs-health-panel',
     templateUrl: './data-jobs-health-panel.component.html',
-    styleUrls: ['./data-jobs-health-panel.component.scss'],
+    styleUrls: ['./data-jobs-health-panel.component.scss']
 })
 export class DataJobsHealthPanelComponent
     extends TaurusBaseComponent
-    implements
-        OnInit,
-        OnTaurusModelInit,
-        OnTaurusModelLoad,
-        OnTaurusModelChange,
-        OnTaurusModelError
+    implements OnInit, OnTaurusModelInit, OnTaurusModelLoad, OnTaurusModelChange, OnTaurusModelError
 {
     @Input() manageLink: string;
     @Output() componentStateEvent = new EventEmitter<string>();
@@ -104,7 +86,7 @@ export class DataJobsHealthPanelComponent
      */
     listenForErrorPatterns: string[] = [
         LOAD_JOB_ERROR_CODES[TASK_LOAD_JOB_EXECUTIONS].All,
-        LOAD_JOBS_ERROR_CODES[TASK_LOAD_JOBS_STATE].All,
+        LOAD_JOBS_ERROR_CODES[TASK_LOAD_JOBS_STATE].All
     ];
 
     constructor(
@@ -114,7 +96,7 @@ export class DataJobsHealthPanelComponent
         private readonly routerService: RouterService,
         private readonly dataJobsService: DataJobsService,
         @Inject(DATA_PIPELINES_CONFIGS)
-        public readonly dataPipelinesModuleConfig: DataPipelinesConfig,
+        public readonly dataPipelinesModuleConfig: DataPipelinesConfig
     ) {
         super(componentService, navigationService, activatedRoute);
     }
@@ -127,7 +109,7 @@ export class DataJobsHealthPanelComponent
             filters.push({
                 property: 'config.team',
                 pattern: this.teamName,
-                sort: null,
+                sort: null
             });
         }
 
@@ -138,9 +120,9 @@ export class DataJobsHealthPanelComponent
                 .withFilter(filters)
                 .withRequestParam(ORDER_REQ_PARAM, {
                     property: 'startTime',
-                    direction: DESC,
+                    direction: DESC
                 })
-                .withPage(1, 1000),
+                .withPage(1, 1000)
         );
     }
 
@@ -153,17 +135,14 @@ export class DataJobsHealthPanelComponent
                 .withRequestParam(TEAM_NAME_REQ_PARAM, 'no-team-specified')
                 .withRequestParam(JOB_NAME_REQ_PARAM, '')
                 .withRequestParam(FILTER_REQ_PARAM, {
-                    statusIn: [
-                        DataJobExecutionStatus.USER_ERROR,
-                        DataJobExecutionStatus.PLATFORM_ERROR,
-                    ],
+                    statusIn: [DataJobExecutionStatus.USER_ERROR, DataJobExecutionStatus.PLATFORM_ERROR],
                     startTimeGte: d,
-                    teamNameIn: this.teamName ? [this.teamName] : [],
+                    teamNameIn: this.teamName ? [this.teamName] : []
                 } as DataJobExecutionFilter)
                 .withRequestParam(ORDER_REQ_PARAM, {
                     property: 'startTime',
-                    direction: DESC,
-                } as DataJobExecutionOrder),
+                    direction: DESC
+                } as DataJobExecutionOrder)
         );
     }
 
@@ -187,27 +166,17 @@ export class DataJobsHealthPanelComponent
      */
     onModelChange(model: ComponentModel, task: string): void {
         if (task === TASK_LOAD_JOB_EXECUTIONS) {
-            const executions: DataJobExecutions = model
-                .getComponentState()
-                .data.get(JOB_EXECUTIONS_DATA_KEY);
+            const executions: DataJobExecutions = model.getComponentState().data.get(JOB_EXECUTIONS_DATA_KEY);
             if (executions) {
-                const remappedExecutions =
-                    DataJobExecutionToGridDataJobExecution.convertToDataJobExecution(
-                        [...executions],
-                    );
-                this.jobExecutions = remappedExecutions.filter(
-                    (ex) => ex.status !== DataJobExecutionStatus.SUCCEEDED,
-                );
+                const remappedExecutions = DataJobExecutionToGridDataJobExecution.convertToDataJobExecution([...executions]);
+                this.jobExecutions = remappedExecutions.filter((ex) => ex.status !== DataJobExecutionStatus.SUCCEEDED);
                 this.loadingExecutions = false;
             }
         } else if (task === TASK_LOAD_JOBS_STATE) {
             const componentState = model.getComponentState();
-            const dataJobsData: DataJobPage =
-                componentState.data.get(JOBS_DATA_KEY);
+            const dataJobsData: DataJobPage = componentState.data.get(JOBS_DATA_KEY);
 
-            this.dataJobs = CollectionsUtil.isArray(dataJobsData?.content)
-                ? [...dataJobsData?.content]
-                : [];
+            this.dataJobs = CollectionsUtil.isArray(dataJobsData?.content) ? [...dataJobsData?.content] : [];
             this.loadingJobs = false;
         }
 
@@ -217,11 +186,7 @@ export class DataJobsHealthPanelComponent
     /**
      * @inheritDoc
      */
-    onModelError(
-        model: ComponentModel,
-        task: string,
-        newErrorRecords: ErrorRecord[],
-    ): void {
+    onModelError(model: ComponentModel, task: string, newErrorRecords: ErrorRecord[]): void {
         newErrorRecords.forEach((errorRecord) => {
             const error = ErrorUtil.extractError(errorRecord.error);
 
@@ -245,9 +210,7 @@ export class DataJobsHealthPanelComponent
         // attach listener to ErrorStore and listen for Errors change
         this.errors.onChange((store) => {
             // if there is record for listened error code patterns set component in error state
-            this.isComponentInErrorState = store.hasCodePattern(
-                ...this.listenForErrorPatterns,
-            );
+            this.isComponentInErrorState = store.hasCodePattern(...this.listenForErrorPatterns);
         });
 
         super.ngOnInit();
@@ -256,10 +219,7 @@ export class DataJobsHealthPanelComponent
     private _emitNewState() {
         if (this.loadingJobs || this.loadingExecutions) {
             this.componentStateEvent.emit(State.loading);
-        } else if (
-            this.jobExecutions.length === 0 &&
-            this.dataJobs.length === 0
-        ) {
+        } else if (this.jobExecutions.length === 0 && this.dataJobs.length === 0) {
             this.componentStateEvent.emit(State.empty);
         } else if (this.isComponentInErrorState) {
             this.componentStateEvent.emit(State.error);
@@ -269,29 +229,24 @@ export class DataJobsHealthPanelComponent
     }
 
     private _subscribeForTeamChange(): void {
-        if (
-            this.dataPipelinesModuleConfig.manageConfig
-                ?.selectedTeamNameObservable
-        ) {
+        if (this.dataPipelinesModuleConfig.manageConfig?.selectedTeamNameObservable) {
             this.subscriptions.push(
-                this.dataPipelinesModuleConfig.manageConfig?.selectedTeamNameObservable.subscribe(
-                    {
-                        next: (newTeamName: string) => {
-                            if (newTeamName !== this.teamName) {
-                                if (newTeamName && newTeamName !== '') {
-                                    this.teamName = newTeamName;
-                                    this.fetchDataJobExecutions();
-                                    this.fetchDataJobs();
-                                }
+                this.dataPipelinesModuleConfig.manageConfig?.selectedTeamNameObservable.subscribe({
+                    next: (newTeamName: string) => {
+                        if (newTeamName !== this.teamName) {
+                            if (newTeamName && newTeamName !== '') {
+                                this.teamName = newTeamName;
+                                this.fetchDataJobExecutions();
+                                this.fetchDataJobs();
                             }
-                        },
-                        error: (error: unknown) => {
-                            this.jobExecutions = [];
-                            this.dataJobs = [];
-                            console.error('Error loading selected team', error);
-                        },
+                        }
                     },
-                ),
+                    error: (error: unknown) => {
+                        this.jobExecutions = [];
+                        this.dataJobs = [];
+                        console.error('Error loading selected team', error);
+                    }
+                })
             );
         } else {
             this.fetchDataJobExecutions();

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/widgets/data-jobs-widget-one.component.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/widgets/data-jobs-widget-one.component.spec.ts
@@ -12,10 +12,7 @@ import { FormatSchedulePipe } from '../../shared/pipes';
 
 import { DataJobsApiService } from '../../services';
 
-import {
-    DataJobsWidgetOneComponent,
-    WidgetTab,
-} from './data-jobs-widget-one.component';
+import { DataJobsWidgetOneComponent, WidgetTab } from './data-jobs-widget-one.component';
 
 describe('DataJobsWidgetOneComponent', () => {
     let errorHandlerServiceStub: jasmine.SpyObj<ErrorHandlerService>;
@@ -37,32 +34,29 @@ describe('DataJobsWidgetOneComponent', () => {
                                 item: {
                                     config: {
                                         schedule: {
-                                            scheduleCron: '*/5 * * * *',
-                                        },
-                                    },
-                                },
-                            },
-                        ],
-                    },
-                }),
+                                            scheduleCron: '*/5 * * * *'
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                })
         });
-        errorHandlerServiceStub = jasmine.createSpyObj<ErrorHandlerService>(
-            'errorHandlerService',
-            ['processError', 'handleError'],
-        );
+        errorHandlerServiceStub = jasmine.createSpyObj<ErrorHandlerService>('errorHandlerService', ['processError', 'handleError']);
 
         await TestBed.configureTestingModule({
             declarations: [DataJobsWidgetOneComponent, FormatSchedulePipe],
             providers: [
                 {
                     provide: DataJobsApiService,
-                    useFactory: dataJobsServiceStub,
+                    useFactory: dataJobsServiceStub
                 },
                 {
                     provide: ErrorHandlerService,
-                    useValue: errorHandlerServiceStub,
-                },
-            ],
+                    useValue: errorHandlerServiceStub
+                }
+            ]
         }).compileComponents();
     });
 
@@ -78,8 +72,7 @@ describe('DataJobsWidgetOneComponent', () => {
 
     describe('ngOnInit', () => {
         it('make expected calls', () => {
-            const dataJobsServiceStub: DataJobsApiService =
-                fixture.debugElement.injector.get(DataJobsApiService);
+            const dataJobsServiceStub: DataJobsApiService = fixture.debugElement.injector.get(DataJobsApiService);
             spyOn(dataJobsServiceStub, 'getJobs').and.callThrough();
             component.ngOnInit();
             expect(dataJobsServiceStub.getJobs).toHaveBeenCalled();
@@ -105,11 +98,8 @@ describe('DataJobsWidgetOneComponent', () => {
     describe('handle errors', () => {
         it('should catch error when API fails', () => {
             expect(component.errorJobs).toEqual(false);
-            const dataJobsServiceStub: DataJobsApiService =
-                fixture.debugElement.injector.get(DataJobsApiService);
-            spyOn(dataJobsServiceStub, 'getJobs').and.returnValue(
-                throwError(() => true),
-            );
+            const dataJobsServiceStub: DataJobsApiService = fixture.debugElement.injector.get(DataJobsApiService);
+            spyOn(dataJobsServiceStub, 'getJobs').and.returnValue(throwError(() => true));
             component.refresh(1, WidgetTab.DATAJOBS);
 
             component.jobs$.subscribe();

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/widgets/data-jobs-widget-one.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/widgets/data-jobs-widget-one.component.ts
@@ -24,7 +24,7 @@ export enum WidgetTab {
     /* eslint-disable-next-line @typescript-eslint/naming-convention */
     FAILURES,
     /* eslint-disable-next-line @typescript-eslint/naming-convention */
-    NONE,
+    NONE
 }
 
 // TODO: Remove when consume data from API
@@ -34,70 +34,70 @@ const executionsMock = [
         status: DataJobExecutionStatus.FINISHED,
         startTime: Date.now(),
         endTime: Date.now(),
-        startedBy: 'auserov',
+        startedBy: 'auserov'
     },
     {
         jobName: 'data-job-2',
         status: DataJobExecutionStatus.FAILED,
         startTime: Date.now(),
         endTime: Date.now(),
-        startedBy: 'buserov',
+        startedBy: 'buserov'
     },
     {
         jobName: 'data-job-3',
         status: DataJobExecutionStatus.FINISHED,
         startTime: Date.now(),
         endTime: Date.now(),
-        startedBy: 'cuserov',
+        startedBy: 'cuserov'
     },
     {
         jobName: 'data-job-long-name-test-1',
         status: DataJobExecutionStatus.FINISHED,
         startTime: Date.now(),
         endTime: Date.now(),
-        startedBy: 'duserov',
+        startedBy: 'duserov'
     },
     {
         jobName: 'data-job-long-name-test-2',
         status: DataJobExecutionStatus.FAILED,
         startTime: Date.now(),
         endTime: Date.now(),
-        startedBy: 'euserov',
+        startedBy: 'euserov'
     },
     {
         jobName: 'data-job-long-name-test-3',
         status: DataJobExecutionStatus.SUBMITTED,
         startTime: Date.now(),
         endTime: Date.now(),
-        startedBy: 'fuserov',
+        startedBy: 'fuserov'
     },
     {
         jobName: 'data-job-long-name-test-4',
         status: DataJobExecutionStatus.PLATFORM_ERROR,
         startTime: Date.now(),
         endTime: Date.now(),
-        startedBy: 'guserov',
+        startedBy: 'guserov'
     },
     {
         jobName: 'data-job-long-name-test-5',
         status: DataJobExecutionStatus.USER_ERROR,
         startTime: Date.now(),
         endTime: Date.now(),
-        startedBy: 'huserov',
+        startedBy: 'huserov'
     },
     {
         jobName: 'data-job-a-very-long-name-listed-here-test-1',
         status: DataJobExecutionStatus.FINISHED,
         startTime: Date.now(),
         endTime: Date.now(),
-        startedBy: 'fuserov',
-    },
+        startedBy: 'fuserov'
+    }
 ];
 
 @Component({
     selector: 'lib-data-jobs-widget-one',
     templateUrl: './data-jobs-widget-one.component.html',
-    styleUrls: ['./data-jobs-widget-one.component.scss', './widget.scss'],
+    styleUrls: ['./data-jobs-widget-one.component.scss', './widget.scss']
 })
 export class DataJobsWidgetOneComponent implements OnInit {
     @Input() manageLink: string;
@@ -114,10 +114,7 @@ export class DataJobsWidgetOneComponent implements OnInit {
 
     errorJobs: boolean;
 
-    constructor(
-        private readonly dataJobsService: DataJobsApiService,
-        private readonly errorHandlerService: ErrorHandlerService,
-    ) {}
+    constructor(private readonly dataJobsService: DataJobsApiService, private readonly errorHandlerService: ErrorHandlerService) {}
 
     @HostListener('window:resize')
     onWindowResize() {
@@ -148,20 +145,16 @@ export class DataJobsWidgetOneComponent implements OnInit {
         switch (tab) {
             case WidgetTab.DATAJOBS:
                 this.errorJobs = false;
-                this.jobs$ = this.dataJobsService
-                    .getJobs([], '', this.currentPage, this.pageSize)
-                    .pipe(
-                        map((result) => result?.data),
-                        catchError((error: unknown) => {
-                            this.errorJobs = !!error;
+                this.jobs$ = this.dataJobsService.getJobs([], '', this.currentPage, this.pageSize).pipe(
+                    map((result) => result?.data),
+                    catchError((error: unknown) => {
+                        this.errorJobs = !!error;
 
-                            this.errorHandlerService.processError(
-                                ErrorUtil.extractError(error as Error),
-                            );
+                        this.errorHandlerService.processError(ErrorUtil.extractError(error as Error));
 
-                            return throwError(() => error);
-                        }),
-                    );
+                        return throwError(() => error);
+                    })
+                );
                 break;
             case WidgetTab.EXECUTIONS:
                 // TODO: Consume data from API
@@ -169,27 +162,25 @@ export class DataJobsWidgetOneComponent implements OnInit {
                     data: {
                         totalItems: 0,
                         totalPages: executionsMock.length / this.pageSize,
-                        content: [],
-                    },
+                        content: []
+                    }
                 }).pipe(
                     map((result) => result?.data),
-                    delay(1200), // TODO: Remove delay when consume data from API
+                    delay(1200) // TODO: Remove delay when consume data from API
                 );
                 break;
             case WidgetTab.FAILURES:
                 // TODO: Consume data from API
-                const failuresMock = executionsMock.filter(
-                    (e) => e.status === DataJobExecutionStatus.FAILED,
-                );
+                const failuresMock = executionsMock.filter((e) => e.status === DataJobExecutionStatus.FAILED);
                 this.failures$ = of({
                     data: {
                         totalItems: 0,
                         totalPages: failuresMock.length / this.pageSize,
-                        content: [],
-                    },
+                        content: []
+                    }
                 }).pipe(
                     map((result) => result?.data),
-                    delay(1800), // TODO: Remove delay when consume data from API
+                    delay(1800) // TODO: Remove delay when consume data from API
                 );
                 break;
         }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/widgets/widget-execution-status-gauge/widget-execution-status-gauge.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/widgets/widget-execution-status-gauge/widget-execution-status-gauge.component.ts
@@ -10,7 +10,7 @@ import { DataJob } from '../../../model';
 @Component({
     selector: 'lib-widget-execution-status-gauge',
     templateUrl: './widget-execution-status-gauge.component.html',
-    styleUrls: ['./widget-execution-status-gauge.component.scss'],
+    styleUrls: ['./widget-execution-status-gauge.component.scss']
 })
 export class WidgetExecutionStatusGaugeComponent implements OnChanges {
     @Input() allJobs: DataJob[];
@@ -24,18 +24,13 @@ export class WidgetExecutionStatusGaugeComponent implements OnChanges {
         if (changes['allJobs'].currentValue) {
             this.failedExecutions = 0;
             this.successfulExecutions = 0;
-            (changes['allJobs'].currentValue as DataJob[]).forEach(
-                (dataJob) => {
-                    if (dataJob.deployments) {
-                        this.failedExecutions +=
-                            dataJob.deployments[0].failedExecutions;
-                        this.successfulExecutions +=
-                            dataJob.deployments[0].successfulExecutions;
-                    }
-                },
-            );
-            this.totalExecutions =
-                this.failedExecutions + this.successfulExecutions;
+            (changes['allJobs'].currentValue as DataJob[]).forEach((dataJob) => {
+                if (dataJob.deployments) {
+                    this.failedExecutions += dataJob.deployments[0].failedExecutions;
+                    this.successfulExecutions += dataJob.deployments[0].successfulExecutions;
+                }
+            });
+            this.totalExecutions = this.failedExecutions + this.successfulExecutions;
             this.successRate = this.successfulExecutions / this.totalExecutions;
             this.loading = false;
         }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/constants.model.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/constants.model.ts
@@ -10,9 +10,7 @@ import { DataPipelinesConfig } from './config.model';
 /**
  * ** Injection Token for Data pipelines config.
  */
-export const DATA_PIPELINES_CONFIGS = new InjectionToken<DataPipelinesConfig>(
-    'DataPipelinesConfig',
-);
+export const DATA_PIPELINES_CONFIGS = new InjectionToken<DataPipelinesConfig>('DataPipelinesConfig');
 
 /**
  * ** Team name constant used as key identifier in {@link ComponentState.requestParams}.

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/data-job-base.model.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/data-job-base.model.ts
@@ -17,9 +17,7 @@ export interface GraphQLResponsePage<T> {
 
 // Deployment
 
-export interface BaseDataJobDeployment<
-    E extends DataJobExecution = DataJobExecution,
-> extends StatusDetails {
+export interface BaseDataJobDeployment<E extends DataJobExecution = DataJobExecution> extends StatusDetails {
     id: string;
     contacts?: DataJobContacts;
     jobVersion?: string;
@@ -37,7 +35,7 @@ export enum DataJobDeploymentStatus {
     NONE = 'NONE',
     SUCCESS = 'SUCCESS',
     PLATFORM_ERROR = 'PLATFORM_ERROR',
-    USER_ERROR = 'USER_ERROR',
+    USER_ERROR = 'USER_ERROR'
 }
 
 export interface DataJobContacts {
@@ -80,7 +78,7 @@ export interface DataJobExecution {
 
 export enum DataJobExecutionType {
     MANUAL = 'MANUAL',
-    SCHEDULED = 'SCHEDULED',
+    SCHEDULED = 'SCHEDULED'
 }
 
 /**
@@ -95,5 +93,5 @@ export enum DataJobExecutionStatus {
     SKIPPED = 'SKIPPED',
     FAILED = 'FAILED', // Keep for backward compatibility
     USER_ERROR = 'USER_ERROR',
-    PLATFORM_ERROR = 'PLATFORM_ERROR',
+    PLATFORM_ERROR = 'PLATFORM_ERROR'
 }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/data-job-deployments.model.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/data-job-deployments.model.ts
@@ -3,10 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-    BaseDataJobDeployment,
-    DataJobExecutionStatus,
-} from './data-job-base.model';
+import { BaseDataJobDeployment, DataJobExecutionStatus } from './data-job-base.model';
 
 export interface DataJobDeployment extends BaseDataJobDeployment {
     lastDeployedDate?: string;

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/data-job-executions.model.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/data-job-executions.model.ts
@@ -7,11 +7,7 @@
 
 import { DirectionType } from '@versatiledatakit/shared';
 
-import {
-    DataJobExecution,
-    DataJobExecutionStatus,
-    GraphQLResponsePage,
-} from './data-job-base.model';
+import { DataJobExecution, DataJobExecutionStatus, GraphQLResponsePage } from './data-job-base.model';
 
 export type DataJobExecutions = DataJobExecution[];
 
@@ -30,7 +26,7 @@ export enum DataJobExecutionStatusDeprecated {
     SKIPPED = 'skipped',
     FAILED = 'failed', // Keep for backward compatibility
     USER_ERROR = 'user_error',
-    PLATFORM_ERROR = 'platform_error',
+    PLATFORM_ERROR = 'platform_error'
 }
 
 /**

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/data-job.model.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/data-job.model.ts
@@ -7,11 +7,7 @@
 
 import { ApiPredicate } from '@versatiledatakit/shared';
 
-import {
-    DataJobContacts,
-    DataJobSchedule,
-    GraphQLResponsePage,
-} from './data-job-base.model';
+import { DataJobContacts, DataJobSchedule, GraphQLResponsePage } from './data-job-base.model';
 
 import { DataJobDeployment } from './data-job-deployments.model';
 
@@ -46,5 +42,5 @@ export interface DataJobReqVariables {
 export enum DataJobStatus {
     ENABLED = 'Enabled',
     DISABLED = 'Disabled',
-    NOT_DEPLOYED = 'Not Deployed',
+    NOT_DEPLOYED = 'Not Deployed'
 }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/grid-config.model.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/grid-config.model.ts
@@ -7,5 +7,5 @@ export enum DisplayMode {
     /* eslint-disable-next-line @typescript-eslint/naming-convention */
     COMPACT = 'compact',
     /* eslint-disable-next-line @typescript-eslint/naming-convention */
-    STANDARD = 'standard',
+    STANDARD = 'standard'
 }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/route.model.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/route.model.ts
@@ -9,7 +9,7 @@ import {
     TaurusRouteData,
     TaurusRouteNavigateBackData,
     TaurusRouteNavigateToData,
-    TaurusRoutes,
+    TaurusRoutes
 } from '@versatiledatakit/shared';
 
 export interface DataPipelinesRestoreUI {
@@ -22,9 +22,7 @@ export interface DataPipelinesRestoreUI {
 /**
  * ** Data pipelines Route data.
  */
-export interface DataPipelinesRouteData
-    extends TaurusRouteNavigateToData,
-        TaurusRouteNavigateBackData {
+export interface DataPipelinesRouteData extends TaurusRouteNavigateToData, TaurusRouteNavigateBackData {
     /**
      * ** Field that has pointer to paramKey for Team in Route config.
      */
@@ -80,6 +78,4 @@ export type DataPipelinesRoute = ArrayElement<DataPipelinesRoutes>;
 /**
  * ** Data pipelines Routes configs.
  */
-export type DataPipelinesRoutes = TaurusRoutes<
-    TaurusRouteData<DataPipelinesRouteData>
->;
+export type DataPipelinesRoutes = TaurusRoutes<TaurusRouteData<DataPipelinesRouteData>>;

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/toast-definitions.model.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/toast-definitions.model.ts
@@ -10,7 +10,7 @@ export class ToastDefinitions {
         return {
             type: VmwToastType.INFO,
             title: `Data job Queued for execution`,
-            description: `Data job "${jobName}" successfully queued for execution.`,
+            description: `Data job "${jobName}" successfully queued for execution.`
         };
     }
 }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/services/data-jobs-base.api.service.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/services/data-jobs-base.api.service.spec.ts
@@ -16,12 +16,7 @@ import { HttpLink, HttpLinkHandler } from 'apollo-angular/http';
 
 import { ErrorHandlerService } from '@versatiledatakit/shared';
 
-import {
-    DataJobExecutionsPage,
-    DataJobExecutionsReqVariables,
-    DataJobPage,
-    DataJobReqVariables,
-} from '../model';
+import { DataJobExecutionsPage, DataJobExecutionsReqVariables, DataJobPage, DataJobReqVariables } from '../model';
 
 import { DataJobsBaseApiService } from './data-jobs-base.api.service';
 
@@ -35,25 +30,12 @@ describe('DataJobsBaseApiService', () => {
     let apolloBaseStub: jasmine.SpyObj<ApolloBase>;
 
     beforeEach(() => {
-        apolloStub = jasmine.createSpyObj<Apollo>('apolloService', [
-            'use',
-            'createNamed',
-        ]);
-        httpLinkStub = jasmine.createSpyObj<HttpLink>('httpLinkService', [
-            'create',
-        ]);
-        httpClientStub = jasmine.createSpyObj<HttpClient>('httpClientService', [
-            'request',
-        ]);
-        errorHandlerServiceStub = jasmine.createSpyObj<ErrorHandlerService>(
-            'errorHandlerService',
-            ['processError', 'handleError'],
-        );
+        apolloStub = jasmine.createSpyObj<Apollo>('apolloService', ['use', 'createNamed']);
+        httpLinkStub = jasmine.createSpyObj<HttpLink>('httpLinkService', ['create']);
+        httpClientStub = jasmine.createSpyObj<HttpClient>('httpClientService', ['request']);
+        errorHandlerServiceStub = jasmine.createSpyObj<ErrorHandlerService>('errorHandlerService', ['processError', 'handleError']);
 
-        apolloBaseStub = jasmine.createSpyObj<ApolloBase>('apolloBase', [
-            'query',
-            'watchQuery',
-        ]);
+        apolloBaseStub = jasmine.createSpyObj<ApolloBase>('apolloBase', ['query', 'watchQuery']);
 
         TestBed.configureTestingModule({
             providers: [
@@ -63,9 +45,9 @@ describe('DataJobsBaseApiService', () => {
                 { provide: HttpClient, useValue: httpClientStub },
                 {
                     provide: ErrorHandlerService,
-                    useValue: errorHandlerServiceStub,
-                },
-            ],
+                    useValue: errorHandlerServiceStub
+                }
+            ]
         });
 
         service = TestBed.inject(DataJobsBaseApiService);
@@ -100,17 +82,17 @@ describe('DataJobsBaseApiService', () => {
                     pageNumber: 2,
                     pageSize: 25,
                     filter: [],
-                    search: 'sup',
+                    search: 'sup'
                 };
                 const apolloLinkHandlerStub: HttpLinkHandler = {} as any;
                 const apolloMockResponse: ApolloQueryResult<DataJobPage> = {
                     data: {
                         content: [],
                         totalItems: 25,
-                        totalPages: 1,
+                        totalPages: 1
                     },
                     networkStatus: 7,
-                    loading: false,
+                    loading: false
                 };
 
                 apolloBaseStub.query.and.returnValue(of(apolloMockResponse));
@@ -119,43 +101,33 @@ describe('DataJobsBaseApiService', () => {
 
                 // When
                 let dataJobPage: DataJobPage;
-                service
-                    .getJobs(ownerTeam, gqlQuery, dataJobReqVariables)
-                    .subscribe((r) => (dataJobPage = r.data));
+                service.getJobs(ownerTeam, gqlQuery, dataJobReqVariables).subscribe((r) => (dataJobPage = r.data));
 
                 // Then
                 expect(apolloStub.use.calls.argsFor(0)).toEqual([ownerTeam]);
                 expect(httpLinkStub.create).toHaveBeenCalledWith({
                     uri: `/data-jobs/for-team/${ownerTeam}/jobs`,
-                    method: 'GET',
+                    method: 'GET'
                 });
-                expect(apolloStub.createNamed.calls.argsFor(0)[0]).toEqual(
-                    ownerTeam,
-                );
-                expect(
-                    apolloStub.createNamed.calls.argsFor(0)[1].cache,
-                ).toEqual(jasmine.any(InMemoryCache));
-                expect(apolloStub.createNamed.calls.argsFor(0)[1].link).toBe(
-                    apolloLinkHandlerStub,
-                );
-                expect(
-                    apolloStub.createNamed.calls.argsFor(0)[1].defaultOptions,
-                ).toEqual({
+                expect(apolloStub.createNamed.calls.argsFor(0)[0]).toEqual(ownerTeam);
+                expect(apolloStub.createNamed.calls.argsFor(0)[1].cache).toEqual(jasmine.any(InMemoryCache));
+                expect(apolloStub.createNamed.calls.argsFor(0)[1].link).toBe(apolloLinkHandlerStub);
+                expect(apolloStub.createNamed.calls.argsFor(0)[1].defaultOptions).toEqual({
                     watchQuery: {
                         fetchPolicy: 'no-cache',
-                        errorPolicy: 'all',
+                        errorPolicy: 'all'
                     },
                     query: {
                         fetchPolicy: 'no-cache',
-                        errorPolicy: 'all',
-                    },
+                        errorPolicy: 'all'
+                    }
                 });
                 expect(apolloStub.use.calls.argsFor(1)).toEqual([ownerTeam]);
                 expect(apolloBaseStub.query).toHaveBeenCalledWith({
                     query: gql`
                         ${gqlQuery}
                     `,
-                    variables: dataJobReqVariables,
+                    variables: dataJobReqVariables
                 });
                 expect(dataJobPage).toBe(apolloMockResponse.data);
             });
@@ -184,23 +156,20 @@ describe('DataJobsBaseApiService', () => {
                     pageNumber: 2,
                     pageSize: 25,
                     filter: [],
-                    search: 'sup',
+                    search: 'sup'
                 };
                 const apolloLinkHandlerStub = {} as HttpLinkHandler;
                 const apolloQueryResult: ApolloQueryResult<DataJobPage> = {
                     data: {
                         content: [],
                         totalItems: 25,
-                        totalPages: 1,
+                        totalPages: 1
                     },
                     networkStatus: 7,
-                    loading: false,
+                    loading: false
                 };
-                const apolloMockResponse: QueryRef<
-                    DataJobPage,
-                    DataJobReqVariables
-                > = {
-                    valueChanges: of(apolloQueryResult),
+                const apolloMockResponse: QueryRef<DataJobPage, DataJobReqVariables> = {
+                    valueChanges: of(apolloQueryResult)
                 } as QueryRef<DataJobPage, DataJobReqVariables>;
 
                 apolloBaseStub.watchQuery.and.returnValue(apolloMockResponse);
@@ -209,43 +178,33 @@ describe('DataJobsBaseApiService', () => {
 
                 // When
                 let dataJobPage: DataJobPage;
-                service
-                    .watchForJobs(ownerTeam, gqlQuery, dataJobReqVariables)
-                    .valueChanges.subscribe((r) => (dataJobPage = r.data));
+                service.watchForJobs(ownerTeam, gqlQuery, dataJobReqVariables).valueChanges.subscribe((r) => (dataJobPage = r.data));
 
                 // Then
                 expect(apolloStub.use.calls.argsFor(0)).toEqual([ownerTeam]);
                 expect(httpLinkStub.create).toHaveBeenCalledWith({
                     uri: `/data-jobs/for-team/${ownerTeam}/jobs`,
-                    method: 'GET',
+                    method: 'GET'
                 });
-                expect(apolloStub.createNamed.calls.argsFor(0)[0]).toEqual(
-                    ownerTeam,
-                );
-                expect(
-                    apolloStub.createNamed.calls.argsFor(0)[1].cache,
-                ).toEqual(jasmine.any(InMemoryCache));
-                expect(apolloStub.createNamed.calls.argsFor(0)[1].link).toBe(
-                    apolloLinkHandlerStub,
-                );
-                expect(
-                    apolloStub.createNamed.calls.argsFor(0)[1].defaultOptions,
-                ).toEqual({
+                expect(apolloStub.createNamed.calls.argsFor(0)[0]).toEqual(ownerTeam);
+                expect(apolloStub.createNamed.calls.argsFor(0)[1].cache).toEqual(jasmine.any(InMemoryCache));
+                expect(apolloStub.createNamed.calls.argsFor(0)[1].link).toBe(apolloLinkHandlerStub);
+                expect(apolloStub.createNamed.calls.argsFor(0)[1].defaultOptions).toEqual({
                     watchQuery: {
                         fetchPolicy: 'no-cache',
-                        errorPolicy: 'all',
+                        errorPolicy: 'all'
                     },
                     query: {
                         fetchPolicy: 'no-cache',
-                        errorPolicy: 'all',
-                    },
+                        errorPolicy: 'all'
+                    }
                 });
                 expect(apolloStub.use.calls.argsFor(1)).toEqual([ownerTeam]);
                 expect(apolloBaseStub.watchQuery).toHaveBeenCalledWith({
                     query: gql`
                         ${gqlQuery}
                     `,
-                    variables: dataJobReqVariables,
+                    variables: dataJobReqVariables
                 });
                 expect(dataJobPage).toBe(apolloQueryResult.data);
             });
@@ -280,19 +239,18 @@ describe('DataJobsBaseApiService', () => {
                 const ownerTeam = 'supercollider_test';
                 const dataJobReqVariables: DataJobExecutionsReqVariables = {
                     pageNumber: 2,
-                    pageSize: 25,
+                    pageSize: 25
                 };
                 const apolloLinkHandlerStub = {} as HttpLinkHandler;
-                const apolloMockResponse: ApolloQueryResult<DataJobExecutionsPage> =
-                    {
-                        data: {
-                            content: [],
-                            totalItems: 25,
-                            totalPages: 1,
-                        },
-                        networkStatus: 7,
-                        loading: false,
-                    };
+                const apolloMockResponse: ApolloQueryResult<DataJobExecutionsPage> = {
+                    data: {
+                        content: [],
+                        totalItems: 25,
+                        totalPages: 1
+                    },
+                    networkStatus: 7,
+                    loading: false
+                };
 
                 apolloBaseStub.query.and.returnValue(of(apolloMockResponse));
                 apolloStub.use.and.returnValues(null, apolloBaseStub);
@@ -300,43 +258,33 @@ describe('DataJobsBaseApiService', () => {
 
                 // When
                 let dataJobExecutionsPage: DataJobExecutionsPage;
-                service
-                    .getExecutions(ownerTeam, gqlQuery, dataJobReqVariables)
-                    .subscribe((r) => (dataJobExecutionsPage = r.data));
+                service.getExecutions(ownerTeam, gqlQuery, dataJobReqVariables).subscribe((r) => (dataJobExecutionsPage = r.data));
 
                 // Then
                 expect(apolloStub.use.calls.argsFor(0)).toEqual([ownerTeam]);
                 expect(httpLinkStub.create).toHaveBeenCalledWith({
                     uri: `/data-jobs/for-team/${ownerTeam}/jobs`,
-                    method: 'GET',
+                    method: 'GET'
                 });
-                expect(apolloStub.createNamed.calls.argsFor(0)[0]).toEqual(
-                    ownerTeam,
-                );
-                expect(
-                    apolloStub.createNamed.calls.argsFor(0)[1].cache,
-                ).toEqual(jasmine.any(InMemoryCache));
-                expect(apolloStub.createNamed.calls.argsFor(0)[1].link).toBe(
-                    apolloLinkHandlerStub,
-                );
-                expect(
-                    apolloStub.createNamed.calls.argsFor(0)[1].defaultOptions,
-                ).toEqual({
+                expect(apolloStub.createNamed.calls.argsFor(0)[0]).toEqual(ownerTeam);
+                expect(apolloStub.createNamed.calls.argsFor(0)[1].cache).toEqual(jasmine.any(InMemoryCache));
+                expect(apolloStub.createNamed.calls.argsFor(0)[1].link).toBe(apolloLinkHandlerStub);
+                expect(apolloStub.createNamed.calls.argsFor(0)[1].defaultOptions).toEqual({
                     watchQuery: {
                         fetchPolicy: 'no-cache',
-                        errorPolicy: 'all',
+                        errorPolicy: 'all'
                     },
                     query: {
                         fetchPolicy: 'no-cache',
-                        errorPolicy: 'all',
-                    },
+                        errorPolicy: 'all'
+                    }
                 });
                 expect(apolloStub.use.calls.argsFor(1)).toEqual([ownerTeam]);
                 expect(apolloBaseStub.query).toHaveBeenCalledWith({
                     query: gql`
                         ${gqlQuery}
                     `,
-                    variables: dataJobReqVariables,
+                    variables: dataJobReqVariables
                 });
                 expect(dataJobExecutionsPage).toBe(apolloMockResponse.data);
             });

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/services/data-jobs-base.api.service.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/services/data-jobs-base.api.service.ts
@@ -9,25 +9,14 @@ import { Injectable } from '@angular/core';
 
 import { Observable } from 'rxjs';
 
-import {
-    ApolloQueryResult,
-    DefaultOptions,
-    gql,
-    InMemoryCache,
-} from '@apollo/client/core';
+import { ApolloQueryResult, DefaultOptions, gql, InMemoryCache } from '@apollo/client/core';
 
 import { Apollo, ApolloBase, QueryRef } from 'apollo-angular';
 import { HttpLink } from 'apollo-angular/http';
 
 import { TaurusBaseApiService } from '@versatiledatakit/shared';
 
-import {
-    DataJob,
-    DataJobExecutionsPage,
-    DataJobExecutionsReqVariables,
-    DataJobPage,
-    DataJobReqVariables,
-} from '../model';
+import { DataJob, DataJobExecutionsPage, DataJobExecutionsReqVariables, DataJobPage, DataJobReqVariables } from '../model';
 
 /**
  * ** Data Jobs Service build on top of Apollo gql client.
@@ -48,21 +37,18 @@ export class DataJobsBaseApiService extends TaurusBaseApiService<DataJobsBaseApi
     private static readonly APOLLO_DEFAULT_OPTIONS: DefaultOptions = {
         watchQuery: {
             fetchPolicy: 'no-cache',
-            errorPolicy: 'all',
+            errorPolicy: 'all'
         },
         query: {
             fetchPolicy: 'no-cache',
-            errorPolicy: 'all',
-        },
+            errorPolicy: 'all'
+        }
     };
 
     /**
      * ** Constructor.
      */
-    constructor(
-        private readonly apollo: Apollo,
-        private readonly httpLink: HttpLink,
-    ) {
+    constructor(private readonly apollo: Apollo, private readonly httpLink: HttpLink) {
         super(DataJobsBaseApiService.CLASS_NAME);
 
         this.registerErrorCodes(DataJobsBaseApiService);
@@ -71,32 +57,24 @@ export class DataJobsBaseApiService extends TaurusBaseApiService<DataJobsBaseApi
     /**
      * ** Get all DataJobs for provided OwnerTeam and load data based on provided gqlQuery.
      */
-    getJobs(
-        ownerTeam: string,
-        gqlQuery: string,
-        variables: DataJobReqVariables,
-    ): Observable<ApolloQueryResult<DataJobPage>> {
+    getJobs(ownerTeam: string, gqlQuery: string, variables: DataJobReqVariables): Observable<ApolloQueryResult<DataJobPage>> {
         return this.getApolloClientFor(ownerTeam).query({
             query: gql`
                 ${gqlQuery}
             `,
-            variables,
+            variables
         });
     }
 
     /**
      * ** Create Apollo watcher for gqlQuery.
      */
-    watchForJobs(
-        ownerTeam: string,
-        gqlQuery: string,
-        variables: DataJobReqVariables,
-    ): QueryRef<DataJobPage, DataJobReqVariables> {
+    watchForJobs(ownerTeam: string, gqlQuery: string, variables: DataJobReqVariables): QueryRef<DataJobPage, DataJobReqVariables> {
         return this.getApolloClientFor(ownerTeam).watchQuery({
             query: gql`
                 ${gqlQuery}
             `,
-            variables,
+            variables
         });
     }
 
@@ -106,13 +84,13 @@ export class DataJobsBaseApiService extends TaurusBaseApiService<DataJobsBaseApi
     getExecutions(
         ownerTeam: string,
         gqlQuery: string,
-        variables: DataJobExecutionsReqVariables,
+        variables: DataJobExecutionsReqVariables
     ): Observable<ApolloQueryResult<DataJobExecutionsPage>> {
         return this.getApolloClientFor(ownerTeam).query({
             query: gql`
                 ${gqlQuery}
             `,
-            variables,
+            variables
         });
     }
 
@@ -128,16 +106,16 @@ export class DataJobsBaseApiService extends TaurusBaseApiService<DataJobsBaseApi
                                 },
                                 executions: (_existing, _options) => {
                                     return {};
-                                },
-                            },
-                        },
-                    },
+                                }
+                            }
+                        }
+                    }
                 }),
                 link: this.httpLink.create({
                     uri: `/data-jobs/for-team/${ownerTeam}/jobs`,
-                    method: DataJobsBaseApiService.APOLLO_METHOD,
+                    method: DataJobsBaseApiService.APOLLO_METHOD
                 }),
-                defaultOptions: DataJobsBaseApiService.APOLLO_DEFAULT_OPTIONS,
+                defaultOptions: DataJobsBaseApiService.APOLLO_DEFAULT_OPTIONS
             });
         }
 

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/services/data-jobs-public.api.service.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/services/data-jobs-public.api.service.spec.ts
@@ -22,22 +22,17 @@ describe('DataJobsPublicApiService', () => {
     let service: DataJobsPublicApiService;
 
     beforeEach(() => {
-        dataJobsBaseServiceStub = jasmine.createSpyObj<DataJobsBaseApiService>(
-            'dataJobsBaseServiceStub',
-            ['getJobs'],
-        );
-        dataJobsBaseServiceStub.getJobs.and.returnValue(
-            new Subject<ApolloQueryResult<DataJobPage>>(),
-        );
+        dataJobsBaseServiceStub = jasmine.createSpyObj<DataJobsBaseApiService>('dataJobsBaseServiceStub', ['getJobs']);
+        dataJobsBaseServiceStub.getJobs.and.returnValue(new Subject<ApolloQueryResult<DataJobPage>>());
 
         TestBed.configureTestingModule({
             providers: [
                 DataJobsPublicApiService,
                 {
                     provide: DataJobsBaseApiService,
-                    useValue: dataJobsBaseServiceStub,
-                },
-            ],
+                    useValue: dataJobsBaseServiceStub
+                }
+            ]
         });
         service = TestBed.inject(DataJobsPublicApiService);
     });
@@ -54,10 +49,10 @@ describe('DataJobsPublicApiService', () => {
                     data: {
                         content: [{}],
                         totalItems: 1,
-                        totalPages: 1,
+                        totalPages: 1
                     },
                     loading: false,
-                    networkStatus: 7,
+                    networkStatus: 7
                 };
                 const apolloQueryRef = of(apolloQueryResult);
 
@@ -88,8 +83,8 @@ describe('DataJobsPublicApiService', () => {
                         filter: [],
                         search: null,
                         pageNumber: 1,
-                        pageSize: 1000,
-                    },
+                        pageSize: 1000
+                    }
                 );
             });
 
@@ -99,10 +94,10 @@ describe('DataJobsPublicApiService', () => {
                     data: {
                         content: [{}],
                         totalItems: 2500,
-                        totalPages: 3,
+                        totalPages: 3
                     },
                     loading: false,
-                    networkStatus: 7,
+                    networkStatus: 7
                 };
                 const apolloQueryRef = of(apolloQueryResult);
                 let counter = 0;
@@ -111,9 +106,7 @@ describe('DataJobsPublicApiService', () => {
 
                 // When/Then
                 service.getAllDataJobs('teamA').subscribe((value) => {
-                    expect(
-                        dataJobsBaseServiceStub.getJobs.calls.argsFor(counter),
-                    ).toEqual([
+                    expect(dataJobsBaseServiceStub.getJobs.calls.argsFor(counter)).toEqual([
                         'teamA',
                         `query jobsQuery($filter: [Predicate], $search: String, $pageNumber: Int, $pageSize: Int)
 						{
@@ -134,8 +127,8 @@ describe('DataJobsPublicApiService', () => {
                             filter: [],
                             search: null,
                             pageNumber: counter + 1,
-                            pageSize: 1000,
-                        },
+                            pageSize: 1000
+                        }
                     ]);
 
                     counter++;
@@ -156,17 +149,17 @@ describe('DataJobsPublicApiService', () => {
                     data: {
                         content: [{}, {}, {}, {}, {}],
                         totalItems: 5,
-                        totalPages: 1,
+                        totalPages: 1
                     },
                     loading: false,
-                    networkStatus: 7,
+                    networkStatus: 7
                 };
                 const assertionFilters: ApiPredicate[] = [
                     {
                         property: 'config.team',
                         pattern: 'teamA',
-                        sort: null,
-                    },
+                        sort: null
+                    }
                 ];
 
                 dataJobsBaseServiceStub.getJobs.and.returnValues(
@@ -175,15 +168,15 @@ describe('DataJobsPublicApiService', () => {
                     of(undefined),
                     of({
                         ...apolloQueryResult,
-                        data: undefined,
+                        data: undefined
                     }),
                     of({
                         ...apolloQueryResult,
                         data: {
                             ...apolloQueryResult.data,
-                            totalItems: undefined,
-                        },
-                    }),
+                            totalItems: undefined
+                        }
+                    })
                 );
 
                 // When/Then
@@ -191,15 +184,13 @@ describe('DataJobsPublicApiService', () => {
                     service.getDataJobsTotal('teamA'),
                     service.getDataJobsTotal('teamA'),
                     service.getDataJobsTotal('teamA'),
-                    service.getDataJobsTotal('teamA'),
+                    service.getDataJobsTotal('teamA')
                 ]).subscribe(([value1, value2, value3, value4]) => {
                     expect(value1).toEqual(5);
                     expect(value2).toEqual(0);
                     expect(value3).toEqual(0);
                     expect(value4).toEqual(0);
-                    expect(
-                        dataJobsBaseServiceStub.getJobs,
-                    ).toHaveBeenCalledWith(
+                    expect(dataJobsBaseServiceStub.getJobs).toHaveBeenCalledWith(
                         'teamA',
                         `query jobsQuery($filter: [Predicate], $search: String, $pageNumber: Int, $pageSize: Int)
 						{
@@ -218,8 +209,8 @@ describe('DataJobsPublicApiService', () => {
                             filter: assertionFilters,
                             search: null,
                             pageNumber: 1,
-                            pageSize: 1,
-                        },
+                            pageSize: 1
+                        }
                     );
 
                     done();

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/services/data-jobs-public.api.service.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/services/data-jobs-public.api.service.ts
@@ -63,15 +63,11 @@ export class DataJobsPublicApiService extends TaurusBaseApiService<DataJobsPubli
                 }
             }),
             map((dataJobPage) => {
-                dataJobs = dataJobs.concat(
-                    dataJobPage.content as unknown as DataJob[],
-                );
+                dataJobs = dataJobs.concat(dataJobPage.content as unknown as DataJob[]);
 
                 return dataJobs;
             }),
-            catchError((error: unknown) =>
-                throwError(() => ErrorUtil.extractError(error as Error)),
-            ),
+            catchError((error: unknown) => throwError(() => ErrorUtil.extractError(error as Error)))
         );
     }
 
@@ -83,8 +79,8 @@ export class DataJobsPublicApiService extends TaurusBaseApiService<DataJobsPubli
             {
                 property: 'config.team',
                 pattern: team,
-                sort: null,
-            },
+                sort: null
+            }
         ];
 
         return this.dataJobsBaseService
@@ -107,14 +103,12 @@ export class DataJobsPublicApiService extends TaurusBaseApiService<DataJobsPubli
                     filter: filters,
                     search: null,
                     pageNumber: 1,
-                    pageSize: 1,
-                },
+                    pageSize: 1
+                }
             )
             .pipe(
                 map((response) => response?.data?.totalItems ?? 0),
-                catchError((error: unknown) =>
-                    throwError(() => ErrorUtil.extractError(error as Error)),
-                ),
+                catchError((error: unknown) => throwError(() => ErrorUtil.extractError(error as Error)))
             );
     }
 
@@ -126,7 +120,7 @@ export class DataJobsPublicApiService extends TaurusBaseApiService<DataJobsPubli
         pageNumber: number,
         pageSize: number,
         filters: ApiPredicate[] = [],
-        searchQueryValue: string = null,
+        searchQueryValue: string = null
     ): Observable<DataJobPage> {
         return this.dataJobsBaseService
             .getJobs(
@@ -150,8 +144,8 @@ export class DataJobsPublicApiService extends TaurusBaseApiService<DataJobsPubli
                     filter: filters,
                     search: searchQueryValue,
                     pageNumber,
-                    pageSize,
-                },
+                    pageSize
+                }
             )
             .pipe(map((response) => response.data));
     }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/services/data-jobs.api.service.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/services/data-jobs.api.service.spec.ts
@@ -14,11 +14,7 @@ import { DATA_PIPELINES_CONFIGS, DataJob, DataJobPage } from '../model';
 
 import { DataJobsBaseApiService } from './data-jobs-base.api.service';
 
-import {
-    DataJobsApiService,
-    MISSING_DEFAULT_TEAM_MESSAGE,
-    RESERVED_DEFAULT_TEAM_NAME_MESSAGE,
-} from './data-jobs.api.service';
+import { DataJobsApiService, MISSING_DEFAULT_TEAM_MESSAGE, RESERVED_DEFAULT_TEAM_NAME_MESSAGE } from './data-jobs.api.service';
 
 describe('DataJobsApiService', () => {
     let service: DataJobsApiService;
@@ -29,21 +25,12 @@ describe('DataJobsApiService', () => {
         /* eslint-disable-next-line @typescript-eslint/naming-convention */
         job_name: 'job001',
         team: 'taurus',
-        description: 'descpription001',
+        description: 'descpription001'
     };
 
     beforeEach(() => {
-        dataJobsBaseServiceStub = jasmine.createSpyObj<DataJobsBaseApiService>(
-            'dataJobsBaseService',
-            ['getJobs'],
-        );
-        httpClientStub = jasmine.createSpyObj<HttpClient>('httpClient', [
-            'get',
-            'post',
-            'patch',
-            'put',
-            'delete',
-        ]);
+        dataJobsBaseServiceStub = jasmine.createSpyObj<DataJobsBaseApiService>('dataJobsBaseService', ['getJobs']);
+        httpClientStub = jasmine.createSpyObj<HttpClient>('httpClient', ['get', 'post', 'patch', 'put', 'delete']);
 
         httpClientStub.get.and.returnValue(of({}));
         httpClientStub.post.and.returnValue(of({}));
@@ -57,15 +44,15 @@ describe('DataJobsApiService', () => {
                 { provide: HttpClient, useValue: httpClientStub },
                 {
                     provide: DataJobsBaseApiService,
-                    useValue: dataJobsBaseServiceStub,
+                    useValue: dataJobsBaseServiceStub
                 },
                 {
                     provide: DATA_PIPELINES_CONFIGS,
                     useFactory: () => ({
-                        defaultOwnerTeamName: 'all',
-                    }),
-                },
-            ],
+                        defaultOwnerTeamName: 'all'
+                    })
+                }
+            ]
         });
 
         service = TestBed.inject(DataJobsApiService);
@@ -83,10 +70,10 @@ describe('DataJobsApiService', () => {
                     data: {
                         content: [{}],
                         totalItems: 1,
-                        totalPages: 1,
+                        totalPages: 1
                     },
                     loading: false,
-                    networkStatus: 7,
+                    networkStatus: 7
                 };
                 const apolloQueryRef = of(apolloQueryResult);
 
@@ -143,8 +130,8 @@ describe('DataJobsApiService', () => {
                         pageNumber: 1,
                         pageSize: 1,
                         filter: [],
-                        search: 'searchQueryValue',
-                    },
+                        search: 'searchQueryValue'
+                    }
                 );
             });
         });
@@ -156,14 +143,12 @@ describe('DataJobsApiService', () => {
                     data: {
                         content: [{}],
                         totalItems: 1,
-                        totalPages: 1,
+                        totalPages: 1
                     },
                     loading: false,
-                    networkStatus: 7,
+                    networkStatus: 7
                 };
-                dataJobsBaseServiceStub.getJobs.and.returnValue(
-                    of(apolloQueryResult),
-                );
+                dataJobsBaseServiceStub.getJobs.and.returnValue(of(apolloQueryResult));
 
                 // When
                 service.getJob('supercollider_demo', 'test-job-taur');
@@ -213,74 +198,69 @@ describe('DataJobsApiService', () => {
                             {
                                 property: 'config.team',
                                 pattern: 'supercollider_demo',
-                                sort: null,
+                                sort: null
                             },
                             {
                                 property: 'jobName',
                                 pattern: 'test-job-taur',
-                                sort: null,
-                            },
-                        ],
-                    },
+                                sort: null
+                            }
+                        ]
+                    }
                 );
             });
 
             it('should verify will return expected data for given response', (done) => {
                 // Given
                 const dataJob: DataJob = {};
-                const apolloQueryResult1: ApolloQueryResult<DataJobPage> =
-                    undefined;
+                const apolloQueryResult1: ApolloQueryResult<DataJobPage> = undefined;
                 const apolloQueryResult2: ApolloQueryResult<DataJobPage> = {
                     data: undefined,
                     loading: false,
-                    networkStatus: 7,
+                    networkStatus: 7
                 };
                 const apolloQueryResult3: ApolloQueryResult<DataJobPage> = {
                     data: {
-                        content: undefined,
+                        content: undefined
                     },
                     loading: false,
-                    networkStatus: 7,
+                    networkStatus: 7
                 };
                 const apolloQueryResult4: ApolloQueryResult<DataJobPage> = {
                     data: {
-                        content: [],
+                        content: []
                     },
                     loading: false,
-                    networkStatus: 7,
+                    networkStatus: 7
                 };
                 const apolloQueryResult5: ApolloQueryResult<DataJobPage> = {
                     data: {
                         content: [dataJob],
                         totalItems: 1,
-                        totalPages: 1,
+                        totalPages: 1
                     },
                     loading: false,
-                    networkStatus: 7,
+                    networkStatus: 7
                 };
                 dataJobsBaseServiceStub.getJobs.and.returnValues(
                     of(apolloQueryResult1),
                     of(apolloQueryResult2),
                     of(apolloQueryResult3),
                     of(apolloQueryResult4),
-                    of(apolloQueryResult5),
+                    of(apolloQueryResult5)
                 );
 
                 const executeNextCall = (executionId) => {
                     if (executionId === 4) {
-                        service
-                            .getJob('supercollider_demo', 'test-job-taur')
-                            .subscribe((value) => {
-                                expect(value).toBe(dataJob);
-                                done();
-                            });
+                        service.getJob('supercollider_demo', 'test-job-taur').subscribe((value) => {
+                            expect(value).toBe(dataJob);
+                            done();
+                        });
                     } else {
-                        service
-                            .getJob('supercollider_demo', 'test-job-taur')
-                            .subscribe((value) => {
-                                expect(value).toBeNull();
-                                executeNextCall(++executionId);
-                            });
+                        service.getJob('supercollider_demo', 'test-job-taur').subscribe((value) => {
+                            expect(value).toBeNull();
+                            executeNextCall(++executionId);
+                        });
                     }
                 };
 
@@ -297,16 +277,12 @@ describe('DataJobsApiService', () => {
                 const executionId = 'executionA';
 
                 // When
-                const response = service.getJobExecution(
-                    teamName,
-                    jobName,
-                    executionId,
-                );
+                const response = service.getJobExecution(teamName, jobName, executionId);
 
                 // Then
                 expect(response).toBeDefined();
                 expect(httpClientStub.get).toHaveBeenCalledWith(
-                    `/data-jobs/for-team/${teamName}/jobs/${jobName}/executions/${executionId}`,
+                    `/data-jobs/for-team/${teamName}/jobs/${jobName}/executions/${executionId}`
                 );
             });
         });
@@ -317,8 +293,8 @@ describe('DataJobsApiService', () => {
             expect(() =>
                 // @ts-ignore
                 service._validateModuleConfig({
-                    defaultOwnerTeamName: '',
-                }),
+                    defaultOwnerTeamName: ''
+                })
             ).toThrow(new Error(MISSING_DEFAULT_TEAM_MESSAGE));
         });
 
@@ -326,18 +302,15 @@ describe('DataJobsApiService', () => {
             expect(() =>
                 // @ts-ignore
                 service._validateModuleConfig({
-                    defaultOwnerTeamName: 'default',
-                }),
+                    defaultOwnerTeamName: 'default'
+                })
             ).toThrow(new Error(RESERVED_DEFAULT_TEAM_NAME_MESSAGE));
         });
     });
 
     describe('getJobDetails', () => {
         it('returs observable', () => {
-            const jobDetailsObservable = service.getJobDetails(
-                'team001',
-                'job001',
-            );
+            const jobDetailsObservable = service.getJobDetails('team001', 'job001');
             expect(jobDetailsObservable).toBeDefined();
         });
     });
@@ -351,65 +324,42 @@ describe('DataJobsApiService', () => {
 
     describe('downloadFile', () => {
         it('returs observable', () => {
-            const downloadFileObservable = service.downloadFile(
-                'team001',
-                'job001',
-            );
+            const downloadFileObservable = service.downloadFile('team001', 'job001');
             expect(downloadFileObservable).toBeDefined();
         });
     });
 
     describe('getJobDeployments', () => {
         it('returs observable', () => {
-            const getJobDeploymentsObservable = service.getJobDeployments(
-                'team001',
-                'job001',
-            );
+            const getJobDeploymentsObservable = service.getJobDeployments('team001', 'job001');
             expect(getJobDeploymentsObservable).toBeDefined();
         });
     });
 
     describe('updateDataJobStatus', () => {
         it('returs observable', () => {
-            const updateDataJobStatusObservable = service.updateDataJobStatus(
-                'team001',
-                'job001',
-                'deploy001',
-                false,
-            );
+            const updateDataJobStatusObservable = service.updateDataJobStatus('team001', 'job001', 'deploy001', false);
             expect(updateDataJobStatusObservable).toBeDefined();
         });
     });
 
     describe('updateDataJobStatus', () => {
         it('returs observable', () => {
-            const updateDataJobStatusObservable = service.updateDataJobStatus(
-                'team001',
-                'job001',
-                null,
-                false,
-            );
+            const updateDataJobStatusObservable = service.updateDataJobStatus('team001', 'job001', null, false);
             expect(updateDataJobStatusObservable).toBeDefined();
         });
     });
 
     describe('updateDataJob', () => {
         it('returs observable', () => {
-            const updateDataJobStatusObservable = service.updateDataJob(
-                'team001',
-                'job001',
-                TEST_JOB_DETAILS,
-            );
+            const updateDataJobStatusObservable = service.updateDataJob('team001', 'job001', TEST_JOB_DETAILS);
             expect(updateDataJobStatusObservable).toBeDefined();
         });
     });
 
     describe('getJobExecutions', () => {
         it('returs observable', () => {
-            const jobExecutionsObservable = service.getJobExecutions(
-                'team001',
-                'job001',
-            );
+            const jobExecutionsObservable = service.getJobExecutions('team001', 'job001');
             expect(jobExecutionsObservable).toBeDefined();
         });
     });
@@ -420,15 +370,11 @@ describe('DataJobsApiService', () => {
             const jobName = 'job001';
             const deploymentId = 'hhw-dff-fgg-100';
 
-            const executeDataJobObservable = service.executeDataJob(
-                teamName,
-                jobName,
-                deploymentId,
-            );
+            const executeDataJobObservable = service.executeDataJob(teamName, jobName, deploymentId);
             expect(executeDataJobObservable).toBeDefined();
             expect(httpClientStub.post).toHaveBeenCalledWith(
                 `/data-jobs/for-team/${teamName}/jobs/${jobName}/deployments/${deploymentId}/executions`,
-                {},
+                {}
             );
         });
     });
@@ -440,23 +386,16 @@ describe('DataJobsApiService', () => {
             const deploymentId = 'hhw-dff-fgg-100';
             const executionId = 'hhw-dff-fgg-100';
 
-            const executeDataJobObservable = service.executeDataJob(
-                teamName,
-                jobName,
-                deploymentId,
-            );
+            const executeDataJobObservable = service.executeDataJob(teamName, jobName, deploymentId);
             expect(executeDataJobObservable).toBeDefined();
             expect(httpClientStub.post).toHaveBeenCalledWith(
                 `/data-jobs/for-team/${teamName}/jobs/${jobName}/deployments/${deploymentId}/executions`,
-                {},
+                {}
             );
 
-            const cancelExecutionDataJobObservable =
-                service.cancelDataJobExecution(teamName, jobName, executionId);
+            const cancelExecutionDataJobObservable = service.cancelDataJobExecution(teamName, jobName, executionId);
             expect(cancelExecutionDataJobObservable).toBeDefined();
-            expect(httpClientStub.delete).toHaveBeenCalledWith(
-                `/data-jobs/for-team/${teamName}/jobs/${jobName}/executions/${executionId}`,
-            );
+            expect(httpClientStub.delete).toHaveBeenCalledWith(`/data-jobs/for-team/${teamName}/jobs/${jobName}/executions/${executionId}`);
         });
     });
 });

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/services/data-jobs.api.service.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/services/data-jobs.api.service.ts
@@ -11,11 +11,7 @@ import { map } from 'rxjs/operators';
 
 import { ApolloQueryResult } from '@apollo/client/core';
 
-import {
-    ApiPredicate,
-    CollectionsUtil,
-    TaurusBaseApiService,
-} from '@versatiledatakit/shared';
+import { ApiPredicate, CollectionsUtil, TaurusBaseApiService } from '@versatiledatakit/shared';
 
 import {
     DATA_PIPELINES_CONFIGS,
@@ -27,13 +23,12 @@ import {
     DataJobExecutionOrder,
     DataJobExecutionsPage,
     DataJobPage,
-    DataPipelinesConfig,
+    DataPipelinesConfig
 } from '../model';
 
 import { DataJobsBaseApiService } from './data-jobs-base.api.service';
 
-export const MISSING_DEFAULT_TEAM_MESSAGE =
-    'The defaultOwnerTeamName property need to be set for the DATA_PIPELINES_CONFIGS';
+export const MISSING_DEFAULT_TEAM_MESSAGE = 'The defaultOwnerTeamName property need to be set for the DATA_PIPELINES_CONFIGS';
 
 export const RESERVED_DEFAULT_TEAM_NAME_MESSAGE = `The 'default' value is reserved, and can not be used for defaultOwnerTeamName property`;
 
@@ -55,7 +50,7 @@ export class DataJobsApiService extends TaurusBaseApiService<DataJobsApiService>
         @Inject(DATA_PIPELINES_CONFIGS)
         dataPipelinesModuleConfig: DataPipelinesConfig,
         private readonly http: HttpClient,
-        private readonly dataJobsBaseService: DataJobsBaseApiService,
+        private readonly dataJobsBaseService: DataJobsBaseApiService
     ) {
         super(DataJobsApiService.CLASS_NAME);
 
@@ -65,14 +60,12 @@ export class DataJobsApiService extends TaurusBaseApiService<DataJobsApiService>
 
         this.ownerTeamName = dataPipelinesModuleConfig?.defaultOwnerTeamName;
         if (dataPipelinesModuleConfig?.ownerTeamNamesObservable) {
-            dataPipelinesModuleConfig.ownerTeamNamesObservable.subscribe(
-                (result: string[]) => {
-                    if (result?.length) {
-                        //Take the first element from the teams array
-                        this.ownerTeamName = result[0];
-                    }
-                },
-            );
+            dataPipelinesModuleConfig.ownerTeamNamesObservable.subscribe((result: string[]) => {
+                if (result?.length) {
+                    //Take the first element from the teams array
+                    this.ownerTeamName = result[0];
+                }
+            });
         }
     }
 
@@ -80,7 +73,7 @@ export class DataJobsApiService extends TaurusBaseApiService<DataJobsApiService>
         filters: ApiPredicate[],
         searchQueryValue: string,
         pageNumber: number,
-        pageSize: number,
+        pageSize: number
     ): Observable<ApolloQueryResult<DataJobPage>> {
         return this.dataJobsBaseService.getJobs(
             this.ownerTeamName,
@@ -129,8 +122,8 @@ export class DataJobsApiService extends TaurusBaseApiService<DataJobsApiService>
                 pageNumber,
                 pageSize,
                 filter: filters,
-                search: searchQueryValue,
-            },
+                search: searchQueryValue
+            }
         );
     }
 
@@ -176,55 +169,39 @@ export class DataJobsApiService extends TaurusBaseApiService<DataJobsApiService>
                 }
               }`,
                 {
-                    filter: this._createTeamJobNameFilter(teamName, jobName),
-                },
+                    filter: this._createTeamJobNameFilter(teamName, jobName)
+                }
             )
             .pipe(
                 map((response: ApolloQueryResult<DataJobPage>) => {
-                    if (
-                        !CollectionsUtil.isArray(response?.data?.content) ||
-                        response.data.content.length === 0
-                    ) {
+                    if (!CollectionsUtil.isArray(response?.data?.content) || response.data.content.length === 0) {
                         return null;
                     }
 
                     return response.data.content[0];
-                }),
+                })
             );
     }
 
-    getJobDetails(
-        teamName: string,
-        jobName: string,
-    ): Observable<DataJobDetails> {
-        return this.http.get<DataJobDetails>(
-            `/data-jobs/for-team/${teamName}/jobs/${jobName}`,
-        );
+    getJobDetails(teamName: string, jobName: string): Observable<DataJobDetails> {
+        return this.http.get<DataJobDetails>(`/data-jobs/for-team/${teamName}/jobs/${jobName}`);
     }
 
     removeJob(teamName: string, jobName: string): Observable<DataJobDetails> {
-        return this.http.delete(
-            `/data-jobs/for-team/${teamName}/jobs/${jobName}`,
-        );
+        return this.http.delete(`/data-jobs/for-team/${teamName}/jobs/${jobName}`);
     }
 
     downloadFile(teamName: string, jobName: string): Observable<Blob> {
         const httpHeaders = new HttpHeaders();
         httpHeaders.append('Accept', 'application/octet-stream');
 
-        return this.http.get(
-            `/data-jobs/for-team/${teamName}/jobs/${jobName}/keytab`,
-            {
-                headers: httpHeaders,
-                responseType: 'blob',
-            },
-        );
+        return this.http.get(`/data-jobs/for-team/${teamName}/jobs/${jobName}/keytab`, {
+            headers: httpHeaders,
+            responseType: 'blob'
+        });
     }
 
-    getJobExecutions(
-        teamName: string,
-        jobName: string,
-    ): Observable<DataJobExecutionDetails[]>;
+    getJobExecutions(teamName: string, jobName: string): Observable<DataJobExecutionDetails[]>;
     getJobExecutions(
         teamName: string,
         jobName: string,
@@ -232,7 +209,7 @@ export class DataJobsApiService extends TaurusBaseApiService<DataJobsApiService>
         filter?: DataJobExecutionFilter,
         order?: DataJobExecutionOrder,
         pageNumber?: number,
-        pageSize?: number,
+        pageSize?: number
     ): Observable<DataJobExecutionsPage>;
     getJobExecutions(
         teamName: string,
@@ -241,14 +218,10 @@ export class DataJobsApiService extends TaurusBaseApiService<DataJobsApiService>
         filter: DataJobExecutionFilter = null,
         order: DataJobExecutionOrder = null,
         pageNumber: number = null,
-        pageSize: number = null,
-    ):
-        | Observable<DataJobExecutionDetails[]>
-        | Observable<DataJobExecutionsPage> {
+        pageSize: number = null
+    ): Observable<DataJobExecutionDetails[]> | Observable<DataJobExecutionsPage> {
         if (!forceGraphQL) {
-            return this.http.get<DataJobExecutionDetails[]>(
-                `/data-jobs/for-team/${teamName}/jobs/${jobName}/executions`,
-            );
+            return this.http.get<DataJobExecutionDetails[]>(`/data-jobs/for-team/${teamName}/jobs/${jobName}/executions`);
         }
 
         const preparedFilter = { ...(filter ?? {}) };
@@ -304,94 +277,59 @@ export class DataJobsApiService extends TaurusBaseApiService<DataJobsApiService>
                     pageNumber: pageNumber ?? 1,
                     pageSize: pageSize ?? 500,
                     filter: preparedFilter,
-                    order: order ?? null,
-                },
+                    order: order ?? null
+                }
             )
             .pipe(map((response) => response.data));
     }
 
-    getJobExecution(
-        teamName: string,
-        jobName: string,
-        executionId: string,
-    ): Observable<DataJobExecutionDetails> {
-        return this.http.get<DataJobExecutionDetails>(
-            `/data-jobs/for-team/${teamName}/jobs/${jobName}/executions/${executionId}`,
-        );
+    getJobExecution(teamName: string, jobName: string, executionId: string): Observable<DataJobExecutionDetails> {
+        return this.http.get<DataJobExecutionDetails>(`/data-jobs/for-team/${teamName}/jobs/${jobName}/executions/${executionId}`);
     }
 
-    getJobDeployments(
-        teamName: string,
-        jobName: string,
-    ): Observable<DataJobDeploymentDetails[]> {
-        return this.http.get<DataJobDeploymentDetails[]>(
-            `/data-jobs/for-team/${teamName}/jobs/${jobName}/deployments`,
-        );
+    getJobDeployments(teamName: string, jobName: string): Observable<DataJobDeploymentDetails[]> {
+        return this.http.get<DataJobDeploymentDetails[]>(`/data-jobs/for-team/${teamName}/jobs/${jobName}/deployments`);
     }
 
     updateDataJobStatus(
         teamName: string,
         jobName: string,
         deploymentId: string,
-        dataJobEnabled: boolean,
+        dataJobEnabled: boolean
     ): Observable<{ enabled: boolean }> {
         const deploymentStatus = { enabled: dataJobEnabled };
 
         if (!deploymentId) {
-            console.log(
-                `Status update will be processed with default deploymentId`,
-            );
+            console.log(`Status update will be processed with default deploymentId`);
             deploymentId = 'default';
         }
 
         return this.http.patch<{ enabled: boolean }>(
             `/data-jobs/for-team/${teamName}/jobs/${jobName}/deployments/${deploymentId}`,
-            deploymentStatus,
+            deploymentStatus
         );
     }
 
-    updateDataJob(
-        teamName: string,
-        jobName: string,
-        dataJob: DataJobDetails,
-    ): Observable<DataJobDetails> {
-        return this.http.put<DataJobDetails>(
-            `/data-jobs/for-team/${teamName}/jobs/${jobName}`,
-            dataJob,
-        );
+    updateDataJob(teamName: string, jobName: string, dataJob: DataJobDetails): Observable<DataJobDetails> {
+        return this.http.put<DataJobDetails>(`/data-jobs/for-team/${teamName}/jobs/${jobName}`, dataJob);
     }
 
-    executeDataJob(
-        teamName: string,
-        jobName: string,
-        deploymentId: string,
-    ): Observable<undefined> {
-        return this.http.post<undefined>(
-            `/data-jobs/for-team/${teamName}/jobs/${jobName}/deployments/${deploymentId}/executions`,
-            {},
-        );
+    executeDataJob(teamName: string, jobName: string, deploymentId: string): Observable<undefined> {
+        return this.http.post<undefined>(`/data-jobs/for-team/${teamName}/jobs/${jobName}/deployments/${deploymentId}/executions`, {});
     }
 
-    cancelDataJobExecution(
-        teamName: string,
-        jobName: string,
-        executionId: string,
-    ): Observable<any> {
-        return this.http.delete(
-            `/data-jobs/for-team/${teamName}/jobs/${jobName}/executions/${executionId}`,
-        );
+    cancelDataJobExecution(teamName: string, jobName: string, executionId: string): Observable<any> {
+        return this.http.delete(`/data-jobs/for-team/${teamName}/jobs/${jobName}/executions/${executionId}`);
     }
 
     private _createTeamJobNameFilter(teamName: string, jobName: string) {
         return [
             { property: 'config.team', pattern: teamName, sort: null },
-            { property: 'jobName', pattern: jobName, sort: null },
+            { property: 'jobName', pattern: jobName, sort: null }
         ];
     }
 
-    private _validateModuleConfig(
-        dataPipelinesModuleConfig: DataPipelinesConfig,
-    ) {
+    private _validateModuleConfig(dataPipelinesModuleConfig: DataPipelinesConfig) {
         if (!dataPipelinesModuleConfig?.defaultOwnerTeamName) {
             throw new Error(MISSING_DEFAULT_TEAM_MESSAGE);
         }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/services/data-jobs.service.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/services/data-jobs.service.spec.ts
@@ -7,20 +7,9 @@ import { TestBed } from '@angular/core/testing';
 
 import { Observable } from 'rxjs';
 
-import {
-    ComponentModel,
-    ComponentService,
-    ComponentStateImpl,
-    RouterState,
-    RouteState,
-} from '@versatiledatakit/shared';
+import { ComponentModel, ComponentService, ComponentStateImpl, RouterState, RouteState } from '@versatiledatakit/shared';
 
-import {
-    FETCH_DATA_JOB,
-    FETCH_DATA_JOB_EXECUTIONS,
-    FETCH_DATA_JOBS,
-    UPDATE_DATA_JOB,
-} from '../state/actions';
+import { FETCH_DATA_JOB, FETCH_DATA_JOB_EXECUTIONS, FETCH_DATA_JOBS, UPDATE_DATA_JOB } from '../state/actions';
 import { TASK_UPDATE_JOB_DESCRIPTION } from '../state/tasks';
 
 import { DataJobsService, DataJobsServiceImpl } from './data-jobs.service';
@@ -31,16 +20,13 @@ describe('DataJobsService -> DataJobsServiceImpl', () => {
     let service: DataJobsService;
 
     beforeEach(() => {
-        componentServiceStub = jasmine.createSpyObj<ComponentService>(
-            'componentService',
-            ['load', 'dispatchAction'],
-        );
+        componentServiceStub = jasmine.createSpyObj<ComponentService>('componentService', ['load', 'dispatchAction']);
 
         TestBed.configureTestingModule({
             providers: [
                 { provide: ComponentService, useValue: componentServiceStub },
-                { provide: DataJobsService, useClass: DataJobsServiceImpl },
-            ],
+                { provide: DataJobsService, useClass: DataJobsServiceImpl }
+            ]
         });
 
         service = TestBed.inject(DataJobsService);
@@ -57,24 +43,17 @@ describe('DataJobsService -> DataJobsServiceImpl', () => {
                 // Given
                 const model = ComponentModel.of(
                     ComponentStateImpl.of({
-                        id: 'test-component',
+                        id: 'test-component'
                     }),
-                    RouterState.of(RouteState.empty(), 1),
+                    RouterState.of(RouteState.empty(), 1)
                 );
 
                 // When
                 service.loadJob(model);
 
                 // Then
-                expect(componentServiceStub.load).toHaveBeenCalledWith(
-                    model.getComponentState(),
-                );
-                expect(
-                    componentServiceStub.dispatchAction,
-                ).toHaveBeenCalledWith(
-                    FETCH_DATA_JOB,
-                    model.getComponentState(),
-                );
+                expect(componentServiceStub.load).toHaveBeenCalledWith(model.getComponentState());
+                expect(componentServiceStub.dispatchAction).toHaveBeenCalledWith(FETCH_DATA_JOB, model.getComponentState());
             });
         });
 
@@ -83,24 +62,17 @@ describe('DataJobsService -> DataJobsServiceImpl', () => {
                 // Given
                 const model = ComponentModel.of(
                     ComponentStateImpl.of({
-                        id: 'test-component',
+                        id: 'test-component'
                     }),
-                    RouterState.of(RouteState.empty(), 1),
+                    RouterState.of(RouteState.empty(), 1)
                 );
 
                 // When
                 service.loadJobs(model);
 
                 // Then
-                expect(componentServiceStub.load).toHaveBeenCalledWith(
-                    model.getComponentState(),
-                );
-                expect(
-                    componentServiceStub.dispatchAction,
-                ).toHaveBeenCalledWith(
-                    FETCH_DATA_JOBS,
-                    model.getComponentState(),
-                );
+                expect(componentServiceStub.load).toHaveBeenCalledWith(model.getComponentState());
+                expect(componentServiceStub.dispatchAction).toHaveBeenCalledWith(FETCH_DATA_JOBS, model.getComponentState());
             });
         });
 
@@ -109,24 +81,17 @@ describe('DataJobsService -> DataJobsServiceImpl', () => {
                 // Given
                 const model = ComponentModel.of(
                     ComponentStateImpl.of({
-                        id: 'test-component',
+                        id: 'test-component'
                     }),
-                    RouterState.of(RouteState.empty(), 1),
+                    RouterState.of(RouteState.empty(), 1)
                 );
 
                 // When
                 service.loadJobExecutions(model);
 
                 // Then
-                expect(componentServiceStub.load).toHaveBeenCalledWith(
-                    model.getComponentState(),
-                );
-                expect(
-                    componentServiceStub.dispatchAction,
-                ).toHaveBeenCalledWith(
-                    FETCH_DATA_JOB_EXECUTIONS,
-                    model.getComponentState(),
-                );
+                expect(componentServiceStub.load).toHaveBeenCalledWith(model.getComponentState());
+                expect(componentServiceStub.dispatchAction).toHaveBeenCalledWith(FETCH_DATA_JOB_EXECUTIONS, model.getComponentState());
             });
         });
 
@@ -135,24 +100,20 @@ describe('DataJobsService -> DataJobsServiceImpl', () => {
                 // Given
                 const model = ComponentModel.of(
                     ComponentStateImpl.of({
-                        id: 'test-component',
+                        id: 'test-component'
                     }),
-                    RouterState.of(RouteState.empty(), 1),
+                    RouterState.of(RouteState.empty(), 1)
                 );
 
                 // When
                 service.updateJob(model, TASK_UPDATE_JOB_DESCRIPTION);
 
                 // Then
-                expect(componentServiceStub.load).toHaveBeenCalledWith(
-                    model.getComponentState(),
-                );
-                expect(
-                    componentServiceStub.dispatchAction,
-                ).toHaveBeenCalledWith(
+                expect(componentServiceStub.load).toHaveBeenCalledWith(model.getComponentState());
+                expect(componentServiceStub.dispatchAction).toHaveBeenCalledWith(
                     UPDATE_DATA_JOB,
                     model.getComponentState(),
-                    TASK_UPDATE_JOB_DESCRIPTION,
+                    TASK_UPDATE_JOB_DESCRIPTION
                 );
             });
         });
@@ -161,14 +122,10 @@ describe('DataJobsService -> DataJobsServiceImpl', () => {
             it('should verify will return Observable', () => {
                 // Given
                 // eslint-disable-next-line @typescript-eslint/dot-notation
-                const asObservableSpy = spyOn(
-                    (service as DataJobsServiceImpl)['_runningJobExecutionId'],
-                    'asObservable',
-                ).and.callThrough();
+                const asObservableSpy = spyOn((service as DataJobsServiceImpl)['_runningJobExecutionId'], 'asObservable').and.callThrough();
 
                 // When
-                const observable =
-                    service.getNotifiedForRunningJobExecutionId();
+                const observable = service.getNotifiedForRunningJobExecutionId();
 
                 // Then
                 expect(observable).toBeInstanceOf(Observable);
@@ -180,10 +137,7 @@ describe('DataJobsService -> DataJobsServiceImpl', () => {
             it('should verify will notify correct Subject', () => {
                 // Given
                 // eslint-disable-next-line @typescript-eslint/dot-notation
-                const nextSpy = spyOn(
-                    (service as DataJobsServiceImpl)['_runningJobExecutionId'],
-                    'next',
-                ).and.callThrough();
+                const nextSpy = spyOn((service as DataJobsServiceImpl)['_runningJobExecutionId'], 'next').and.callThrough();
 
                 // When
                 service.notifyForRunningJobExecutionId('xy');
@@ -197,10 +151,7 @@ describe('DataJobsService -> DataJobsServiceImpl', () => {
             it('should verify will return Observable', () => {
                 // Given
                 // eslint-disable-next-line @typescript-eslint/dot-notation
-                const asObservableSpy = spyOn(
-                    (service as DataJobsServiceImpl)['_jobExecutions'],
-                    'asObservable',
-                ).and.callThrough();
+                const asObservableSpy = spyOn((service as DataJobsServiceImpl)['_jobExecutions'], 'asObservable').and.callThrough();
 
                 // When
                 const observable = service.getNotifiedForJobExecutions();
@@ -215,10 +166,7 @@ describe('DataJobsService -> DataJobsServiceImpl', () => {
             it('should verify will notify correct Subject', () => {
                 // Given
                 // eslint-disable-next-line @typescript-eslint/dot-notation
-                const nextSpy = spyOn(
-                    (service as DataJobsServiceImpl)['_jobExecutions'],
-                    'next',
-                ).and.callThrough();
+                const nextSpy = spyOn((service as DataJobsServiceImpl)['_jobExecutions'], 'next').and.callThrough();
 
                 // When
                 service.notifyForJobExecutions([null]);
@@ -232,10 +180,7 @@ describe('DataJobsService -> DataJobsServiceImpl', () => {
             it('should verify will return Observable', () => {
                 // Given
                 // eslint-disable-next-line @typescript-eslint/dot-notation
-                const asObservableSpy = spyOn(
-                    (service as DataJobsServiceImpl)['_implicitTeam'],
-                    'asObservable',
-                ).and.callThrough();
+                const asObservableSpy = spyOn((service as DataJobsServiceImpl)['_implicitTeam'], 'asObservable').and.callThrough();
 
                 // When
                 const observable = service.getNotifiedForTeamImplicitly();
@@ -250,10 +195,7 @@ describe('DataJobsService -> DataJobsServiceImpl', () => {
             it('should verify will notify correct BehaviorSubject', () => {
                 // Given
                 // eslint-disable-next-line @typescript-eslint/dot-notation
-                const nextSpy = spyOn(
-                    (service as DataJobsServiceImpl)['_implicitTeam'],
-                    'next',
-                ).and.callThrough();
+                const nextSpy = spyOn((service as DataJobsServiceImpl)['_implicitTeam'], 'next').and.callThrough();
 
                 // When
                 service.notifyForTeamImplicitly('teamZero');

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/services/data-jobs.service.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/services/data-jobs.service.ts
@@ -11,12 +11,7 @@ import { BehaviorSubject, Observable, Subject } from 'rxjs';
 
 import { ComponentModel, ComponentService } from '@versatiledatakit/shared';
 
-import {
-    FETCH_DATA_JOB,
-    FETCH_DATA_JOB_EXECUTIONS,
-    FETCH_DATA_JOBS,
-    UPDATE_DATA_JOB,
-} from '../state/actions';
+import { FETCH_DATA_JOB, FETCH_DATA_JOB_EXECUTIONS, FETCH_DATA_JOBS, UPDATE_DATA_JOB } from '../state/actions';
 import { DataJobUpdateTasks } from '../state/tasks';
 
 import { DataJobExecutions } from '../model';
@@ -95,18 +90,12 @@ export class DataJobsServiceImpl extends DataJobsService {
      */
     loadJobs(model: ComponentModel): void {
         this.componentService.load(model.getComponentState());
-        this.componentService.dispatchAction(
-            FETCH_DATA_JOBS,
-            model.getComponentState(),
-        );
+        this.componentService.dispatchAction(FETCH_DATA_JOBS, model.getComponentState());
     }
 
     loadJob(model: ComponentModel): void {
         this.componentService.load(model.getComponentState());
-        this.componentService.dispatchAction(
-            FETCH_DATA_JOB,
-            model.getComponentState(),
-        );
+        this.componentService.dispatchAction(FETCH_DATA_JOB, model.getComponentState());
     }
 
     /**
@@ -114,10 +103,7 @@ export class DataJobsServiceImpl extends DataJobsService {
      */
     loadJobExecutions(model: ComponentModel): void {
         this.componentService.load(model.getComponentState());
-        this.componentService.dispatchAction(
-            FETCH_DATA_JOB_EXECUTIONS,
-            model.getComponentState(),
-        );
+        this.componentService.dispatchAction(FETCH_DATA_JOB_EXECUTIONS, model.getComponentState());
     }
 
     /**
@@ -125,11 +111,7 @@ export class DataJobsServiceImpl extends DataJobsService {
      */
     updateJob(model: ComponentModel, task: DataJobUpdateTasks): void {
         this.componentService.load(model.getComponentState());
-        this.componentService.dispatchAction(
-            UPDATE_DATA_JOB,
-            model.getComponentState(),
-            task,
-        );
+        this.componentService.dispatchAction(UPDATE_DATA_JOB, model.getComponentState(), task);
     }
 
     /**

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/confirmation-dialog-modal/confirmation-dialog-modal.component.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/confirmation-dialog-modal/confirmation-dialog-modal.component.spec.ts
@@ -12,7 +12,7 @@ describe('ConfirmationDialogModalComponent', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [ConfirmationDialogModalComponent],
+            declarations: [ConfirmationDialogModalComponent]
         }).compileComponents();
     });
 

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/confirmation-dialog-modal/confirmation-dialog-modal.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/confirmation-dialog-modal/confirmation-dialog-modal.component.ts
@@ -10,7 +10,7 @@ import { ModalComponentDirective } from '../modal/modal.component';
 @Component({
     selector: 'lib-confirmation-dialog-modal',
     templateUrl: './confirmation-dialog-modal.component.html',
-    styleUrls: ['./confirmation-dialog-modal.component.scss'],
+    styleUrls: ['./confirmation-dialog-modal.component.scss']
 })
 export class ConfirmationDialogModalComponent extends ModalComponentDirective {
     @Input() confirmationInput: string;

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/data-grid/column-filter/column-filter.component.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/data-grid/column-filter/column-filter.component.spec.ts
@@ -21,10 +21,10 @@ describe('ColumnFilterComponent', () => {
                 {
                     provide: ClrDatagridFilter,
                     useFactory: () => ({
-                        setFilter: () => ({}),
-                    }),
-                },
-            ],
+                        setFilter: () => ({})
+                    })
+                }
+            ]
         }).compileComponents();
     });
 
@@ -41,7 +41,7 @@ describe('ColumnFilterComponent', () => {
     describe('toggle selection', () => {
         it('change value', () => {
             component.toggleSelection({
-                target: { value: TEST_VALUE } as unknown as EventTarget,
+                target: { value: TEST_VALUE } as unknown as EventTarget
             } as Event);
             expect(component.value).toBe(TEST_VALUE);
         });

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/data-grid/column-filter/column-filter.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/data-grid/column-filter/column-filter.component.ts
@@ -3,16 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-    Component,
-    EventEmitter,
-    Input,
-    OnChanges,
-    Output,
-    SimpleChanges,
-    TemplateRef,
-    ViewEncapsulation,
-} from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, TemplateRef, ViewEncapsulation } from '@angular/core';
 
 import { Observable, Subject } from 'rxjs';
 
@@ -24,11 +15,9 @@ import { DataJob } from '../../../../model';
     selector: 'lib-column-filter',
     templateUrl: './column-filter.component.html',
     styleUrls: ['./column-filter.component.scss'],
-    encapsulation: ViewEncapsulation.None,
+    encapsulation: ViewEncapsulation.None
 })
-export class ColumnFilterComponent
-    implements ClrDatagridFilterInterface<DataJob>, OnChanges
-{
+export class ColumnFilterComponent implements ClrDatagridFilterInterface<DataJob>, OnChanges {
     @Input() property: string;
     @Input() listOfOptions: string[];
     @Input() isExecutionStatus = false;

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/data-grid/grid-action/grid-action.component.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/data-grid/grid-action/grid-action.component.spec.ts
@@ -14,7 +14,7 @@ describe('GridActionComponent', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             schemas: [NO_ERRORS_SCHEMA],
-            declarations: [GridActionComponent],
+            declarations: [GridActionComponent]
         });
         fixture = TestBed.createComponent(GridActionComponent);
         component = fixture.componentInstance;

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/data-grid/grid-action/grid-action.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/data-grid/grid-action/grid-action.component.ts
@@ -3,16 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-    AfterViewInit,
-    Component,
-    EventEmitter,
-    Input,
-    OnChanges,
-    Output,
-    SimpleChanges,
-    ViewEncapsulation,
-} from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, ViewEncapsulation } from '@angular/core';
 
 import { CollectionsUtil } from '@versatiledatakit/shared';
 
@@ -22,7 +13,7 @@ import { QuickFilterChangeEvent, QuickFilters } from '../../quick-filters';
     selector: 'lib-grid-action',
     templateUrl: './grid-action.component.html',
     styleUrls: ['./grid-action.component.scss'],
-    encapsulation: ViewEncapsulation.None,
+    encapsulation: ViewEncapsulation.None
 })
 export class GridActionComponent implements AfterViewInit, OnChanges {
     @Input() id = 'lib-ga-search-id';
@@ -84,8 +75,7 @@ export class GridActionComponent implements AfterViewInit, OnChanges {
     get editDisabled(): boolean {
         return (
             CollectionsUtil.isNil(this.selectedValue) ||
-            (CollectionsUtil.isString(this.selectedValue) &&
-                this.selectedValue.length === 0) ||
+            (CollectionsUtil.isString(this.selectedValue) && this.selectedValue.length === 0) ||
             this.disableEdit
         );
     }
@@ -97,8 +87,7 @@ export class GridActionComponent implements AfterViewInit, OnChanges {
     get removeDisabled(): boolean {
         return (
             CollectionsUtil.isNil(this.selectedValue) ||
-            (CollectionsUtil.isString(this.selectedValue) &&
-                this.selectedValue.length === 0) ||
+            (CollectionsUtil.isString(this.selectedValue) && this.selectedValue.length === 0) ||
             this.disableRemove
         );
     }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/delete-modal/delete-modal.component.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/delete-modal/delete-modal.component.spec.ts
@@ -14,7 +14,7 @@ describe('DeleteModalComponent', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             schemas: [NO_ERRORS_SCHEMA],
-            declarations: [DeleteModalComponent],
+            declarations: [DeleteModalComponent]
         });
         fixture = TestBed.createComponent(DeleteModalComponent);
         component = fixture.componentInstance;

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/delete-modal/delete-modal.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/delete-modal/delete-modal.component.ts
@@ -12,7 +12,7 @@ import { ModalComponentDirective } from '../modal';
 @Component({
     selector: 'lib-delete-modal',
     templateUrl: './delete-modal.component.html',
-    styleUrls: ['./delete-modal.component.css'],
+    styleUrls: ['./delete-modal.component.css']
 })
 export class DeleteModalComponent extends ModalComponentDirective {
     @Output() delete: EventEmitter<undefined> = new EventEmitter<undefined>();

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/empty-state/empty-state.component.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/empty-state/empty-state.component.spec.ts
@@ -19,7 +19,7 @@ describe('EmptyStateComponent', () => {
 
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
-            declarations: [EmptyStateComponent],
+            declarations: [EmptyStateComponent]
         }).compileComponents();
     }));
 

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/empty-state/empty-state.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/empty-state/empty-state.component.ts
@@ -10,7 +10,7 @@ import { Component, Input } from '@angular/core';
 @Component({
     selector: 'lib-empty-state',
     templateUrl: './empty-state.component.html',
-    styleUrls: ['./empty-state.component.scss'],
+    styleUrls: ['./empty-state.component.scss']
 })
 export class EmptyStateComponent {
     @Input() title = 'Empty State';
@@ -19,8 +19,7 @@ export class EmptyStateComponent {
     @Input() imgSrc: string;
     @Input() hideImage = false;
     @Input() opacity = 1;
-    @Input() animSrc =
-        'assets/animations/no-events-in-timeframe-animation.json';
+    @Input() animSrc = 'assets/animations/no-events-in-timeframe-animation.json';
     @Input() marginTop = '3rem';
     @Input() marginBottom = '20px';
 }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/executions-timeline/executions-timeline.component.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/executions-timeline/executions-timeline.component.spec.ts
@@ -7,11 +7,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ExecutionsTimelineComponent } from './executions-timeline.component';
 
-import {
-    DATA_PIPELINES_CONFIGS,
-    DataJobExecution,
-    DataJobExecutionType,
-} from '../../../model';
+import { DATA_PIPELINES_CONFIGS, DataJobExecution, DataJobExecutionType } from '../../../model';
 
 describe('ExecutionsTimelineComponent', () => {
     let component: ExecutionsTimelineComponent;
@@ -27,12 +23,12 @@ describe('ExecutionsTimelineComponent', () => {
                         defaultOwnerTeamName: 'all',
                         manageConfig: {
                             allowKeyTabDownloads: true,
-                            allowExecuteNow: true,
+                            allowExecuteNow: true
                         },
-                        healthStatusUrl: 'baseUrl',
-                    }),
-                },
-            ],
+                        healthStatusUrl: 'baseUrl'
+                    })
+                }
+            ]
         }).compileComponents();
     });
 
@@ -49,29 +45,21 @@ describe('ExecutionsTimelineComponent', () => {
     it('should create', () => {
         const mockExec = {
             /* eslint-disable-next-line @typescript-eslint/naming-convention */
-            startedBy: 'manual/auser',
+            startedBy: 'manual/auser'
         } as DataJobExecution;
-        expect(component.getManualExecutedByTitle(mockExec)).toBe(
-            ExecutionsTimelineComponent.manualRunKnownUser + ' auser',
-        );
+        expect(component.getManualExecutedByTitle(mockExec)).toBe(ExecutionsTimelineComponent.manualRunKnownUser + ' auser');
 
         mockExec.startedBy = 'manual/manual';
         mockExec.type = DataJobExecutionType.MANUAL;
-        expect(component.getManualExecutedByTitle(mockExec)).toBe(
-            ExecutionsTimelineComponent.manualRunKnownUser + ' manual',
-        );
+        expect(component.getManualExecutedByTitle(mockExec)).toBe(ExecutionsTimelineComponent.manualRunKnownUser + ' manual');
 
         mockExec.startedBy = 'scheduled/runtime';
         mockExec.type = DataJobExecutionType.SCHEDULED;
-        expect(component.getManualExecutedByTitle(mockExec)).toContain(
-            ExecutionsTimelineComponent.manualRunNoUser,
-        );
+        expect(component.getManualExecutedByTitle(mockExec)).toContain(ExecutionsTimelineComponent.manualRunNoUser);
 
         mockExec.startedBy = 'scheduled/runtime';
         mockExec.type = null;
-        expect(component.getManualExecutedByTitle(mockExec)).toContain(
-            ExecutionsTimelineComponent.manualRunNoUser,
-        );
+        expect(component.getManualExecutedByTitle(mockExec)).toContain(ExecutionsTimelineComponent.manualRunNoUser);
     });
 
     describe('Methods::', () => {

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/executions-timeline/executions-timeline.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/executions-timeline/executions-timeline.component.ts
@@ -3,12 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-    ChangeDetectionStrategy,
-    Component,
-    Inject,
-    Input,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Inject, Input } from '@angular/core';
 
 import {
     DATA_PIPELINES_CONFIGS,
@@ -16,19 +11,18 @@ import {
     DataJobExecutions,
     DataJobExecutionStatus,
     DataJobExecutionType,
-    DataPipelinesConfig,
+    DataPipelinesConfig
 } from '../../../model';
 
 @Component({
     selector: 'lib-executions-timeline',
     templateUrl: './executions-timeline.component.html',
     styleUrls: ['./executions-timeline.component.scss'],
-    changeDetection: ChangeDetectionStrategy.OnPush,
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ExecutionsTimelineComponent {
     static manualRunKnownUser = 'This job is triggered manually by user';
-    static manualRunNoUser =
-        'This job is triggered manually, but there is no info about the user';
+    static manualRunNoUser = 'This job is triggered manually, but there is no info about the user';
 
     @Input() jobExecutions: DataJobExecutions = [];
     @Input() next: Date = null;
@@ -37,7 +31,7 @@ export class ExecutionsTimelineComponent {
 
     constructor(
         @Inject(DATA_PIPELINES_CONFIGS)
-        public dataPipelinesModuleConfig: DataPipelinesConfig,
+        public dataPipelinesModuleConfig: DataPipelinesConfig
     ) {}
 
     /**
@@ -52,11 +46,7 @@ export class ExecutionsTimelineComponent {
     }
 
     getManualExecutedByTitle(execution: DataJobExecution): string {
-        if (
-            !execution ||
-            !execution.startedBy ||
-            !execution.startedBy.startsWith('manual/')
-        ) {
+        if (!execution || !execution.startedBy || !execution.startedBy.startsWith('manual/')) {
             // execution has no info abot user provided
             return ExecutionsTimelineComponent.manualRunNoUser;
         }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/modal/modal.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/modal/modal.component.ts
@@ -13,11 +13,9 @@ import { ModalOptions } from '../../model';
 export abstract class ModalComponentDirective extends TaurusObject {
     @Input() options: ModalOptions;
 
-    @Output() optionsChange: EventEmitter<ModalOptions> =
-        new EventEmitter<ModalOptions>();
+    @Output() optionsChange: EventEmitter<ModalOptions> = new EventEmitter<ModalOptions>();
 
-    @Output() cancelAction: EventEmitter<undefined> =
-        new EventEmitter<undefined>();
+    @Output() cancelAction: EventEmitter<undefined> = new EventEmitter<undefined>();
 
     constructor() {
         super();

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/quick-filters/quick-filters.component.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/quick-filters/quick-filters.component.spec.ts
@@ -13,7 +13,7 @@ describe('QuickFiltersComponent', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [QuickFiltersComponent],
+            declarations: [QuickFiltersComponent]
         }).compileComponents();
     });
 

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/quick-filters/quick-filters.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/quick-filters/quick-filters.component.ts
@@ -3,14 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-    Component,
-    EventEmitter,
-    Input,
-    OnChanges,
-    Output,
-    SimpleChanges,
-} from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
 
 import { CollectionsUtil } from '@versatiledatakit/shared';
 
@@ -19,7 +12,7 @@ import { QuickFilter, QuickFilterChangeEvent, QuickFilters } from './model';
 @Component({
     selector: 'lib-quick-filters',
     templateUrl: './quick-filters.component.html',
-    styleUrls: ['./quick-filters.component.scss'],
+    styleUrls: ['./quick-filters.component.scss']
 })
 export class QuickFiltersComponent implements OnChanges {
     /**
@@ -105,20 +98,15 @@ export class QuickFiltersComponent implements OnChanges {
         }
 
         if (this.suppressQuickFilterChangeEvent) {
-            if (
-                CollectionsUtil.isDefined(this.activatedFilter) &&
-                CollectionsUtil.isFunction(this.activatedFilter.onActivate)
-            ) {
+            if (CollectionsUtil.isDefined(this.activatedFilter) && CollectionsUtil.isFunction(this.activatedFilter.onActivate)) {
                 this.activatedFilter.onActivate();
             } else {
-                console.warn(
-                    'QuickFiltersComponent: No listener for onActivate callback while Event Emitter is suppressed.',
-                );
+                console.warn('QuickFiltersComponent: No listener for onActivate callback while Event Emitter is suppressed.');
             }
         } else {
             this.quickFilterChange.emit({
                 activatedFilter: this.activatedFilter,
-                deactivatedFilter: this._deactivatedFilter,
+                deactivatedFilter: this._deactivatedFilter
             });
         }
     }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/status/status-cell/status-cell.component.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/status/status-cell/status-cell.component.spec.ts
@@ -11,8 +11,8 @@ import { StatusCellComponent } from './status-cell.component';
 const TEST_JOB = {
     jobName: 'job002',
     config: {
-        description: 'description002',
-    },
+        description: 'description002'
+    }
 };
 
 describe('StatusCellComponent', () => {
@@ -21,7 +21,7 @@ describe('StatusCellComponent', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [StatusCellComponent, ExtractJobStatusPipe],
+            declarations: [StatusCellComponent, ExtractJobStatusPipe]
         }).compileComponents();
     });
 

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/status/status-cell/status-cell.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/status/status-cell/status-cell.component.ts
@@ -9,7 +9,7 @@ import { DataJob } from '../../../../model/data-job.model';
 @Component({
     selector: 'lib-status-cell',
     templateUrl: './status-cell.component.html',
-    styleUrls: ['./status-cell.component.css'],
+    styleUrls: ['./status-cell.component.css']
 })
 export class StatusCellComponent {
     @Input() dataJob: DataJob;

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/status/status-panel/status-panel.component.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/status/status-panel/status-panel.component.spec.ts
@@ -14,7 +14,7 @@ describe('StatusPanelComponent', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [StatusPanelComponent, ExtractJobStatusPipe],
+            declarations: [StatusPanelComponent, ExtractJobStatusPipe]
         }).compileComponents();
     });
 

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/status/status-panel/status-panel.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/status/status-panel/status-panel.component.ts
@@ -10,7 +10,7 @@ import { DataJobDeployment } from '../../../../model';
 @Component({
     selector: 'lib-status-panel',
     templateUrl: './status-panel.component.html',
-    styleUrls: ['./status-panel.component.css'],
+    styleUrls: ['./status-panel.component.css']
 })
 export class StatusPanelComponent {
     @Input() jobDeployments: DataJobDeployment[];

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/widget-value/widget-value.component.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/widget-value/widget-value.component.spec.ts
@@ -13,7 +13,7 @@ describe('WidgetValueComponent', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [WidgetValueComponent],
+            declarations: [WidgetValueComponent]
         }).compileComponents();
     });
 

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/widget-value/widget-value.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/widget-value/widget-value.component.ts
@@ -9,7 +9,7 @@ import { Observable } from 'rxjs';
 @Component({
     selector: 'lib-widget-value',
     templateUrl: './widget-value.component.html',
-    changeDetection: ChangeDetectionStrategy.OnPush,
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class WidgetValueComponent {
     @Input() observable$: Observable<unknown>;

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/directives/attribute.directive.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/directives/attribute.directive.spec.ts
@@ -17,12 +17,9 @@ describe('AttributesDirective', () => {
     beforeEach(() => {
         nativeElementStub = {};
         elementRefStub = {
-            nativeElement: nativeElementStub,
+            nativeElement: nativeElementStub
         };
-        rendererStub = jasmine.createSpyObj<Renderer2>('renderer2', [
-            'setAttribute',
-            'removeAttribute',
-        ]);
+        rendererStub = jasmine.createSpyObj<Renderer2>('renderer2', ['setAttribute', 'removeAttribute']);
 
         directive = new AttributesDirective(elementRefStub, rendererStub);
     });
@@ -72,7 +69,7 @@ describe('AttributesDirective', () => {
             shape: 'square',
             class: 'css-class-1, css-class-2, css-class-3',
             tabIndex: 0,
-            'data-cy': 'cypress-selector',
+            'data-cy': 'cypress-selector'
         };
         directive.ngOnInit();
 
@@ -87,7 +84,7 @@ describe('AttributesDirective', () => {
             shape: 'square',
             class: 'css-class-1, css-class-2, css-class-3',
             tabIndex: 0,
-            'data-cy': 'cypress-selector',
+            'data-cy': 'cypress-selector'
         };
         directive.ngOnChanges({});
 
@@ -105,7 +102,7 @@ describe('AttributesDirective', () => {
             class: 'css-class-1, css-class-2, css-class-3',
             'aria-label': 'aria-element-title',
             tabIndex: 0,
-            'data-cy': 'cypress-selector',
+            'data-cy': 'cypress-selector'
         };
         directive.ngOnInit();
 
@@ -127,7 +124,7 @@ describe('AttributesDirective', () => {
             'data-index': false,
             'data-attribute': 'delete',
             'data-btn': 'false',
-            'data-attr': '',
+            'data-attr': ''
         };
         directive.ngOnInit();
 
@@ -144,7 +141,7 @@ describe('AttributesDirective', () => {
             shape: 'square',
             class: 'css-class-1, css-class-2, css-class-3',
             tabIndex: 0,
-            'data-cy': 'cypress-selector',
+            'data-cy': 'cypress-selector'
         };
         directive.ngOnInit();
 

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/directives/attribute.directive.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/directives/attribute.directive.ts
@@ -3,21 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-    Directive,
-    ElementRef,
-    Input,
-    OnChanges,
-    OnInit,
-    Renderer2,
-    SimpleChanges,
-} from '@angular/core';
+import { Directive, ElementRef, Input, OnChanges, OnInit, Renderer2, SimpleChanges } from '@angular/core';
 
-import {
-    CollectionsUtil,
-    PrimitivesNil,
-    TaurusObject,
-} from '@versatiledatakit/shared';
+import { CollectionsUtil, PrimitivesNil, TaurusObject } from '@versatiledatakit/shared';
 
 export interface Attributes {
     [attribute: string]: PrimitivesNil;
@@ -29,12 +17,9 @@ export interface Attributes {
  * @author gorankokin
  */
 @Directive({
-    selector: '[libSetAttributes]',
+    selector: '[libSetAttributes]'
 })
-export class AttributesDirective
-    extends TaurusObject
-    implements OnInit, OnChanges
-{
+export class AttributesDirective extends TaurusObject implements OnInit, OnChanges {
     /**
      * ** Input attributes that should be applied to host element.
      */
@@ -45,10 +30,7 @@ export class AttributesDirective
     /**
      * ** Constructor.
      */
-    constructor(
-        private readonly el: ElementRef,
-        private readonly renderer: Renderer2,
-    ) {
+    constructor(private readonly el: ElementRef, private readonly renderer: Renderer2) {
         super();
     }
 
@@ -76,12 +58,9 @@ export class AttributesDirective
                 return;
             }
 
-            CollectionsUtil.iterateObject(
-                this._attributesCopy,
-                (_attributeValue, attributeName) => {
-                    this._removeAttribute(attributeName);
-                },
-            );
+            CollectionsUtil.iterateObject(this._attributesCopy, (_attributeValue, attributeName) => {
+                this._removeAttribute(attributeName);
+            });
 
             return;
         }
@@ -92,18 +71,12 @@ export class AttributesDirective
 
         this._attributesCopy = CollectionsUtil.cloneDeep(this.attributes);
 
-        CollectionsUtil.iterateObject(
-            this._attributesCopy,
-            (attributeValue, attributeName) => {
-                this._setOrRemoveAttribute(attributeName, attributeValue);
-            },
-        );
+        CollectionsUtil.iterateObject(this._attributesCopy, (attributeValue, attributeName) => {
+            this._setOrRemoveAttribute(attributeName, attributeValue);
+        });
     }
 
-    private _setOrRemoveAttribute(
-        attributeName: string,
-        attributeValue: unknown,
-    ): void {
+    private _setOrRemoveAttribute(attributeName: string, attributeValue: unknown): void {
         if (AttributesDirective._isTruthy(attributeValue)) {
             this._setAttribute(attributeName, attributeValue);
         } else {
@@ -111,15 +84,8 @@ export class AttributesDirective
         }
     }
 
-    private _setAttribute(
-        attributeName: string,
-        attributeValue: unknown,
-    ): void {
-        this.renderer.setAttribute(
-            this.el.nativeElement,
-            attributeName,
-            attributeValue as string,
-        );
+    private _setAttribute(attributeName: string, attributeValue: unknown): void {
+        this.renderer.setAttribute(this.el.nativeElement, attributeName, attributeValue as string);
     }
 
     private _removeAttribute(attributeName: string): void {
@@ -128,14 +94,7 @@ export class AttributesDirective
 
     // eslint-disable-next-line @typescript-eslint/member-ordering,@typescript-eslint/no-explicit-any
     private static _isTruthy(value: any): boolean {
-        return AttributesDirective._valueNotIn(value, [
-            undefined,
-            false,
-            null,
-            'delete',
-            'false',
-            '',
-        ]);
+        return AttributesDirective._valueNotIn(value, [undefined, false, null, 'delete', 'false', '']);
     }
 
     // eslint-disable-next-line @typescript-eslint/member-ordering,@typescript-eslint/no-explicit-any

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/model/modal-options.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/model/modal-options.spec.ts
@@ -3,11 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-    EditModalOptions,
-    ConfirmationModalOptions,
-    DeleteModalOptions,
-} from './modal-options';
+import { EditModalOptions, ConfirmationModalOptions, DeleteModalOptions } from './modal-options';
 
 describe('ModalOptions', () => {
     it('DeleteModalOptions have initial values', () => {

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/contacts-present.pipe.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/contacts-present.pipe.spec.ts
@@ -34,73 +34,71 @@ describe('ContactsPresentPipe', () => {
                         notifiedOnJobSuccess: undefined,
                         notifiedOnJobDeploy: undefined,
                         notifiedOnJobFailurePlatformError: undefined,
-                        notifiedOnJobFailureUserError: undefined,
+                        notifiedOnJobFailureUserError: undefined
                     },
-                    expected: false,
+                    expected: false
                 },
                 {
                     contacts: {
                         notifiedOnJobSuccess: [],
                         notifiedOnJobDeploy: [],
                         notifiedOnJobFailurePlatformError: [],
-                        notifiedOnJobFailureUserError: [],
+                        notifiedOnJobFailureUserError: []
                     },
-                    expected: false,
+                    expected: false
                 },
                 {
                     contacts: {
                         notifiedOnJobSuccess: ['alpha@abc.com'],
                         notifiedOnJobDeploy: [],
                         notifiedOnJobFailurePlatformError: [],
-                        notifiedOnJobFailureUserError: [],
+                        notifiedOnJobFailureUserError: []
                     },
-                    expected: true,
+                    expected: true
                 },
                 {
                     contacts: {
                         notifiedOnJobSuccess: [],
                         notifiedOnJobDeploy: ['beta@abc.com'],
                         notifiedOnJobFailurePlatformError: [],
-                        notifiedOnJobFailureUserError: [],
+                        notifiedOnJobFailureUserError: []
                     },
-                    expected: true,
+                    expected: true
                 },
                 {
                     contacts: {
                         notifiedOnJobSuccess: [],
                         notifiedOnJobDeploy: [],
                         notifiedOnJobFailurePlatformError: ['gama@abc.com'],
-                        notifiedOnJobFailureUserError: [],
+                        notifiedOnJobFailureUserError: []
                     },
-                    expected: true,
+                    expected: true
                 },
                 {
                     contacts: {
                         notifiedOnJobSuccess: [],
                         notifiedOnJobDeploy: [],
                         notifiedOnJobFailurePlatformError: [],
-                        notifiedOnJobFailureUserError: ['delta@abc.com'],
+                        notifiedOnJobFailureUserError: ['delta@abc.com']
                     },
-                    expected: true,
+                    expected: true
                 },
                 {
                     contacts: {
                         notifiedOnJobSuccess: ['alpha@abc.com'],
                         notifiedOnJobDeploy: ['beta@abc.com'],
                         notifiedOnJobFailurePlatformError: ['gama@abc.com'],
-                        notifiedOnJobFailureUserError: ['delta@abc.com'],
+                        notifiedOnJobFailureUserError: ['delta@abc.com']
                     },
-                    expected: true,
-                },
+                    expected: true
+                }
             ];
 
             let cnt = 0;
             for (const params of parameters) {
                 cnt++;
 
-                it(`should verify will return ${
-                    params.expected as unknown as string
-                } case ${cnt}`, () => {
+                it(`should verify will return ${params.expected as unknown as string} case ${cnt}`, () => {
                     // When
                     const value = pipe.transform(params.contacts);
 

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/contacts-present.pipe.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/contacts-present.pipe.ts
@@ -10,7 +10,7 @@ import { CollectionsUtil } from '@versatiledatakit/shared';
 import { DataJobContacts } from '../../model';
 
 @Pipe({
-    name: 'contactsPresent',
+    name: 'contactsPresent'
 })
 export class ContactsPresentPipe implements PipeTransform {
     /**
@@ -19,18 +19,10 @@ export class ContactsPresentPipe implements PipeTransform {
     transform(contacts: DataJobContacts): boolean {
         return (
             CollectionsUtil.isDefined(contacts) &&
-            (ContactsPresentPipe.contactIsPresent(
-                contacts.notifiedOnJobSuccess,
-            ) ||
-                ContactsPresentPipe.contactIsPresent(
-                    contacts.notifiedOnJobDeploy,
-                ) ||
-                ContactsPresentPipe.contactIsPresent(
-                    contacts.notifiedOnJobFailureUserError,
-                ) ||
-                ContactsPresentPipe.contactIsPresent(
-                    contacts.notifiedOnJobFailurePlatformError,
-                ))
+            (ContactsPresentPipe.contactIsPresent(contacts.notifiedOnJobSuccess) ||
+                ContactsPresentPipe.contactIsPresent(contacts.notifiedOnJobDeploy) ||
+                ContactsPresentPipe.contactIsPresent(contacts.notifiedOnJobFailureUserError) ||
+                ContactsPresentPipe.contactIsPresent(contacts.notifiedOnJobFailurePlatformError))
         );
     }
 

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/execution-success-rate.pipe.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/execution-success-rate.pipe.spec.ts
@@ -18,8 +18,8 @@ describe('ExecutionSuccessRatePipe', () => {
         deployments = [
             {
                 successfulExecutions: 20,
-                failedExecutions: 5,
-            } as DataJobDeployment,
+                failedExecutions: 5
+            } as DataJobDeployment
         ];
     });
 

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/execution-success-rate.pipe.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/execution-success-rate.pipe.ts
@@ -11,7 +11,7 @@ import { CollectionsUtil } from '@versatiledatakit/shared';
 import { DataJobDeployment } from '../../model';
 
 @Pipe({
-    name: 'executionSuccessRate',
+    name: 'executionSuccessRate'
 })
 export class ExecutionSuccessRatePipe implements PipeTransform {
     private readonly _percentPipe: PercentPipe;
@@ -34,18 +34,13 @@ export class ExecutionSuccessRatePipe implements PipeTransform {
         }
 
         const firstDeployment = deployments[0];
-        const allExecutions =
-            firstDeployment.successfulExecutions +
-            firstDeployment.failedExecutions;
+        const allExecutions = firstDeployment.successfulExecutions + firstDeployment.failedExecutions;
 
         if (allExecutions === 0) {
             return result;
         }
 
-        result += this._percentPipe.transform(
-            firstDeployment.successfulExecutions / allExecutions,
-            '1.2-2',
-        );
+        result += this._percentPipe.transform(firstDeployment.successfulExecutions / allExecutions, '1.2-2');
 
         if (firstDeployment.failedExecutions > 0) {
             result += ` (${firstDeployment.failedExecutions} failed)`;

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/extract-contacts.pipe.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/extract-contacts.pipe.ts
@@ -6,7 +6,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-    name: 'extractContacts',
+    name: 'extractContacts'
 })
 export class ExtractContactsPipe implements PipeTransform {
     static transform(contacts: string[]): string[] {

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/extract-job-status.pipe.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/extract-job-status.pipe.spec.ts
@@ -23,8 +23,8 @@ const TEST_JOB_DEPLOYMENT_DETAILS: DataJobDeploymentDetails = {
         memory_limit: 1000,
         memory_request: 1000,
         cpu_limit: 0.5,
-        cpu_request: 0.5,
-    },
+        cpu_request: 0.5
+    }
     /* eslint-enable @typescript-eslint/naming-convention */
 };
 

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/extract-job-status.pipe.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/extract-job-status.pipe.ts
@@ -9,7 +9,7 @@ import { DataJobStatus, StatusDetails } from '../../model';
 
 @Pipe({
     name: 'extractJobStatus',
-    pure: false,
+    pure: false
 })
 export class ExtractJobStatusPipe implements PipeTransform {
     /**

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/format-delta.pipe.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/format-delta.pipe.spec.ts
@@ -5,11 +5,7 @@
 
 import { TestBed } from '@angular/core/testing';
 
-import {
-    DataJobExecution,
-    DataJobExecutionStatus,
-    DataJobExecutionType,
-} from '../../model';
+import { DataJobExecution, DataJobExecutionStatus, DataJobExecutionType } from '../../model';
 
 import { FormatDeltaPipe } from './format-delta.pipe';
 
@@ -22,7 +18,7 @@ const TEST_JOBS_EXECUTIONS = {
     type: DataJobExecutionType.SCHEDULED,
     endTime: new Date().toISOString(),
     opId: 'op001',
-    message: 'Message 001',
+    message: 'Message 001'
 } as DataJobExecution;
 
 describe('FormatDeltaPipe', () => {

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/format-delta.pipe.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/format-delta.pipe.ts
@@ -24,7 +24,7 @@ import { DataJobExecution } from '../../model';
  *   4: If the duration is more than 1 day, the format is `${days}d ${hours}h`
  */
 @Pipe({
-    name: 'formatDelta',
+    name: 'formatDelta'
 })
 export class FormatDeltaPipe implements PipeTransform {
     static formatDelta(delta: number): string {
@@ -58,10 +58,7 @@ export class FormatDeltaPipe implements PipeTransform {
             return '';
         }
 
-        const delta =
-            (FormatDeltaPipe._getEndTime(execution) -
-                FormatDeltaPipe._getStartTime(execution)) /
-            1000;
+        const delta = (FormatDeltaPipe._getEndTime(execution) - FormatDeltaPipe._getStartTime(execution)) / 1000;
 
         return FormatDeltaPipe.formatDelta(delta);
     }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/format-duration.pipe.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/format-duration.pipe.ts
@@ -7,15 +7,13 @@ import { Pipe, PipeTransform } from '@angular/core';
 import { FormatDeltaPipe } from './format-delta.pipe';
 
 @Pipe({
-    name: 'formatDuration',
+    name: 'formatDuration'
 })
 export class FormatDurationPipe implements PipeTransform {
     /**
      * @inheritDoc
      */
     transform(durationSeconds: number): string {
-        return durationSeconds
-            ? FormatDeltaPipe.formatDelta(durationSeconds)
-            : null;
+        return durationSeconds ? FormatDeltaPipe.formatDelta(durationSeconds) : null;
     }
 }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/format-schedule.pipe.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/format-schedule.pipe.spec.ts
@@ -63,9 +63,7 @@ describe('FormatSchedulePipe', () => {
 
                 // Then
                 expect(result).toBeDefined();
-                expect(result).toContain(
-                    `Invalid Cron expression "${schedule}"`,
-                );
+                expect(result).toContain(`Invalid Cron expression "${schedule}"`);
             });
 
             describe('testing minute range', () => {
@@ -78,9 +76,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        'At 11:00 AM, on day 10 of the month, only in July',
-                    );
+                    expect(result).toContain('At 11:00 AM, on day 10 of the month, only in July');
                 });
 
                 it('should verify will correctly translate cron "59 11 10 7 *"', () => {
@@ -92,9 +88,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        'At 11:59 AM, on day 10 of the month, only in July',
-                    );
+                    expect(result).toContain('At 11:59 AM, on day 10 of the month, only in July');
                 });
 
                 it('should verify will return parsing error message invalid cron "60 11 10 7 *"', () => {
@@ -106,9 +100,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        `Invalid Cron expression "${schedule}"`,
-                    );
+                    expect(result).toContain(`Invalid Cron expression "${schedule}"`);
                 });
             });
 
@@ -122,9 +114,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        'At 12:30 AM, on day 10 of the month, only in July',
-                    );
+                    expect(result).toContain('At 12:30 AM, on day 10 of the month, only in July');
                 });
 
                 it('should verify will correctly translate cron "30 23 10 7 *"', () => {
@@ -136,9 +126,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        'At 11:30 PM, on day 10 of the month, only in July',
-                    );
+                    expect(result).toContain('At 11:30 PM, on day 10 of the month, only in July');
                 });
 
                 it('should verify will return parsing error message invalid cron "30 24 10 7 *"', () => {
@@ -150,9 +138,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        `Invalid Cron expression "${schedule}"`,
-                    );
+                    expect(result).toContain(`Invalid Cron expression "${schedule}"`);
                 });
             });
 
@@ -166,9 +152,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        'At 11:30 AM, on day 1 of the month, only in July',
-                    );
+                    expect(result).toContain('At 11:30 AM, on day 1 of the month, only in July');
                 });
 
                 it('should verify will correctly translate cron "30 11 31 7 *"', () => {
@@ -180,9 +164,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        'At 11:30 AM, on day 31 of the month, only in July',
-                    );
+                    expect(result).toContain('At 11:30 AM, on day 31 of the month, only in July');
                 });
 
                 it('should verify will return parsing error message invalid cron "30 11 0 7 *"', () => {
@@ -194,9 +176,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        `Invalid Cron expression "${schedule}"`,
-                    );
+                    expect(result).toContain(`Invalid Cron expression "${schedule}"`);
                 });
 
                 it('should verify will return parsing error message invalid cron "30 11 32 7 *"', () => {
@@ -208,9 +188,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        `Invalid Cron expression "${schedule}"`,
-                    );
+                    expect(result).toContain(`Invalid Cron expression "${schedule}"`);
                 });
             });
 
@@ -224,9 +202,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        'At 11:30 AM, on day 10 of the month, only in January',
-                    );
+                    expect(result).toContain('At 11:30 AM, on day 10 of the month, only in January');
                 });
 
                 it('should verify will correctly translate cron "30 11 10 12 *"', () => {
@@ -238,9 +214,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        'At 11:30 AM, on day 10 of the month, only in December',
-                    );
+                    expect(result).toContain('At 11:30 AM, on day 10 of the month, only in December');
                 });
 
                 it('should verify will return parsing error message invalid cron "30 11 10 0 *"', () => {
@@ -252,9 +226,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        `Invalid Cron expression "${schedule}"`,
-                    );
+                    expect(result).toContain(`Invalid Cron expression "${schedule}"`);
                 });
 
                 it('should verify will return parsing error message invalid cron "30 11 10 13 *"', () => {
@@ -266,9 +238,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        `Invalid Cron expression "${schedule}"`,
-                    );
+                    expect(result).toContain(`Invalid Cron expression "${schedule}"`);
                 });
             });
 
@@ -282,9 +252,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        'At 11:30 AM, on day 10 of the month, and on Sunday, only in July',
-                    );
+                    expect(result).toContain('At 11:30 AM, on day 10 of the month, and on Sunday, only in July');
                 });
 
                 it('should verify will correctly translate cron "30 11 10 7 6"', () => {
@@ -296,9 +264,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        'At 11:30 AM, on day 10 of the month, and on Saturday, only in July',
-                    );
+                    expect(result).toContain('At 11:30 AM, on day 10 of the month, and on Saturday, only in July');
                 });
 
                 it('should verify will correctly translate cron "30 11 10 7 7"', () => {
@@ -310,9 +276,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        'At 11:30 AM, on day 10 of the month, and on Sunday, only in July',
-                    );
+                    expect(result).toContain('At 11:30 AM, on day 10 of the month, and on Sunday, only in July');
                 });
 
                 it('should verify will return parsing error message invalid cron "30 11 10 7 8"', () => {
@@ -324,9 +288,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        `Invalid Cron expression "${schedule}"`,
-                    );
+                    expect(result).toContain(`Invalid Cron expression "${schedule}"`);
                 });
             });
 
@@ -340,9 +302,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        'Run once an hour at the beginning of the hour',
-                    );
+                    expect(result).toContain('Run once an hour at the beginning of the hour');
                 });
 
                 it('should verify will correctly translate cron "@daily" and "@midnight"', () => {
@@ -370,9 +330,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        'Run once a week at midnight on Sunday morning',
-                    );
+                    expect(result).toContain('Run once a week at midnight on Sunday morning');
                 });
 
                 it('should verify will correctly translate cron "@monthly"', () => {
@@ -384,9 +342,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        'Run once a month at midnight of the first day of the month',
-                    );
+                    expect(result).toContain('Run once a month at midnight of the first day of the month');
                 });
 
                 it('should verify will correctly translate cron "@yearly" and "@annually"', () => {
@@ -400,13 +356,9 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result1).toBeDefined();
-                    expect(result1).toContain(
-                        'Run once a year at midnight of 1 January',
-                    );
+                    expect(result1).toContain('Run once a year at midnight of 1 January');
                     expect(result2).toBeDefined();
-                    expect(result2).toContain(
-                        'Run once a year at midnight of 1 January',
-                    );
+                    expect(result2).toContain('Run once a year at midnight of 1 January');
                 });
 
                 it('should verify will return parsing error message invalid cron "yearly"', () => {
@@ -418,9 +370,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        `Invalid Cron expression "${schedule}"`,
-                    );
+                    expect(result).toContain(`Invalid Cron expression "${schedule}"`);
                 });
 
                 it('should verify will return parsing error message invalid cron "some random text"', () => {
@@ -432,9 +382,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        `Invalid Cron expression "${schedule}"`,
-                    );
+                    expect(result).toContain(`Invalid Cron expression "${schedule}"`);
                 });
 
                 it('should verify will return parsing error message invalid cron "some random text"', () => {
@@ -446,9 +394,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        `Invalid Cron expression "${schedule}"`,
-                    );
+                    expect(result).toContain(`Invalid Cron expression "${schedule}"`);
                 });
 
                 it('should verify will return parsing error message invalid cron "yearly"', () => {
@@ -460,9 +406,7 @@ describe('FormatSchedulePipe', () => {
 
                     // Then
                     expect(result).toBeDefined();
-                    expect(result).toContain(
-                        `Invalid Cron expression "${schedule}"`,
-                    );
+                    expect(result).toContain(`Invalid Cron expression "${schedule}"`);
                 });
             });
         });

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/format-schedule.pipe.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/format-schedule.pipe.ts
@@ -12,15 +12,11 @@ import cronstrue from 'cronstrue';
 import { CollectionsUtil } from '@versatiledatakit/shared';
 
 @Pipe({
-    name: 'formatSchedule',
+    name: 'formatSchedule'
 })
 export class FormatSchedulePipe implements PipeTransform {
     private static _fallbackTransformNonStandardCron(cron: string): string {
-        const match = `${cron}`
-            .trim()
-            .match(
-                /^@hourly|@daily|@midnight|@weekly|@monthly|@yearly|@annually$/,
-            );
+        const match = `${cron}`.trim().match(/^@hourly|@daily|@midnight|@weekly|@monthly|@yearly|@annually$/);
 
         if (CollectionsUtil.isNil(match)) {
             throw new Error('Cron expression cannot be null or undefined.');
@@ -40,9 +36,7 @@ export class FormatSchedulePipe implements PipeTransform {
             case '@annually':
                 return 'Run once a year at midnight of 1 January';
             default:
-                throw new Error(
-                    'Cron expression is NOT nonstandard predefined scheduling definition.',
-                );
+                throw new Error('Cron expression is NOT nonstandard predefined scheduling definition.');
         }
     }
 
@@ -64,17 +58,13 @@ export class FormatSchedulePipe implements PipeTransform {
             // cronstrue doesn't support timezones. Need to use another library
             return cronstrue.toString(cronSchedule, {
                 monthStartIndexZero: false,
-                dayOfWeekStartIndexZero: true,
+                dayOfWeekStartIndexZero: true
             });
         } catch (e) {
             try {
-                return FormatSchedulePipe._fallbackTransformNonStandardCron(
-                    cronSchedule,
-                );
+                return FormatSchedulePipe._fallbackTransformNonStandardCron(cronSchedule);
             } catch (_e) {
-                console.error(
-                    `Parsing error. Cron expression "${cronSchedule}"`,
-                );
+                console.error(`Parsing error. Cron expression "${cronSchedule}"`);
 
                 return `Invalid Cron expression "${cronSchedule}"`;
             }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/parse-epoch.pipe.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/parse-epoch.pipe.spec.ts
@@ -27,8 +27,6 @@ describe('ParseEpochPipe', () => {
     it('transforms valid epoch to valid result', () => {
         const result = pipe.transform(TEST_EPOCH_SECONDS);
         expect(result).toBeDefined();
-        expect(result).toEqual(
-            new Date(TEST_EPOCH_SECONDS * MILLIS_MULTIPLIER),
-        );
+        expect(result).toEqual(new Date(TEST_EPOCH_SECONDS * MILLIS_MULTIPLIER));
     });
 });

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/parse-epoch.pipe.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/parse-epoch.pipe.ts
@@ -6,7 +6,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-    name: 'parseEpoch',
+    name: 'parseEpoch'
 })
 export class ParseEpochPipe implements PipeTransform {
     /**

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/parse-next-run.pipe.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/parse-next-run.pipe.spec.ts
@@ -50,11 +50,7 @@ describe('ParseNextRunPipe', () => {
                 const expected = new Date();
                 let useTimeout = false;
 
-                if (
-                    expected.getUTCHours() === 11 &&
-                    expected.getUTCMinutes() === 59 &&
-                    expected.getUTCSeconds() === 59
-                ) {
+                if (expected.getUTCHours() === 11 && expected.getUTCMinutes() === 59 && expected.getUTCSeconds() === 59) {
                     useTimeout = true;
                     expected.setUTCDate(expected.getUTCDate() + 1);
                 } else if (expected.getUTCHours() >= 12) {
@@ -83,9 +79,7 @@ describe('ParseNextRunPipe', () => {
 
                         // Then
                         console.log(date.toISOString());
-                        expect(date.toISOString()).toEqual(
-                            `${y}-${m}-${d}T12:00:00.000Z`,
-                        );
+                        expect(date.toISOString()).toEqual(`${y}-${m}-${d}T12:00:00.000Z`);
 
                         done();
                     });
@@ -95,9 +89,7 @@ describe('ParseNextRunPipe', () => {
 
                     // Then
                     console.log(date.toISOString());
-                    expect(date.toISOString()).toEqual(
-                        `${y}-${m}-${d}T12:00:00.000Z`,
-                    );
+                    expect(date.toISOString()).toEqual(`${y}-${m}-${d}T12:00:00.000Z`);
 
                     done();
                 }
@@ -113,20 +105,10 @@ describe('ParseNextRunPipe', () => {
                 let hh: string;
                 let mm: string;
 
-                if (
-                    expected.getUTCHours() === 12 &&
-                    expected.getUTCMinutes() === 44 &&
-                    expected.getUTCSeconds() === 59
-                ) {
+                if (expected.getUTCHours() === 12 && expected.getUTCMinutes() === 44 && expected.getUTCSeconds() === 59) {
                     lunchTime = true;
                     useTimeout = true;
-                } else if (
-                    !(
-                        (expected.getUTCHours() === 12 &&
-                            expected.getUTCMinutes() <= 44) ||
-                        expected.getUTCHours() < 12
-                    )
-                ) {
+                } else if (!((expected.getUTCHours() === 12 && expected.getUTCMinutes() <= 44) || expected.getUTCHours() < 12)) {
                     lunchTime = true;
                 }
 
@@ -162,9 +144,7 @@ describe('ParseNextRunPipe', () => {
 
                         // Then
                         console.log(date.toISOString());
-                        expect(date.toISOString()).toEqual(
-                            `${y}-${m}-${d}T${hh}:${mm}:00.000Z`,
-                        );
+                        expect(date.toISOString()).toEqual(`${y}-${m}-${d}T${hh}:${mm}:00.000Z`);
 
                         done();
                     }, 2000);
@@ -174,9 +154,7 @@ describe('ParseNextRunPipe', () => {
 
                     // Then
                     console.log(date.toISOString());
-                    expect(date.toISOString()).toEqual(
-                        `${y}-${m}-${d}T${hh}:${mm}:00.000Z`,
-                    );
+                    expect(date.toISOString()).toEqual(`${y}-${m}-${d}T${hh}:${mm}:00.000Z`);
 
                     done();
                 }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/parse-next-run.pipe.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/parse-next-run.pipe.ts
@@ -8,7 +8,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 import * as parser from 'cron-parser';
 
 @Pipe({
-    name: 'parseNextRun',
+    name: 'parseNextRun'
 })
 export class ParseNextRunPipe implements PipeTransform {
     /**

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/utils/cron.util.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/utils/cron.util.spec.ts
@@ -7,9 +7,7 @@ import { CronUtil } from './cron.util';
 
 describe('DateUtil', () => {
     it('expect null argument to return null result', () => {
-        expect(CronUtil.getNextExecutionErrors(null)).toBe(
-            'No schedule cron configured for this job',
-        );
+        expect(CronUtil.getNextExecutionErrors(null)).toBe('No schedule cron configured for this job');
     });
 
     it('expect invalid argument to return error text', () => {

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/utils/data-job.util.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/utils/data-job.util.spec.ts
@@ -10,7 +10,7 @@ import {
     DataJobExecutionDetails,
     DataJobExecutionStatus,
     DataJobExecutionStatusDeprecated,
-    DataJobExecutionType,
+    DataJobExecutionType
 } from '../../model';
 
 import { DataJobUtil } from './data-job.util';
@@ -20,7 +20,7 @@ describe('DataJobUtil', () => {
         it('should verify will return true if status is RUNNING', () => {
             // Given
             const execution: DataJobExecutionDetails = {
-                status: DataJobExecutionStatusDeprecated.RUNNING,
+                status: DataJobExecutionStatusDeprecated.RUNNING
             } as any;
 
             // When
@@ -33,7 +33,7 @@ describe('DataJobUtil', () => {
         it('should verify will return true if status is SUBMITTED', () => {
             // Given
             const execution: DataJobExecutionDetails = {
-                status: DataJobExecutionStatusDeprecated.SUBMITTED,
+                status: DataJobExecutionStatusDeprecated.SUBMITTED
             } as any;
 
             // When
@@ -46,16 +46,16 @@ describe('DataJobUtil', () => {
         it('should verify will return false if status is different from RUNNING or SUBMITTED', () => {
             // Given
             const execution1: DataJobExecutionDetails = {
-                status: DataJobExecutionStatusDeprecated.USER_ERROR,
+                status: DataJobExecutionStatusDeprecated.USER_ERROR
             } as any;
             const execution2: DataJobExecutionDetails = {
-                status: DataJobExecutionStatusDeprecated.SKIPPED,
+                status: DataJobExecutionStatusDeprecated.SKIPPED
             } as any;
             const execution3: DataJobExecutionDetails = {
-                status: DataJobExecutionStatusDeprecated.PLATFORM_ERROR,
+                status: DataJobExecutionStatusDeprecated.PLATFORM_ERROR
             } as any;
             const execution4: DataJobExecutionDetails = {
-                status: DataJobExecutionStatusDeprecated.SUCCEEDED,
+                status: DataJobExecutionStatusDeprecated.SUCCEEDED
             } as any;
 
             // When
@@ -75,13 +75,8 @@ describe('DataJobUtil', () => {
     describe('|isJobRunning|', () => {
         it('should verify will invoke correct method', () => {
             // Given
-            const spy = spyOn(
-                DataJobUtil,
-                'isJobRunningPredicate',
-            ).and.callThrough();
-            const executions: DataJobExecutionDetails[] = [
-                { status: DataJobExecutionStatusDeprecated.RUNNING },
-            ] as any;
+            const spy = spyOn(DataJobUtil, 'isJobRunningPredicate').and.callThrough();
+            const executions: DataJobExecutionDetails[] = [{ status: DataJobExecutionStatusDeprecated.RUNNING }] as any;
 
             // When
             DataJobUtil.isJobRunning(executions);
@@ -92,15 +87,12 @@ describe('DataJobUtil', () => {
 
         it('should verify will invoke correct method until find RUNNING or SUBMITTED status', () => {
             // Given
-            const spy = spyOn(
-                DataJobUtil,
-                'isJobRunningPredicate',
-            ).and.callThrough();
+            const spy = spyOn(DataJobUtil, 'isJobRunningPredicate').and.callThrough();
             const executions: DataJobExecutionDetails[] = [
                 { status: DataJobExecutionStatusDeprecated.FAILED },
                 { status: DataJobExecutionStatusDeprecated.PLATFORM_ERROR },
                 { status: DataJobExecutionStatusDeprecated.SUBMITTED },
-                { status: DataJobExecutionStatusDeprecated.RUNNING },
+                { status: DataJobExecutionStatusDeprecated.RUNNING }
             ] as any;
 
             // When
@@ -115,15 +107,12 @@ describe('DataJobUtil', () => {
 
         it('should verify will invoke correct method with all elements no RUNNING or SUBMITTED status', () => {
             // Given
-            const spy = spyOn(
-                DataJobUtil,
-                'isJobRunningPredicate',
-            ).and.callThrough();
+            const spy = spyOn(DataJobUtil, 'isJobRunningPredicate').and.callThrough();
             const executions: DataJobExecutionDetails[] = [
                 { status: DataJobExecutionStatusDeprecated.FAILED },
                 { status: DataJobExecutionStatusDeprecated.PLATFORM_ERROR },
                 { status: DataJobExecutionStatusDeprecated.SUCCEEDED },
-                { status: DataJobExecutionStatusDeprecated.SKIPPED },
+                { status: DataJobExecutionStatusDeprecated.SKIPPED }
             ] as any;
 
             // When
@@ -156,7 +145,7 @@ describe('DataJobUtil', () => {
                 logs_url: 'http://url',
                 deployment: {
                     schedule: {
-                        schedule_cron: '5 5 5 5 *',
+                        schedule_cron: '5 5 5 5 *'
                     },
                     id: 'id002',
                     enabled: true,
@@ -167,11 +156,11 @@ describe('DataJobUtil', () => {
                         memory_limit: 1000,
                         memory_request: 1000,
                         cpu_limit: 0.5,
-                        cpu_request: 0.5,
+                        cpu_request: 0.5
                     },
                     deployed_date: '2020-11-11T10:10:10Z',
-                    deployed_by: 'pmitev',
-                },
+                    deployed_by: 'pmitev'
+                }
             };
             expectedExecution = {
                 id: 'id001',
@@ -186,7 +175,7 @@ describe('DataJobUtil', () => {
                 logsUrl: 'http://url',
                 deployment: {
                     schedule: {
-                        scheduleCron: '5 5 5 5 *',
+                        scheduleCron: '5 5 5 5 *'
                     },
                     id: 'id002',
                     enabled: true,
@@ -197,22 +186,18 @@ describe('DataJobUtil', () => {
                         memoryLimit: 1000,
                         memoryRequest: 1000,
                         cpuLimit: 0.5,
-                        cpuRequest: 0.5,
+                        cpuRequest: 0.5
                     },
                     deployedDate: '2020-11-11T10:10:10Z',
-                    deployedBy: 'pmitev',
-                },
+                    deployedBy: 'pmitev'
+                }
             };
         });
 
         it('should verify will return empty execution when null and undefined provided', () => {
             // When
-            const res1 =
-                DataJobUtil.convertFromExecutionDetailsToExecutionState(null);
-            const res2 =
-                DataJobUtil.convertFromExecutionDetailsToExecutionState(
-                    undefined,
-                );
+            const res1 = DataJobUtil.convertFromExecutionDetailsToExecutionState(null);
+            const res2 = DataJobUtil.convertFromExecutionDetailsToExecutionState(undefined);
 
             // Then
             expect(res1).toEqual({ id: null });
@@ -221,10 +206,7 @@ describe('DataJobUtil', () => {
 
         it('should verify will correctly convert case 1', () => {
             // When
-            const converted =
-                DataJobUtil.convertFromExecutionDetailsToExecutionState(
-                    executionDetails,
-                );
+            const converted = DataJobUtil.convertFromExecutionDetailsToExecutionState(executionDetails);
 
             // Then
             expect(converted).toEqual(expectedExecution);
@@ -236,10 +218,7 @@ describe('DataJobUtil', () => {
             expectedExecution.deployment.resources = {} as any;
 
             // When
-            const converted =
-                DataJobUtil.convertFromExecutionDetailsToExecutionState(
-                    executionDetails,
-                );
+            const converted = DataJobUtil.convertFromExecutionDetailsToExecutionState(executionDetails);
 
             // Then
             expect(converted).toEqual(expectedExecution);
@@ -251,10 +230,7 @@ describe('DataJobUtil', () => {
             expectedExecution.deployment.schedule = {} as any;
 
             // When
-            const converted =
-                DataJobUtil.convertFromExecutionDetailsToExecutionState(
-                    executionDetails,
-                );
+            const converted = DataJobUtil.convertFromExecutionDetailsToExecutionState(executionDetails);
 
             // Then
             expect(converted).toEqual(expectedExecution);
@@ -265,14 +241,11 @@ describe('DataJobUtil', () => {
             delete executionDetails.deployment;
             expectedExecution.deployment = {
                 schedule: {},
-                resources: {},
+                resources: {}
             } as any;
 
             // When
-            const converted =
-                DataJobUtil.convertFromExecutionDetailsToExecutionState(
-                    executionDetails,
-                );
+            const converted = DataJobUtil.convertFromExecutionDetailsToExecutionState(executionDetails);
 
             // Then
             expect(converted).toEqual(expectedExecution);

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/utils/data-job.util.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/utils/data-job.util.ts
@@ -11,7 +11,7 @@ import {
     DataJobExecutionDetails,
     DataJobExecutionStatus,
     DataJobExecutionStatusDeprecated,
-    DataJobExecutionType,
+    DataJobExecutionType
 } from '../../model';
 
 /**
@@ -21,39 +21,27 @@ export class DataJobUtil {
     /**
      * ** Predicate for Job Running.
      */
-    static isJobRunningPredicate = (
-        jobExecution: DataJobExecution | DataJobExecutionDetails,
-    ): boolean => {
+    static isJobRunningPredicate = (jobExecution: DataJobExecution | DataJobExecutionDetails): boolean => {
         return (
-            (jobExecution as DataJobExecution).status ===
-                DataJobExecutionStatus.RUNNING ||
-            (jobExecution as DataJobExecution).status ===
-                DataJobExecutionStatus.SUBMITTED ||
-            (jobExecution as DataJobExecutionDetails).status ===
-                DataJobExecutionStatusDeprecated.RUNNING ||
-            (jobExecution as DataJobExecutionDetails).status ===
-                DataJobExecutionStatusDeprecated.SUBMITTED
+            (jobExecution as DataJobExecution).status === DataJobExecutionStatus.RUNNING ||
+            (jobExecution as DataJobExecution).status === DataJobExecutionStatus.SUBMITTED ||
+            (jobExecution as DataJobExecutionDetails).status === DataJobExecutionStatusDeprecated.RUNNING ||
+            (jobExecution as DataJobExecutionDetails).status === DataJobExecutionStatusDeprecated.SUBMITTED
         );
     };
 
     /**
      * ** Find if some Job is running in provided Executions.
      */
-    static isJobRunning(
-        jobExecutions: DataJobExecution[] | DataJobExecutionDetails[],
-    ): boolean {
+    static isJobRunning(jobExecutions: DataJobExecution[] | DataJobExecutionDetails[]): boolean {
         // eslint-disable-next-line @typescript-eslint/unbound-method
-        return (
-            jobExecutions.findIndex(DataJobUtil.isJobRunningPredicate) !== -1
-        );
+        return jobExecutions.findIndex(DataJobUtil.isJobRunningPredicate) !== -1;
     }
 
-    static convertFromExecutionDetailsToExecutionState(
-        jobExecutionDetails: DataJobExecutionDetails,
-    ): DataJobExecution {
+    static convertFromExecutionDetailsToExecutionState(jobExecutionDetails: DataJobExecutionDetails): DataJobExecution {
         if (CollectionsUtil.isNil(jobExecutionDetails)) {
             return {
-                id: null,
+                id: null
             };
         }
 
@@ -70,46 +58,28 @@ export class DataJobUtil {
             logsUrl: jobExecutionDetails.logs_url,
             deployment: {
                 schedule: {},
-                resources: {},
-            } as DataJobDeployment,
+                resources: {}
+            } as DataJobDeployment
         };
 
         if (CollectionsUtil.isLiteralObject(jobExecutionDetails.deployment)) {
             execution.deployment.id = jobExecutionDetails.deployment.id;
-            execution.deployment.enabled =
-                jobExecutionDetails.deployment.enabled;
-            execution.deployment.jobVersion =
-                jobExecutionDetails.deployment.job_version;
-            execution.deployment.vdkVersion =
-                jobExecutionDetails.deployment.vdk_version;
+            execution.deployment.enabled = jobExecutionDetails.deployment.enabled;
+            execution.deployment.jobVersion = jobExecutionDetails.deployment.job_version;
+            execution.deployment.vdkVersion = jobExecutionDetails.deployment.vdk_version;
             execution.deployment.mode = jobExecutionDetails.deployment.mode;
-            execution.deployment.deployedDate =
-                jobExecutionDetails.deployment.deployed_date;
-            execution.deployment.deployedBy =
-                jobExecutionDetails.deployment.deployed_by;
+            execution.deployment.deployedDate = jobExecutionDetails.deployment.deployed_date;
+            execution.deployment.deployedBy = jobExecutionDetails.deployment.deployed_by;
 
-            if (
-                CollectionsUtil.isLiteralObject(
-                    jobExecutionDetails.deployment.schedule,
-                )
-            ) {
-                execution.deployment.schedule.scheduleCron =
-                    jobExecutionDetails.deployment.schedule.schedule_cron;
+            if (CollectionsUtil.isLiteralObject(jobExecutionDetails.deployment.schedule)) {
+                execution.deployment.schedule.scheduleCron = jobExecutionDetails.deployment.schedule.schedule_cron;
             }
 
-            if (
-                CollectionsUtil.isLiteralObject(
-                    jobExecutionDetails.deployment.resources,
-                )
-            ) {
-                execution.deployment.resources.cpuRequest =
-                    jobExecutionDetails.deployment.resources.cpu_request;
-                execution.deployment.resources.cpuLimit =
-                    jobExecutionDetails.deployment.resources.cpu_limit;
-                execution.deployment.resources.memoryRequest =
-                    jobExecutionDetails.deployment.resources.memory_request;
-                execution.deployment.resources.memoryLimit =
-                    jobExecutionDetails.deployment.resources.memory_limit;
+            if (CollectionsUtil.isLiteralObject(jobExecutionDetails.deployment.resources)) {
+                execution.deployment.resources.cpuRequest = jobExecutionDetails.deployment.resources.cpu_request;
+                execution.deployment.resources.cpuLimit = jobExecutionDetails.deployment.resources.cpu_limit;
+                execution.deployment.resources.memoryRequest = jobExecutionDetails.deployment.resources.memory_request;
+                execution.deployment.resources.memoryLimit = jobExecutionDetails.deployment.resources.memory_limit;
             }
         }
 

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/utils/date.util.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/utils/date.util.spec.ts
@@ -3,11 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-    DataJobExecution,
-    DataJobExecutionStatus,
-    DataJobExecutionType,
-} from '../../model';
+import { DataJobExecution, DataJobExecutionStatus, DataJobExecutionType } from '../../model';
 
 import { DateUtil } from './date.util';
 
@@ -21,7 +17,7 @@ const LESSER_DATE_JOBS_EXECUTION: DataJobExecution = {
     endTime: new Date(1).toISOString(),
     opId: 'oneOp',
     message: 'oneMessage',
-    logsUrl: 'https::/logs.com',
+    logsUrl: 'https::/logs.com'
 };
 
 const GREATER_DATE_JOBS_EXECUTION: DataJobExecution = {
@@ -34,40 +30,23 @@ const GREATER_DATE_JOBS_EXECUTION: DataJobExecution = {
     endTime: new Date(2).toISOString(),
     opId: 'twoOp',
     message: 'twoMessage',
-    logsUrl: 'https::/logs.com',
+    logsUrl: 'https::/logs.com'
 };
 
 describe('DateUtil', () => {
     it('Compare Dates Asc for equal left and right', () => {
-        expect(
-            DateUtil.compareDatesAsc(
-                LESSER_DATE_JOBS_EXECUTION,
-                LESSER_DATE_JOBS_EXECUTION,
-            ),
-        ).toEqual(0);
+        expect(DateUtil.compareDatesAsc(LESSER_DATE_JOBS_EXECUTION, LESSER_DATE_JOBS_EXECUTION)).toEqual(0);
     });
 
     it('Compare Dates Asc for greater left', () => {
-        expect(
-            DateUtil.compareDatesAsc(
-                GREATER_DATE_JOBS_EXECUTION,
-                LESSER_DATE_JOBS_EXECUTION,
-            ),
-        ).toBeGreaterThan(0);
+        expect(DateUtil.compareDatesAsc(GREATER_DATE_JOBS_EXECUTION, LESSER_DATE_JOBS_EXECUTION)).toBeGreaterThan(0);
     });
 
     it('Compare Dates Asc for greater right', () => {
-        expect(
-            DateUtil.compareDatesAsc(
-                LESSER_DATE_JOBS_EXECUTION,
-                GREATER_DATE_JOBS_EXECUTION,
-            ),
-        ).toBeLessThan(0);
+        expect(DateUtil.compareDatesAsc(LESSER_DATE_JOBS_EXECUTION, GREATER_DATE_JOBS_EXECUTION)).toBeLessThan(0);
     });
 
     it('GetDateInUTC', () => {
-        expect(
-            DateUtil.normalizeToUTC('2021-12-10T10:12:12Z').getHours(),
-        ).toEqual(10);
+        expect(DateUtil.normalizeToUTC('2021-12-10T10:12:12Z').getHours()).toEqual(10);
     });
 });

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/utils/date.util.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/utils/date.util.ts
@@ -6,17 +6,11 @@
 import { DataJobExecution } from '../../model';
 
 export class DateUtil {
-    static compareDatesAsc(
-        left: DataJobExecution,
-        right: DataJobExecution,
-    ): number {
+    static compareDatesAsc(left: DataJobExecution, right: DataJobExecution): number {
         const leftStartTime = left.startTime ?? 0;
         const rightStartTime = right.endTime ?? 0;
 
-        return (
-            new Date(leftStartTime).getTime() -
-            new Date(rightStartTime).getTime()
-        );
+        return new Date(leftStartTime).getTime() - new Date(rightStartTime).getTime();
     }
 
     static normalizeToUTC(dateISO: string): Date {

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/utils/error.util.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/utils/error.util.ts
@@ -17,10 +17,7 @@ export class ErrorUtil {
      * ** Extract root Error depending of the format.
      */
     static extractError(error: Error): Error {
-        if (
-            error instanceof ApolloError &&
-            CollectionsUtil.isDefined(error.networkError)
-        ) {
+        if (error instanceof ApolloError && CollectionsUtil.isDefined(error.networkError)) {
             return error.networkError;
         }
 

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/utils/string.util.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/utils/string.util.spec.ts
@@ -7,26 +7,18 @@ import { StringUtil } from './string.util';
 
 describe('StringUtil', () => {
     it('parsing string with single var', () => {
-        expect(StringUtil.stringFormat('Hello {0}', 'World!')).toBe(
-            'Hello World!',
-        );
+        expect(StringUtil.stringFormat('Hello {0}', 'World!')).toBe('Hello World!');
     });
 
     it('parsing string with multiple var', () => {
-        expect(
-            StringUtil.stringFormat('Hello {0} {1}', 'beautiful', 'World!'),
-        ).toBe('Hello beautiful World!');
+        expect(StringUtil.stringFormat('Hello {0} {1}', 'beautiful', 'World!')).toBe('Hello beautiful World!');
     });
 
     it('parsing string with multiple same var', () => {
-        expect(
-            StringUtil.stringFormat('Hello {0} {0}', 'beautiful', 'World!'),
-        ).toBe('Hello beautiful beautiful');
+        expect(StringUtil.stringFormat('Hello {0} {0}', 'beautiful', 'World!')).toBe('Hello beautiful beautiful');
     });
 
     it('parsing string with same var', () => {
-        expect(StringUtil.stringFormat('Hello {0} {0}', 'beautiful')).toBe(
-            'Hello beautiful beautiful',
-        );
+        expect(StringUtil.stringFormat('Hello {0} {0}', 'beautiful')).toBe('Hello beautiful beautiful');
     });
 });

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/utils/string.util.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/utils/string.util.ts
@@ -4,6 +4,5 @@
  */
 
 export class StringUtil {
-    static stringFormat = (str: string, ...args: string[]) =>
-        str.replace(/{(\d+)}/g, (match, index: number) => args[index] || '');
+    static stringFormat = (str: string, ...args: string[]) => str.replace(/{(\d+)}/g, (match, index: number) => args[index] || '');
 }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/state/actions/data-jobs.actions.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/state/actions/data-jobs.actions.ts
@@ -16,8 +16,7 @@ export const FETCH_DATA_JOB = '[feature::data-pipelines] Fetch Data Job';
 /**
  * ** Action type Fetch Data Job executions.
  */
-export const FETCH_DATA_JOB_EXECUTIONS =
-    '[feature::data-pipelines] Fetch Data Job Executions';
+export const FETCH_DATA_JOB_EXECUTIONS = '[feature::data-pipelines] Fetch Data Job Executions';
 
 /**
  * ** Action type Update Data job.

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/state/effects/data-jobs.effects.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/state/effects/data-jobs.effects.spec.ts
@@ -31,7 +31,7 @@ import {
     LOADING,
     RouterState,
     RouteState,
-    StatusType,
+    StatusType
 } from '@versatiledatakit/shared';
 
 import { DataJobsApiService } from '../../services';
@@ -47,15 +47,10 @@ import {
     JOB_NAME_REQ_PARAM,
     JOB_STATE_DATA_KEY,
     JOBS_DATA_KEY,
-    TEAM_NAME_REQ_PARAM,
+    TEAM_NAME_REQ_PARAM
 } from '../../model';
 
-import {
-    FETCH_DATA_JOB,
-    FETCH_DATA_JOB_EXECUTIONS,
-    FETCH_DATA_JOBS,
-    UPDATE_DATA_JOB,
-} from '../actions';
+import { FETCH_DATA_JOB, FETCH_DATA_JOB_EXECUTIONS, FETCH_DATA_JOBS, UPDATE_DATA_JOB } from '../actions';
 
 import { DataJobsEffects } from './data-jobs.effects';
 import {
@@ -64,7 +59,7 @@ import {
     TASK_LOAD_JOB_STATE,
     TASK_LOAD_JOBS_STATE,
     TASK_UPDATE_JOB_DESCRIPTION,
-    TASK_UPDATE_JOB_STATUS,
+    TASK_UPDATE_JOB_STATUS
 } from '../tasks';
 
 describe('DataJobsEffects', () => {
@@ -76,21 +71,15 @@ describe('DataJobsEffects', () => {
     let componentServiceStub: jasmine.SpyObj<ComponentService>;
 
     beforeEach(waitForAsync(() => {
-        dataJobsApiServiceStub = jasmine.createSpyObj<DataJobsApiService>(
-            'dataJobsApiService',
-            [
-                'getJobs',
-                'getJob',
-                'getJobDetails',
-                'getJobExecutions',
-                'updateDataJob',
-                'updateDataJobStatus',
-            ],
-        );
-        componentServiceStub = jasmine.createSpyObj<ComponentService>(
-            'componentService',
-            ['getModel'],
-        );
+        dataJobsApiServiceStub = jasmine.createSpyObj<DataJobsApiService>('dataJobsApiService', [
+            'getJobs',
+            'getJob',
+            'getJobDetails',
+            'getJobExecutions',
+            'updateDataJob',
+            'updateDataJobStatus'
+        ]);
+        componentServiceStub = jasmine.createSpyObj<ComponentService>('componentService', ['getModel']);
 
         generateErrorCodes<DataJobsApiService>(dataJobsApiServiceStub, [
             'getJob',
@@ -98,22 +87,22 @@ describe('DataJobsEffects', () => {
             'getJobExecutions',
             'getJobs',
             'updateDataJobStatus',
-            'updateDataJob',
+            'updateDataJob'
         ]);
 
         TestBed.configureTestingModule({
             providers: [
                 {
                     provide: DataJobsApiService,
-                    useValue: dataJobsApiServiceStub,
+                    useValue: dataJobsApiServiceStub
                 },
                 {
                     provide: ComponentService,
-                    useValue: componentServiceStub,
+                    useValue: componentServiceStub
                 },
                 provideMockActions(() => actions$),
-                DataJobsEffects,
-            ],
+                DataJobsEffects
+            ]
         });
 
         effects = TestBed.inject(DataJobsEffects);
@@ -131,18 +120,12 @@ describe('DataJobsEffects', () => {
                     const errorRecord: ErrorRecord = {
                         code: dataJobsApiServiceStub.errorCodes.getJobs.Unknown,
                         error,
-                        objectUUID: effects.objectUUID,
+                        objectUUID: effects.objectUUID
                     };
 
                     actions$ = m.cold('-a---------b', {
-                        a: GenericAction.of(
-                            FETCH_DATA_JOBS,
-                            createModel().getComponentState(),
-                        ),
-                        b: GenericAction.of(
-                            FETCH_DATA_JOBS,
-                            createModel(null, 4).getComponentState(),
-                        ),
+                        a: GenericAction.of(FETCH_DATA_JOBS, createModel().getComponentState()),
+                        b: GenericAction.of(FETCH_DATA_JOBS, createModel(null, 4).getComponentState())
                     });
 
                     let cntComponentServiceStub = 0;
@@ -158,14 +141,10 @@ describe('DataJobsEffects', () => {
 
                     const result = {
                         data: {
-                            content: [
-                                { jobName: 'job1' },
-                                { jobName: 'job2' },
-                                { jobName: 'job3' },
-                            ],
+                            content: [{ jobName: 'job1' }, { jobName: 'job2' }, { jobName: 'job3' }],
                             totalPages: 0,
-                            totalItems: 0,
-                        },
+                            totalItems: 0
+                        }
                     } as ApolloQueryResult<DataJobPage>;
 
                     let cntDataJobsApiServiceStub = 0;
@@ -174,13 +153,11 @@ describe('DataJobsEffects', () => {
 
                         if (cntDataJobsApiServiceStub === 1) {
                             return m.cold('-----a', {
-                                a: result,
+                                a: result
                             });
                         }
 
-                        return throwError(
-                            () => new Error('Something bad happened'),
-                        );
+                        return throwError(() => new Error('Something bad happened'));
                     });
 
                     const expected$ = m.cold('--------a------b', {
@@ -189,20 +166,20 @@ describe('DataJobsEffects', () => {
                                 .withData(JOBS_DATA_KEY, result.data)
                                 .withTask(TASK_LOAD_JOBS_STATE)
                                 .withStatusLoaded()
-                                .getComponentState(),
+                                .getComponentState()
                         ),
                         b: ComponentFailed.of(
                             createModel(null, 4)
                                 .withData(JOBS_DATA_KEY, {
                                     content: [],
                                     totalItems: 0,
-                                    totalPages: 0,
+                                    totalPages: 0
                                 } as DataJobPage)
                                 .withError(errorRecord)
                                 .withTask(TASK_LOAD_JOBS_STATE)
                                 .withStatusFailed()
-                                .getComponentState(),
-                        ),
+                                .getComponentState()
+                        )
                     });
 
                     // When
@@ -210,7 +187,7 @@ describe('DataJobsEffects', () => {
 
                     // Then
                     m.expect(response$).toBeObservable(expected$);
-                }),
+                })
             );
         });
 
@@ -220,10 +197,7 @@ describe('DataJobsEffects', () => {
                 marbles((m) => {
                     // Given
                     actions$ = m.cold('-a----------', {
-                        a: GenericAction.of(
-                            FETCH_DATA_JOB,
-                            createModel().getComponentState(),
-                        ),
+                        a: GenericAction.of(FETCH_DATA_JOB, createModel().getComponentState())
                     });
 
                     let cntComponentServiceStub = 0;
@@ -237,24 +211,11 @@ describe('DataJobsEffects', () => {
                                 return m.cold('---a', { a: createModel() });
                             case 3:
                                 return m.cold('---a', {
-                                    a: createModel(
-                                        new Map<string, any>([
-                                            getJobStateTuple(),
-                                        ]),
-                                        1,
-                                        LOADED,
-                                    ),
+                                    a: createModel(new Map<string, any>([getJobStateTuple()]), 1, LOADED)
                                 });
                             case 4:
                                 return m.cold('---a', {
-                                    a: createModel(
-                                        new Map<string, any>([
-                                            getJobStateTuple(),
-                                            getDataJobDetailsTuple(),
-                                        ]),
-                                        1,
-                                        LOADED,
-                                    ),
+                                    a: createModel(new Map<string, any>([getJobStateTuple(), getDataJobDetailsTuple()]), 1, LOADED)
                                 });
                             default:
                                 return m.cold('---a', {
@@ -262,35 +223,31 @@ describe('DataJobsEffects', () => {
                                         new Map<string, any>([
                                             getJobStateTuple(),
                                             getDataJobDetailsTuple(),
-                                            [
-                                                getExecutionsTuples()[0],
-                                                getExecutionsTuples()[1]
-                                                    .content,
-                                            ],
+                                            [getExecutionsTuples()[0], getExecutionsTuples()[1].content]
                                         ]),
                                         1,
-                                        LOADED,
-                                    ),
+                                        LOADED
+                                    )
                                 });
                         }
                     });
 
                     dataJobsApiServiceStub.getJob.and.returnValue(
                         m.cold('--a', {
-                            a: getJobStateTuple()[1],
-                        }),
+                            a: getJobStateTuple()[1]
+                        })
                     );
 
                     dataJobsApiServiceStub.getJobDetails.and.returnValue(
                         m.cold('----a', {
-                            a: getDataJobDetailsTuple()[1],
-                        }),
+                            a: getDataJobDetailsTuple()[1]
+                        })
                     );
 
                     dataJobsApiServiceStub.getJobExecutions.and.returnValue(
                         m.cold('------a', {
-                            a: getExecutionsTuples()[1],
-                        }),
+                            a: getExecutionsTuples()[1]
+                        })
                     );
 
                     const expected$ = m.cold('--------a-b-c', {
@@ -301,47 +258,29 @@ describe('DataJobsEffects', () => {
                             createModel()
                                 .clearErrors()
                                 .withTask(TASK_LOAD_JOB_STATE)
-                                .withData(
-                                    JOB_STATE_DATA_KEY,
-                                    getJobStateTuple()[1],
-                                )
+                                .withData(JOB_STATE_DATA_KEY, getJobStateTuple()[1])
                                 .withStatusLoaded()
-                                .getComponentState(),
+                                .getComponentState()
                         ),
                         b: ComponentUpdate.of(
                             createModel()
                                 .clearErrors()
                                 .withTask(TASK_LOAD_JOB_DETAILS)
-                                .withData(
-                                    JOB_STATE_DATA_KEY,
-                                    getJobStateTuple()[1],
-                                )
-                                .withData(
-                                    JOB_DETAILS_DATA_KEY,
-                                    getDataJobDetailsTuple()[1],
-                                )
+                                .withData(JOB_STATE_DATA_KEY, getJobStateTuple()[1])
+                                .withData(JOB_DETAILS_DATA_KEY, getDataJobDetailsTuple()[1])
                                 .withStatusLoaded()
-                                .getComponentState(),
+                                .getComponentState()
                         ),
                         c: ComponentUpdate.of(
                             createModel()
                                 .clearErrors()
                                 .withTask(TASK_LOAD_JOB_EXECUTIONS)
-                                .withData(
-                                    JOB_STATE_DATA_KEY,
-                                    getJobStateTuple()[1],
-                                )
-                                .withData(
-                                    JOB_DETAILS_DATA_KEY,
-                                    getDataJobDetailsTuple()[1],
-                                )
-                                .withData(
-                                    JOB_EXECUTIONS_DATA_KEY,
-                                    getExecutionsTuples()[1].content,
-                                )
+                                .withData(JOB_STATE_DATA_KEY, getJobStateTuple()[1])
+                                .withData(JOB_DETAILS_DATA_KEY, getDataJobDetailsTuple()[1])
+                                .withData(JOB_EXECUTIONS_DATA_KEY, getExecutionsTuples()[1].content)
                                 .withStatusLoaded()
-                                .getComponentState(),
-                        ),
+                                .getComponentState()
+                        )
                     });
 
                     // When
@@ -349,7 +288,7 @@ describe('DataJobsEffects', () => {
 
                     // Then
                     m.expect(response$).toBeObservable(expected$);
-                }),
+                })
             );
         });
 
@@ -358,12 +297,9 @@ describe('DataJobsEffects', () => {
                 'should verify will load data-job executions',
                 marbles((m) => {
                     // Given
-                    const genericAction = GenericAction.of(
-                        FETCH_DATA_JOB_EXECUTIONS,
-                        createModel().getComponentState(),
-                    );
+                    const genericAction = GenericAction.of(FETCH_DATA_JOB_EXECUTIONS, createModel().getComponentState());
                     actions$ = m.cold('-a----------', {
-                        a: genericAction,
+                        a: genericAction
                     });
 
                     let cntComponentServiceStub = 0;
@@ -378,24 +314,18 @@ describe('DataJobsEffects', () => {
                             default:
                                 return m.cold('---a', {
                                     a: createModel(
-                                        new Map<string, any>([
-                                            [
-                                                getExecutionsTuples()[0],
-                                                getExecutionsTuples()[1]
-                                                    .content,
-                                            ],
-                                        ]),
+                                        new Map<string, any>([[getExecutionsTuples()[0], getExecutionsTuples()[1].content]]),
                                         1,
-                                        LOADED,
-                                    ),
+                                        LOADED
+                                    )
                                 });
                         }
                     });
 
                     dataJobsApiServiceStub.getJobExecutions.and.returnValue(
                         m.cold('--a', {
-                            a: getExecutionsTuples()[1],
-                        }),
+                            a: getExecutionsTuples()[1]
+                        })
                     );
 
                     const expected$ = m.cold('--------a', {
@@ -403,13 +333,10 @@ describe('DataJobsEffects', () => {
                             createModel()
                                 .clearErrors()
                                 .withTask(TASK_LOAD_JOB_EXECUTIONS)
-                                .withData(
-                                    JOB_EXECUTIONS_DATA_KEY,
-                                    getExecutionsTuples()[1].content,
-                                )
+                                .withData(JOB_EXECUTIONS_DATA_KEY, getExecutionsTuples()[1].content)
                                 .withStatusLoaded()
-                                .getComponentState(),
-                        ),
+                                .getComponentState()
+                        )
                     });
 
                     // When
@@ -417,7 +344,7 @@ describe('DataJobsEffects', () => {
 
                     // Then
                     m.expect(response$).toBeObservable(expected$);
-                }),
+                })
             );
         });
 
@@ -429,22 +356,22 @@ describe('DataJobsEffects', () => {
                     const genericAction1 = GenericAction.of(
                         UPDATE_DATA_JOB,
                         createModel(undefined, 1, LOADING).getComponentState(),
-                        TASK_UPDATE_JOB_DESCRIPTION,
+                        TASK_UPDATE_JOB_DESCRIPTION
                     );
                     actions$ = m.cold('-a----------', {
-                        a: genericAction1,
+                        a: genericAction1
                     });
 
                     componentServiceStub.getModel.and.callFake(() =>
                         m.cold('---a', {
-                            a: createModel(undefined, 1, LOADING),
-                        }),
+                            a: createModel(undefined, 1, LOADING)
+                        })
                     );
 
                     dataJobsApiServiceStub.updateDataJob.and.returnValue(
                         m.cold('-----a', {
-                            a: getDataJobDetailsTuple()[1],
-                        }),
+                            a: getDataJobDetailsTuple()[1]
+                        })
                     );
 
                     const expected$ = m.cold('---------a-', {
@@ -454,8 +381,8 @@ describe('DataJobsEffects', () => {
                                 .withTask(genericAction1.task)
                                 .withData(JOB_DETAILS_DATA_KEY, undefined)
                                 .withStatusLoaded()
-                                .getComponentState(),
-                        ),
+                                .getComponentState()
+                        )
                     });
 
                     // When
@@ -463,7 +390,7 @@ describe('DataJobsEffects', () => {
 
                     // Then
                     m.expect(response$).toBeObservable(expected$);
-                }),
+                })
             );
 
             it(
@@ -473,22 +400,22 @@ describe('DataJobsEffects', () => {
                     const genericAction1 = GenericAction.of(
                         UPDATE_DATA_JOB,
                         createModel(undefined, 1, LOADING).getComponentState(),
-                        TASK_UPDATE_JOB_STATUS,
+                        TASK_UPDATE_JOB_STATUS
                     );
                     actions$ = m.cold('-a----------', {
-                        a: genericAction1,
+                        a: genericAction1
                     });
 
                     componentServiceStub.getModel.and.callFake(() =>
                         m.cold('---a', {
-                            a: createModel(undefined, 1, LOADING),
-                        }),
+                            a: createModel(undefined, 1, LOADING)
+                        })
                     );
 
                     dataJobsApiServiceStub.updateDataJobStatus.and.returnValue(
                         m.cold('-----a', {
-                            a: { enabled: true },
-                        }),
+                            a: { enabled: true }
+                        })
                     );
 
                     const expected$ = m.cold('---------a-', {
@@ -498,8 +425,8 @@ describe('DataJobsEffects', () => {
                                 .withTask(genericAction1.task)
                                 .withData(JOB_STATE_DATA_KEY, undefined)
                                 .withStatusLoaded()
-                                .getComponentState(),
-                        ),
+                                .getComponentState()
+                        )
                     });
 
                     // When
@@ -507,7 +434,7 @@ describe('DataJobsEffects', () => {
 
                     // Then
                     m.expect(response$).toBeObservable(expected$);
-                }),
+                })
             );
 
             it(
@@ -516,42 +443,36 @@ describe('DataJobsEffects', () => {
                     // Given
                     const dateNow = Date.now();
                     spyOn(CollectionsUtil, 'dateNow').and.returnValue(dateNow);
-                    const error = new Error(
-                        'Unsupported action task for Data Pipelines, update Data Job.',
-                    );
+                    const error = new Error('Unsupported action task for Data Pipelines, update Data Job.');
                     const errorRecord: ErrorRecord = {
                         code: generateErrorCode(
                             DataJobsEffects.CLASS_NAME,
                             DataJobsEffects.PUBLIC_NAME,
                             '_updateJob',
-                            'UnsupportedActionTask',
+                            'UnsupportedActionTask'
                         ),
                         error,
-                        objectUUID: effects.objectUUID,
+                        objectUUID: effects.objectUUID
                     };
                     const genericAction1 = GenericAction.of(
                         UPDATE_DATA_JOB,
                         createModel(undefined, 1, LOADING).getComponentState(),
-                        TASK_LOAD_JOB_STATE,
+                        TASK_LOAD_JOB_STATE
                     );
                     actions$ = m.cold('-a----------', {
-                        a: genericAction1,
+                        a: genericAction1
                     });
 
                     componentServiceStub.getModel.and.callFake(() =>
                         m.cold('---a', {
-                            a: createModel(),
-                        }),
+                            a: createModel()
+                        })
                     );
 
                     const expected$ = m.cold('----a-', {
                         a: ComponentFailed.of(
-                            createModel()
-                                .withTask(genericAction1.task)
-                                .withError(errorRecord)
-                                .withStatusFailed()
-                                .getComponentState(),
-                        ),
+                            createModel().withTask(genericAction1.task).withError(errorRecord).withStatusFailed().getComponentState()
+                        )
                     });
 
                     // When
@@ -559,18 +480,13 @@ describe('DataJobsEffects', () => {
 
                     // Then
                     m.expect(response$).toBeObservable(expected$);
-                }),
+                })
             );
         });
     });
 });
 
-const createModel = (
-    data?: Map<string, any>,
-    navigationId = 1,
-    status: StatusType = LOADING,
-    requestParams: Array<[string, any]> = [],
-) =>
+const createModel = (data?: Map<string, any>, navigationId = 1, status: StatusType = LOADING, requestParams: Array<[string, any]> = []) =>
     ComponentModel.of(
         ComponentStateImpl.of({
             id: 'testComponent',
@@ -580,11 +496,11 @@ const createModel = (
                 [TEAM_NAME_REQ_PARAM, 'aTeam'],
                 [JOB_NAME_REQ_PARAM, 'aJob'],
                 [JOB_DEPLOYMENT_ID_REQ_PARAM, 'aJobDeploymentId'],
-                ...requestParams,
+                ...requestParams
             ]),
-            navigationId,
+            navigationId
         }),
-        RouterState.of(RouteState.empty(), navigationId),
+        RouterState.of(RouteState.empty(), navigationId)
     );
 
 const getJobStateTuple = () =>
@@ -595,14 +511,14 @@ const getJobStateTuple = () =>
             deployments: [],
             config: {
                 schedule: {
-                    scheduleCron: '5 5 5 5 *',
+                    scheduleCron: '5 5 5 5 *'
                 },
                 description: 'aDesc',
                 team: 'aTeam',
                 logsUrl: 'http://url',
-                sourceUrl: 'http://urlsource',
-            },
-        },
+                sourceUrl: 'http://urlsource'
+            }
+        }
     ] as [string, DataJob];
 
 const getDataJobDetailsTuple = () =>
@@ -614,16 +530,16 @@ const getDataJobDetailsTuple = () =>
             description: 'aDesc',
             config: {
                 schedule: {
-                    schedule_cron: '5 5 5 5 *',
+                    schedule_cron: '5 5 5 5 *'
                 },
                 contacts: {
                     notified_on_job_success: [],
                     notified_on_job_failure_user_error: [],
                     notified_on_job_failure_platform_error: [],
-                    notified_on_job_deploy: [],
-                },
-            },
-        },
+                    notified_on_job_deploy: []
+                }
+            }
+        }
     ] as [string, DataJobDetails];
 
 const getExecutionsTuples = () =>
@@ -634,9 +550,9 @@ const getExecutionsTuples = () =>
                 { jobName: 'aJob', logsUrl: 'http://a1', id: 'a1' },
                 { jobName: 'aJob', logsUrl: 'http://a2', id: 'a2' },
                 { jobName: 'aJob', logsUrl: 'http://a3', id: 'a3' },
-                { jobName: 'aJob', logsUrl: 'http://a4', id: 'a4' },
+                { jobName: 'aJob', logsUrl: 'http://a4', id: 'a4' }
             ],
             totalPages: 1,
-            totalItems: 4,
-        },
+            totalItems: 4
+        }
     ] as [string, DataJobExecutionsPage];

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/state/effects/data-jobs.effects.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/state/effects/data-jobs.effects.ts
@@ -26,7 +26,7 @@ import {
     processServiceRequestError,
     ServiceHttpErrorCodes,
     StatusType,
-    TaurusBaseEffects,
+    TaurusBaseEffects
 } from '@versatiledatakit/shared';
 
 import { ErrorUtil } from '../../shared/utils';
@@ -48,7 +48,7 @@ import {
     JOB_STATUS_REQ_PARAM,
     JOBS_DATA_KEY,
     ORDER_REQ_PARAM,
-    TEAM_NAME_REQ_PARAM,
+    TEAM_NAME_REQ_PARAM
 } from '../../model';
 
 import {
@@ -60,21 +60,12 @@ import {
     TASK_LOAD_JOB_STATE,
     TASK_LOAD_JOBS_STATE,
     TASK_UPDATE_JOB_DESCRIPTION,
-    TASK_UPDATE_JOB_STATUS,
+    TASK_UPDATE_JOB_STATUS
 } from '../tasks';
 
-import {
-    LOAD_JOB_ERROR_CODES,
-    LOAD_JOBS_ERROR_CODES,
-    UPDATE_JOB_DETAILS_ERROR_CODES,
-} from '../error-codes';
+import { LOAD_JOB_ERROR_CODES, LOAD_JOBS_ERROR_CODES, UPDATE_JOB_DETAILS_ERROR_CODES } from '../error-codes';
 
-import {
-    FETCH_DATA_JOB,
-    FETCH_DATA_JOB_EXECUTIONS,
-    FETCH_DATA_JOBS,
-    UPDATE_DATA_JOB,
-} from '../actions';
+import { FETCH_DATA_JOB, FETCH_DATA_JOB_EXECUTIONS, FETCH_DATA_JOBS, UPDATE_DATA_JOB } from '../actions';
 
 import { DataJobsApiService } from '../../services';
 
@@ -100,8 +91,8 @@ export class DataJobsEffects extends TaurusBaseEffects {
         this.actions$.pipe(
             ofType(FETCH_DATA_JOBS),
             getModel(this.componentService),
-            switchMap((model: ComponentModel) => this._loadDataJobs(model)),
-        ),
+            switchMap((model: ComponentModel) => this._loadDataJobs(model))
+        )
     );
 
     loadDataJob$ = createEffect(() =>
@@ -112,38 +103,32 @@ export class DataJobsEffects extends TaurusBaseEffects {
                 merge(
                     this._executeJobTask(model, TASK_LOAD_JOB_STATE),
                     this._executeJobTask(model, TASK_LOAD_JOB_DETAILS),
-                    this._executeJobTask(model, TASK_LOAD_JOB_EXECUTIONS),
-                ),
-            ),
-        ),
+                    this._executeJobTask(model, TASK_LOAD_JOB_EXECUTIONS)
+                )
+            )
+        )
     );
 
     loadDataJobExecutions$ = createEffect(() =>
         this.actions$.pipe(
             ofType(FETCH_DATA_JOB_EXECUTIONS),
             getModel(this.componentService),
-            switchMap((model) =>
-                this._executeJobTask(model, TASK_LOAD_JOB_EXECUTIONS),
-            ),
-        ),
+            switchMap((model) => this._executeJobTask(model, TASK_LOAD_JOB_EXECUTIONS))
+        )
     );
 
     updateDataJob$ = createEffect(() =>
         this.actions$.pipe(
             ofType(UPDATE_DATA_JOB),
             getModelAndTask(this.componentService),
-            switchMap(([model, task]) => this._updateJob(model, task)), // eslint-disable-line rxjs/no-unsafe-switchmap
-        ),
+            switchMap(([model, task]) => this._updateJob(model, task)) // eslint-disable-line rxjs/no-unsafe-switchmap
+        )
     );
 
     /**
      * ** Constructor.
      */
-    constructor(
-        actions$: Actions,
-        componentService: ComponentService,
-        private readonly dataJobsApiService: DataJobsApiService,
-    ) {
+    constructor(actions$: Actions, componentService: ComponentService, private readonly dataJobsApiService: DataJobsApiService) {
         super(actions$, componentService, DataJobsEffects.CLASS_NAME);
 
         this.registerEffectsErrorCodes();
@@ -154,57 +139,36 @@ export class DataJobsEffects extends TaurusBaseEffects {
      * @protected
      */
     protected registerEffectsErrorCodes(): void {
-        LOAD_JOB_ERROR_CODES[TASK_LOAD_JOB_STATE] =
-            this.dataJobsApiService.errorCodes.getJob;
-        LOAD_JOB_ERROR_CODES[TASK_LOAD_JOB_DETAILS] =
-            this.dataJobsApiService.errorCodes.getJobDetails;
-        LOAD_JOB_ERROR_CODES[TASK_LOAD_JOB_EXECUTIONS] =
-            this.dataJobsApiService.errorCodes.getJobExecutions;
+        LOAD_JOB_ERROR_CODES[TASK_LOAD_JOB_STATE] = this.dataJobsApiService.errorCodes.getJob;
+        LOAD_JOB_ERROR_CODES[TASK_LOAD_JOB_DETAILS] = this.dataJobsApiService.errorCodes.getJobDetails;
+        LOAD_JOB_ERROR_CODES[TASK_LOAD_JOB_EXECUTIONS] = this.dataJobsApiService.errorCodes.getJobExecutions;
 
-        LOAD_JOBS_ERROR_CODES[TASK_LOAD_JOBS_STATE] =
-            this.dataJobsApiService.errorCodes.getJobs;
+        LOAD_JOBS_ERROR_CODES[TASK_LOAD_JOBS_STATE] = this.dataJobsApiService.errorCodes.getJobs;
 
-        UPDATE_JOB_DETAILS_ERROR_CODES[TASK_UPDATE_JOB_STATUS] =
-            this.dataJobsApiService.errorCodes.updateDataJobStatus;
-        UPDATE_JOB_DETAILS_ERROR_CODES[TASK_UPDATE_JOB_DESCRIPTION] =
-            this.dataJobsApiService.errorCodes.updateDataJob;
+        UPDATE_JOB_DETAILS_ERROR_CODES[TASK_UPDATE_JOB_STATUS] = this.dataJobsApiService.errorCodes.updateDataJobStatus;
+        UPDATE_JOB_DETAILS_ERROR_CODES[TASK_UPDATE_JOB_DESCRIPTION] = this.dataJobsApiService.errorCodes.updateDataJob;
     }
 
-    private _loadDataJobs(
-        componentModel: ComponentModel,
-    ): Observable<ComponentLoaded | ComponentFailed> {
+    private _loadDataJobs(componentModel: ComponentModel): Observable<ComponentLoaded | ComponentFailed> {
         const componentState = componentModel.getComponentState();
         const task: DataJobsLoadTasks = TASK_LOAD_JOBS_STATE;
 
         return of(componentModel).pipe(
             switchMap((model) =>
                 this.dataJobsApiService
-                    .getJobs(
-                        componentState.filter.criteria,
-                        componentState.search,
-                        componentState.page.page,
-                        componentState.page.size,
-                    )
+                    .getJobs(componentState.filter.criteria, componentState.search, componentState.page.page, componentState.page.size)
                     .pipe(
                         map((response) =>
                             model
                                 .clearTask()
-                                .removeErrorCodePatterns(
-                                    LOAD_JOBS_ERROR_CODES[TASK_LOAD_JOBS_STATE]
-                                        .All,
-                                )
+                                .removeErrorCodePatterns(LOAD_JOBS_ERROR_CODES[TASK_LOAD_JOBS_STATE].All)
                                 .withData(JOBS_DATA_KEY, response.data)
                                 .withTask(task)
                                 .withStatusLoaded()
-                                .getComponentState(),
+                                .getComponentState()
                         ),
-                        map<ComponentState, ComponentLoaded>((state) =>
-                            ComponentLoaded.of(state),
-                        ),
-                        catchError<
-                            ComponentFailed,
-                            Observable<ComponentFailed>
-                        >((error: unknown) =>
+                        map<ComponentState, ComponentLoaded>((state) => ComponentLoaded.of(state)),
+                        catchError<ComponentFailed, Observable<ComponentFailed>>((error: unknown) =>
                             this._getLatestModel(model).pipe(
                                 map((newModel) =>
                                     ComponentFailed.of(
@@ -212,199 +176,143 @@ export class DataJobsEffects extends TaurusBaseEffects {
                                             .withData(JOBS_DATA_KEY, {
                                                 content: [],
                                                 totalItems: 0,
-                                                totalPages: 0,
+                                                totalPages: 0
                                             } as DataJobPage)
                                             .withError(
                                                 processServiceRequestError(
                                                     this.objectUUID,
-                                                    LOAD_JOBS_ERROR_CODES[
-                                                        TASK_LOAD_JOBS_STATE
-                                                    ],
-                                                    ErrorUtil.extractError(
-                                                        error as Error,
-                                                    ),
-                                                ),
+                                                    LOAD_JOBS_ERROR_CODES[TASK_LOAD_JOBS_STATE],
+                                                    ErrorUtil.extractError(error as Error)
+                                                )
                                             )
                                             .withTask(task)
                                             .withStatusFailed()
-                                            .getComponentState(),
-                                    ),
-                                ),
-                            ),
-                        ),
-                    ),
-            ),
+                                            .getComponentState()
+                                    )
+                                )
+                            )
+                        )
+                    )
+            )
         );
     }
 
-    private _executeJobTask(
-        model: ComponentModel,
-        task: DataJobLoadTasks,
-    ): Observable<ComponentLoaded | ComponentFailed> {
+    private _executeJobTask(model: ComponentModel, task: DataJobLoadTasks): Observable<ComponentLoaded | ComponentFailed> {
         switch (task) {
             case TASK_LOAD_JOB_STATE:
                 return this._fetchJobData<DataJob>(
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                    this.dataJobsApiService.getJob.bind(
-                        this.dataJobsApiService,
-                    ),
+                    this.dataJobsApiService.getJob.bind(this.dataJobsApiService),
                     LOAD_JOB_ERROR_CODES[TASK_LOAD_JOB_STATE],
                     model,
                     TASK_LOAD_JOB_STATE,
-                    JOB_STATE_DATA_KEY,
+                    JOB_STATE_DATA_KEY
                 );
             case TASK_LOAD_JOB_DETAILS:
                 return this._fetchJobData(
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                    this.dataJobsApiService.getJobDetails.bind(
-                        this.dataJobsApiService,
-                    ),
+                    this.dataJobsApiService.getJobDetails.bind(this.dataJobsApiService),
                     LOAD_JOB_ERROR_CODES[TASK_LOAD_JOB_DETAILS],
                     model,
                     TASK_LOAD_JOB_DETAILS,
-                    JOB_DETAILS_DATA_KEY,
+                    JOB_DETAILS_DATA_KEY
                 );
             case TASK_LOAD_JOB_EXECUTIONS:
                 return this._loadDataJobExecutionsGraphQL(model);
             default:
-                return throwError(
-                    () => new Error('Unknown action task for Data Pipelines.'),
-                ).pipe(this._handleError(model, null, task));
+                return throwError(() => new Error('Unknown action task for Data Pipelines.')).pipe(this._handleError(model, null, task));
         }
     }
 
     private _fetchJobData<T>(
         executor: (param1: string, param2: string) => Observable<T>,
-        executorErrorCodes: Readonly<
-            Record<keyof ServiceHttpErrorCodes, string>
-        >,
+        executorErrorCodes: Readonly<Record<keyof ServiceHttpErrorCodes, string>>,
         componentModel: ComponentModel,
         task: DataJobLoadTasks | string,
-        dataKey: string,
+        dataKey: string
     ): Observable<ComponentLoaded | ComponentUpdate | ComponentFailed> {
         return of(componentModel).pipe(
             switchMap((model) =>
                 executor(
-                    componentModel
-                        .getComponentState()
-                        .requestParams.get(TEAM_NAME_REQ_PARAM) as string,
-                    componentModel
-                        .getComponentState()
-                        .requestParams.get(JOB_NAME_REQ_PARAM) as string,
+                    componentModel.getComponentState().requestParams.get(TEAM_NAME_REQ_PARAM) as string,
+                    componentModel.getComponentState().requestParams.get(JOB_NAME_REQ_PARAM) as string
                 ).pipe(
                     switchMap((data) => {
                         let obsoleteStatus: StatusType;
 
                         return this._getLatestModel(model).pipe(
-                            tap(
-                                (newModel) =>
-                                    (obsoleteStatus = newModel.status),
-                            ),
+                            tap((newModel) => (obsoleteStatus = newModel.status)),
                             map((newModel) =>
                                 newModel
-                                    .removeErrorCodePatterns(
-                                        executorErrorCodes.All,
-                                    )
+                                    .removeErrorCodePatterns(executorErrorCodes.All)
                                     .withTask(task)
                                     .withData(dataKey, data)
                                     .withStatusLoaded()
-                                    .getComponentState(),
+                                    .getComponentState()
                             ),
-                            map((state) =>
-                                obsoleteStatus === LOADED
-                                    ? ComponentUpdate.of(state)
-                                    : ComponentLoaded.of(state),
-                            ),
+                            map((state) => (obsoleteStatus === LOADED ? ComponentUpdate.of(state) : ComponentLoaded.of(state)))
                         );
                     }),
-                    this._handleError(model, executorErrorCodes, task),
-                ),
-            ),
+                    this._handleError(model, executorErrorCodes, task)
+                )
+            )
         );
     }
 
-    private _updateJob(
-        model: ComponentModel,
-        taskIdentifier: string,
-    ): Observable<ComponentUpdate | ComponentFailed> {
-        const task =
-            extractTaskFromIdentifier<DataJobUpdateTasks>(taskIdentifier);
+    private _updateJob(model: ComponentModel, taskIdentifier: string): Observable<ComponentUpdate | ComponentFailed> {
+        const task = extractTaskFromIdentifier<DataJobUpdateTasks>(taskIdentifier);
         const requestParams = model.getComponentState().requestParams;
 
         if (task === TASK_UPDATE_JOB_DESCRIPTION) {
-            const jobDetails: DataJobDetails = requestParams.get(
-                JOB_DETAILS_REQ_PARAM,
-            );
+            const jobDetails: DataJobDetails = requestParams.get(JOB_DETAILS_REQ_PARAM);
 
             return this.dataJobsApiService
                 .updateDataJob(
                     requestParams.get(TEAM_NAME_REQ_PARAM) as string,
                     requestParams.get(JOB_NAME_REQ_PARAM) as string,
-                    jobDetails,
+                    jobDetails
                 )
                 .pipe(
                     map(() =>
                         ComponentLoaded.of(
                             model
-                                .removeErrorCodePatterns(
-                                    UPDATE_JOB_DETAILS_ERROR_CODES[
-                                        TASK_UPDATE_JOB_DESCRIPTION
-                                    ].All,
-                                )
+                                .removeErrorCodePatterns(UPDATE_JOB_DETAILS_ERROR_CODES[TASK_UPDATE_JOB_DESCRIPTION].All)
                                 .withTask(taskIdentifier)
                                 .withData(JOB_DETAILS_DATA_KEY, jobDetails)
                                 .withStatusLoaded()
-                                .getComponentState(),
-                        ),
+                                .getComponentState()
+                        )
                     ),
-                    this._handleError(
-                        model,
-                        UPDATE_JOB_DETAILS_ERROR_CODES[
-                            TASK_UPDATE_JOB_DESCRIPTION
-                        ],
-                        taskIdentifier,
-                    ),
+                    this._handleError(model, UPDATE_JOB_DETAILS_ERROR_CODES[TASK_UPDATE_JOB_DESCRIPTION], taskIdentifier)
                 );
         }
 
         if (task === TASK_UPDATE_JOB_STATUS) {
-            const jobState: DataJob = model
-                .getComponentState()
-                .requestParams.get(JOB_STATE_REQ_PARAM);
+            const jobState: DataJob = model.getComponentState().requestParams.get(JOB_STATE_REQ_PARAM);
 
             return this.dataJobsApiService
                 .updateDataJobStatus(
                     requestParams.get(TEAM_NAME_REQ_PARAM) as string,
                     requestParams.get(JOB_NAME_REQ_PARAM) as string,
                     requestParams.get(JOB_DEPLOYMENT_ID_REQ_PARAM) as string,
-                    requestParams.get(JOB_STATUS_REQ_PARAM) as boolean,
+                    requestParams.get(JOB_STATUS_REQ_PARAM) as boolean
                 )
                 .pipe(
                     map(() =>
                         ComponentLoaded.of(
                             model
-                                .removeErrorCodePatterns(
-                                    UPDATE_JOB_DETAILS_ERROR_CODES[
-                                        TASK_UPDATE_JOB_STATUS
-                                    ].All,
-                                )
+                                .removeErrorCodePatterns(UPDATE_JOB_DETAILS_ERROR_CODES[TASK_UPDATE_JOB_STATUS].All)
                                 .withTask(taskIdentifier)
                                 .withData(JOB_STATE_DATA_KEY, jobState)
                                 .withStatusLoaded()
-                                .getComponentState(),
-                        ),
+                                .getComponentState()
+                        )
                     ),
-                    this._handleError(
-                        model,
-                        UPDATE_JOB_DETAILS_ERROR_CODES[TASK_UPDATE_JOB_STATUS],
-                        taskIdentifier,
-                    ),
+                    this._handleError(model, UPDATE_JOB_DETAILS_ERROR_CODES[TASK_UPDATE_JOB_STATUS], taskIdentifier)
                 );
         }
 
-        const error = new Error(
-            'Unsupported action task for Data Pipelines, update Data Job.',
-        );
+        const error = new Error('Unsupported action task for Data Pipelines, update Data Job.');
 
         console.error(error);
 
@@ -418,19 +326,17 @@ export class DataJobsEffects extends TaurusBaseEffects {
                             DataJobsEffects.CLASS_NAME,
                             DataJobsEffects.PUBLIC_NAME,
                             '_updateJob',
-                            'UnsupportedActionTask',
+                            'UnsupportedActionTask'
                         ),
-                        error,
+                        error
                     })
                     .withStatusFailed()
-                    .getComponentState(),
-            ),
+                    .getComponentState()
+            )
         );
     }
 
-    private _loadDataJobExecutionsGraphQL(
-        componentModel: ComponentModel,
-    ): Observable<ComponentLoaded> {
+    private _loadDataJobExecutionsGraphQL(componentModel: ComponentModel): Observable<ComponentLoaded> {
         const componentState = componentModel.getComponentState();
         const requestParams = componentState.requestParams;
 
@@ -441,105 +347,66 @@ export class DataJobsEffects extends TaurusBaseEffects {
                         requestParams.get(TEAM_NAME_REQ_PARAM) as string,
                         requestParams.get(JOB_NAME_REQ_PARAM) as string,
                         true,
-                        requestParams.get(
-                            FILTER_REQ_PARAM,
-                        ) as DataJobExecutionFilter,
-                        requestParams.get(
-                            ORDER_REQ_PARAM,
-                        ) as DataJobExecutionOrder,
+                        requestParams.get(FILTER_REQ_PARAM) as DataJobExecutionFilter,
+                        requestParams.get(ORDER_REQ_PARAM) as DataJobExecutionOrder
                     )
                     .pipe(
                         switchMap((response) => {
                             let obsoleteStatus: StatusType;
 
                             return this._getLatestModel(model).pipe(
-                                tap(
-                                    (newModel) =>
-                                        (obsoleteStatus = newModel.status),
-                                ),
+                                tap((newModel) => (obsoleteStatus = newModel.status)),
                                 map((newModel) =>
                                     newModel
-                                        .removeErrorCodePatterns(
-                                            LOAD_JOB_ERROR_CODES[
-                                                TASK_LOAD_JOB_EXECUTIONS
-                                            ].All,
-                                        )
+                                        .removeErrorCodePatterns(LOAD_JOB_ERROR_CODES[TASK_LOAD_JOB_EXECUTIONS].All)
                                         .withTask(TASK_LOAD_JOB_EXECUTIONS)
-                                        .withData(
-                                            JOB_EXECUTIONS_DATA_KEY,
-                                            response.content,
-                                        )
+                                        .withData(JOB_EXECUTIONS_DATA_KEY, response.content)
                                         .withStatusLoaded()
-                                        .getComponentState(),
+                                        .getComponentState()
                                 ),
-                                map((state) =>
-                                    obsoleteStatus === LOADED
-                                        ? ComponentUpdate.of(state)
-                                        : ComponentLoaded.of(state),
-                                ),
+                                map((state) => (obsoleteStatus === LOADED ? ComponentUpdate.of(state) : ComponentLoaded.of(state)))
                             );
                         }),
-                        this._handleError(
-                            model,
-                            LOAD_JOB_ERROR_CODES[TASK_LOAD_JOB_EXECUTIONS],
-                            TASK_LOAD_JOB_EXECUTIONS,
-                        ),
-                    ),
-            ),
+                        this._handleError(model, LOAD_JOB_ERROR_CODES[TASK_LOAD_JOB_EXECUTIONS], TASK_LOAD_JOB_EXECUTIONS)
+                    )
+            )
         );
     }
 
-    private _getLatestModel(
-        componentModel: ComponentModel,
-    ): Observable<ComponentModel> {
+    private _getLatestModel(componentModel: ComponentModel): Observable<ComponentModel> {
         const componentState = componentModel.getComponentState();
 
-        return this.componentService
-            .getModel(componentState.id, componentState.routePathSegments, [
-                '*',
-            ])
-            .pipe(take(1));
+        return this.componentService.getModel(componentState.id, componentState.routePathSegments, ['*']).pipe(take(1));
     }
 
     private _handleError(
         obsoleteModel: ComponentModel,
-        executorErrorCodes: Readonly<
-            Record<keyof ServiceHttpErrorCodes, string>
-        >,
-        task: DataJobLoadTasks | string,
+        executorErrorCodes: Readonly<Record<keyof ServiceHttpErrorCodes, string>>,
+        task: DataJobLoadTasks | string
     ) {
-        return catchError<
-            ComponentLoaded | ComponentUpdate,
-            Observable<ComponentFailed>
-        >((error: unknown) => {
+        return catchError<ComponentLoaded | ComponentUpdate, Observable<ComponentFailed>>((error: unknown) => {
             return this._getLatestModel(obsoleteModel).pipe(
                 map((newModel) =>
                     newModel
                         .withTask(task)
                         .withError(
                             CollectionsUtil.isLiteralObject(executorErrorCodes)
-                                ? processServiceRequestError(
-                                      this.objectUUID,
-                                      executorErrorCodes,
-                                      ErrorUtil.extractError(error as Error),
-                                  )
+                                ? processServiceRequestError(this.objectUUID, executorErrorCodes, ErrorUtil.extractError(error as Error))
                                 : {
                                       objectUUID: this.objectUUID,
                                       code: generateErrorCode(
                                           DataJobsEffects.CLASS_NAME,
                                           DataJobsEffects.PUBLIC_NAME,
                                           '_handleError',
-                                          'GenericError',
+                                          'GenericError'
                                       ),
-                                      error: error as Error,
-                                  },
+                                      error: error as Error
+                                  }
                         )
                         .withStatusFailed()
-                        .getComponentState(),
+                        .getComponentState()
                 ),
-                map<ComponentState, ComponentFailed>((state) =>
-                    ComponentFailed.of(state),
-                ),
+                map<ComponentState, ComponentFailed>((state) => ComponentFailed.of(state))
             );
         });
     }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/state/error-codes/data-job.error-codes.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/state/error-codes/data-job.error-codes.ts
@@ -11,45 +11,33 @@ import {
     TASK_LOAD_JOB_STATE,
     TASK_LOAD_JOBS_STATE,
     TASK_UPDATE_JOB_DESCRIPTION,
-    TASK_UPDATE_JOB_STATUS,
+    TASK_UPDATE_JOB_STATUS
 } from '../tasks';
 
 // load tasks error codes
 
 export const LOAD_JOB_ERROR_CODES: {
-    [TASK_LOAD_JOB_STATE]: Readonly<
-        Record<keyof ServiceHttpErrorCodes, string>
-    >;
-    [TASK_LOAD_JOB_DETAILS]: Readonly<
-        Record<keyof ServiceHttpErrorCodes, string>
-    >;
-    [TASK_LOAD_JOB_EXECUTIONS]: Readonly<
-        Record<keyof ServiceHttpErrorCodes, string>
-    >;
+    [TASK_LOAD_JOB_STATE]: Readonly<Record<keyof ServiceHttpErrorCodes, string>>;
+    [TASK_LOAD_JOB_DETAILS]: Readonly<Record<keyof ServiceHttpErrorCodes, string>>;
+    [TASK_LOAD_JOB_EXECUTIONS]: Readonly<Record<keyof ServiceHttpErrorCodes, string>>;
 } = {
     [TASK_LOAD_JOB_STATE]: null,
     [TASK_LOAD_JOB_DETAILS]: null,
-    [TASK_LOAD_JOB_EXECUTIONS]: null,
+    [TASK_LOAD_JOB_EXECUTIONS]: null
 };
 
 export const LOAD_JOBS_ERROR_CODES: {
-    [TASK_LOAD_JOBS_STATE]: Readonly<
-        Record<keyof ServiceHttpErrorCodes, string>
-    >;
+    [TASK_LOAD_JOBS_STATE]: Readonly<Record<keyof ServiceHttpErrorCodes, string>>;
 } = {
-    [TASK_LOAD_JOBS_STATE]: null,
+    [TASK_LOAD_JOBS_STATE]: null
 };
 
 // update tasks error codes
 
 export const UPDATE_JOB_DETAILS_ERROR_CODES: {
-    [TASK_UPDATE_JOB_STATUS]: Readonly<
-        Record<keyof ServiceHttpErrorCodes, string>
-    >;
-    [TASK_UPDATE_JOB_DESCRIPTION]: Readonly<
-        Record<keyof ServiceHttpErrorCodes, string>
-    >;
+    [TASK_UPDATE_JOB_STATUS]: Readonly<Record<keyof ServiceHttpErrorCodes, string>>;
+    [TASK_UPDATE_JOB_DESCRIPTION]: Readonly<Record<keyof ServiceHttpErrorCodes, string>>;
 } = {
     [TASK_UPDATE_JOB_STATUS]: null,
-    [TASK_UPDATE_JOB_DESCRIPTION]: null,
+    [TASK_UPDATE_JOB_DESCRIPTION]: null
 };

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/state/tasks/data-job.tasks.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/state/tasks/data-job.tasks.ts
@@ -11,10 +11,7 @@ export const TASK_LOAD_JOB_DETAILS = 'load_job_details';
 
 export const TASK_LOAD_JOB_EXECUTIONS = 'load_job_executions';
 
-export type DataJobLoadTasks =
-    | typeof TASK_LOAD_JOB_STATE
-    | typeof TASK_LOAD_JOB_DETAILS
-    | typeof TASK_LOAD_JOB_EXECUTIONS;
+export type DataJobLoadTasks = typeof TASK_LOAD_JOB_STATE | typeof TASK_LOAD_JOB_DETAILS | typeof TASK_LOAD_JOB_EXECUTIONS;
 
 export const TASK_LOAD_JOBS_STATE = 'load_jobs_state';
 
@@ -26,6 +23,4 @@ export const TASK_UPDATE_JOB_DESCRIPTION = 'update_job_description';
 
 export const TASK_UPDATE_JOB_STATUS = 'update_job_status';
 
-export type DataJobUpdateTasks =
-    | typeof TASK_UPDATE_JOB_DESCRIPTION
-    | typeof TASK_UPDATE_JOB_STATUS;
+export type DataJobUpdateTasks = typeof TASK_UPDATE_JOB_DESCRIPTION | typeof TASK_UPDATE_JOB_STATUS;

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/vdk-data-pipelines.module.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/vdk-data-pipelines.module.ts
@@ -19,11 +19,7 @@ import { DpDatePickerModule } from 'ng2-date-picker';
 
 import { ClarityModule } from '@clr/angular';
 
-import {
-    VdkSharedComponentsModule,
-    VdkSharedFeaturesModule,
-    VdkSharedNgRxModule,
-} from '@versatiledatakit/shared';
+import { VdkSharedComponentsModule, VdkSharedFeaturesModule, VdkSharedNgRxModule } from '@versatiledatakit/shared';
 
 import { AttributesDirective } from './shared/directives';
 
@@ -35,7 +31,7 @@ import {
     FormatDeltaPipe,
     FormatSchedulePipe,
     ParseEpochPipe,
-    ParseNextRunPipe,
+    ParseNextRunPipe
 } from './shared/pipes';
 
 import {
@@ -48,16 +44,10 @@ import {
     QuickFiltersComponent,
     StatusCellComponent,
     StatusPanelComponent,
-    WidgetValueComponent,
+    WidgetValueComponent
 } from './shared/components';
 
-import {
-    DataJobsApiService,
-    DataJobsBaseApiService,
-    DataJobsPublicApiService,
-    DataJobsService,
-    DataJobsServiceImpl,
-} from './services';
+import { DataJobsApiService, DataJobsBaseApiService, DataJobsPublicApiService, DataJobsService, DataJobsServiceImpl } from './services';
 
 import { DATA_PIPELINES_CONFIGS, DataPipelinesConfig } from './model';
 
@@ -83,7 +73,7 @@ import {
     DataJobExecutionTypeFilterComponent,
     ExecutionDurationChartComponent,
     ExecutionStatusChartComponent,
-    TimePeriodFilterComponent,
+    TimePeriodFilterComponent
 } from './components/data-job/pages/executions';
 
 import {
@@ -91,7 +81,7 @@ import {
     DataJobsFailedWidgetComponent,
     DataJobsHealthPanelComponent,
     DataJobsWidgetOneComponent,
-    WidgetExecutionStatusGaugeComponent,
+    WidgetExecutionStatusGaugeComponent
 } from './components/widgets';
 
 const routes: Routes = [];
@@ -110,7 +100,7 @@ const routes: Routes = [];
         NgxChartsModule,
         VdkSharedComponentsModule.forChild(),
         VdkSharedFeaturesModule.forChild(),
-        VdkSharedNgRxModule.forFeatureEffects([DataJobsEffects]),
+        VdkSharedNgRxModule.forFeatureEffects([DataJobsEffects])
     ],
     declarations: [
         AttributesDirective,
@@ -154,7 +144,7 @@ const routes: Routes = [];
         DataJobsFailedWidgetComponent,
         WidgetExecutionStatusGaugeComponent,
         DataJobsHealthPanelComponent,
-        EmptyStateComponent,
+        EmptyStateComponent
     ],
     exports: [
         DataJobsExplorePageComponent,
@@ -168,14 +158,12 @@ const routes: Routes = [];
         DataJobsExecutionsWidgetComponent,
         DataJobsFailedWidgetComponent,
         WidgetExecutionStatusGaugeComponent,
-        DataJobsHealthPanelComponent,
-    ],
+        DataJobsHealthPanelComponent
+    ]
 })
 export class VdkDataPipelinesModule {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    static forRoot(
-        config: DataPipelinesConfig = {} as any,
-    ): ModuleWithProviders<VdkDataPipelinesModule> {
+    static forRoot(config: DataPipelinesConfig = {} as any): ModuleWithProviders<VdkDataPipelinesModule> {
         return {
             ngModule: VdkDataPipelinesModule,
             providers: [
@@ -183,8 +171,8 @@ export class VdkDataPipelinesModule {
                 DataJobsPublicApiService,
                 DataJobsApiService,
                 { provide: DataJobsService, useClass: DataJobsServiceImpl },
-                { provide: DATA_PIPELINES_CONFIGS, useValue: config },
-            ],
+                { provide: DATA_PIPELINES_CONFIGS, useValue: config }
+            ]
         };
     }
 }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/test.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/test.ts
@@ -8,16 +8,13 @@
 import 'zone.js';
 import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
-import {
-    BrowserDynamicTestingModule,
-    platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 
 declare const require: {
     context(
         path: string,
         deep?: boolean,
-        filter?: RegExp,
+        filter?: RegExp
     ): {
         keys(): string[];
         <T>(id: string): T;
@@ -25,13 +22,9 @@ declare const require: {
 };
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(
-    BrowserDynamicTestingModule,
-    platformBrowserDynamicTesting(),
-    {
-        teardown: { destroyAfterEach: false },
-    },
-);
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+    teardown: { destroyAfterEach: false }
+});
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.

--- a/projects/frontend/data-pipelines/gui/projects/ui/.eslintrc.json
+++ b/projects/frontend/data-pipelines/gui/projects/ui/.eslintrc.json
@@ -40,7 +40,6 @@
             ],
             "leadingUnderscore": "allow",
             "filter": {
-              // you can expand this regex to add more allowed names
               "regex": "^((\\$\\..+))$",
               "match": false
             }
@@ -59,7 +58,7 @@
         ],
         "@typescript-eslint/no-shadow": "error",
         "no-shadow": "off",
-        "prefer-arrow/prefer-arrow-functions": "error"
+        "prefer-arrow/prefer-arrow-functions": "warn"
       }
     },
     {

--- a/projects/frontend/data-pipelines/gui/projects/ui/karma.conf.js
+++ b/projects/frontend/data-pipelines/gui/projects/ui/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function (config) {
             require('karma-jasmine-html-reporter'),
             require('karma-junit-reporter'),
             require('karma-coverage'),
-            require('@angular-devkit/build-angular/plugins/karma'),
+            require('@angular-devkit/build-angular/plugins/karma')
         ],
         client: {
             jasmine: {
@@ -25,35 +25,35 @@ module.exports = function (config) {
                 // for example, you can disable the random execution with `random: false`
                 // or set a specific seed with `seed: 4321`
             },
-            clearContext: false, // leave Jasmine Spec Runner output visible in browser
+            clearContext: false // leave Jasmine Spec Runner output visible in browser
         },
         coverageReporter: {
             dir: require('path').join(
                 __dirname,
-                '../../reports/coverage/data-pipelines-ui',
+                '../../reports/coverage/data-pipelines-ui'
             ),
             reporters: [
                 //Code coverage - output only in HTML file
                 { type: 'html' },
                 { type: 'text-summary' },
-                { type: 'lcovonly' },
+                { type: 'lcovonly' }
             ],
             check: {
                 global: {
-                    lines: 20,
-                },
-            },
+                    lines: 20
+                }
+            }
         },
         jasmineHtmlReporter: {
-            suppressAll: true, // removes the duplicated traces
+            suppressAll: true // removes the duplicated traces
         },
         junitReporter: {
             outputDir: require('path').join(
                 __dirname,
-                '../../reports/test-results/data-pipelines-ui',
+                '../../reports/test-results/data-pipelines-ui'
             ),
             outputFile: 'unit-tests.xml',
-            useBrowserName: false,
+            useBrowserName: false
         },
         reporters: ['progress', 'junit', 'coverage'],
         port: 9876,
@@ -64,10 +64,10 @@ module.exports = function (config) {
         customLaunchers: {
             ChromeHeadless_No_Sandbox: {
                 base: 'ChromeHeadless',
-                flags: ['--no-sandbox'],
-            },
+                flags: ['--no-sandbox']
+            }
         },
         singleRun: false,
-        restartOnFileChange: true,
+        restartOnFileChange: true
     });
 };

--- a/projects/frontend/data-pipelines/gui/projects/ui/src/app/app.component.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/ui/src/app/app.component.spec.ts
@@ -21,10 +21,7 @@ describe('AppComponent', () => {
     let navigationServiceStub: jasmine.SpyObj<NavigationService>;
 
     beforeEach(() => {
-        routerServiceStub = jasmine.createSpyObj<RouterService>(
-            'routerService',
-            ['getState'],
-        );
+        routerServiceStub = jasmine.createSpyObj<RouterService>('routerService', ['getState']);
         oAuthServiceStub = jasmine.createSpyObj<OAuthService>('oAuthService', [
             'configure',
             'loadDiscoveryDocumentAndLogin',
@@ -32,22 +29,15 @@ describe('AppComponent', () => {
             'refreshToken',
             'logOut',
             'getIdToken',
-            'getIdentityClaims',
+            'getIdentityClaims'
         ]);
-        navigationServiceStub = jasmine.createSpyObj<NavigationService>(
-            'navigationService',
-            ['initialize'],
-        );
+        navigationServiceStub = jasmine.createSpyObj<NavigationService>('navigationService', ['initialize']);
 
         routerServiceStub.getState.and.returnValue(new Subject());
         oAuthServiceStub.getIdentityClaims.and.returnValue({});
-        oAuthServiceStub.loadDiscoveryDocumentAndLogin.and.returnValue(
-            Promise.resolve(true),
-        );
+        oAuthServiceStub.loadDiscoveryDocumentAndLogin.and.returnValue(Promise.resolve(true));
         oAuthServiceStub.getAccessTokenExpiration.and.returnValue(0);
-        oAuthServiceStub.refreshToken.and.returnValue(
-            Promise.resolve({} as TokenResponse),
-        );
+        oAuthServiceStub.refreshToken.and.returnValue(Promise.resolve({} as TokenResponse));
 
         TestBed.configureTestingModule({
             schemas: [NO_ERRORS_SCHEMA],
@@ -57,8 +47,8 @@ describe('AppComponent', () => {
                 UrlHelperService,
                 { provide: OAuthService, useValue: oAuthServiceStub },
                 { provide: NavigationService, useValue: navigationServiceStub },
-                { provide: RouterService, useValue: routerServiceStub },
-            ],
+                { provide: RouterService, useValue: routerServiceStub }
+            ]
         });
     });
 

--- a/projects/frontend/data-pipelines/gui/projects/ui/src/app/app.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/ui/src/app/app.component.ts
@@ -20,16 +20,13 @@ const CONSOLE_CLOUD_URL = 'https://console-stg.cloud.vmware.com/';
 @Component({
     selector: 'app-root',
     templateUrl: './app.component.html',
-    styleUrls: ['./app.component.scss'],
+    styleUrls: ['./app.component.scss']
 })
 export class AppComponent implements OnInit {
     title = 'core';
     collapsed = false;
 
-    constructor(
-        private readonly oauthService: OAuthService,
-        private readonly navigationService: NavigationService,
-    ) {
+    constructor(private readonly oauthService: OAuthService, private readonly navigationService: NavigationService) {
         this.oauthService.configure(authCodeFlowConfig);
         this.oauthService
             .loadDiscoveryDocumentAndLogin()
@@ -50,9 +47,7 @@ export class AppComponent implements OnInit {
     }
 
     get userName(): string {
-        return this.oauthService.getIdentityClaims()
-            ? this.getIdentityClaim('username')
-            : 'N/A';
+        return this.oauthService.getIdentityClaims() ? this.getIdentityClaim('username') : 'N/A';
     }
 
     /**
@@ -71,18 +66,9 @@ export class AppComponent implements OnInit {
     }
 
     private initTokenRefresh() {
-        timer(
-            REFRESH_TOKEN_START,
-            AppComponent.toMillis(refreshTokenConfig.refreshTokenCheckInterval),
-        ).subscribe(() => {
-            const remainiTimeMillis =
-                this.oauthService.getAccessTokenExpiration() - Date.now();
-            if (
-                remainiTimeMillis <=
-                AppComponent.toMillis(
-                    refreshTokenConfig.refreshTokenRemainingTime,
-                )
-            ) {
+        timer(REFRESH_TOKEN_START, AppComponent.toMillis(refreshTokenConfig.refreshTokenCheckInterval)).subscribe(() => {
+            const remainiTimeMillis = this.oauthService.getAccessTokenExpiration() - Date.now();
+            if (remainiTimeMillis <= AppComponent.toMillis(refreshTokenConfig.refreshTokenRemainingTime)) {
                 this.setCustomTokenAttributes(false, null);
                 this.oauthService.refreshToken().finally(() => {
                     // No-op.
@@ -91,16 +77,11 @@ export class AppComponent implements OnInit {
         });
     }
 
-    private setCustomTokenAttributes(
-        redirectToConsole: boolean,
-        defaultOrg: { refLink: string },
-    ) {
+    private setCustomTokenAttributes(redirectToConsole: boolean, defaultOrg: { refLink: string }) {
         const linkOrgQuery = AppComponent.getOrgLinkFromQueryParams(defaultOrg);
         this.oauthService.customQueryParams = {
             orgLink: linkOrgQuery,
-            targetUri: redirectToConsole
-                ? CONSOLE_CLOUD_URL
-                : window.location.href,
+            targetUri: redirectToConsole ? CONSOLE_CLOUD_URL : window.location.href
         };
         if (redirectToConsole) {
             // Redirect to console cloud because we dont know the tenant url, but console does
@@ -108,9 +89,7 @@ export class AppComponent implements OnInit {
         }
     }
 
-    private static getOrgLinkFromQueryParams(defaultOrg: {
-        refLink: string;
-    }): string {
+    private static getOrgLinkFromQueryParams(defaultOrg: { refLink: string }): string {
         const params = new URLSearchParams(window.location.search);
         const orgLinkUnderscored = params.get('org_link');
         const orgLinkBase = params.get('orgLink');

--- a/projects/frontend/data-pipelines/gui/projects/ui/src/app/app.module.ts
+++ b/projects/frontend/data-pipelines/gui/projects/ui/src/app/app.module.ts
@@ -17,12 +17,7 @@ import { ApolloModule } from 'apollo-angular';
 
 import { ClarityModule } from '@clr/angular';
 
-import {
-    VdkSharedCoreModule,
-    VdkSharedFeaturesModule,
-    VdkSharedNgRxModule,
-    VdkSharedComponentsModule,
-} from '@versatiledatakit/shared';
+import { VdkSharedCoreModule, VdkSharedFeaturesModule, VdkSharedNgRxModule, VdkSharedComponentsModule } from '@versatiledatakit/shared';
 
 import { VdkDataPipelinesModule } from '@versatiledatakit/data-pipelines';
 
@@ -50,13 +45,9 @@ export function lottiePlayerLoader() {
         HttpClientModule,
         OAuthModule.forRoot({
             resourceServer: {
-                allowedUrls: [
-                    'https://console-stg.cloud.vmware.com/',
-                    'https://gaz-preview.csp-vidm-prod.com/',
-                    '/data-jobs',
-                ],
-                sendAccessToken: true,
-            },
+                allowedUrls: ['https://console-stg.cloud.vmware.com/', 'https://gaz-preview.csp-vidm-prod.com/', '/data-jobs'],
+                sendAccessToken: true
+            }
         }),
         ApolloModule,
         TimeagoModule.forRoot(),
@@ -68,33 +59,33 @@ export function lottiePlayerLoader() {
         VdkDataPipelinesModule.forRoot({
             defaultOwnerTeamName: 'taurus',
             manageConfig: {
-                allowKeyTabDownloads: true,
+                allowKeyTabDownloads: true
             },
             exploreConfig: {
-                showTeamsColumn: true,
+                showTeamsColumn: true
             },
             healthStatusUrl: '/explore/data-jobs?search={0}',
             showExecutionsPage: true,
             showLineagePage: false,
-            dataPipelinesDocumentationUrl: '#',
-        }),
+            dataPipelinesDocumentationUrl: '#'
+        })
     ],
     declarations: [AppComponent, GettingStartedComponent],
     providers: [
         {
             provide: OAuthStorage,
-            useValue: localStorage,
+            useValue: localStorage
         },
         {
             provide: AuthConfig,
-            useValue: authCodeFlowConfig,
+            useValue: authCodeFlowConfig
         },
         {
             provide: HTTP_INTERCEPTORS,
             useClass: AuthorizationInterceptor,
-            multi: true,
-        },
+            multi: true
+        }
     ],
-    bootstrap: [AppComponent],
+    bootstrap: [AppComponent]
 })
 export class AppModule {}

--- a/projects/frontend/data-pipelines/gui/projects/ui/src/app/app.routing.ts
+++ b/projects/frontend/data-pipelines/gui/projects/ui/src/app/app.routing.ts
@@ -13,7 +13,7 @@ import {
     DataJobPageComponent,
     DataJobsExplorePageComponent,
     DataJobsManagePageComponent,
-    DataPipelinesRoutes,
+    DataPipelinesRoutes
 } from '@versatiledatakit/data-pipelines';
 
 import { GettingStartedComponent } from './getting-started/getting-started.component';
@@ -31,20 +31,20 @@ const routes: DataPipelinesRoutes = [
                 path: '/explore/data-jobs/{0}/{1}',
                 replacers: [
                     { searchValue: '{0}', replaceValue: '$.team' },
-                    { searchValue: '{1}', replaceValue: '$.job' },
-                ],
+                    { searchValue: '{1}', replaceValue: '$.job' }
+                ]
             },
             restoreUiWhen: {
-                previousConfigPathLike: '/explore/data-jobs/:team/:job',
-            },
-        },
+                previousConfigPathLike: '/explore/data-jobs/:team/:job'
+            }
+        }
     },
     {
         path: 'explore/data-jobs/:team/:job',
         component: DataJobPageComponent,
         data: {
             teamParamKey: 'team',
-            jobParamKey: 'job',
+            jobParamKey: 'job'
         },
         children: [
             {
@@ -53,16 +53,16 @@ const routes: DataPipelinesRoutes = [
                 data: {
                     editable: false,
                     navigateBack: {
-                        path: '/explore/data-jobs',
-                    },
-                },
+                        path: '/explore/data-jobs'
+                    }
+                }
             },
             {
                 path: 'executions',
-                redirectTo: 'details',
+                redirectTo: 'details'
             },
-            { path: '**', redirectTo: 'details' },
-        ],
+            { path: '**', redirectTo: 'details' }
+        ]
     },
 
     //Manage
@@ -74,20 +74,20 @@ const routes: DataPipelinesRoutes = [
                 path: '/manage/data-jobs/{0}/{1}',
                 replacers: [
                     { searchValue: '{0}', replaceValue: '$.team' },
-                    { searchValue: '{1}', replaceValue: '$.job' },
-                ],
+                    { searchValue: '{1}', replaceValue: '$.job' }
+                ]
             },
             restoreUiWhen: {
-                previousConfigPathLike: '/manage/data-jobs/:team/:job',
-            },
-        } as DataPipelinesRoute,
+                previousConfigPathLike: '/manage/data-jobs/:team/:job'
+            }
+        } as DataPipelinesRoute
     },
     {
         path: 'manage/data-jobs/:team/:job',
         component: DataJobPageComponent,
         data: {
             teamParamKey: 'team',
-            jobParamKey: 'job',
+            jobParamKey: 'job'
         },
         children: [
             {
@@ -96,9 +96,9 @@ const routes: DataPipelinesRoutes = [
                 data: {
                     editable: true,
                     navigateBack: {
-                        path: '/manage/data-jobs',
-                    },
-                },
+                        path: '/manage/data-jobs'
+                    }
+                }
             },
             {
                 path: 'executions',
@@ -106,19 +106,19 @@ const routes: DataPipelinesRoutes = [
                 data: {
                     editable: true,
                     navigateBack: {
-                        path: '/manage/data-jobs',
-                    },
-                },
+                        path: '/manage/data-jobs'
+                    }
+                }
             },
-            { path: '**', redirectTo: 'details' },
-        ],
+            { path: '**', redirectTo: 'details' }
+        ]
     },
 
-    { path: '**', redirectTo: 'get-started' },
+    { path: '**', redirectTo: 'get-started' }
 ];
 
 @NgModule({
     imports: [RouterModule.forRoot(routes)],
-    exports: [RouterModule],
+    exports: [RouterModule]
 })
 export class AppRouting {}

--- a/projects/frontend/data-pipelines/gui/projects/ui/src/app/auth.ts
+++ b/projects/frontend/data-pipelines/gui/projects/ui/src/app/auth.ts
@@ -22,9 +22,8 @@ export const authCodeFlowConfig: AuthConfig = {
     timeoutFactor: 0.25, // For faster testing
     sessionChecksEnabled: true,
     clearHashAfterLogin: false, // https://github.com/manfredsteyer/angular-oauth2-oidc/issues/457#issuecomment-431807040,
-    logoutUrl:
-        'https://console-stg.cloud.vmware.com/csp/gateway/discovery?logout',
-    nonceStateSeparator: 'semicolon', // Real semicolon gets mangled by IdentityServer's URI encoding
+    logoutUrl: 'https://console-stg.cloud.vmware.com/csp/gateway/discovery?logout',
+    nonceStateSeparator: 'semicolon' // Real semicolon gets mangled by IdentityServer's URI encoding
 };
 
 export const refreshTokenConfig = {
@@ -32,5 +31,5 @@ export const refreshTokenConfig = {
     refreshTokenRemainingTime: 360,
 
     // Check interval (in seconds), if token refresh need to be initalized. This value must be less than refreshTokenRemainingTime
-    refreshTokenCheckInterval: 60,
+    refreshTokenCheckInterval: 60
 };

--- a/projects/frontend/data-pipelines/gui/projects/ui/src/app/getting-started/getting-started.component.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/ui/src/app/getting-started/getting-started.component.spec.ts
@@ -15,7 +15,7 @@ describe('GettingStartedComponent', () => {
         TestBed.configureTestingModule({
             declarations: [GettingStartedComponent],
             providers: [OAuthService],
-            imports: [],
+            imports: []
         }).compileComponents();
     }));
 

--- a/projects/frontend/data-pipelines/gui/projects/ui/src/app/getting-started/getting-started.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/ui/src/app/getting-started/getting-started.component.ts
@@ -8,7 +8,7 @@ import { Component } from '@angular/core';
 @Component({
     selector: 'app-getting-started',
     templateUrl: './getting-started.component.html',
-    styleUrls: ['./getting-started.component.scss'],
+    styleUrls: ['./getting-started.component.scss']
 })
 export class GettingStartedComponent {
     constructor() {

--- a/projects/frontend/data-pipelines/gui/projects/ui/src/app/http.interceptor.ts
+++ b/projects/frontend/data-pipelines/gui/projects/ui/src/app/http.interceptor.ts
@@ -4,17 +4,8 @@
  */
 
 import { Injectable, Optional } from '@angular/core';
-import {
-    OAuthModuleConfig,
-    OAuthResourceServerErrorHandler,
-    OAuthStorage,
-} from 'angular-oauth2-oidc';
-import {
-    HttpEvent,
-    HttpHandler,
-    HttpInterceptor,
-    HttpRequest,
-} from '@angular/common/http';
+import { OAuthModuleConfig, OAuthResourceServerErrorHandler, OAuthStorage } from 'angular-oauth2-oidc';
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 
 import { Observable } from 'rxjs';
 import { authCodeFlowConfig } from './auth';
@@ -24,17 +15,14 @@ export class AuthorizationInterceptor implements HttpInterceptor {
     constructor(
         private authStorage: OAuthStorage,
         private errorHandler: OAuthResourceServerErrorHandler,
-        @Optional() private moduleConfig: OAuthModuleConfig,
+        @Optional() private moduleConfig: OAuthModuleConfig
     ) {}
 
     /**
      * @inheritDoc
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    intercept(
-        req: HttpRequest<any>,
-        next: HttpHandler,
-    ): Observable<HttpEvent<any>> {
+    intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
         const url = req.url.toLowerCase();
         if (!this.moduleConfig) {
             return next.handle(req);
@@ -52,18 +40,10 @@ export class AuthorizationInterceptor implements HttpInterceptor {
             return next.handle(req);
         }
 
-        const sendAccessToken =
-            this.moduleConfig.resourceServer.sendAccessToken;
+        const sendAccessToken = this.moduleConfig.resourceServer.sendAccessToken;
 
-        if (
-            sendAccessToken &&
-            url.startsWith(authCodeFlowConfig.issuer) &&
-            url.endsWith('api/auth/token')
-        ) {
-            const headers = req.headers.set(
-                'Authorization',
-                'Basic ' + btoa(authCodeFlowConfig.clientId + ':'),
-            );
+        if (sendAccessToken && url.startsWith(authCodeFlowConfig.issuer) && url.endsWith('api/auth/token')) {
+            const headers = req.headers.set('Authorization', 'Basic ' + btoa(authCodeFlowConfig.clientId + ':'));
 
             return next.handle(req.clone({ headers }));
         } else if (sendAccessToken) {
@@ -78,9 +58,7 @@ export class AuthorizationInterceptor implements HttpInterceptor {
     }
 
     private checkUrl(url: string): boolean {
-        const found = this.moduleConfig.resourceServer.allowedUrls.find((u) =>
-            url.startsWith(u),
-        );
+        const found = this.moduleConfig.resourceServer.allowedUrls.find((u) => url.startsWith(u));
         return !!found;
     }
 }

--- a/projects/frontend/data-pipelines/gui/projects/ui/src/environments/environment.prod.ts
+++ b/projects/frontend/data-pipelines/gui/projects/ui/src/environments/environment.prod.ts
@@ -4,5 +4,5 @@
  */
 
 export const environment = {
-    production: true,
+    production: true
 };

--- a/projects/frontend/data-pipelines/gui/projects/ui/src/environments/environment.ts
+++ b/projects/frontend/data-pipelines/gui/projects/ui/src/environments/environment.ts
@@ -8,7 +8,7 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-    production: false,
+    production: false
 };
 
 /*

--- a/projects/frontend/data-pipelines/gui/projects/ui/src/test.ts
+++ b/projects/frontend/data-pipelines/gui/projects/ui/src/test.ts
@@ -7,16 +7,13 @@
 
 import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
-import {
-    BrowserDynamicTestingModule,
-    platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 
 declare const require: {
     context(
         path: string,
         deep?: boolean,
-        filter?: RegExp,
+        filter?: RegExp
     ): {
         keys(): string[];
         <T>(id: string): T;
@@ -24,13 +21,9 @@ declare const require: {
 };
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(
-    BrowserDynamicTestingModule,
-    platformBrowserDynamicTesting(),
-    {
-        teardown: { destroyAfterEach: false },
-    },
-);
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+    teardown: { destroyAfterEach: false }
+});
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.


### PR DESCRIPTION
Aligned formatting in shared and data-pipelines frontend using same configuration for prettier and .editorconfig Executed auto format on project data-pipelines.
No regression are expected, because only formatting is committed.
Tested local builds, linking built lib to UI and manual validatino on every screen, and seems there is no problems. ESLint executed successfully and there no issues.
Addressing issue #1801

---------

Signed-off-by: gorankokin <gorankokin@gmail.com>