### PR TITLE
control-service: Rework supported python version logic

### DIFF
--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/security/SecurityConfiguration.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/security/SecurityConfiguration.java
@@ -217,6 +217,7 @@ public class SecurityConfiguration {
     }
     return Collections.emptySet();
   }
+
   /*
      KERBEROS config settings, a lot of these are optional.
   */

--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/telemetry/Telemetry.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/service/diag/telemetry/Telemetry.java
@@ -33,6 +33,7 @@ public class Telemetry implements ITelemetry {
       log.info("Telemetry endpoint is empty and sending telemetry is skipped");
     }
   }
+
   // TODO: add support for buffering, re-tries (with back-off)
   private final String telemetryEndpoint;
   private final HttpClient client;

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -300,17 +300,18 @@ deploymentDataJobBaseImage:
 ## Only the installed python modules (vdk and its dependencies) will be used from the image.
 ## Everything else is effectively discarded since another image is used as base during execution.
 ##
-## Example: {"3.9": {"baseImage": "python:3.9-latest", "vdkImage": "example-registry.com/some-user/vdk:3.9-release"}}
-deploymentSupportedPythonVersions:
-  3.7:
-    baseImage: "registry.hub.docker.com/versatiledatakit/data-job-base-python-3.7:latest"
-    vdkImage: "registry.hub.docker.com/versatiledatakit/quickstart-vdk:release"
+## Example:
+## deploymentSupportedPythonVersions:
+##   3.7:
+##     baseImage: "registry.hub.docker.com/versatiledatakit/data-job-base-python-3.7:latest"
+##     vdkImage: "registry.hub.docker.com/versatiledatakit/quickstart-vdk:release"
+deploymentSupportedPythonVersions: {}
 
 
 ## Default python version to be used for data job deployments. The value should be a string and would be
 ## used when a user has not provided a specific python_version for their data job's deployment.
 ## Example: "3.9"
