### PR TITLE
frontend: publish docker image for ui

### DIFF
--- a/projects/frontend/cicd/.gitlab-ci.yml
+++ b/projects/frontend/cicd/.gitlab-ci.yml
@@ -1,6 +1,15 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+.frontend_publish_docker_image:
+  image: docker:23.0.1
+  variables:
+    DOCKER_DRIVER: overlay2
+    DOCKER_TLS_CERTDIR: ''
+    DOCKER_HOST: tcp://localhost:2375
+  services:
+    - docker:23.0.1-dind
+
 .frontend_shared_components_changes: &frontend_shared_components_locations
   - "projects/frontend/cicd/**/*"
   - "projects/frontend/shared-components/**/*"
@@ -8,6 +17,11 @@
 .frontend_data_pipelines_changes: &frontend_data_pipelines_locations
   - "projects/frontend/cicd/**/*"
   - "projects/frontend/data-pipelines/**/*"
+
+.frontend_paths_do_not_trigger_e2e: &frontend_do_not_trigger_e2e
+  - "projects/frontend/data-pipelines/README.md"
+  - "projects/frontend/data-pipelines/gui/Dockerfile"
+  - "projects/frontend/data-pipelines/gui/config/nginx.conf"
 
 frontend-data-pipelines-build:
   image: "versatiledatakit/vdk-cicd-base-gui:2.0.0"
@@ -39,6 +53,7 @@ frontend-data-pipelines-build:
       - projects/frontend/data-pipelines/gui/node_modules/
     expire_in: 1 week
 
+# TODO: Add the cicd path back to the rule once e2e tests are stabilized
 frontend-data-pipelines-e2e-tests:
   image: "versatiledatakit/vdk-cicd-base-gui:2.0.0"
   stage: pre_release_test
@@ -48,10 +63,14 @@ frontend-data-pipelines-e2e-tests:
     - ./cicd/test_e2e_data_pipelines.sh "$VDK_API_TOKEN"
   retry: !reference [.retry, retry_options]
   rules:
+    - changes: *frontend_do_not_trigger_e2e
+      when: never
     - if: '$CI_COMMIT_BRANCH == "main" || $CI_PIPELINE_SOURCE == "external_pull_request_event"'
-      changes: *frontend_shared_components_locations
+      changes:
+        - "projects/frontend/shared-components/**/*"
     - if: '$CI_COMMIT_BRANCH == "main" || $CI_PIPELINE_SOURCE == "external_pull_request_event"'
-      changes: *frontend_data_pipelines_locations
+      changes:
+        - "projects/frontend/data-pipelines/**/*"
   artifacts:
     when: always
     paths:
@@ -82,14 +101,24 @@ frontend-data-pipelines-release:
       - projects/frontend/data-pipelines/gui/package-lock.json
     expire_in: 1 week
 
+frontend_publish_ui_image:
+  stage: release
+  before_script:
+    - cd projects/frontend
+  script:
+    - apk --no-cache add bash
+    - docker login --username "${VDK_DOCKER_REGISTRY_USERNAME}" --password "${VDK_DOCKER_REGISTRY_PASSWORD}" "${VDK_DOCKER_REGISTRY_URL}"
+    - ./cicd/publish_image_dockerhub.sh vdk-operations-ui ./data-pipelines/gui $CI_PIPELINE_ID
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes: *frontend_shared_components_locations
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes: *frontend_data_pipelines_locations
+  extends: .frontend_publish_docker_image
+
 frontend_publish_test_image:
-  image: docker:19.03.15
-  variables:
-    DOCKER_DRIVER: overlay2
-    DOCKER_TLS_CERTDIR: ''
-    DOCKER_HOST: tcp://localhost:2375
-  services:
-    - docker:19.03.15-dind
   stage: release
   script:
     - docker login --username "${VDK_DOCKER_REGISTRY_USERNAME}" --password "${VDK_DOCKER_REGISTRY_PASSWORD}" "${VDK_DOCKER_REGISTRY_URL}"
@@ -104,6 +133,7 @@ frontend_publish_test_image:
     - if: '$CI_COMMIT_BRANCH == "main"'
       changes:
         - projects/frontend/cicd/version.txt
+  extends: .frontend_publish_docker_image
 
 frontend-shared-components-build:
   image: "versatiledatakit/vdk-cicd-base-gui:2.0.0"

