### PR TITLE
control-service: [Bug fix] Fix supported python versions helm configuration

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -281,7 +281,7 @@ spec:
             {{- end }}
             {{- if .Values.deploymentSupportedPythonVersions }}
             - name: DATAJOBS_DEPLOYMENT_SUPPORTED_PYTHON_VERSIONS
-              value: {{ toJson .Values.deploymentSupportedPythonVersions }}
+              value: {{ .Values.deploymentSupportedPythonVersions | toJson | quote }}
             {{- end }}
 
 


### PR DESCRIPTION
A regression was introduced in the Control Service's helm chart when https://github.com/vmware/versatile-data-kit/commit/54914a09f633219081e6d8003c0c767641b597d3 was merged, which caused Control Service installation failures. The error observed at `helm upgrade` command execution is

```
Error: UPGRADE FAILED: error validating "": error validating data:
ValidationError(Deployment.spec.template.spec.containers[0].env[79].value): invalid type for
io.k8s.api.core.v1.EnvVar.value: got "map", expected "string"
```

The error was raised because the map was not properly converted to string.

This change fixes the error.

Testing Done: Executed locally `helm install ...` against a kind cluster and verified that the environment variable was properly set.
```
DATAJOBS_DEPLOYMENT_DEFAULT_PYTHON_VERSION: 3.7
DATAJOBS_DEPLOYMENT_SUPPORTED_PYTHON_VERSIONS: {"3.7":{"baseImage":"registry.hub.docker.com/versatiledatakit/data-job-base-python-3.7:latest",
"vdkImage":"registry.hub.docker.com/versatiledatakit/quickstart-vdk:release"}}
```