-deploymentDefaultPythonVersion: "3.7"
+deploymentDefaultPythonVersion: ""
 
 ## ini formatted options that provides default and per-job VDK options.
 ## Allows to provide VDK configuration via environment variables.

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
@@ -326,12 +326,15 @@ public class JobImageDeployer {
 
   private String getJobVdkImage(JobDeployment jobDeployment) {
     // TODO: Refactor when vdkImage is deprecated.
-    if (StringUtils.isNotBlank(jobDeployment.getVdkVersion()) && StringUtils.isNotBlank(vdkImage)) {
-      return DockerImageName.updateImageWithTag(vdkImage, jobDeployment.getVdkVersion());
+    if (!supportedPythonVersions.getSupportedPythonVersions().isEmpty()
+            && supportedPythonVersions.isPythonVersionSupported(jobDeployment.getPythonVersion())) {
+      return supportedPythonVersions.getVdkImage(jobDeployment.getPythonVersion());
     } else {
-      return vdkImage != null && !vdkImage.isBlank()
-          ? vdkImage
-          : supportedPythonVersions.getVdkImage(jobDeployment.getPythonVersion());
+      if (StringUtils.isNotBlank(jobDeployment.getVdkVersion()) && StringUtils.isNotBlank(vdkImage)) {
+        return DockerImageName.updateImageWithTag(vdkImage, jobDeployment.getVdkVersion());
+      } else {
+        return vdkImage;
+      }
     }
   }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
@@ -327,10 +327,11 @@ public class JobImageDeployer {
   private String getJobVdkImage(JobDeployment jobDeployment) {
     // TODO: Refactor when vdkImage is deprecated.
     if (!supportedPythonVersions.getSupportedPythonVersions().isEmpty()
-            && supportedPythonVersions.isPythonVersionSupported(jobDeployment.getPythonVersion())) {
+        && supportedPythonVersions.isPythonVersionSupported(jobDeployment.getPythonVersion())) {
       return supportedPythonVersions.getVdkImage(jobDeployment.getPythonVersion());
     } else {
-      if (StringUtils.isNotBlank(jobDeployment.getVdkVersion()) && StringUtils.isNotBlank(vdkImage)) {
+      if (StringUtils.isNotBlank(jobDeployment.getVdkVersion())
+          && StringUtils.isNotBlank(vdkImage)) {
         return DockerImageName.updateImageWithTag(vdkImage, jobDeployment.getVdkVersion());
       } else {
         return vdkImage;

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/SupportedPythonVersions.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/SupportedPythonVersions.java
@@ -70,10 +70,10 @@ public class SupportedPythonVersions {
    * @return a string of the data job base image.
    */
   public String getJobBaseImage(String pythonVersion) {
-    if (deploymentDataJobBaseImage != null && !deploymentDataJobBaseImage.isBlank()) {
-      return deploymentDataJobBaseImage;
-    } else if (isPythonVersionSupported(pythonVersion)) {
+    if (isPythonVersionSupported(pythonVersion)) {
       return supportedPythonVersions.get(pythonVersion).get(BASE_IMAGE);
+    } else if (deploymentDataJobBaseImage != null && !deploymentDataJobBaseImage.isBlank()) {
+      return deploymentDataJobBaseImage;
     } else {
       log.warn(
           "An issue with the passed pythonVersion or supportedPythonVersions configuration has"

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -126,10 +126,10 @@ datajobs.deployment.dataJobBaseImage=python:3.9-slim
 
 # The map of python version and respective data job base and vdk images that would be
 # used for data job deployments
-datajobs.deployment.supportedPythonVersions=${DATAJOBS_DEPLOYMENT_SUPPORTED_PYTHON_VERSIONS:{3.9: {vdkImage: 'registry.hub.docker.com/versatiledatakit/quickstart-vdk:release', baseImage: 'python:3.9-slim'}}}
+datajobs.deployment.supportedPythonVersions=${DATAJOBS_DEPLOYMENT_SUPPORTED_PYTHON_VERSIONS}
 # The default python version, which is to be used when selecting the vdk and job base images from
 # the supportedPythonVersions for data job deployments
-datajobs.deployment.defaultPythonVersion=${DATAJOBS_DEPLOYMENT_DEFAULT_PYTHON_VERSION:3.9}
+datajobs.deployment.defaultPythonVersion=${DATAJOBS_DEPLOYMENT_DEFAULT_PYTHON_VERSION}
 
 #Configuration variables used for data job execution cleanup
 #This is a spring cron expression, used to schedule the clean up job / default is every 3 hours

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
@@ -299,7 +299,7 @@ public class JobImageBuilderTest {
     when(dockerRegistryService.builderImage()).thenReturn(TEST_BUILDER_IMAGE_NAME);
     when(kubernetesService.listJobs()).thenReturn(Collections.emptySet());
     var builderJobResult =
-            new KubernetesService.JobStatusCondition(true, "type", "test-reason", "test-message", 0);
+        new KubernetesService.JobStatusCondition(true, "type", "test-reason", "test-message", 0);
     when(kubernetesService.watchJob(any(), anyInt(), any())).thenReturn(builderJobResult);
     when(supportedPythonVersions.getJobBaseImage("3.11")).thenReturn("test-base-image");
 
@@ -314,23 +314,23 @@ public class JobImageBuilderTest {
     var result = jobImageBuilder.buildImage("test-image", testDataJob, jobDeployment, true);
 
     verify(kubernetesService)
-            .createJob(
-                    eq(TEST_BUILDER_JOB_NAME),
-                    eq(TEST_BUILDER_IMAGE_NAME),
-                    eq(false),
-                    eq(false),
-                    captor.capture(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    anyLong(),
-                    anyLong(),
-                    anyLong(),
-                    any(),
-                    any());
+        .createJob(
+            eq(TEST_BUILDER_JOB_NAME),
+            eq(TEST_BUILDER_IMAGE_NAME),
+            eq(false),
+            eq(false),
+            captor.capture(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any(),
+            any());
 
     Map<String, String> capturedEnvs = captor.getValue();
     Assertions.assertEquals("test-base-image", capturedEnvs.get("BASE_IMAGE"));

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
@@ -292,16 +292,16 @@ public class JobImageBuilderTest {
 
   @Test
   public void
-      buildImage_deploymentDataJobBaseImageNotNull_shouldCreateCronjobUsingDeploymentDataJobBaseImage()
+      buildImage_deploymentDataJobBaseImageNotNull_shouldCreateCronjobUsingSupportedPythonVersions()
           throws InterruptedException, ApiException, IOException {
     ReflectionTestUtils.setField(
         supportedPythonVersions, "deploymentDataJobBaseImage", "python:3.7-slim");
     when(dockerRegistryService.builderImage()).thenReturn(TEST_BUILDER_IMAGE_NAME);
     when(kubernetesService.listJobs()).thenReturn(Collections.emptySet());
     var builderJobResult =
-        new KubernetesService.JobStatusCondition(true, "type", "test-reason", "test-message", 0);
+            new KubernetesService.JobStatusCondition(true, "type", "test-reason", "test-message", 0);
     when(kubernetesService.watchJob(any(), anyInt(), any())).thenReturn(builderJobResult);
-    when(supportedPythonVersions.getJobBaseImage(any())).thenCallRealMethod();
+    when(supportedPythonVersions.getJobBaseImage("3.11")).thenReturn("test-base-image");
 
     JobDeployment jobDeployment = new JobDeployment();
     jobDeployment.setDataJobName(TEST_JOB_NAME);
@@ -313,29 +313,27 @@ public class JobImageBuilderTest {
 
     var result = jobImageBuilder.buildImage("test-image", testDataJob, jobDeployment, true);
 
-    verify(supportedPythonVersions, never()).isPythonVersionSupported("3.11");
-
     verify(kubernetesService)
-        .createJob(
-            eq(TEST_BUILDER_JOB_NAME),
-            eq(TEST_BUILDER_IMAGE_NAME),
-            eq(false),
-            eq(false),
-            captor.capture(),
-            any(),
-            any(),
-            any(),
-            any(),
-            any(),
-            any(),
-            anyLong(),
-            anyLong(),
-            anyLong(),
-            any(),
-            any());
+            .createJob(
+                    eq(TEST_BUILDER_JOB_NAME),
+                    eq(TEST_BUILDER_IMAGE_NAME),
+                    eq(false),
+                    eq(false),
+                    captor.capture(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    anyLong(),
+                    anyLong(),
+                    anyLong(),
+                    any(),
+                    any());
 
     Map<String, String> capturedEnvs = captor.getValue();
-    Assertions.assertEquals("python:3.7-slim", capturedEnvs.get("BASE_IMAGE"));
+    Assertions.assertEquals("test-base-image", capturedEnvs.get("BASE_IMAGE"));
 
     verify(kubernetesService).deleteJob(TEST_BUILDER_JOB_NAME);
     Assertions.assertTrue(result);

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/SupportedPythonVersionsTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/SupportedPythonVersionsTest.java
@@ -100,7 +100,7 @@ public class SupportedPythonVersionsTest {
   public void getJobBaseImage_shouldReturnDeploymentDataJobBaseImage() {
     var supportedVersions = generateSupportedPythonVersionsConf();
 
-    final String resultBaseImg = "python:3.9-slim";
+    final String resultBaseImg = "python:3.8-slim";
     ReflectionTestUtils.setField(
         supportedPythonVersions, SUPPORTED_PYTHON_VERSIONS, supportedVersions);
     ReflectionTestUtils.setField(


### PR DESCRIPTION
Currently, there are two groups of configurations to set the vdk and job base images used in data job deployments. The old way, through the `datajobs.deployment.dataJobBaseImage` and `datajobs.vdk.image`, and the new way, through the support for multiple python versions in data job deployments.

The two groups of configurations are in conflict, as the old configuration options take precedence and cleanly migrating to the support for multiple python versions is practically impossible.

This change removes the default values for the `datajobs.deployment.supportedPythonVersions` and `datajobs.deployment.defaultPythonVersion` properties, and updates the service logic so that when these properties are set in an environment, they take precedence over the old configuration.

Testing Done: CI/CD