### PR TITLE
control-service: custom app config values can we passed to helm.

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/configmap.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ui-config
+data:
+  config.json: {{ .Values.operationsUi.config | toJson }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/deployment.yaml
@@ -45,3 +45,11 @@ spec:
              limits:
                memory: {{ .Values.operationsUi.resources.limits.memory }}
                cpu: {{ .Values.operationsUi.resources.limits.cpu }}
+           volumeMounts:
+             - name: config-volume
+               mountPath: /usr/share/nginx/html/assets/data/appConfig.json
+               subPath: config.json
+      volumes:
+        - name: config-volume
+          configMap:
+            name: ui-config

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -43,6 +43,8 @@ operationsUi:
     requests:
       memory: 250Mi
       cpu: 25m
+  config: '{"auth": {"skipAuth": true}}'
+
 
 # The image configuration for builder jobs used during deployment of data jobs.
 # Generally those should be left as it is.


### PR DESCRIPTION
# Why
We want to be able to change the frontend config depending on the situation it is deployed in. 
This lets users provide their own appConfig file to the frontend. 
An example of this is toggling auth on and off. 

# What
Use k8s volumemounts to load in the config file.

# How has this been tested?
Deployed the helm locally. 

