### PR TITLE
control-service: Fix backwards-compatibility issues

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -302,17 +302,18 @@ deploymentDataJobBaseImage:
 ## Only the installed python modules (vdk and its dependencies) will be used from the image.
 ## Everything else is effectively discarded since another image is used as base during execution.
 ##
-## Example: {"3.9": {"baseImage": "python:3.9-latest", "vdkImage": "example-registry.com/some-user/vdk:3.9-release"}}
-deploymentSupportedPythonVersions:
-  3.7:
-    baseImage: "registry.hub.docker.com/versatiledatakit/data-job-base-python-3.7:latest"
-    vdkImage: "registry.hub.docker.com/versatiledatakit/quickstart-vdk:release"
+## Example:
+## deploymentSupportedPythonVersions:
+##   3.7:
+##     baseImage: "registry.hub.docker.com/versatiledatakit/data-job-base-python-3.7:latest"
+##     vdkImage: "registry.hub.docker.com/versatiledatakit/quickstart-vdk:release"
+deploymentSupportedPythonVersions: {}
 
 
 ## Default python version to be used for data job deployments. The value should be a string and would be
 ## used when a user has not provided a specific python_version for their data job's deployment.
 ## Example: "3.9"
-deploymentDefaultPythonVersion: "3.7"
+deploymentDefaultPythonVersion: ""
 
 ## ini formatted options that provides default and per-job VDK options.
 ## Allows to provide VDK configuration via environment variables.

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentService.java
@@ -273,8 +273,7 @@ public class DeploymentService {
         || readDeployment(dataJobName).isPresent();
   }
 
