### PR TITLE
vdk-dag: Drop deprecation warnings

### DIFF
--- a/projects/vdk-plugins/vdk-dag/README.md
+++ b/projects/vdk-plugins/vdk-dag/README.md
@@ -1,7 +1,5 @@
 # VDK DAGs
 
-## This plugin has been deprecated. Please use vdk-dag instead. You may install it by running `pip install vdk-dag`.
-
 Express dependencies between data jobs.
 
 A plugin for Versatile Data Kit extends its Job API with an additional feature that allows users to trigger so-called VDK DAGs.

--- a/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/dag.py
+++ b/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/dag.py
@@ -29,12 +29,6 @@ class Dag:
         :param team_name: the name of the owning team
         :param dags_config: the DAG job configuration
         """
-        log.warning(
-            "-------------------------------------------"
-            "This plugin has been deprecated. Please use vdk-dag instead. "
-            "You may install it by running `pip install vdk-dag`."
-            "-------------------------------------------"
-        )
         self._team_name = team_name
         self._topological_sorter = TopologicalSorter()
         self._delayed_starting_jobs = TimeBasedQueue(


### PR DESCRIPTION
Deprecation warnings were accidentally left in when renaming the plugin.

Testing done: trivial