### PR TITLE
vdk-github-workflows: ubuntu latest update

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   autoupdate:
     name: autoupdate
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: docker://chinthakagodawita/autoupdate-action:v1
         env:


### PR DESCRIPTION
An older hardcoded ubuntu was used.

Ubuntu updated to latest, in sync with the rest of the workflows.

Testing done: verified no version limitations regarding public docs.