-  private void setPythonVersionIfNull(
-      JobDeployment oldDeployment, JobDeployment newDeployment) {
+  private void setPythonVersionIfNull(JobDeployment oldDeployment, JobDeployment newDeployment) {
     if (oldDeployment.getPythonVersion() == null && newDeployment.getPythonVersion() == null) {
       newDeployment.setPythonVersion(supportedPythonVersions.getDefaultPythonVersion());
     }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentService.java
@@ -68,7 +68,6 @@ public class DeploymentService {
       var oldDeployment =
           DeploymentModelConverter.toJobDeployment(
               dataJob.getJobConfig().getTeam(), dataJob.getName(), deploymentStatus.get());
-      setPythonVersionIfNull(oldDeployment, jobDeployment);
       var mergedDeployment =
           DeploymentModelConverter.mergeDeployments(oldDeployment, jobDeployment);
       validateFieldsCanBePatched(oldDeployment, mergedDeployment);
@@ -274,11 +273,10 @@ public class DeploymentService {
         || readDeployment(dataJobName).isPresent();
   }
 
-  private JobDeployment setPythonVersionIfNull(
+  private void setPythonVersionIfNull(
       JobDeployment oldDeployment, JobDeployment newDeployment) {
     if (oldDeployment.getPythonVersion() == null && newDeployment.getPythonVersion() == null) {
       newDeployment.setPythonVersion(supportedPythonVersions.getDefaultPythonVersion());
     }
-    return newDeployment;
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
@@ -316,12 +316,16 @@ public class JobImageDeployer {
 
   private String getJobVdkImage(JobDeployment jobDeployment) {
     // TODO: Refactor when vdkImage is deprecated.
-    if (StringUtils.isNotBlank(jobDeployment.getVdkVersion()) && StringUtils.isNotBlank(vdkImage)) {
-      return DockerImageName.updateImageWithTag(vdkImage, jobDeployment.getVdkVersion());
+    if (!supportedPythonVersions.getSupportedPythonVersions().isEmpty()
+            && supportedPythonVersions.isPythonVersionSupported(jobDeployment.getPythonVersion())) {
+      return supportedPythonVersions.getVdkImage(jobDeployment.getPythonVersion());
     } else {
-      return vdkImage != null && !vdkImage.isBlank()
-          ? vdkImage
-          : supportedPythonVersions.getVdkImage(jobDeployment.getPythonVersion());
+      if (StringUtils.isNotBlank(jobDeployment.getVdkVersion())
+              && StringUtils.isNotBlank(vdkImage)) {
+        return DockerImageName.updateImageWithTag(vdkImage, jobDeployment.getVdkVersion());
+      } else {
+        return vdkImage;
+      }
     }
   }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
@@ -317,11 +317,11 @@ public class JobImageDeployer {
   private String getJobVdkImage(JobDeployment jobDeployment) {
     // TODO: Refactor when vdkImage is deprecated.
     if (!supportedPythonVersions.getSupportedPythonVersions().isEmpty()
-            && supportedPythonVersions.isPythonVersionSupported(jobDeployment.getPythonVersion())) {
+        && supportedPythonVersions.isPythonVersionSupported(jobDeployment.getPythonVersion())) {
       return supportedPythonVersions.getVdkImage(jobDeployment.getPythonVersion());
     } else {
       if (StringUtils.isNotBlank(jobDeployment.getVdkVersion())
-              && StringUtils.isNotBlank(vdkImage)) {
+          && StringUtils.isNotBlank(vdkImage)) {
         return DockerImageName.updateImageWithTag(vdkImage, jobDeployment.getVdkVersion());
       } else {
         return vdkImage;

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/SupportedPythonVersions.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/SupportedPythonVersions.java
@@ -70,10 +70,10 @@ public class SupportedPythonVersions {
    * @return a string of the data job base image.
    */
   public String getJobBaseImage(String pythonVersion) {
-    if (deploymentDataJobBaseImage != null && !deploymentDataJobBaseImage.isBlank()) {
-      return deploymentDataJobBaseImage;
-    } else if (isPythonVersionSupported(pythonVersion)) {
+    if (supportedPythonVersions != null && isPythonVersionSupported(pythonVersion)) {
       return supportedPythonVersions.get(pythonVersion).get(BASE_IMAGE);
+    } else if (deploymentDataJobBaseImage != null && !deploymentDataJobBaseImage.isBlank()) {
+      return deploymentDataJobBaseImage;
     } else {
       log.warn(
           "An issue with the passed pythonVersion or supportedPythonVersions configuration has"

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -126,10 +126,10 @@ datajobs.deployment.dataJobBaseImage=python:3.9-slim
 
 # The map of python version and respective data job base and vdk images that would be
 # used for data job deployments
-datajobs.deployment.supportedPythonVersions=${DATAJOBS_DEPLOYMENT_SUPPORTED_PYTHON_VERSIONS:{3.9: {vdkImage: 'registry.hub.docker.com/versatiledatakit/quickstart-vdk:release', baseImage: 'python:3.9-slim'}}}
+datajobs.deployment.supportedPythonVersions=${DATAJOBS_DEPLOYMENT_SUPPORTED_PYTHON_VERSIONS:{}}
 # The default python version, which is to be used when selecting the vdk and job base images from
 # the supportedPythonVersions for data job deployments
-datajobs.deployment.defaultPythonVersion=${DATAJOBS_DEPLOYMENT_DEFAULT_PYTHON_VERSION:3.9}
+datajobs.deployment.defaultPythonVersion=${DATAJOBS_DEPLOYMENT_DEFAULT_PYTHON_VERSION:#{null}}
 
 #Configuration variables used for data job execution cleanup
 #This is a spring cron expression, used to schedule the clean up job / default is every 3 hours

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
@@ -357,37 +357,42 @@ public class DeploymentServiceTest {
     jobDeployment.setEnabled(true);
     jobDeployment.setPythonVersion("3.10");
 
-    ApiConstraintError error = assertThrows(ApiConstraintError.class, () -> { deploymentService.patchDeployment(testDataJob, jobDeployment); });
+    ApiConstraintError error =
+        assertThrows(
+            ApiConstraintError.class,
+            () -> {
+              deploymentService.patchDeployment(testDataJob, jobDeployment);
+            });
     assertThat(error.getErrorMessage().toString(), containsString("python_version is not valid"));
 
     verify(kubernetesService, never())
-            .updateCronJob(
-                    any(),
-                    any(),
-                    any(),
-                    anyString(),
-                    anyBoolean(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any());
+        .updateCronJob(
+            any(),
+            any(),
+            any(),
+            anyString(),
+            anyBoolean(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
     verify(kubernetesService, never())
-            .createCronJob(
-                    any(),
-                    any(),
-                    any(),
-                    anyString(),
-                    anyBoolean(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any());
+        .createCronJob(
+            any(),
+            any(),
+            any(),
+            anyString(),
+            anyBoolean(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
   }
 
   @Test

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
@@ -350,7 +350,7 @@ public class DeploymentServiceTest {
   }
 
   @Test
-  public void patchDeployment_setPythonVersion_failPatch() throws ApiException, ApiConstraintError {
+  public void patchDeployment_notValidPythonVersion_shouldFail() throws ApiException, ApiConstraintError {
     JobDeployment jobDeployment = new JobDeployment();
     jobDeployment.setDataJobTeam(testDataJob.getJobConfig().getTeam());
     jobDeployment.setDataJobName(testDataJob.getName());

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
@@ -6,6 +6,7 @@
 package com.vmware.taurus.service.deploy;
 
 import com.vmware.taurus.datajobs.TestUtils;
+import com.vmware.taurus.exception.ApiConstraintError;
 import com.vmware.taurus.service.JobsRepository;
 import com.vmware.taurus.service.KubernetesService;
 import com.vmware.taurus.service.credentials.JobCredentialsService;
@@ -19,6 +20,8 @@ import io.kubernetes.client.openapi.ApiException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -34,6 +37,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -343,6 +347,47 @@ public class DeploymentServiceTest {
         .updateCronJob(any(), any(), anyString(), anyBoolean(), any(), any(), any(), any());
     verify(kubernetesService, never())
         .createCronJob(any(), any(), anyString(), anyBoolean(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void patchDeployment_setPythonVersion_failPatch() throws ApiException, ApiConstraintError {
+    JobDeployment jobDeployment = new JobDeployment();
+    jobDeployment.setDataJobTeam(testDataJob.getJobConfig().getTeam());
+    jobDeployment.setDataJobName(testDataJob.getName());
+    jobDeployment.setEnabled(true);
+    jobDeployment.setPythonVersion("3.10");
+
+    ApiConstraintError error = assertThrows(ApiConstraintError.class, () -> { deploymentService.patchDeployment(testDataJob, jobDeployment); });
+    assertThat(error.getErrorMessage().toString(), containsString("python_version is not valid"));
+
+    verify(kubernetesService, never())
+            .updateCronJob(
+                    any(),
+                    any(),
+                    any(),
+                    anyString(),
+                    anyBoolean(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any());
+    verify(kubernetesService, never())
+            .createCronJob(
+                    any(),
+                    any(),
+                    any(),
+                    anyString(),
+                    anyBoolean(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any());
   }
 
   @Test

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
@@ -369,7 +369,6 @@ public class DeploymentServiceTest {
         .updateCronJob(
             any(),
             any(),
-            any(),
             anyString(),
             anyBoolean(),
             any(),
@@ -381,7 +380,6 @@ public class DeploymentServiceTest {
             any());
     verify(kubernetesService, never())
         .createCronJob(
-            any(),
             any(),
             any(),
             anyString(),

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
@@ -350,7 +350,8 @@ public class DeploymentServiceTest {
   }
 
   @Test
-  public void patchDeployment_notValidPythonVersion_shouldFail() throws ApiException, ApiConstraintError {
+  public void patchDeployment_notValidPythonVersion_shouldFail()
+      throws ApiException, ApiConstraintError {
     JobDeployment jobDeployment = new JobDeployment();
     jobDeployment.setDataJobTeam(testDataJob.getJobConfig().getTeam());
     jobDeployment.setDataJobName(testDataJob.getName());

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
@@ -292,12 +292,12 @@ public class JobImageBuilderTest {
 
   @Test
   public void
-  buildImage_deploymentDataJobBaseImageNotNull_shouldCreateCronjobUsingSupportedPythonVersions()
+      buildImage_deploymentDataJobBaseImageNotNull_shouldCreateCronjobUsingSupportedPythonVersions()
           throws InterruptedException, ApiException, IOException {
     ReflectionTestUtils.setField(
         supportedPythonVersions, "deploymentDataJobBaseImage", "python:3.7-slim");
     ReflectionTestUtils.setField(
-            supportedPythonVersions, "supportedPythonVersions", generateSupportedPythonVersionsConf());
+        supportedPythonVersions, "supportedPythonVersions", generateSupportedPythonVersionsConf());
     when(dockerRegistryService.builderImage()).thenReturn(TEST_BUILDER_IMAGE_NAME);
     when(kubernetesService.listJobs()).thenReturn(Collections.emptySet());
     var builderJobResult =
@@ -382,7 +382,7 @@ public class JobImageBuilderTest {
 
   private static Map<String, Map<String, String>> generateSupportedPythonVersionsConf() {
     return Map.of(
-            "3.10", Map.of("baseImage", "python:3.10-slim", "vdkImage", "test_vdk_image_3.10"),
-            "3.11", Map.of("baseImage", "python:3.11-slim", "vdkImage", "test_vdk_image_3.11"));
+        "3.10", Map.of("baseImage", "python:3.10-slim", "vdkImage", "test_vdk_image_3.10"),
+        "3.11", Map.of("baseImage", "python:3.11-slim", "vdkImage", "test_vdk_image_3.11"));
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageBuilderTest.java
@@ -292,15 +292,18 @@ public class JobImageBuilderTest {
 
   @Test
   public void
-      buildImage_deploymentDataJobBaseImageNotNull_shouldCreateCronjobUsingDeploymentDataJobBaseImage()
+  buildImage_deploymentDataJobBaseImageNotNull_shouldCreateCronjobUsingSupportedPythonVersions()
           throws InterruptedException, ApiException, IOException {
     ReflectionTestUtils.setField(
         supportedPythonVersions, "deploymentDataJobBaseImage", "python:3.7-slim");
+    ReflectionTestUtils.setField(
+            supportedPythonVersions, "supportedPythonVersions", generateSupportedPythonVersionsConf());
     when(dockerRegistryService.builderImage()).thenReturn(TEST_BUILDER_IMAGE_NAME);
     when(kubernetesService.listJobs()).thenReturn(Collections.emptySet());
     var builderJobResult =
         new KubernetesService.JobStatusCondition(true, "type", "test-reason", "test-message", 0);
     when(kubernetesService.watchJob(any(), anyInt(), any())).thenReturn(builderJobResult);
+    when(supportedPythonVersions.isPythonVersionSupported("3.11")).thenReturn(true);
     when(supportedPythonVersions.getJobBaseImage(any())).thenCallRealMethod();
 
     JobDeployment jobDeployment = new JobDeployment();
@@ -312,8 +315,6 @@ public class JobImageBuilderTest {
     ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
 
     var result = jobImageBuilder.buildImage("test-image", testDataJob, jobDeployment, true);
-
-    verify(supportedPythonVersions, never()).isPythonVersionSupported("3.11");
 
     verify(kubernetesService)
         .createJob(
@@ -335,7 +336,7 @@ public class JobImageBuilderTest {
             any());
 
     Map<String, String> capturedEnvs = captor.getValue();
-    Assertions.assertEquals("python:3.7-slim", capturedEnvs.get("BASE_IMAGE"));
+    Assertions.assertEquals("python:3.11-slim", capturedEnvs.get("BASE_IMAGE"));
 
     verify(kubernetesService).deleteJob(TEST_BUILDER_JOB_NAME);
     Assertions.assertTrue(result);
@@ -377,5 +378,11 @@ public class JobImageBuilderTest {
             any());
 
     Assertions.assertFalse(result);
+  }
+
+  private static Map<String, Map<String, String>> generateSupportedPythonVersionsConf() {
+    return Map.of(
+            "3.10", Map.of("baseImage", "python:3.10-slim", "vdkImage", "test_vdk_image_3.10"),
+            "3.11", Map.of("baseImage", "python:3.11-slim", "vdkImage", "test_vdk_image_3.11"));
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/SupportedPythonVersionsTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/SupportedPythonVersionsTest.java
@@ -97,10 +97,10 @@ public class SupportedPythonVersionsTest {
   }
 
   @Test
-  public void getJobBaseImage_shouldReturnDeploymentDataJobBaseImage() {
+  public void getJobBaseImage_shouldIgnoreDeploymentDataJobBaseImage() {
     var supportedVersions = generateSupportedPythonVersionsConf();
 
-    final String resultBaseImg = "python:3.9-slim";
+    final String resultBaseImg = "python:3.8-slim";
     ReflectionTestUtils.setField(
         supportedPythonVersions, SUPPORTED_PYTHON_VERSIONS, supportedVersions);
     ReflectionTestUtils.setField(


### PR DESCRIPTION
Currently, there are some backwards-compatibility issues with Control Service deployments that do not integrate support for multiple python versions and move to introduce it. The issues surface, when service administrators decite to add multiple supported python versions in their private values.yaml configuration files. The new configurations are ignored and it is not possible to cleanly migrate to support multiple python versions, as only the old configurations through `datajobs.vdk.image` and `datajobs.deployment.dataJobBaseImage` are recognised.

This change relaxes the service behaviour, so that if the `datajobs.deployment.supportedPythonVersions` and `datajobs.deployment.defaultPythonVersion` configuration options are set, they would take precedence over the old configurations. Additionally, a bug is also fixed, where enabling or disabling data jobs, deployed before the support for multiple python versions was introduced, was failing after the new configurations are set, due to the default python_version being added to JobDeployment at patch request, which should not happen.

Testing Done: New and existing tests. Additionally, the whole setup was tested locally against a kind k8s cluster, and a stand-alone CockroachDB instance.