### PR TITLE
control-service: new python client.

### DIFF
--- a/projects/control-service/projects/model/apidefs/build.gradle
+++ b/projects/control-service/projects/model/apidefs/build.gradle
@@ -47,10 +47,33 @@ subprojects {
     }
 
     task buildPython(type: org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
-        generatorName = "python"
+        generatorName = "python-nextgen"
         inputSpec = "$projectDir/api.yaml"
         outputDir = "$projectDir/build/python"
         configFile = "$projectDir/config-python.json"
+        doLast {
+
+            fileTree("$projectDir/build/python/taurus_datajob_api/api") {
+            }.each { File propFile ->
+                if(propFile.getName().endsWith("data_jobs_sources_api.py")) {
+                    // Everything in this section can be removed when the ticket(https://github.com/OpenAPITools/openapi-generator/issues/15327) is closed
+                    String content = propFile.getText()
+                    content = content
+                            .replace(
+                                    'def sources_upload(self, team_name : Annotated[StrictStr, Field(..., description="Team Name")], job_name : Annotated[StrictStr, Field(..., description="Data Job Name.")], body : StrictStr, reason : Annotated[Optional[StrictStr], Field(description="The reason for executing the request")] = None, **kwargs) -> DataJobVersion:  # noqa: E501',
+                                    'def sources_upload(self, team_name : Annotated[StrictStr, Field(..., description="Team Name")], job_name : Annotated[StrictStr, Field(..., description="Data Job Name.")], body : bytes, reason : Annotated[Optional[StrictStr], Field(description="The reason for executing the request")] = None, **kwargs) -> DataJobVersion:  # noqa: E501').
+                            replace('def sources_upload_with_http_info(self, team_name : Annotated[StrictStr, Field(..., description="Team Name")], job_name : Annotated[StrictStr, Field(..., description="Data Job Name.")], body : StrictStr, reason : Annotated[Optional[StrictStr], Field(description="The reason for executing the request")] = None, **kwargs):  # noqa: E501',
+                                    'def sources_upload_with_http_info(self, team_name : Annotated[StrictStr, Field(..., description="Team Name")], job_name : Annotated[StrictStr, Field(..., description="Data Job Name.")], body : bytes, reason : Annotated[Optional[StrictStr], Field(description="The reason for executing the request")] = None, **kwargs):  # noqa: E501')
+                    propFile.setText(content)
+                }else if(propFile.getName().endsWith("data_jobs_properties_api.py")) {
+                    // Everything in this section can be removed when the ticket(https://github.com/OpenAPITools/openapi-generator/issues/15328) is closed
+                    String content = propFile.getText()
+                    content = content.
+                            replace("if _params['request_body']:", "if _params['request_body'] is not None:")
+                    propFile.setText(content)
+                }
+            }
+        }
     }
     cleanUpUnwantedGeneratedFiles.dependsOn 'openApiGenerate'
     compileJava.dependsOn 'openApiGenerate' //generate Java from openapi specs

--- a/projects/control-service/projects/model/apidefs/datajob-api/config-python.json
+++ b/projects/control-service/projects/model/apidefs/datajob-api/config-python.json
@@ -1,6 +1,5 @@
 {
   "packageName": "taurus_datajob_api",
   "projectName": "vdk-control-service-api",
-  "verbose": true,
-  "packageVersion": "1.0.8"
+  "packageVersion": "1.0.9"
 }


### PR DESCRIPTION
# Why 
The newest python api client is broken and the last working one is very old. 

# What
In this PR I use the python-nextgen generator instead of the python generator. The behaviour is much more correct and predictable. 

There are two bugs in the generated code. 
For both these I have created tickets in the openapi generator github project.

I have added string replace workarounds in the gradle step to fix these bugs before we publish the pip package. 


next steps(will be tackled in the next few weeks not days): https://github.com/vmware/versatile-data-kit/issues/1982 

closes: https://github.com/vmware/versatile-data-kit/issues/1979


# How has this been tested? 
Locally. 
There is actually a draft branch where I import this new version into the cli project and run tests against it to confirm everything is green: https://github.com/vmware/versatile-data-kit/pull/1969

This will always fail in github because 1.0.9 is not released yet till this PR is merged. Then I will open a new PR where I import into cli tool.
 