--- a/projects/frontend/cicd/publish_image_dockerhub.sh
+++ b/projects/frontend/cicd/publish_image_dockerhub.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+VDK_DOCKER_REGISTRY_URL=${VDK_DOCKER_REGISTRY_URL:-"registry.hub.docker.com/versatiledatakit"}
+
+[ $# -eq 0 ] && echo "ERROR: No argument for docker image name provided." && exit 1
+[ $# -eq 1 ] && echo "ERROR: No argument for UI project path provided." && exit 1
+[ $# -eq 2 ] && echo "ERROR: No argument for unique patch version provided." && exit 1
+
+name="$1"
+ui_path="$2"
+patch_version="$3"
+
+[ ! -d "$ui_path/dist/ui" ] && echo "ERROR: dist/ui directory does not exist under path $ui_path" && exit 1
+
+version_tag=$(awk -v id=$patch_version 'BEGIN { FS="."; OFS = "."; ORS = "" } { gsub("0",id,$3); print $1, $2, $3 }' $ui_path/version.txt)
+
+image_repo="$VDK_DOCKER_REGISTRY_URL/$name"
+image_tag="$image_repo:$version_tag"
+
+docker build -t "$image_tag" -t "$image_repo:latest" $ui_path
+docker push "$image_tag"
+docker push "$image_repo:latest"

--- a/projects/frontend/data-pipelines/gui/Dockerfile
+++ b/projects/frontend/data-pipelines/gui/Dockerfile
@@ -1,0 +1,8 @@
+FROM nginxinc/nginx-unprivileged:stable-alpine
+LABEL maintainer="Versatile Data Kit <join-versatiledatakit@groups.vmware.com>"
+
+# Default (prod) nginx config file
+ARG nginxConfig=nginx.conf
+
+COPY ./config/${nginxConfig} /etc/nginx/conf.d/default.conf
+COPY ./dist/ui /usr/share/nginx/html

--- a/projects/frontend/data-pipelines/gui/config/nginx.conf
+++ b/projects/frontend/data-pipelines/gui/config/nginx.conf
@@ -1,0 +1,10 @@
+server {
+    listen 8091;
+    root /usr/share/nginx/html;
+    large_client_header_buffers 4 32k;
+    add_header Strict-Transport-Security "max-age=0; includeSubDomains" always;
+
+    location / {
+        try_files $uri $uri/ /index.html =404;
+    }
+}

--- a/specs/vep-1507-vdk-operations-ui/README.md
+++ b/specs/vep-1507-vdk-operations-ui/README.md
@@ -25,6 +25,9 @@
         - [Quickstart-vdk image](#quickstart-vdk-image)
       - [Release](#release)
   - [Implementation Stories](#implementation-stories)
+>>>>>>> 9e772dc5 (frontend: create dockerfile for vdk operations ui)
+      - [Release](#release)
+  - [Implementation Stories](#implementation-stories)
 
 ## Summary
 

--- a/specs/vep-1507-vdk-operations-ui/README.md
+++ b/specs/vep-1507-vdk-operations-ui/README.md
@@ -22,6 +22,7 @@
       - [Dependency Management](#dependency-management)
       - [Build and Test](#build-and-test)
         - [e2e test image](#e2e-test-image)
+        - [Quickstart-vdk image](#quickstart-vdk-image)
       - [Release](#release)
   - [Implementation Stories](#implementation-stories)
 
@@ -469,6 +470,10 @@ packages. Merging changes into `main` requires that these pipelines pass
 successfully.
 
 ##### e2e test image
+
+Used for running end-to-end tests for the `data-pipelines` package. Exposes all
+`data-pipelines` features in order to run tests. Not user-facing.
+
 End-to-end tests have lots dependencies (browsers, build systems, etc.). Cypress
 (e2e framework) are aware of this and provide a base image. We extend the base
 image with the extra functionality we need. This extended image is used for
@@ -491,6 +496,25 @@ New versions are released by changing the version in
 
 New releases are published under the image name
 [registry.hub.docker.com/versatiledatakit/vdk-cicd-base-gui](https://hub.docker.com/r/versatiledatakit/vdk-cicd-base-gui)
+
+##### Quickstart-vdk image
+
+Dockerized VDK Operations UI for local or production use.
+
+The VDK Operations UI ships with `quickstart-vdk`. The CI/CD pipeline builds the
+image on every change to `data-pipelines` and `shared`. The image is uploaded to
+dockerhub and can then be used in the helm charts for `quickstart-vdk`.
+
+The image contains:
+
+1. An nginx server, configured to listen on port 8091
+2. The Angular UI application running on the server
+
+The actual dockerfile can be found at
+[Dockerfile](/projects/frontend/data-pipelines/gui/Dockerfile)
+
+New releases are published under the image name
+[registry.hub.docker.com/versatiledatakit/vdk-operations-ui](https://hub.docker.com/r/versatiledatakit/vdk-operations-ui)
 
 **Related Issues**
 


### PR DESCRIPTION
## Note

Stacked on top of https://github.com/vmware/versatile-data-kit/pull/1862

## Why?
    
Part of the wider effort to add the UI to quickstart-vdk
    
## What?
    
Build and publish a docker image for the UI as part
of the release step in the CI/CD pipeline. Image tags
follow the same versioning schema as the data-pipelines
package in the npm registry
    
## How has this been tested?
    
Ran the gitlab script locally

https://gitlab.com/vmware-analytics/versatile-data-kit/-/jobs/4148986837
    
## What type of change are you making?
    
New feature (non-breaking change which adds functionality)
    
Signed-off-by: Dilyan Marinov <mdilyan@vmware.com>