### PR TITLE
vdk-jupyter: add UI vdk cell marks

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/index.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/index.ts
@@ -15,6 +15,7 @@ import { FileBrowserModel, IFileBrowserFactory } from '@jupyterlab/filebrowser';
 import { IChangedArgs } from '@jupyterlab/coreutils';
 import { INotebookTracker } from '@jupyterlab/notebook';
 import { trackVdkTags } from './vdkTags';
+import { IThemeManager } from '@jupyterlab/apputils';
 
 /**
  * Current working directory in Jupyter
@@ -28,12 +29,18 @@ export let workingDirectory: string = '';
 const plugin: JupyterFrontEndPlugin<void> = {
   id: 'vdk-jupyterlab-extension:plugin',
   autoStart: true,
-  optional: [ISettingRegistry, IFileBrowserFactory, INotebookTracker],
+  optional: [
+    ISettingRegistry,
+    IFileBrowserFactory,
+    INotebookTracker,
+    IThemeManager
+  ],
   activate: async (
     app: JupyterFrontEnd,
     settingRegistry: ISettingRegistry | null,
     factory: IFileBrowserFactory,
-    notebookTracker: INotebookTracker
+    notebookTracker: INotebookTracker,
+    themeManager: IThemeManager
   ) => {
     const { commands } = app;
 
@@ -42,7 +49,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     const fileBrowser = factory.defaultBrowser;
     fileBrowser.model.pathChanged.connect(onPathChanged);
 
-    trackVdkTags(notebookTracker);
+    trackVdkTags(notebookTracker, themeManager);
   }
 };
 

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/index.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/index.ts
@@ -13,6 +13,8 @@ import { updateVDKMenu } from './commandsAndMenu';
 
 import { FileBrowserModel, IFileBrowserFactory } from '@jupyterlab/filebrowser';
 import { IChangedArgs } from '@jupyterlab/coreutils';
+import { INotebookTracker } from '@jupyterlab/notebook';
+import { trackVdkTags } from './vdkTags';
 
 /**
  * Current working directory in Jupyter
@@ -26,11 +28,12 @@ export let workingDirectory: string = '';
 const plugin: JupyterFrontEndPlugin<void> = {
   id: 'vdk-jupyterlab-extension:plugin',
   autoStart: true,
-  optional: [ISettingRegistry, IFileBrowserFactory],
+  optional: [ISettingRegistry, IFileBrowserFactory, INotebookTracker],
   activate: async (
     app: JupyterFrontEnd,
     settingRegistry: ISettingRegistry | null,
-    factory: IFileBrowserFactory
+    factory: IFileBrowserFactory,
+    notebookTracker: INotebookTracker
   ) => {
     const { commands } = app;
 
@@ -38,6 +41,8 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
     const fileBrowser = factory.defaultBrowser;
     fileBrowser.model.pathChanged.connect(onPathChanged);
+
+    trackVdkTags(notebookTracker);
   }
 };
 

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/jobData.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/jobData.ts
@@ -26,7 +26,6 @@ export function setJobDataToDefault() {
   for (const option of Object.values(VdkOption)) {
     jobData.set(option as VdkOption, '');
   }
-  console.log('I have been called');
 }
 
 /*
@@ -50,7 +49,6 @@ export function getJobDataJsonObject() {
     deploymentReason: jobData.get(VdkOption.DEPLOYMENT_REASON),
     enableDeploy: jobData.get(VdkOption.DEPLOY_ENABLE)
   };
-  console.log(jsObj);
   return jsObj;
 }
 

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/vdkTags.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/vdkTags.ts
@@ -91,7 +91,7 @@ export const trackVdkTags = (
         notebookTracker.currentWidget.model &&
         notebookTracker.currentWidget.model.cells.get(cellIndex)
       ) {
-        let currentCellTags = notebookTracker.currentWidget?.model?.cells
+        const currentCellTags = notebookTracker.currentWidget.model.cells
           .get(cellIndex)
           .metadata.get('tags')! as ReadonlyArray<String>;
         if (currentCellTags && currentCellTags.includes('vdk'))
@@ -106,7 +106,7 @@ export const trackVdkTags = (
       ) {
         addVdkCellDesign(
           notebookTracker.activeCell.node,
-          Array.from(notebookTracker.activeCell?.parent?.node.children!),
+          Array.from(notebookTracker.activeCell.parent.node.children!),
           vdkCellIndices,
           themeManager
         );

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/vdkTags.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/vdkTags.ts
@@ -65,7 +65,7 @@ const addVdkCellDesign = (
       // We do not add logo to the active cell since it blocks other UI elements
       if (cells[i] != currentCell) addVdkLogo(cells[i]);
 
-      addNumberElement(vdkCellCounter++, cells[i]);
+      addNumberElement(++vdkCellCounter, cells[i]);
     } else {
       cells[i].classList.remove('jp-vdk-cell');
       cells[i].classList.remove('jp-vdk-cell-dark');

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/vdkTags.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/vdkTags.ts
@@ -12,7 +12,24 @@ function addNumberElement(number: Number, node: Element): void {
   node.appendChild(numberElement);
 }
 
-function makeVdkCell(cells: Element[], vdkCellIndices: Array<Number>): void {
+function addVdkLogo(node: Element) {
+  const logo = document.createElement('img'); // Create an SVG element
+  logo.setAttribute(
+    'src',
+    'https://raw.githubusercontent.com/vmware/versatile-data-kit/dc15f7489f763a0e0e29370b2e06a714448fc234/support/images/versatile-data-kit-logo.svg'
+  );
+  logo.setAttribute('width', '20');
+  logo.setAttribute('height', '20');
+
+  logo.classList.add('jp-vdk-logo');
+  node.appendChild(logo);
+}
+
+function makeVdkCell(
+  currentCell: Element,
+  cells: Element[],
+  vdkCellIndices: Array<Number>
+): void {
   // delete previous numbering in case of untagging elements
   let vdkCellNums = Array.from(
     document.getElementsByClassName('jp-vdk-cell-num')
@@ -20,10 +37,16 @@ function makeVdkCell(cells: Element[], vdkCellIndices: Array<Number>): void {
   vdkCellNums.forEach(element => {
     element.remove();
   });
+  let vdkCellLogo = Array.from(document.getElementsByClassName('jp-vdk-logo'));
+  vdkCellLogo.forEach(element => {
+    element.remove();
+  });
   let vdkCellCounter = 0;
   for (let i = 0; i < cells.length; i++) {
     if (vdkCellIndices.includes(i)) {
       cells[i].classList.add('jp-vdk-cell');
+      // we do not add logo to the active cell since it blocks other UI elements
+      if (cells[i] != currentCell) addVdkLogo(cells[i]);
       addNumberElement(vdkCellCounter++, cells[i]);
     } else {
       cells[i].classList.remove('jp-vdk-cell');
@@ -47,6 +70,7 @@ export function trackVdkTags(notebookTracker: INotebookTracker): void {
       }
       if (notebookTracker.activeCell?.parent?.node.children) {
         makeVdkCell(
+          notebookTracker.activeCell.node,
           Array.from(notebookTracker.activeCell?.parent?.node.children!),
           vdkCellIndices
         );

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/vdkTags.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/vdkTags.ts
@@ -5,10 +5,19 @@
 
 import { INotebookTracker } from '@jupyterlab/notebook';
 
-function addVdkClass(cells: Element[], vdkCellIndices: Array<Number>) {
+function addNumberElement(number: Number, node: Element): void {
+  const numberElement = document.createElement('div');
+  numberElement.innerText = String(number);
+  numberElement.classList.add('jp-vdk-cell-num');
+  node.appendChild(numberElement);
+}
+
+function makeVdkCell(cells: Element[], vdkCellIndices: Array<Number>): void {
+  let vdkCellCounter = 0;
   for (let i = 0; i < cells.length; i++) {
     if (vdkCellIndices.includes(i)) {
       cells[i].classList.add('jp-vdk-cell');
+      addNumberElement(vdkCellCounter++, cells[i]);
     } else {
       cells[i].classList.remove('jp-vdk-cell');
     }
@@ -30,7 +39,7 @@ export function trackVdkTags(notebookTracker: INotebookTracker): void {
         cellIndex++;
       }
       if (notebookTracker.activeCell?.parent?.node.children) {
-        addVdkClass(
+        makeVdkCell(
           Array.from(notebookTracker.activeCell?.parent?.node.children!),
           vdkCellIndices
         );

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/vdkTags.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/vdkTags.ts
@@ -13,6 +13,13 @@ function addNumberElement(number: Number, node: Element): void {
 }
 
 function makeVdkCell(cells: Element[], vdkCellIndices: Array<Number>): void {
+  // delete previous numbering in case of untagging elements
+  let vdkCellNums = Array.from(
+    document.getElementsByClassName('jp-vdk-cell-num')
+  );
+  vdkCellNums.forEach(element => {
+    element.remove();
+  });
   let vdkCellCounter = 0;
   for (let i = 0; i < cells.length; i++) {
     if (vdkCellIndices.includes(i)) {

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/vdkTags.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/vdkTags.ts
@@ -6,15 +6,15 @@
 import { INotebookTracker } from '@jupyterlab/notebook';
 import { IThemeManager } from '@jupyterlab/apputils';
 
-function addNumberElement(number: Number, node: Element): void {
+const addNumberElement = (number: Number, node: Element) => {
   const numberElement = document.createElement('div');
   numberElement.innerText = String(number);
   numberElement.classList.add('jp-vdk-cell-num');
 
   node.appendChild(numberElement);
-}
+};
 
-function addVdkLogo(node: Element): void {
+const addVdkLogo = (node: Element) => {
   const logo = document.createElement('img');
   logo.setAttribute(
     'src',
@@ -25,16 +25,16 @@ function addVdkLogo(node: Element): void {
 
   logo.classList.add('jp-vdk-logo');
   node.appendChild(logo);
-}
+};
 
-function addVdkCellDesign(
+const addVdkCellDesign = (
   currentCell: Element,
   cells: Element[],
   vdkCellIndices: Array<Number>,
   themeManager: IThemeManager
-): void {
+) => {
   // Delete previous numbering in case of untagging elements
-  let vdkCellNums = Array.from(
+  const vdkCellNums = Array.from(
     document.getElementsByClassName('jp-vdk-cell-num')
   );
   vdkCellNums.forEach(element => {
@@ -42,7 +42,9 @@ function addVdkCellDesign(
   });
 
   // Delete previously added logo in case of untagging elements
-  let vdkCellLogo = Array.from(document.getElementsByClassName('jp-vdk-logo'));
+  const vdkCellLogo = Array.from(
+    document.getElementsByClassName('jp-vdk-logo')
+  );
   vdkCellLogo.forEach(element => {
     element.remove();
   });
@@ -50,7 +52,10 @@ function addVdkCellDesign(
   let vdkCellCounter = 0;
   for (let i = 0; i < cells.length; i++) {
     if (vdkCellIndices.includes(i)) {
-      if (themeManager.isLight(themeManager.theme?.toString()!)) {
+      if (
+        themeManager.theme &&
+        themeManager.isLight(themeManager.theme.toString())
+      ) {
         cells[i].classList.remove('jp-vdk-cell-dark');
         cells[i].classList.add('jp-vdk-cell');
       } else {
@@ -66,18 +71,26 @@ function addVdkCellDesign(
       cells[i].classList.remove('jp-vdk-cell-dark');
     }
   }
-}
+};
 
-export function trackVdkTags(
+export const trackVdkTags = (
   notebookTracker: INotebookTracker,
   themeManager: IThemeManager
-): void {
+): void => {
   const changeCells = () => {
-    if (notebookTracker.currentWidget?.model?.cells.get(0)) {
+    if (
+      notebookTracker.currentWidget &&
+      notebookTracker.currentWidget.model &&
+      notebookTracker.currentWidget.model.cells.length !== 0
+    ) {
       // Get indices of the vdk cells using cell metadata
-      let vdkCellIndices = [];
+      const vdkCellIndices = [];
       let cellIndex = 0;
-      while (notebookTracker.currentWidget?.model?.cells.get(cellIndex)) {
+      while (
+        notebookTracker.currentWidget &&
+        notebookTracker.currentWidget.model &&
+        notebookTracker.currentWidget.model.cells.get(cellIndex)
+      ) {
         let currentCellTags = notebookTracker.currentWidget?.model?.cells
           .get(cellIndex)
           .metadata.get('tags')! as ReadonlyArray<String>;
@@ -86,7 +99,11 @@ export function trackVdkTags(
         cellIndex++;
       }
 
-      if (notebookTracker.activeCell?.parent?.node.children) {
+      if (
+        notebookTracker.activeCell &&
+        notebookTracker.activeCell.parent &&
+        notebookTracker.activeCell.parent.node.children
+      ) {
         addVdkCellDesign(
           notebookTracker.activeCell.node,
           Array.from(notebookTracker.activeCell?.parent?.node.children!),
@@ -99,4 +116,4 @@ export function trackVdkTags(
 
   notebookTracker.activeCellChanged.connect(changeCells);
   themeManager.themeChanged.connect(changeCells);
-}
+};

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/vdkTags.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/vdkTags.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { INotebookTracker } from '@jupyterlab/notebook';
+
+function addVdkClass(cells: Element[], vdkCellIndices: Array<Number>) {
+  for (let i = 0; i < cells.length; i++) {
+    if (vdkCellIndices.includes(i)) {
+      cells[i].classList.add('jp-vdk-cell');
+    } else {
+      cells[i].classList.remove('jp-vdk-cell');
+    }
+  }
+}
+
+export function trackVdkTags(notebookTracker: INotebookTracker): void {
+  const handleActiveCellChanged = () => {
+    if (notebookTracker.currentWidget?.model?.cells.get(0)) {
+      let vdkCellIndices = [];
+      let cellIndex = 0;
+      while (notebookTracker.currentWidget?.model?.cells.get(cellIndex)) {
+        let currentCellTags = notebookTracker.currentWidget?.model?.cells
+          .get(cellIndex)
+          .metadata.get('tags')! as ReadonlyArray<String>;
+        if (currentCellTags && currentCellTags.includes('vdk')) {
+          vdkCellIndices.push(cellIndex);
+        }
+        cellIndex++;
+      }
+      if (notebookTracker.activeCell?.parent?.node.children) {
+        addVdkClass(
+          Array.from(notebookTracker.activeCell?.parent?.node.children!),
+          vdkCellIndices
+        );
+      }
+    }
+  };
+
+  notebookTracker.activeCellChanged.connect(handleActiveCellChanged);
+}

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/vdkTags.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/vdkTags.ts
@@ -4,16 +4,18 @@
  */
 
 import { INotebookTracker } from '@jupyterlab/notebook';
