### PR TITLE
vdk-jupyter: remove react-test-renderer package from package.json

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package.json
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package.json
@@ -81,7 +81,6 @@
     "mkdirp": "^1.0.3",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.1.1",
-    "react-test-renderer": "^18.2.0",
     "rimraf": "^3.0.2",
     "stylelint": "^14.3.0",
     "stylelint-config-prettier": "^9.0.4",


### PR DESCRIPTION
What: 
Removed react-test-renderer package from package.json

Why:
It was unused and was causing some problems because of react version mismatch

Signed-off-by: Duygu Hasan [hduygu@vmware.com](mailto:hduygu@vmware.com)