### PR TITLE
control service: Dynamically set job base image in builder

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
@@ -141,8 +141,7 @@ public class JobImageBuilder {
     // TODO: Remove when deploymentDataJobBaseImage deprecated.
     if (jobDeployment.getPythonVersion() == null && deploymentDataJobBaseImage == null) {
       log.debug(
-              "Missing pythonVersion and deploymentDataJobBaseImage. Data Job cannot be deployed."
-      );
+          "Missing pythonVersion and deploymentDataJobBaseImage. Data Job cannot be deployed.");
       return false;
     }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
@@ -140,7 +140,7 @@ public class JobImageBuilder {
 
     // TODO: Remove when deploymentDataJobBaseImage deprecated.
     if (jobDeployment.getPythonVersion() == null && deploymentDataJobBaseImage == null) {
-      log.debug(
+      log.warn(
           "Missing pythonVersion and deploymentDataJobBaseImage. Data Job cannot be deployed.");
       return false;
     }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
@@ -262,7 +262,8 @@ public class JobImageBuilder {
     // TODO: Remove this part when datajobs.deployment.dataJobBaseImage is deprecated.
     if (deploymentDataJobBaseImage != null) {
       baseImage = deploymentDataJobBaseImage;
-    } else if (pythonVersion != null && supportedPythonVersions.isPythonVersionSupported(pythonVersion)) {
+    } else if (pythonVersion != null
+        && supportedPythonVersions.isPythonVersionSupported(pythonVersion)) {
       baseImage = supportedPythonVersions.getJobBaseImage(pythonVersion);
     } else {
       baseImage = supportedPythonVersions.getDefaultJobBaseImage();

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/SupportedPythonVersions.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/SupportedPythonVersions.java
@@ -33,6 +33,10 @@ public class SupportedPythonVersions {
   @Value("${datajobs.deployment.defaultPythonVersion}")
   private String defaultPythonVersion;
 
+  // TODO: Remove when property is deprecated.
+  @Value("${datajobs.deployment.dataJobBaseImage:python:3.9-slim}")
+  private String deploymentDataJobBaseImage;
+
   /**
    * Check if the pythonVersion passed by the user is supported by the Control Service.
    *
@@ -66,7 +70,9 @@ public class SupportedPythonVersions {
    * @return a string of the data job base image.
    */
   public String getJobBaseImage(String pythonVersion) {
-    if (isPythonVersionSupported(pythonVersion)) {
+    if (deploymentDataJobBaseImage != null) {
+      return deploymentDataJobBaseImage;
+    } else if (isPythonVersionSupported(pythonVersion)) {
       return supportedPythonVersions.get(pythonVersion).get(BASE_IMAGE);
     } else {
       log.warn(

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application-prod.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application-prod.properties
@@ -58,6 +58,8 @@ datajobs.kadmin_password=${KADMIN_PASSWORD}
 # This is the full image name of the data job builder
 datajobs.builder.image=registry.hub.docker.com/versatiledatakit/job-builder:1.1
 datajobs.deployment.dataJobBaseImage=registry.hub.docker.com/versatiledatakit/data-job-base-python-3.7:latest
+datajobs.deployment.supportedPythonVersions=${SUPPORTED_PYTHON_VERSIONS}
+datajobs.deployment.defaultPythonVersion=${DEFAULT_PYTHON_VERSION}
 
 # Path to an ini config file that contains vdk runtime options
 datajobs.vdk_options_ini=${VDK_OPTIONS_INI}

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application-prod.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application-prod.properties
@@ -58,8 +58,6 @@ datajobs.kadmin_password=${KADMIN_PASSWORD}
 # This is the full image name of the data job builder
 datajobs.builder.image=registry.hub.docker.com/versatiledatakit/job-builder:1.1
 datajobs.deployment.dataJobBaseImage=registry.hub.docker.com/versatiledatakit/data-job-base-python-3.7:latest
-datajobs.deployment.supportedPythonVersions=${SUPPORTED_PYTHON_VERSIONS}
-datajobs.deployment.defaultPythonVersion=${DEFAULT_PYTHON_VERSION}
 
 # Path to an ini config file that contains vdk runtime options
 datajobs.vdk_options_ini=${VDK_OPTIONS_INI}

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
@@ -245,7 +245,7 @@ public class JobImageBuilderTest {
     when(dockerRegistryService.builderImage()).thenReturn(TEST_BUILDER_IMAGE_NAME);
     when(kubernetesService.listJobs()).thenReturn(Collections.emptySet());
     var builderJobResult =
-            new KubernetesService.JobStatusCondition(true, "type", "test-reason", "test-message", 0);
+        new KubernetesService.JobStatusCondition(true, "type", "test-reason", "test-message", 0);
     when(kubernetesService.watchJob(any(), anyInt(), any())).thenReturn(builderJobResult);
     when(supportedPythonVersions.isPythonVersionSupported("3.11")).thenReturn(true);
     when(supportedPythonVersions.getJobBaseImage("3.11")).thenReturn("test-base-image");
@@ -261,23 +261,23 @@ public class JobImageBuilderTest {
     var result = jobImageBuilder.buildImage("test-image", testDataJob, jobDeployment, true);
 
     verify(kubernetesService)
-            .createJob(
-                    eq(TEST_BUILDER_JOB_NAME),
-                    eq(TEST_BUILDER_IMAGE_NAME),
-                    eq(false),
-                    eq(false),
-                    captor.capture(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    anyLong(),
-                    anyLong(),
-                    anyLong(),
-                    any(),
-                    any());
+        .createJob(
+            eq(TEST_BUILDER_JOB_NAME),
+            eq(TEST_BUILDER_IMAGE_NAME),
+            eq(false),
+            eq(false),
+            captor.capture(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any(),
+            any());
 
     Map<String, String> capturedEnvs = captor.getValue();
     Assertions.assertEquals("test-base-image", capturedEnvs.get("BASE_IMAGE"));
@@ -287,11 +287,12 @@ public class JobImageBuilderTest {
   }
 
   @Test
-  public void buildImage_pythonVersion_deploymentDataJobBaseImage() throws InterruptedException, ApiException, IOException {
+  public void buildImage_pythonVersion_deploymentDataJobBaseImage()
+      throws InterruptedException, ApiException, IOException {
     when(dockerRegistryService.builderImage()).thenReturn(TEST_BUILDER_IMAGE_NAME);
     when(kubernetesService.listJobs()).thenReturn(Collections.emptySet());
     var builderJobResult =
-            new KubernetesService.JobStatusCondition(true, "type", "test-reason", "test-message", 0);
+        new KubernetesService.JobStatusCondition(true, "type", "test-reason", "test-message", 0);
     when(kubernetesService.watchJob(any(), anyInt(), any())).thenReturn(builderJobResult);
 
     JobDeployment jobDeployment = new JobDeployment();
@@ -308,23 +309,23 @@ public class JobImageBuilderTest {
     verify(supportedPythonVersions, never()).getJobBaseImage("3.11");
 
     verify(kubernetesService)
-            .createJob(
-                    eq(TEST_BUILDER_JOB_NAME),
-                    eq(TEST_BUILDER_IMAGE_NAME),
-                    eq(false),
-                    eq(false),
-                    captor.capture(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    anyLong(),
-                    anyLong(),
-                    anyLong(),
-                    any(),
-                    any());
+        .createJob(
+            eq(TEST_BUILDER_JOB_NAME),
+            eq(TEST_BUILDER_IMAGE_NAME),
+            eq(false),
+            eq(false),
+            captor.capture(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any(),
+            any());
 
     Map<String, String> capturedEnvs = captor.getValue();
     Assertions.assertEquals("python:3.7-slim", capturedEnvs.get("BASE_IMAGE"));
@@ -332,5 +333,4 @@ public class JobImageBuilderTest {
     verify(kubernetesService).deleteJob(TEST_BUILDER_JOB_NAME);
     Assertions.assertTrue(result);
   }
-
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -24,6 +25,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.*;
@@ -48,6 +50,8 @@ public class JobImageBuilderTest {
   @Mock private KubernetesResources kubernetesResources;
 
   @Mock private AWSCredentialsService awsCredentialsService;
+
+  @Mock private SupportedPythonVersions supportedPythonVersions;
 
   @InjectMocks private JobImageBuilder jobImageBuilder;
 
@@ -232,4 +236,101 @@ public class JobImageBuilderTest {
             true);
     Assertions.assertFalse(result);
   }
+
+  @Test
+  public void buildImage_pythonVersion() throws InterruptedException, ApiException, IOException {
+    // Set base image property to null
+    ReflectionTestUtils.setField(jobImageBuilder, "deploymentDataJobBaseImage", null);
+
+    when(dockerRegistryService.builderImage()).thenReturn(TEST_BUILDER_IMAGE_NAME);
+    when(kubernetesService.listJobs()).thenReturn(Collections.emptySet());
+    var builderJobResult =
+            new KubernetesService.JobStatusCondition(true, "type", "test-reason", "test-message", 0);
+    when(kubernetesService.watchJob(any(), anyInt(), any())).thenReturn(builderJobResult);
+    when(supportedPythonVersions.isPythonVersionSupported("3.11")).thenReturn(true);
+    when(supportedPythonVersions.getJobBaseImage("3.11")).thenReturn("test-base-image");
+
+    JobDeployment jobDeployment = new JobDeployment();
+    jobDeployment.setDataJobName(TEST_JOB_NAME);
+    jobDeployment.setGitCommitSha("test-commit");
+    jobDeployment.setEnabled(true);
+    jobDeployment.setPythonVersion("3.11");
+
+    ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+
+    var result = jobImageBuilder.buildImage("test-image", testDataJob, jobDeployment, true);
+
+    verify(kubernetesService)
+            .createJob(
+                    eq(TEST_BUILDER_JOB_NAME),
+                    eq(TEST_BUILDER_IMAGE_NAME),
+                    eq(false),
+                    eq(false),
+                    captor.capture(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    anyLong(),
+                    anyLong(),
+                    anyLong(),
+                    any(),
+                    any());
+
+    Map<String, String> capturedEnvs = captor.getValue();
+    Assertions.assertEquals("test-base-image", capturedEnvs.get("BASE_IMAGE"));
+
+    verify(kubernetesService).deleteJob(TEST_BUILDER_JOB_NAME);
+    Assertions.assertTrue(result);
+  }
+
+  @Test
+  public void buildImage_pythonVersion_deploymentDataJobBaseImage() throws InterruptedException, ApiException, IOException {
+    when(dockerRegistryService.builderImage()).thenReturn(TEST_BUILDER_IMAGE_NAME);
+    when(kubernetesService.listJobs()).thenReturn(Collections.emptySet());
+    var builderJobResult =
+            new KubernetesService.JobStatusCondition(true, "type", "test-reason", "test-message", 0);
+    when(kubernetesService.watchJob(any(), anyInt(), any())).thenReturn(builderJobResult);
+
+    JobDeployment jobDeployment = new JobDeployment();
+    jobDeployment.setDataJobName(TEST_JOB_NAME);
+    jobDeployment.setGitCommitSha("test-commit");
+    jobDeployment.setEnabled(true);
+    jobDeployment.setPythonVersion("3.11");
+
+    ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+
+    var result = jobImageBuilder.buildImage("test-image", testDataJob, jobDeployment, true);
+
+    verify(supportedPythonVersions, never()).isPythonVersionSupported("3.11");
+    verify(supportedPythonVersions, never()).getJobBaseImage("3.11");
+
+    verify(kubernetesService)
+            .createJob(
+                    eq(TEST_BUILDER_JOB_NAME),
+                    eq(TEST_BUILDER_IMAGE_NAME),
+                    eq(false),
+                    eq(false),
+                    captor.capture(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    anyLong(),
+                    anyLong(),
+                    anyLong(),
+                    any(),
+                    any());
+
+    Map<String, String> capturedEnvs = captor.getValue();
+    Assertions.assertEquals("python:3.7-slim", capturedEnvs.get("BASE_IMAGE"));
+
+    verify(kubernetesService).deleteJob(TEST_BUILDER_JOB_NAME);
+    Assertions.assertTrue(result);
+  }
+
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
@@ -83,6 +83,7 @@ public class JobImageBuilderTest {
     var builderJobResult =
         new KubernetesService.JobStatusCondition(true, "type", "test-reason", "test-message", 0);
     when(kubernetesService.watchJob(any(), anyInt(), any())).thenReturn(builderJobResult);
+    when(supportedPythonVersions.getJobBaseImage(any())).thenReturn("python:3.7-slim");
 
     JobDeployment jobDeployment = new JobDeployment();
     jobDeployment.setDataJobName(TEST_JOB_NAME);
@@ -124,6 +125,7 @@ public class JobImageBuilderTest {
     var builderJobResult =
         new KubernetesService.JobStatusCondition(true, "type", "test-reason", "test-message", 0);
     when(kubernetesService.watchJob(any(), anyInt(), any())).thenReturn(builderJobResult);
+    when(supportedPythonVersions.getJobBaseImage(any())).thenReturn("python:3.7-slim");
 
     JobDeployment jobDeployment = new JobDeployment();
     jobDeployment.setDataJobName(TEST_JOB_NAME);
@@ -198,6 +200,7 @@ public class JobImageBuilderTest {
         new KubernetesService.JobStatusCondition(false, "type", "test-reason", "test-message", 0);
     when(kubernetesService.watchJob(any(), anyInt(), any())).thenReturn(builderJobResult);
     when(kubernetesService.getPodLogs(TEST_BUILDER_JOB_NAME)).thenReturn(TEST_BUILDER_LOGS);
+    when(supportedPythonVersions.getJobBaseImage(any())).thenReturn("python:3.7-slim");
 
     JobDeployment jobDeployment = new JobDeployment();
     jobDeployment.setDataJobName(TEST_JOB_NAME);
@@ -288,13 +291,15 @@ public class JobImageBuilderTest {
   }
 
   @Test
-  public void buildImage_shouldCreateCronjobUsingDeploymentDataJobBaseImage()
+  public void buildImage_deploymentDataJobBaseImageNotNull_shouldCreateCronjobUsingDeploymentDataJobBaseImage()
       throws InterruptedException, ApiException, IOException {
+    ReflectionTestUtils.setField(supportedPythonVersions, "deploymentDataJobBaseImage", "python:3.7-slim");
     when(dockerRegistryService.builderImage()).thenReturn(TEST_BUILDER_IMAGE_NAME);
     when(kubernetesService.listJobs()).thenReturn(Collections.emptySet());
     var builderJobResult =
         new KubernetesService.JobStatusCondition(true, "type", "test-reason", "test-message", 0);
     when(kubernetesService.watchJob(any(), anyInt(), any())).thenReturn(builderJobResult);
+    when(supportedPythonVersions.getJobBaseImage(any())).thenCallRealMethod();
 
     JobDeployment jobDeployment = new JobDeployment();
     jobDeployment.setDataJobName(TEST_JOB_NAME);
@@ -307,7 +312,6 @@ public class JobImageBuilderTest {
     var result = jobImageBuilder.buildImage("test-image", testDataJob, jobDeployment, true);
 
     verify(supportedPythonVersions, never()).isPythonVersionSupported("3.11");
-    verify(supportedPythonVersions, never()).getJobBaseImage("3.11");
 
     verify(kubernetesService)
         .createJob(

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
@@ -238,7 +238,9 @@ public class JobImageBuilderTest {
   }
 
   @Test
-  public void buildImage_deploymentDataJobBaseImageNullAndSupportedPythonVersions_shouldCreateCronjobUsingSupportedPythonVersions() throws InterruptedException, ApiException, IOException {
+  public void
+      buildImage_deploymentDataJobBaseImageNullAndSupportedPythonVersions_shouldCreateCronjobUsingSupportedPythonVersions()
+          throws InterruptedException, ApiException, IOException {
     // Set base image property to null
     ReflectionTestUtils.setField(jobImageBuilder, "deploymentDataJobBaseImage", null);
 
@@ -335,7 +337,7 @@ public class JobImageBuilderTest {
 
   @Test
   public void buildImage_deploymentDataJobBaseImageNullAndPythonVersionNull_shouldNotCreateCronjob()
-          throws InterruptedException, ApiException, IOException {
+      throws InterruptedException, ApiException, IOException {
     // Set base image property to null
     ReflectionTestUtils.setField(jobImageBuilder, "deploymentDataJobBaseImage", null);
 
@@ -350,23 +352,23 @@ public class JobImageBuilderTest {
     verify(supportedPythonVersions, never()).getJobBaseImage("3.11");
 
     verify(kubernetesService, never())
-            .createJob(
-                    eq(TEST_BUILDER_JOB_NAME),
-                    eq(TEST_BUILDER_IMAGE_NAME),
-                    eq(false),
-                    eq(false),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    anyLong(),
-                    anyLong(),
-                    anyLong(),
-                    any(),
-                    any());
+        .createJob(
+            eq(TEST_BUILDER_JOB_NAME),
+            eq(TEST_BUILDER_IMAGE_NAME),
+            eq(false),
+            eq(false),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any(),
+            any());
 
     Assertions.assertFalse(result);
   }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
@@ -291,9 +291,11 @@ public class JobImageBuilderTest {
   }
 
   @Test
-  public void buildImage_deploymentDataJobBaseImageNotNull_shouldCreateCronjobUsingDeploymentDataJobBaseImage()
-      throws InterruptedException, ApiException, IOException {
-    ReflectionTestUtils.setField(supportedPythonVersions, "deploymentDataJobBaseImage", "python:3.7-slim");
+  public void
+      buildImage_deploymentDataJobBaseImageNotNull_shouldCreateCronjobUsingDeploymentDataJobBaseImage()
+          throws InterruptedException, ApiException, IOException {
+    ReflectionTestUtils.setField(
+        supportedPythonVersions, "deploymentDataJobBaseImage", "python:3.7-slim");
     when(dockerRegistryService.builderImage()).thenReturn(TEST_BUILDER_IMAGE_NAME);
     when(kubernetesService.listJobs()).thenReturn(Collections.emptySet());
     var builderJobResult =

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/SupportedPythonVersionsTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/SupportedPythonVersionsTest.java
@@ -102,9 +102,9 @@ public class SupportedPythonVersionsTest {
 
     final String resultBaseImg = "python:3.9-slim";
     ReflectionTestUtils.setField(
-            supportedPythonVersions, SUPPORTED_PYTHON_VERSIONS, supportedVersions);
+        supportedPythonVersions, SUPPORTED_PYTHON_VERSIONS, supportedVersions);
     ReflectionTestUtils.setField(
-            supportedPythonVersions, DEPLOYMENT_DATA_JOB_BASE_IMAGE, "python:3.9-slim");
+        supportedPythonVersions, DEPLOYMENT_DATA_JOB_BASE_IMAGE, "python:3.9-slim");
 
     Assertions.assertEquals(resultBaseImg, supportedPythonVersions.getJobBaseImage("3.8"));
   }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/SupportedPythonVersionsTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/SupportedPythonVersionsTest.java
@@ -21,6 +21,7 @@ public class SupportedPythonVersionsTest {
   private static final String BASE_IMAGE = "baseImage";
   private static final String VDK_IMAGE = "vdkImage";
   private static final String DEFAULT_PYTHON_VERSION = "defaultPythonVersion";
+  private static final String DEPLOYMENT_DATA_JOB_BASE_IMAGE = "deploymentDataJobBaseImage";
 
   @InjectMocks private SupportedPythonVersions supportedPythonVersions;
 
@@ -91,6 +92,19 @@ public class SupportedPythonVersionsTest {
     final String resultBaseImg = "python:3.8-slim";
     ReflectionTestUtils.setField(
         supportedPythonVersions, SUPPORTED_PYTHON_VERSIONS, supportedVersions);
+
+    Assertions.assertEquals(resultBaseImg, supportedPythonVersions.getJobBaseImage("3.8"));
+  }
+
+  @Test
+  public void getJobBaseImage_shouldReturnDeploymentDataJobBaseImage() {
+    var supportedVersions = generateSupportedPythonVersionsConf();
+
+    final String resultBaseImg = "python:3.9-slim";
+    ReflectionTestUtils.setField(
+            supportedPythonVersions, SUPPORTED_PYTHON_VERSIONS, supportedVersions);
+    ReflectionTestUtils.setField(
+            supportedPythonVersions, DEPLOYMENT_DATA_JOB_BASE_IMAGE, "python:3.9-slim");
 
     Assertions.assertEquals(resultBaseImg, supportedPythonVersions.getJobBaseImage("3.8"));
   }


### PR DESCRIPTION
Currently, the job base image used in job builders is set in the `deploymentDataJobBaseImage` application property. This is set once at Control Service deploy and requires re-deploy of the service to be changed.

As part of the initiative to support multiple python versions for data job deployments, a new application property, `supportedPythonVersions`, was introduced in https://github.com/vmware/versatile-data-kit/commit/967898fddec3e0515f1e5817bc2211cebc1b2d92. Additionally, a new API property, `python_version` was introduced in https://github.com/vmware/versatile-data-kit/commit/5086fa3d2fde0bb9db38e3ca1928764c95cf3900 to allow users to set which python version to be used for job deployments.

With all this done, this change updates the JobImageBuilder to use the above-mentioned configuration to set the job base image dynamically, without requiring Control Service redeploy.

Testing Done: New and existing tests.