+import { IThemeManager } from '@jupyterlab/apputils';
 
 function addNumberElement(number: Number, node: Element): void {
   const numberElement = document.createElement('div');
   numberElement.innerText = String(number);
   numberElement.classList.add('jp-vdk-cell-num');
+
   node.appendChild(numberElement);
 }
 
-function addVdkLogo(node: Element) {
-  const logo = document.createElement('img'); // Create an SVG element
+function addVdkLogo(node: Element): void {
+  const logo = document.createElement('img');
   logo.setAttribute(
     'src',
     'https://raw.githubusercontent.com/vmware/versatile-data-kit/dc15f7489f763a0e0e29370b2e06a714448fc234/support/images/versatile-data-kit-logo.svg'
@@ -25,58 +27,76 @@ function addVdkLogo(node: Element) {
   node.appendChild(logo);
 }
 
-function makeVdkCell(
+function addVdkCellDesign(
   currentCell: Element,
   cells: Element[],
-  vdkCellIndices: Array<Number>
+  vdkCellIndices: Array<Number>,
+  themeManager: IThemeManager
 ): void {
-  // delete previous numbering in case of untagging elements
+  // Delete previous numbering in case of untagging elements
   let vdkCellNums = Array.from(
     document.getElementsByClassName('jp-vdk-cell-num')
   );
   vdkCellNums.forEach(element => {
     element.remove();
   });
+
+  // Delete previously added logo in case of untagging elements
   let vdkCellLogo = Array.from(document.getElementsByClassName('jp-vdk-logo'));
   vdkCellLogo.forEach(element => {
     element.remove();
   });
+
   let vdkCellCounter = 0;
   for (let i = 0; i < cells.length; i++) {
     if (vdkCellIndices.includes(i)) {
-      cells[i].classList.add('jp-vdk-cell');
-      // we do not add logo to the active cell since it blocks other UI elements
+      if (themeManager.isLight(themeManager.theme?.toString()!)) {
+        cells[i].classList.remove('jp-vdk-cell-dark');
+        cells[i].classList.add('jp-vdk-cell');
+      } else {
+        cells[i].classList.add('jp-vdk-cell');
+        cells[i].classList.add('jp-vdk-cell-dark');
+      }
+      // We do not add logo to the active cell since it blocks other UI elements
       if (cells[i] != currentCell) addVdkLogo(cells[i]);
+
       addNumberElement(vdkCellCounter++, cells[i]);
     } else {
       cells[i].classList.remove('jp-vdk-cell');
+      cells[i].classList.remove('jp-vdk-cell-dark');
     }
   }
 }
 
-export function trackVdkTags(notebookTracker: INotebookTracker): void {
-  const handleActiveCellChanged = () => {
+export function trackVdkTags(
+  notebookTracker: INotebookTracker,
+  themeManager: IThemeManager
+): void {
+  const changeCells = () => {
     if (notebookTracker.currentWidget?.model?.cells.get(0)) {
+      // Get indices of the vdk cells using cell metadata
       let vdkCellIndices = [];
       let cellIndex = 0;
       while (notebookTracker.currentWidget?.model?.cells.get(cellIndex)) {
         let currentCellTags = notebookTracker.currentWidget?.model?.cells
           .get(cellIndex)
           .metadata.get('tags')! as ReadonlyArray<String>;
-        if (currentCellTags && currentCellTags.includes('vdk')) {
+        if (currentCellTags && currentCellTags.includes('vdk'))
           vdkCellIndices.push(cellIndex);
-        }
         cellIndex++;
       }
+
       if (notebookTracker.activeCell?.parent?.node.children) {
-        makeVdkCell(
+        addVdkCellDesign(
           notebookTracker.activeCell.node,
           Array.from(notebookTracker.activeCell?.parent?.node.children!),
-          vdkCellIndices
+          vdkCellIndices,
+          themeManager
         );
       }
     }
   };
 
-  notebookTracker.activeCellChanged.connect(handleActiveCellChanged);
+  notebookTracker.activeCellChanged.connect(changeCells);
+  themeManager.themeChanged.connect(changeCells);
 }

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/base.css
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/base.css
@@ -17,7 +17,14 @@
   position: absolute;
   top: 0;
   right: 0;
-  background-color: darkblue;
+  background-color: #1e488c;
   color: aliceblue;
   padding: 4px;
+}
+
+.jp-vdk-logo {
+  position: absolute;
+  top: 0;
+  right: -5px;
+  padding-right: 25px;
 }

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/base.css
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/base.css
@@ -13,6 +13,10 @@
   --jp-cell-editor-background: rgb(240, 246, 255);
 }
 
+.jp-vdk-cell-dark {
+  --jp-cell-editor-background: rgb(6, 27, 59);
+}
+
 .jp-vdk-cell-num {
   position: absolute;
   top: 0;

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/base.css
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/base.css
@@ -10,11 +10,11 @@
 @import url('vdkDialogs.css');
 
 .jp-vdk-cell {
-  --jp-cell-editor-background: rgb(240, 246, 255);
+  --jp-cell-editor-background: rgb(240 246 255);
 }
 
 .jp-vdk-cell-dark {
-  --jp-cell-editor-background: rgb(6, 27, 59);
+  --jp-cell-editor-background: rgb(6 27 59);
 }
 
 .jp-vdk-cell-num {

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/base.css
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/base.css
@@ -8,3 +8,7 @@
     https://jupyterlab.readthedocs.io/en/stable/developer/css.html
 */
 @import url('vdkDialogs.css');
+
+.jp-vdk-cell {
+  --jp-cell-editor-background: rgb(240, 246, 255);
+}

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/base.css
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/base.css
@@ -12,3 +12,12 @@
 .jp-vdk-cell {
   --jp-cell-editor-background: rgb(240, 246, 255);
 }
+
+.jp-vdk-cell-num {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background-color: darkblue;
+  color: aliceblue;
+  padding: 4px;
+}

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/images/versatile-data-kit-logo.svg
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/images/versatile-data-kit-logo.svg
@@ -1,0 +1,254 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 25.4.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   version="1.1"
+   id="artwork"
+   x="0px"
+   y="0px"
+   viewBox="0 0 105 105"
+   style="enable-background:new 0 0 105 105;"
+   xml:space="preserve"
+   sodipodi:docname="test.svg"
+   inkscape:version="1.1 (ce6663b3b7, 2021-05-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs64" /><sodipodi:namedview
+   id="namedview62"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   showgrid="false"
+   inkscape:zoom="5.275"
+   inkscape:cx="80"
+   inkscape:cy="47.867299"
+   inkscape:window-width="1848"
+   inkscape:window-height="1016"
+   inkscape:window-x="72"
+   inkscape:window-y="27"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="artwork" />
+<style
+   type="text/css"
+   id="style2">
+	.st0{fill:#717074;}
+	.st1{fill:url(#SVGID_1_);}
+	.st2{fill:#78BE43;}
+	.st3{fill:#EC7700;}
+	.st4{fill:#1ABFD3;}
+	.st5{fill:#218FCF;}
+	.st6{fill:#FFFFFF;}
+</style>
+<!--<g>
+	<path class="st0" d="M208.3,27.2l-18.2,41.2H185l-18.2-41.2h5.1l15.7,35.5l15.6-35.5H208.3z"/>
+	<path class="st0" d="M219.3,31.7v13.6h22.4v4.4h-22.4V64h24.8v4.4h-29.6V27.2h29.6v4.4H219.3z"/>
+	<path class="st0" d="M282.5,46.7c-1.1,1.9-2.7,3.5-4.6,4.6c-2,1.2-4.3,2-6.6,2.2l10.5,14.9h-5.3L266,53.7h-9.1v14.8h-4.7V27.2H269
+		c2.7,0,5.3,0.5,7.7,1.7c2.2,1,4.1,2.7,5.5,4.7C284.7,37.6,284.8,42.6,282.5,46.7L282.5,46.7z M256.9,49.2h11.2
+		c2.9,0.1,5.8-0.7,8.2-2.3c2-1.5,3.2-3.9,3.1-6.4c0.1-2.5-1.1-4.9-3.1-6.4c-2.4-1.7-5.3-2.5-8.2-2.3h-11.2V49.2z"/>
+	<path class="st0" d="M288,62.6l3-3.7c1.8,1.8,3.8,3.3,6.1,4.4c2.3,1.1,4.8,1.6,7.4,1.6c1.8,0,3.6-0.3,5.2-1
+		c1.3-0.6,2.5-1.5,3.3-2.6c0.7-1,1.1-2.3,1.1-3.6c0.1-1.9-0.9-3.8-2.6-4.8c-2.7-1.4-5.5-2.4-8.5-3c-2.5-0.6-5-1.4-7.4-2.4
+		c-1.8-0.8-3.3-2-4.5-3.6c-1.1-1.7-1.7-3.7-1.6-5.7c0-2.1,0.6-4.2,1.8-5.9c1.3-1.8,3-3.3,5-4.2c2.2-1,4.6-1.6,7-1.5
+		c2.7,0,5.4,0.5,7.9,1.5c2.4,1.1,4.6,2.5,6.6,4.3l-2.9,3.7c-1.7-1.6-3.6-2.9-5.6-3.9c-2-0.9-4.1-1.4-6.2-1.4c-1.6,0-3.1,0.3-4.5,1
+		c-1.3,0.6-2.4,1.5-3.2,2.6c-0.7,1-1.1,2.3-1.1,3.5c-0.1,1.9,0.9,3.6,2.6,4.5c2.7,1.4,5.6,2.4,8.5,3c4.4,1,7.8,2.5,10,4.2
+		c2.3,1.9,3.6,4.7,3.5,7.7c0,2.1-0.5,4.2-1.6,6.1c-1.2,1.9-2.9,3.4-5,4.3c-2.5,1.1-5.2,1.6-7.9,1.6C298.2,69.3,292.3,66.9,288,62.6z
+		"/>
+	<path class="st0" d="M353.9,59.1h-23l-4.1,9.4h-5.1l18.2-41.2h5.1l18.2,41.2h-5.1L353.9,59.1z M352,54.7L342.5,33l-9.6,21.7
+		L352,54.7z"/>
+	<path class="st0" d="M378.2,31.7h-13.9v-4.4h32.4v4.4h-13.9v36.8h-4.7V31.7z"/>
+	<path class="st0" d="M403,27.2h4.7v41.2H403V27.2z"/>
+	<path class="st0" d="M446.1,64v4.4H419V27.2h4.7V64H446.1z"/>
+	<path class="st0" d="M457.1,31.7v13.6h22.4v4.4h-22.4V64H482v4.4h-29.6V27.2H482v4.4H457.1z"/>
+	<path class="st0" d="M171.9,92.2h13.9c4-0.1,8,0.8,11.6,2.6c3.3,1.7,6,4.2,7.9,7.3c3.8,6.6,3.8,14.7,0,21.3
+		c-1.9,3.1-4.6,5.7-7.9,7.4c-3.6,1.8-7.5,2.7-11.6,2.6h-13.9V92.2z M185.8,129.2c3.2,0.1,6.3-0.7,9.1-2.1c2.6-1.3,4.7-3.3,6.2-5.8
+		c3-5.2,3-11.7,0-16.9c-1.5-2.5-3.7-4.5-6.2-5.8c-2.8-1.4-5.9-2.2-9.1-2.1h-9.2v32.7H185.8z"/>
+	<path class="st0" d="M243.4,124.1h-23l-4.1,9.4h-5.1l18.2-41.2h5.1l18.2,41.2h-5.1L243.4,124.1z M241.5,119.7L231.9,98l-9.6,21.7
+		L241.5,119.7z"/>
+	<path class="st0" d="M267.7,96.7h-13.9v-4.4h32.4v4.4h-13.9v36.8h-4.7V96.7z"/>
+	<path class="st0" d="M318.2,124.1h-23l-4.2,9.4h-5.1l18.2-41.2h5.1l18.2,41.2h-5.1L318.2,124.1z M316.2,119.7L306.7,98l-9.6,21.7
+		L316.2,119.7z"/>
+	<path class="st0" d="M353.4,92.2h4.7v22.8L379,92.2h6.2l-17.3,18.8l18.5,22.4h-6.1l-15.7-19.2l-6.5,6.8v12.4h-4.7V92.2z"/>
+	<path class="st0" d="M395.4,92.2h4.7v41.2h-4.7V92.2z"/>
+	<path class="st0" d="M424.7,96.7h-13.9v-4.4h32.4v4.4h-13.9v36.8h-4.7V96.7z"/>
+</g>-->
+<g
+   id="g59"
+   transform="translate(-40,-27.5)">
+	<path
+   class="st0"
+   d="M 92.5,27.5 C 63.5,27.5 40,51 40,80 c 0,29 23.5,52.5 52.5,52.5 29,0 52.5,-23.5 52.5,-52.4 0,-29.1 -23.5,-52.6 -52.5,-52.6 0,0 0,0 0,0 z m 0,95.9 c -24,0 -43.5,-19.5 -43.5,-43.5 0,-24 19.5,-43.5 43.5,-43.5 24,0 43.5,19.5 43.5,43.6 0,0 0,0 0,0 0,24 -19.5,43.5 -43.5,43.4 z"
+   id="path4" />
+
+	<linearGradient
+   id="SVGID_1_"
+   gradientUnits="userSpaceOnUse"
+   x1="61.7383"
+   y1="50.2934"
+   x2="123.0984"
+   y2="111.6434"
+   gradientTransform="matrix(1,0,0,-1,0,161)">
+		<stop
+   offset="0"
+   style="stop-color:#218FCF"
+   id="stop6" />
+		<stop
+   offset="5.000000e-02"
+   style="stop-color:#207FC0"
+   id="stop8" />
+		<stop
+   offset="0.13"
+   style="stop-color:#1F69AB"
+   id="stop10" />
+		<stop
+   offset="0.23"
+   style="stop-color:#1F589B"
+   id="stop12" />
+		<stop
+   offset="0.35"
+   style="stop-color:#1E4D90"
+   id="stop14" />
+		<stop
+   offset="0.52"
+   style="stop-color:#1E468A"
+   id="stop16" />
+		<stop
+   offset="1"
+   style="stop-color:#1E4488"
+   id="stop18" />
+	</linearGradient>
+	<circle
+   class="st1"
+   cx="92.5"
+   cy="79.900002"
+   r="43.5"
+   id="circle21"
+   style="fill:url(#SVGID_1_)" />
+	<rect
+   x="110.7"
+   y="60.200001"
+   class="st2"
+   width="7.1999998"
+   height="7.1999998"
+   id="rect23" />
+	<rect
+   x="101.9"
+   y="60.200001"
+   class="st2"
+   width="7.1999998"
+   height="7.1999998"
+   id="rect25" />
+	<rect
+   x="101.8"
+   y="51.299999"
+   class="st3"
+   width="7.1999998"
+   height="7.1999998"
+   id="rect27" />
+	<rect
+   x="101.9"
+   y="42.299999"
+   class="st4"
+   width="7.1999998"
+   height="7.1999998"
+   id="rect29" />
+	<rect
+   x="101.8"
+   y="69.199997"
+   class="st5"
+   width="7.1999998"
+   height="7.1999998"
+   id="rect31" />
+	<rect
+   x="110.7"
+   y="69.199997"
+   class="st5"
+   width="7.1999998"
+   height="7.1999998"
+   id="rect33" />
+	<rect
+   x="119.7"
+   y="60.200001"
+   class="st2"
+   width="7.1999998"
+   height="7.1999998"
+   id="rect35" />
+	<rect
+   x="110.8"
+   y="51.299999"
+   class="st3"
+   width="7.1999998"
+   height="7.1999998"
+   id="rect37" />
+	<rect
+   x="119.7"
+   y="69.199997"
+   class="st5"
+   width="7.1999998"
+   height="7.1999998"
+   id="rect39" />
+	<path
+   class="st6"
+   d="M 126.5,78.3 H 102 c -1,0 -1.9,0.9 -1.9,1.9 v 3.6 c 0,1 0.9,1.9 1.9,1.9 h 2 c -0.3,2.3 -1.3,4.5 -2.9,6.1 v 0 C 97,96.4 90,96.7 85.6,92.5 83.3,90.4 82,87.4 82,84.3 V 81.3 81 64 h 1.6 c 1,0 1.9,-0.9 1.9,-1.9 v -3.6 c 0,-1 -0.9,-1.9 -1.9,-1.9 H 59.1 c -1,0 -1.9,0.9 -1.9,1.9 v 3.6 c 0,1 0.9,1.9 1.9,1.9 h 2 v 17 0.3 3 c 0,17.7 14.3,32 32,32 10.6,0 20.5,-5.3 26.5,-14.1 v 0 c 3.3,-4.9 5.2,-10.6 5.5,-16.5 h 1.5 c 1,0 1.9,-0.9 1.9,-1.9 v -3.6 c 0,-1 -0.9,-1.9 -2,-1.9 z"
+   id="path41" />
+	<rect
+   x="69.900002"
+   y="62.700001"
+   class="st2"
+   width="7.1999998"
+   height="7.1999998"
+   id="rect43" />
+	<rect
+   x="61"
+   y="42.799999"
+   class="st2"
+   width="7.1999998"
+   height="7.1999998"
+   id="rect45" />
+	<rect
+   x="72.099998"
+   y="34.299999"
+   class="st3"
+   width="7.1999998"
+   height="7.1999998"
+   id="rect47" />
+	<rect
+   x="64.199997"
+   y="53.200001"
+   class="st4"
+   width="7.1999998"
+   height="7.1999998"
+   id="rect49" />
+	<rect
+   x="69.699997"
+   y="94"
+   class="st4"
+   width="7.1999998"
+   height="7.1999998"
+   id="rect51" />
+	<rect
+   x="73.099998"
+   y="82.800003"
+   class="st5"
+   width="7.1999998"
+   height="7.1999998"
+   id="rect53" />
+	<rect
+   x="64.300003"
+   y="75.099998"
+   class="st3"
+   width="7.1999998"
+   height="7.1999998"
+   id="rect55" />
+	<rect
+   x="74.199997"
+   y="44.5"
+   class="st5"
+   width="7.1999998"
+   height="7.1999998"
+   id="rect57" />
+</g>
+</svg>

--- a/projects/vdk-plugins/vdk-notebook/src/vdk/plugin/notebook/notebook.py
+++ b/projects/vdk-plugins/vdk-notebook/src/vdk/plugin/notebook/notebook.py
@@ -81,7 +81,7 @@ class Notebook:
                         )
                         notebook_steps.append(step)
                         context.step_builder.add_step(step)
-                index += 1
+                        index += 1
 
             log.debug(f"{len(notebook_steps)} " f"cells with vdk tag were detected!")
         except json.JSONDecodeError as e:


### PR DESCRIPTION
What:
Added new design for the cells that are tagged with vdk
The new design includes different background colour of the vdk cells (light blue and dark blue), vdk logo and vdk cell numbering.
Here are the designs in light and dark mode: 
![Screenshot 2023-04-11 at 13 59 04](https://user-images.githubusercontent.com/87015481/231712470-3bddae51-cf67-4236-9953-7189cbb6b7d1.png)
![Screenshot 2023-04-13 at 10 58 56](https://user-images.githubusercontent.com/87015481/231712504-9e397938-7a65-4dbb-b169-6567ba716499.png)

Why: Up until now, we marked the cells for vdk with Jupyter tags, but they are not really user friendly - it is really easy to forget to mark something or mark something by mistake and never realise that you did it since it is really hard to track tags. With these changes it becomes really easy to see which cells are tagged and which are not which makes the UI more user-friendly and error-proof.

Tests: manual tests with dark and light mode 

Signed-off-by: Duygu Hasan [hduygu@vmware.com](mailto:hduygu@vmware.com)