### PR TITLE
frontend: Fix for e2e tests

### DIFF
--- a/projects/frontend/data-pipelines/gui/e2e/integration/explore/data-jobs/data-jobs.spec.js
+++ b/projects/frontend/data-pipelines/gui/e2e/integration/explore/data-jobs/data-jobs.spec.js
@@ -31,7 +31,7 @@ describe(
                 .then(() => DataJobsExplorePage.login())
                 .then(() => cy.saveLocalStorage('data-jobs-explore'))
                 .then(() =>
-                    DataJobsExplorePage.deleteShortLivedTestJobsNoDeploy()
+                    DataJobsExplorePage.deleteShortLivedTestJobsNoDeploy(true)
                 )
                 .then(() =>
                     DataJobsExplorePage.createShortLivedTestJobsNoDeploy()
@@ -183,6 +183,11 @@ describe(
 
                 dataJobsExplorePage = DataJobsExplorePage.navigateTo();
 
+                // filter by job name substring because there are a lot of jobs, and it could potentially be on second/third page
+                dataJobsExplorePage.filterByJobName(
+                    testJobsFixture[1].job_name.substring(0, 20)
+                );
+
                 dataJobsExplorePage
                     .getDataGridCell(testJobsFixture[1].job_name)
                     .scrollIntoView()
@@ -206,6 +211,11 @@ describe(
                 cy.log('Fixture for name: ' + testJobsFixture[0].job_name);
 
                 dataJobsExplorePage = DataJobsExplorePage.navigateTo();
+
+                // filter by job name substring because there are a lot of jobs, and it could potentially be on second/third page
+                dataJobsExplorePage.filterByJobName(
+                    testJobsFixture[0].job_name.substring(0, 20)
+                );
 
                 // verify 2 test rows visible
                 dataJobsExplorePage

--- a/projects/frontend/data-pipelines/gui/e2e/integration/explore/data-jobs/details/data-job-details.spec.js
+++ b/projects/frontend/data-pipelines/gui/e2e/integration/explore/data-jobs/details/data-job-details.spec.js
@@ -33,7 +33,9 @@ describe(
                 .then(() => DataJobExploreDetailsPage.login())
                 .then(() => cy.saveLocalStorage('data-job-explore-details'))
                 .then(() =>
-                    DataJobExploreDetailsPage.deleteShortLivedTestJobsNoDeploy()
+                    DataJobExploreDetailsPage.deleteShortLivedTestJobsNoDeploy(
+                        true
+                    )
                 )
                 .then(() =>
                     DataJobExploreDetailsPage.createShortLivedTestJobsNoDeploy()

--- a/projects/frontend/data-pipelines/gui/e2e/integration/explore/data-jobs/executions/data-job-executions.spec.js
+++ b/projects/frontend/data-pipelines/gui/e2e/integration/explore/data-jobs/executions/data-job-executions.spec.js
@@ -27,7 +27,9 @@ describe(
                 .then(() => DataJobExploreExecutionsPage.login())
                 .then(() => cy.saveLocalStorage('data-job-explore-executions'))
                 .then(() =>
-                    DataJobExploreExecutionsPage.deleteShortLivedTestJobsNoDeploy()
+                    DataJobExploreExecutionsPage.deleteShortLivedTestJobsNoDeploy(
+                        true
+                    )
                 )
                 .then(() =>
                     DataJobExploreExecutionsPage.createShortLivedTestJobsNoDeploy()

--- a/projects/frontend/data-pipelines/gui/e2e/integration/manage/data-jobs/data-jobs.spec.js
+++ b/projects/frontend/data-pipelines/gui/e2e/integration/manage/data-jobs/data-jobs.spec.js
@@ -37,7 +37,7 @@ describe(
                 .then(() => DataJobsManagePage.login())
                 .then(() => cy.saveLocalStorage('data-jobs-manage'))
                 .then(() =>
-                    DataJobsManagePage.deleteShortLivedTestJobsNoDeploy()
+                    DataJobsManagePage.deleteShortLivedTestJobsNoDeploy(true)
                 )
                 .then(() => DataJobsManagePage.createLongLivedJobs('failing'))
                 .then(() =>

--- a/projects/frontend/data-pipelines/gui/e2e/integration/manage/data-jobs/details/data-job-details.spec.js
+++ b/projects/frontend/data-pipelines/gui/e2e/integration/manage/data-jobs/details/data-job-details.spec.js
@@ -45,7 +45,9 @@ describe(
                 .then(() => DataJobManageDetailsPage.login())
                 .then(() => cy.saveLocalStorage('data-job-manage-details'))
                 .then(() =>
-                    DataJobManageDetailsPage.deleteShortLivedTestJobsNoDeploy()
+                    DataJobManageDetailsPage.deleteShortLivedTestJobsNoDeploy(
+                        true
+                    )
                 )
                 .then(() =>
                     DataJobManageDetailsPage.createLongLivedJobs('failing')

--- a/projects/frontend/data-pipelines/gui/e2e/plugins/helpers/job-helpers.plugins.js
+++ b/projects/frontend/data-pipelines/gui/e2e/plugins/helpers/job-helpers.plugins.js
@@ -500,14 +500,16 @@ const changeJobsStatusesFixtures = (taskConfig, config) => {
 /**
  * ** Delete Jobs for provided fixtures paths.
  *
- * @param {{relativePathToFixtures: Array<{pathToFixture:string;}>}} taskConfig - configuration for task.
+ * @param {{relativePathToFixtures: Array<{pathToFixture:string;}>; optional?: boolean;}} taskConfig - configuration for task.
  *      relativePathToFixtures provides relative paths for fixtures files starting from directory fixtures
+ *      optional if set to true will instruct the plugin to not log console error, if deletion status is different from 2xx, (e.g. 404 or 500)
  *      e.g. {
  *             relativePathToFixtures: [
  *                  {
  *                      pathToFixture: '/base/data-jobs/cy-e2e-vdk/cy-e2e-vdk-failing-v0.json'
  *                  }
- *             ]
+ *             ],
+ *             optional: true
  *           }
  * @param {Cypress.ResolvedConfigOptions} config
  * @returns {Promise<boolean>}
@@ -548,7 +550,10 @@ const deleteJobsFixtures = (taskConfig, config) => {
                         );
                     }
 
-                    if (unsuccessfulDeletion.length > 0) {
+                    if (
+                        !taskConfig.optional &&
+                        unsuccessfulDeletion.length > 0
+                    ) {
                         Logger.error(
                             `Failed to delete Data Jobs: ${unsuccessfulDeletion.toString()}`
                         );

--- a/projects/frontend/data-pipelines/gui/e2e/plugins/index.js
+++ b/projects/frontend/data-pipelines/gui/e2e/plugins/index.js
@@ -123,14 +123,16 @@ module.exports = (on, cypressConfig) => {
         /**
          * ** Delete Jobs for provided fixtures paths.
          *
-         * @param {{relativePathToFixtures: Array<{pathToFixture:string;}>}} taskConfig - configuration for task.
+         * @param {{relativePathToFixtures: Array<{pathToFixture:string;}>; optional?: boolean;}} taskConfig - configuration for task.
          *      relativePathToFixtures provides relative paths for fixtures files starting from directory fixtures
+         *      optional if set to true will instruct the plugin to not log console error, if deletion status is different from 2xx, (e.g. 404 or 500)
          *      e.g. {
          *             relativePathToFixtures: [
          *                  {
          *                      pathToFixture: '/base/data-jobs/cy-e2e-vdk/cy-e2e-vdk-failing-v0.json'
          *                  }
-         *             ]
+         *             ],
+         *             optional: true
          *           }
          * @returns {Promise<boolean>}
          */

--- a/projects/frontend/data-pipelines/gui/e2e/support/pages/base/data-pipelines/data-pipelines-base.po.js
+++ b/projects/frontend/data-pipelines/gui/e2e/support/pages/base/data-pipelines/data-pipelines-base.po.js
@@ -348,9 +348,10 @@ export class DataPipelinesBasePO extends BasePagePO {
      *      - They are created during tests execution and are deleted before and after test suits.
      *      - Executed in context of test environment.
      *
+     * @param {boolean} isDeleteOptional
      * @returns {Cypress.Chainable<unknown>}
      */
-    static deleteShortLivedTestJobsNoDeploy() {
+    static deleteShortLivedTestJobsNoDeploy(isDeleteOptional) {
         return cy.task(
             'deleteJobsFixtures',
             {
@@ -364,7 +365,8 @@ export class DataPipelinesBasePO extends BasePagePO {
                     {
                         pathToFixture: `/base/data-jobs/${TEAM_VDK}/short-lived/${TEAM_VDK_DATA_JOB_TEST_V12}.json`
                     }
-                ]
+                ],
+                optional: isDeleteOptional
             },
             { timeout: DataPipelinesBasePO.WAIT_LONG_TASK }
         );


### PR DESCRIPTION
Fixing failing e2e tests where root cause was many jobs in the list and introduced filtering by jobName before search happens.
Improved logging for delete Data Jobs, when this deletion happens in before suite step.