### PR TITLE
control-service: add the frontend to helm

### DIFF
--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -108,7 +108,7 @@ control_service_integration_test:
 control_service_test_helm_chart:
   stage: build
   script:
-    - export DESIRED_VERSION=v3.11.0 # helm version 3.11.0
+    - export DESIRED_VERSION=v3.11.3 # helm version 3.11.3
     - curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
     - cd projects/control-service/projects/helm_charts/pipelines-control-service
     - helm dependency update
@@ -250,7 +250,7 @@ control_service_deploy_testing_data_pipelines:
   script:
     - apk --no-cache add bash openssl curl git gettext zip py-pip
     - pip install --upgrade pip && pip install awscli
-    - export DESIRED_VERSION=v3.11.0 # helm version 3.11.0
+    - export DESIRED_VERSION=v3.11.3 # helm version 3.11.3
     - curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
     - bash -ex ./projects/control-service/cicd/deploy-testing-pipelines-service.sh
   retry: !reference [.control_service_retry, retry_options]
@@ -291,7 +291,7 @@ control_service_release:
   script:
     - apk --no-cache add bash openssl curl git
     - export IMAGE_TAG="$(git rev-parse --short HEAD)"
-    - export DESIRED_VERSION=v3.11.0 # helm version 3.11.0
+    - export DESIRED_VERSION=v3.11.3 # helm version 3.11.3
     - export CHART_NAME=pipelines-control-service
     - export CHART_VERSION="$(cat projects/control-service/projects/helm_charts/$CHART_NAME/version.txt | grep -o '^[0-9]\+\.[0-9]\+').$CI_PIPELINE_ID"
     - curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/_helpers.tpl
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/_helpers.tpl
@@ -88,6 +88,29 @@ Also, we can't use a single if because lazy evaluation is not an option
 {{- end -}}
 {{- end -}}
 
+
+{{/*
+Return the proper operations ui image name
+*/}}
+{{- define "operations-ui.image" -}}
+{{- $globalRegistryOverrideName := .Values.image.globalRegistryOverride -}}
+{{- $registryName := .Values.operationsUi.registry -}}
+{{- $repositoryName := .Values.operationsUi.repository -}}
+{{- $tag := .Values.operationsUi.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if $globalRegistryOverrideName }}
+    {{- printf "%s/%s:%s" $globalRegistryOverrideName $repositoryName $tag -}}
+{{- else if .Values.global.imageRegistry }}
+    {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Return the proper Control Service deployment builder image name
 */}}
@@ -242,6 +265,10 @@ Image Pull Secret in json format
 
 {{- define "pipelinesControlServicePullSecretJson" }}
     {{ include "buildImagePullSecretJson" (list .Values.image.registry .Values.image.registryUsernameReadOnly .Values.image.registryPasswordReadOnly) }}
+{{- end }}
+
+{{- define "operationsUiPullSecretJson" }}
+    {{ include "buildImagePullSecretJson" (list .Values.operationsUi.registry .Values.operationsUi.username .Values.operationsUi.password) }}
 {{- end }}
 
 {{- define "builderPullSecretJson" }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/_helpers.tpl
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/_helpers.tpl
@@ -94,9 +94,9 @@ Return the proper operations ui image name
 */}}
 {{- define "operations-ui.image" -}}
 {{- $globalRegistryOverrideName := .Values.image.globalRegistryOverride -}}
-{{- $registryName := .Values.operationsUi.registry -}}
-{{- $repositoryName := .Values.operationsUi.repository -}}
-{{- $tag := .Values.operationsUi.tag | toString -}}
+{{- $registryName := .Values.operationsUi.image.registry -}}
+{{- $repositoryName := .Values.operationsUi.image.repository -}}
+{{- $tag := .Values.operationsUi.image.tag | toString -}}
 {{/*
 Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
 but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
@@ -268,7 +268,7 @@ Image Pull Secret in json format
 {{- end }}
 
 {{- define "operationsUiPullSecretJson" }}
-    {{ include "buildImagePullSecretJson" (list .Values.operationsUi.registry .Values.operationsUi.username .Values.operationsUi.password) }}
+    {{ include "buildImagePullSecretJson" (list .Values.operationsUi.image.registry .Values.operationsUi.image.username .Values.operationsUi.image.password) }}
 {{- end }}
 
 {{- define "builderPullSecretJson" }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/deployment.yaml
@@ -1,3 +1,8 @@
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-ui
+  labels:
+    app: {{ .Release.Name }}-ui
+spec:
+  replicas: {{ .Values.operationsUi.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-ui
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-ui
+    spec:
+      {{- if and (.Values.operationsUi.username) (.Values.operationsUi.password) }}
+      imagePullSecrets:
+        - name: {{ template "pipelines-control-service.fullname" . }}-operations-ui-repo-creds
+      {{- end }}
+      containers:
+        -  name: management-service-ui
+           image: {{ template "operations-ui.image" . }}
+           imagePullPolicy: Never
+           ports:
+             -  name: http
+                containerPort: 8091
+                protocol: TCP
+           livenessProbe:
+             httpGet:
+               path: /
+               port: http
+           readinessProbe:
+             httpGet:
+               path: /
+               port: http
+           resources:
+             requests:
+               memory: {{ .Values.operationsUi.resources.requests.memory }}
+               cpu: {{ .Values.operationsUi.resources.requests.cpu }}
+             limits:
+               memory: {{ .Values.operationsUi.resources.limits.memory }}
+               cpu: {{ .Values.operationsUi.resources.limits.cpu }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       labels:
         app: {{ .Release.Name }}-ui
     spec:
-      {{- if and (.Values.operationsUi.username) (.Values.operationsUi.password) }}
+      {{- if and (.Values.operationsUi.image.username) (.Values.operationsUi.image.password) }}
       imagePullSecrets:
         - name: {{ template "pipelines-control-service.fullname" . }}-operations-ui-repo-creds
       {{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/deployment.yaml
@@ -26,7 +26,6 @@ spec:
       containers:
         -  name: management-service-ui
            image: {{ template "operations-ui.image" . }}
-           imagePullPolicy: Never
            ports:
              -  name: http
                 containerPort: 8091

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/secret_pull_pipelines_control_service_img.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/secret_pull_pipelines_control_service_img.yaml
@@ -1,0 +1,16 @@
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
+
+{{- if and (.Values.operationsUi.username) (.Values.operationsUi.password) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "pipelines-control-service.fullname" . }}-operations-ui-repo-creds
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "pipelines-control-service.labels" . | nindent 4 }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "operationsUiPullSecretJson" . }}
+{{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/secret_pull_pipelines_control_service_img.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/secret_pull_pipelines_control_service_img.yaml
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: Apache-2.0
  */}}
 
