### PR TITLE
vdk-frontend: remove not needed config

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/service.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/service.yaml
@@ -7,11 +7,6 @@ apiVersion: v1
 kind: Service
 metadata:
    name: {{ .Release.Name }}-ui
-   annotations:
-{{- if .Values.ingress.enabled }}
-      external-dns.alpha.kubernetes.io/hostname: {{ .Values.ingress.host | quote }}
-      external-dns.alpha.kubernetes.io/ttl: {{ .Values.operationsUi.externalDns.ttl | quote }}
-{{- end }}
 spec:
 {{- if .Values.ingress.enabled }}
    type: ClusterIP


### PR DESCRIPTION
# What
Config that was copied from the private VMWare helm charts has no purpose in the public helm chart.

# How
Here is a good blog that describes what the properties I am removing do: 
https://blog.knoldus.com/introduction-to-external-dns-in-kubernetes/
 
 As you can see they are only used if you have registered and externalDns which we have not. 
 So I am removing them to keep the code clean. 
 
 # How has this been tested? 
 Locally
 