### PR TITLE
control-service: Add python_version to Execution API

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/ToApiModelConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/ToApiModelConverter.java
@@ -202,6 +202,7 @@ public class ToApiModelConverter {
             new DataJobDeployment()
                 .vdkVersion(jobExecutionToConvert.getVdkVersion())
                 .jobVersion(jobExecutionToConvert.getJobVersion())
+                .pythonVersion(jobExecutionToConvert.getJobPythonVersion())
                 .schedule(
                     new DataJobSchedule().scheduleCron(jobExecutionToConvert.getJobSchedule()))
                 .resources(getJobResources(jobExecutionToConvert))

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -1744,7 +1744,7 @@ public abstract class KubernetesService implements InitializingBean {
             .orElse(null));
 
     jobExecutionStatusBuilder.jobPythonVersion(
-            annotations
+        annotations
             .map(stringStringMap -> stringStringMap.get(JobAnnotation.PYTHON_VERSION.getValue()))
             .orElse(null));
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -154,6 +154,7 @@ public abstract class KubernetesService implements InitializingBean {
     OffsetDateTime endTime;
     String jobVersion;
     String jobSchedule;
+    String jobPythonVersion;
     Float resourcesCpuRequest;
     Float resourcesCpuLimit;
     Integer resourcesMemoryRequest;
@@ -1740,6 +1741,11 @@ public abstract class KubernetesService implements InitializingBean {
     jobExecutionStatusBuilder.jobSchedule(
         annotations
             .map(stringStringMap -> stringStringMap.get(JobAnnotation.SCHEDULE.getValue()))
+            .orElse(null));
+
+    jobExecutionStatusBuilder.jobPythonVersion(
+            annotations
+            .map(stringStringMap -> stringStringMap.get(JobAnnotation.PYTHON_VERSION.getValue()))
             .orElse(null));
 
     // Job status

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
@@ -332,6 +332,7 @@ public class JobExecutionService {
             .endTime(jobExecution.getEndTime())
             .vdkVersion(executionResult.getVdkVersion())
             .jobVersion(jobExecution.getJobVersion())
+            .jobPythonVersion(jobExecution.getJobPythonVersion())
             .jobSchedule(jobExecution.getJobSchedule())
             .resourcesCpuRequest(jobExecution.getResourcesCpuRequest())
             .resourcesCpuLimit(jobExecution.getResourcesCpuLimit())

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DataJobExecution.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DataJobExecution.java
@@ -50,6 +50,8 @@ public class DataJobExecution {
 
   private String jobVersion;
 
+  private String jobPythonVersion;
+
   private String jobSchedule;
 
   private Float resourcesCpuRequest;

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/db/migration/V20230410140000__add_column_job_python_version_to_data_job_execution_table.sql
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/db/migration/V20230410140000__add_column_job_python_version_to_data_job_execution_table.sql
@@ -1,0 +1,2 @@
+alter table if exists data_job_execution
+    add column if not exists job_python_version varchar;

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -106,6 +106,7 @@ public class KubernetesServiceTest {
     Assertions.assertNull(actualJobExecution.getExecutionId());
     Assertions.assertNull(actualJobExecution.getJobName());
     Assertions.assertNull(actualJobExecution.getJobVersion());
+    Assertions.assertNull(actualJobExecution.getJobPythonVersion());
     Assertions.assertNull(actualJobExecution.getDeployedDate());
     Assertions.assertNull(actualJobExecution.getExecutionType());
     Assertions.assertNull(actualJobExecution.getOpId());
@@ -123,6 +124,7 @@ public class KubernetesServiceTest {
     String dataJobName = "test-data-job";
     String kubernetesJobName = "test-job";
     String jobVersion = "1234";
+    String jobPythonVersion = "3.11";
     String deployedDate = "2021-06-15T08:04:33.534787Z";
     String deployedBy = "test-user";
     String executionType = "manual";
@@ -145,7 +147,8 @@ public class KubernetesServiceTest {
                     .putAnnotationsItem(JobAnnotation.DEPLOYED_DATE.getValue(), deployedDate)
                     .putAnnotationsItem(JobAnnotation.DEPLOYED_BY.getValue(), deployedBy)
                     .putAnnotationsItem(JobAnnotation.EXECUTION_TYPE.getValue(), executionType)
-                    .putAnnotationsItem(JobAnnotation.OP_ID.getValue(), opId))
+                    .putAnnotationsItem(JobAnnotation.OP_ID.getValue(), opId)
+                    .putAnnotationsItem(JobAnnotation.PYTHON_VERSION.getValue(), jobPythonVersion))
             .spec(
                 new V1JobSpec()
                     .template(
@@ -196,6 +199,7 @@ public class KubernetesServiceTest {
     Assertions.assertEquals(kubernetesJobName, actualJobExecution.getExecutionId());
     Assertions.assertEquals(dataJobName, actualJobExecution.getJobName());
     Assertions.assertEquals(jobVersion, actualJobExecution.getJobVersion());
+    Assertions.assertEquals(jobPythonVersion, actualJobExecution.getJobPythonVersion());
     Assertions.assertEquals(
         OffsetDateTime.parse(deployedDate), actualJobExecution.getDeployedDate());
     Assertions.assertEquals(executionType, actualJobExecution.getExecutionType());

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceUpdateExecutionIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceUpdateExecutionIT.java
@@ -390,6 +390,7 @@ public class JobExecutionServiceUpdateExecutionIT {
             .jobName(actualDataJob.getName())
             .jobVersion("test_job_version")
             .jobSchedule("test_job_schedule")
+            .jobPythonVersion("3.11")
             .startTime(OffsetDateTime.now())
             .endTime(OffsetDateTime.now())
             .resourcesCpuLimit(1f)

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceUtil.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceUtil.java
@@ -56,6 +56,8 @@ public class JobExecutionServiceUtil {
         expectedDataJobExecution.getVdkVersion(), actualDeployment.getVdkVersion());
     Assertions.assertEquals(
         expectedDataJobExecution.getJobVersion(), actualDeployment.getJobVersion());
+    Assertions.assertEquals(
+            expectedDataJobExecution.getJobPythonVersion(), actualDeployment.getPythonVersion());
 
     DataJobResources actualDeploymentResources = actualDeployment.getResources();
     Assertions.assertNotNull(actualDeploymentResources);

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceUtil.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceUtil.java
@@ -57,7 +57,7 @@ public class JobExecutionServiceUtil {
     Assertions.assertEquals(
         expectedDataJobExecution.getJobVersion(), actualDeployment.getJobVersion());
     Assertions.assertEquals(
-            expectedDataJobExecution.getJobPythonVersion(), actualDeployment.getPythonVersion());
+        expectedDataJobExecution.getJobPythonVersion(), actualDeployment.getPythonVersion());
 
     DataJobResources actualDeploymentResources = actualDeployment.getResources();
     Assertions.assertNotNull(actualDeploymentResources);


### PR DESCRIPTION
# Why
As part of the initiative to add support for multiple Python versions,  we need to extend the Execution API to return python_version for each individual execution.

# What
Added job_python_version column to the data_job_execution table and job_python_version field to all DTOs related to the Execution API.

# Test done
Unit tests. IT test will be added later since the feature for adding support for multiple Python versions is not ready for e2e testing.

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com