### PR TITLE
vdk-control-cli: use explicit parameter names

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli_impl.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli_impl.py
@@ -132,10 +132,10 @@ class JobDeploy:
                 "Note that your deployed job will not be scheduled and will only run when manually executed."
             )
         contacts = DataJobContacts(
-            local_config.get_contacts_notified_on_job_failure_user_error(),
-            local_config.get_contacts_notified_on_job_failure_platform_error(),
-            local_config.get_contacts_notified_on_job_success(),
-            local_config.get_contacts_notified_on_job_deploy(),
+            notified_on_job_failure_user_error=local_config.get_contacts_notified_on_job_failure_user_error(),
+            notified_on_job_failure_platform_error=local_config.get_contacts_notified_on_job_failure_platform_error(),
+            notified_on_job_success=local_config.get_contacts_notified_on_job_success(),
+            notified_on_job_deploy=local_config.get_contacts_notified_on_job_deploy(),
         )
         job.config = DataJobConfig(
             enable_execution_notifications=local_config.get_enable_execution_notifications(),


### PR DESCRIPTION
# Why
at newer versions of pydantic parameters must be declared by name. 
On the later version of the api client it will be important to have this change. 

# How has this been tested? 
tests in cicd  