### PR TITLE
control-service: fix api declaration

### DIFF
--- a/projects/control-service/projects/model/apidefs/datajob-api/api.yaml
+++ b/projects/control-service/projects/model/apidefs/datajob-api/api.yaml
@@ -1238,8 +1238,7 @@ components:
     DataJobProperties:
       description: Properties of a Data Job
       type: object
-      additionalProperties:
-        type: object
+      additionalProperties: {}
       example:
         redshift-user: foo
         redshift-password: bar


### PR DESCRIPTION
# Why
This is a very subtle bug in the api declaration for the properties api.

Within the server we want to support clients sending a Map<String, Object> for properties. 
https://github.com/vmware/versatile-data-kit/blob/b2a40491d65c138411ec36d0646a870a893aed03/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/properties/controller/DataJobsPropertiesController.java#L36


Within the declaration for this endpoint we have written it as 

```yaml
type: object
additialProperties: 
     type: object
```

This is actually wrong.
Within the open api docs we can see that an object has the following definition: 

`An object is a collection of property/value pairs. The properties keyword is used to define the object properties – you need to list the property names and specify a schema for each property.`
https://swagger.io/docs/specification/data-models/data-types/#object


The confusion comes from java developers thinking that object in open api specs equates to Object in Java. 
This is sometimes true but it is a terrible way to think of object. It is more like a class or a map. 


While this is mapping to Map<String, Object> it is mapping to Map<String, Map<String, Any>> in python. 

What I have written here is more correct and results in the correct types in both java and python. 


 # How has this been tested. 
 Locally, everything looks good I just want to make this change as a standalone change as it is controversial  