-{{- if and (.Values.operationsUi.username) (.Values.operationsUi.password) }}
+{{- if and (.Values.operationsUi.image.username) (.Values.operationsUi.image.password) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/service.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/service.yaml
@@ -1,3 +1,8 @@
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/service.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+   name: {{ .Release.Name }}-ui
+   annotations:
+{{- if .Values.ingress.enabled }}
+      external-dns.alpha.kubernetes.io/hostname: {{ .Values.ingress.host | quote }}
+      external-dns.alpha.kubernetes.io/ttl: {{ .Values.operationsUi.externalDns.ttl | quote }}
+{{- end }}
+spec:
+{{- if .Values.ingress.enabled }}
+   type: ClusterIP
+{{- else }}
+   type: LoadBalancer
+{{- end }}
+   ports:
+      -  port: 80
+         targetPort: 8091
+   selector:
+      app: {{ .Release.Name }}-ui

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/ingress.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/ingress.yaml
@@ -16,7 +16,14 @@ spec:
     http:
       paths:
       - path: {{ .Values.ingress.path | default "/" }}
-        pathType: {{ .Values.ingress.pathType | default "ImplementationSpecific" }}
+        pathType: "ImplementationSpecific"
+        backend:
+          service:
+            name: {{ .Release.Name }}-ui
+            port:
+              number: 8091
+      - path: {{ .Values.ingress.path | default "/data-jobs" }}
+        pathType: "ImplementationSpecific"
         backend:
           service:
             name: {{ .Release.Name }}-svc

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -14,7 +14,7 @@ global: {}
 image:
   registry: registry.hub.docker.com/versatiledatakit
   repository: pipelines-control-service
-  tag: "1f57f0e"
+  tag: "99a4957"
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -22,6 +22,28 @@ image:
   pullPolicy: IfNotPresent
   registryUsernameReadOnly:
   registryPasswordReadOnly:
+
+
+
+
+# All config related to the operations ui lives under this tag.
+# examples of what can be configured are, what docker image to pull, how many replicas of the service to run and how many resources to give to each replica
+operationsUi:
+  registry: registry.hub.docker.com/versatiledatakit
+  repository: vdk-operations-ui
+  tag: "latest"
+  username:
+  password:
+  replicaCount: 1
+  externalDns:
+    ttl: 300
+  resources:
+    limits:
+      memory: 512Mi
+      cpu: 250m
+    requests:
+      memory: 250Mi
+      cpu: 25m
 
 # The image configuration for builder jobs used during deployment of data jobs.
 # Generally those should be left as it is.

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -29,11 +29,12 @@ image:
 # All config related to the operations ui lives under this tag.
 # examples of what can be configured are, what docker image to pull, how many replicas of the service to run and how many resources to give to each replica
 operationsUi:
-  registry: registry.hub.docker.com/versatiledatakit
-  repository: vdk-operations-ui
-  tag: "latest"
-  username:
-  password:
+  image:
+    registry: registry.hub.docker.com/versatiledatakit
+    repository: vdk-operations-ui
+    tag: "latest"
+    username:
+    password:
   replicaCount: 1
   externalDns:
     ttl: 300


### PR DESCRIPTION
# What
Within the introduction of the frontend docker image we want it to appear when ppl visit the host url.


# How
In this PR we introduce:
1. a new deployment and service to support running the frontend. 
2. an ingress rule to send requests from the root of the host to the frontend and an ingress rule to send any requests for /data-jobs to the control-service. 
3. Support for reading the frontend docker image from a private repo which is something we need within VMWare. 
4. Update the control-service to the a newer version
5. add support for basic configuration of the frontend service e.g. how much cpu the deployment is given. 


What is not in this PR:
1. passing configuration to the frontend via properties or volumeMounts.


# How has this been tested
Locally
