### PR TITLE
heartbeat: add test that pings the frontend url

### DIFF
--- a/projects/vdk-heartbeat/README.md
+++ b/projects/vdk-heartbeat/README.md
@@ -123,3 +123,24 @@ export VDK_HEARTBEAT_INGEST_DESTINATION_TABLE="sample_destination_table"
 export DB_DEFAULT_TYPE="trino"
 export DATABASE_TEST_DB="memory.default"
 ```
+
+### Ping the frontend
+
+No additional configuration is needed for this test.
+
+Point heartbeat to the correct module and class
+
+```
+JOB_RUN_TEST_MODULE_NAME=vdk.internal.heartbeat.ping_frontend_test
+JOB_RUN_TEST_CLASS_NAME=PingFrontendTest
+```
+
+The CONTROL_API_URL environment variable doubles as the frontend url, since both
+th control service and the frontend are deployed to the same host by the helm
+chart.
+
+```
+CONTROL_API_URL=http://cicd-control-service-svc:8092
+```
+
+The test sends a `GET` request to the URL and expects a success response

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/hearbeat.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/hearbeat.py
@@ -3,9 +3,7 @@
 import logging
 
 from vdk.internal.heartbeat.config import Config
-from vdk.internal.heartbeat.heartbeat_test import create_test_instance
-from vdk.internal.heartbeat.heartbeat_test import HeartbeatTest
-from vdk.internal.heartbeat.job_controller import JobController
+from vdk.internal.heartbeat.heartbeat_base_test import HeartbeatBaseTest
 from vdk.internal.heartbeat.reporter import TestDecorator
 
 log = logging.getLogger(__name__)
@@ -27,47 +25,33 @@ class Heartbeat:
 
     @TestDecorator()
     def run(self):
-        run_test = create_test_instance(self._config)
-        job_controller = JobController(self._config)
+        create_test_instance(self._config).run_test()
 
-        try:
-            job_controller.login()
-            job_controller.create_job()
-            job_controller.deploy_job()
 
-            job_controller.check_list_jobs()
-            job_controller.check_deployments()
-            job_controller.disable_deployment()
-            job_controller.check_deployments(enabled=False)
+@staticmethod
+def create_test_instance(config: Config) -> HeartbeatBaseTest:
+    import importlib
 
-            run_test.setup()
-
-            job_controller.enable_deployment()
-            job_controller.show_job_details()
-
-            run_test.execute_test()
-            job_controller.show_last_job_execution_logs()
-
-            job_controller.disable_deployment()
-
-            if self._config.check_manual_job_execution:
-                job_controller.check_job_execution_finished()
-                job_controller.start_job_execution()
-                job_controller.check_job_execution_finished()
-
-            self.clean(run_test, job_controller)
-            log.info("Heartbeat has finished successfully.")
-        except:
-            log.info("Heartbeat has failed.")
-            job_controller.show_job_details()
-            job_controller.show_last_job_execution_logs()
-            if self._config.clean_up_on_failure:
-                log.info("Heartbeat clean up on failure.")
-                self.clean(run_test, job_controller)
-            raise
-
-    @staticmethod
-    def clean(run_test: HeartbeatTest, job_controller: JobController):
-        job_controller.login()
-        job_controller.delete_job()
-        run_test.clean_up()
+    try:
+        module = importlib.import_module(config.database_test_module_name)
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            f"Configured database_test_module_name is not found. Error was: {e}.\n"
+            f"Make sure module {config.database_test_module_name} exists.\n"
+            f"Check if the module name in the configuration is not misspelled "
+            f"or if some 3rd party library needs to be installed to provide it."
+        ) from None
+    try:
+        class_ = getattr(module, config.database_test_class_name)
+    except AttributeError as e:
+        raise AttributeError(
+            f"Configured database_test_class_name is not found. Error was: {e}.\\n"
+            f"Make sure class {config.database_test_class_name} exists.\n"
+            f"Check if the class name in the configuration is not misspelled "
+            f"or if some 3rd party library needs to be installed to provide it."
+        ) from None
+    log.info(
+        f"Run test instance: {config.database_test_module_name}.{config.database_test_class_name}"
+    )
+    instance = class_(config)
+    return instance

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/heartbeat_base_test.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/heartbeat_base_test.py
@@ -1,0 +1,59 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+from abc import ABC
+from abc import abstractmethod
+
+from vdk.internal.heartbeat.config import Config
+from vdk.internal.heartbeat.tracing import LogDecorator
+
+log = logging.getLogger(__name__)
+
+
+class HeartbeatBaseTest(ABC):
+    """
+    Template for defing tests
+    """
+
+    def __init__(self, config: Config):
+        self.config = config
+
+    @LogDecorator(log)
+    @abstractmethod
+    def setup(self):
+        """
+        Setup the test and all that is necessary
+        """
+        pass
+
+    def __exit__(self, *exc):
+        self.clean_up()
+
+    @LogDecorator(log)
+    @abstractmethod
+    def clean_up(self):
+        """
+        After the test is finished it cleans up all resources used by the test.
+        """
+        pass
+
+    @LogDecorator(log)
+    @abstractmethod
+    def execute_test(self):
+        """
+        Execute the test and run assertion and verification. If method returns then test has passed.
+        If method throws an exception then test has failed.
+        """
+        pass
+
+    @LogDecorator(log)
+    def run_test(self):
+        try:
+            self.setup()
+            self.execute_test()
+        except:
+            log.info("Heartbeat has failed.")
+            if self._config.clean_up_on_failure:
+                log.info("Heartbeat clean up on failure.")
+                self.clean_up()
+            raise

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/heartbeat_test.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/heartbeat_test.py
@@ -5,71 +5,67 @@ from abc import ABC
 from abc import abstractmethod
 
 from vdk.internal.heartbeat.config import Config
+from vdk.internal.heartbeat.heartbeat_base_test import HeartbeatBaseTest
+from vdk.internal.heartbeat.job_controller import JobController
 from vdk.internal.heartbeat.tracing import LogDecorator
 
 log = logging.getLogger(__name__)
 
 
-class HeartbeatTest(ABC):
+class HeartbeatTest(HeartbeatBaseTest):
     """
-    Interface for defing tests
+    Executes a heartbeat test that verifies the correct behaviour of Data Pipelines.
+
+    It has the following steps:
+    - Creates a Data Job using VDK CLI for managing jobs
+    - Deploys the data job using the same Versatile Data Kit SDK
+    - Run database test to verify the job works correctly in cloud runtime.
+    - Deletes the Data Job using VDK CLI
     """
 
     def __init__(self, config: Config):
         self.config = config
+        self.__job_controller = JobController(config)
 
     @LogDecorator(log)
-    @abstractmethod
-    def setup(self):
-        """
-        Setup the test and all that is necessary
-        """
-        pass
+    def run_test(self):
+        try:
+            self.__job_controller.login()
+            self.__job_controller.create_job()
+            self.__job_controller.deploy_job()
 
-    def __exit__(self, *exc):
+            self.__job_controller.check_list_jobs()
+            self.__job_controller.check_deployments()
+            self.__job_controller.disable_deployment()
+            self.__job_controller.check_deployments(enabled=False)
+
+            self.setup()
+
+            self.__job_controller.enable_deployment()
+            self.__job_controller.show_job_details()
+
+            self.execute_test()
+            self.__job_controller.show_last_job_execution_logs()
+
+            self.__job_controller.disable_deployment()
+
+            if self._config.check_manual_job_execution:
+                self.__job_controller.check_job_execution_finished()
+                self.__job_controller.start_job_execution()
+                self.__job_controller.check_job_execution_finished()
+
+            self.clean()
+            log.info("Heartbeat has finished successfully.")
+        except:
+            log.info("Heartbeat has failed.")
+            self.__job_controller.show_job_details()
+            self.__job_controller.show_last_job_execution_logs()
+            if self._config.clean_up_on_failure:
+                log.info("Heartbeat clean up on failure.")
+                self.clean()
+            raise
+
+    def clean(self):
+        self.__job_controller.login()
+        self.__job_controller.delete_job()
         self.clean_up()
-
-    @LogDecorator(log)
-    @abstractmethod
-    def clean_up(self):
-        """
-        After the test is finished it cleans up all resources used by the test.
-        """
-        pass
-
-    @LogDecorator(log)
-    @abstractmethod
-    def execute_test(self):
-        """
-        Execute the test and run assertion and verification. If method returns then test has passed.
-        If method throws an exception then test has failed.
-        """
-        pass
-
-
-def create_test_instance(config: Config) -> HeartbeatTest:
-    import importlib
-
-    try:
-        module = importlib.import_module(config.database_test_module_name)
-    except ModuleNotFoundError as e:
-        raise ModuleNotFoundError(
-            f"Configured database_test_module_name is not found. Error was: {e}.\n"
-            f"Make sure module {config.database_test_module_name} exists.\n"
-            f"Check if the module name in the configuration is not misspelled "
-            f"or if some 3rd party library needs to be installed to provide it."
-        ) from None
-    try:
-        class_ = getattr(module, config.database_test_class_name)
-    except AttributeError as e:
-        raise AttributeError(
-            f"Configured database_test_class_name is not found. Error was: {e}.\\n"
-            f"Make sure class {config.database_test_class_name} exists.\n"
-            f"Check if the class name in the configuration is not misspelled "
-            f"or if some 3rd party library needs to be installed to provide it."
-        ) from None
-    log.info(
-        f"Run test instance: {config.database_test_module_name}.{config.database_test_class_name}"
-    )
-    instance = class_(config)
-    return instance

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/ping_frontend_test.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/ping_frontend_test.py
@@ -1,0 +1,44 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+import requests
+from vdk.internal.heartbeat.config import Config
+from vdk.internal.heartbeat.heartbeat_base_test import HeartbeatBaseTest
+from vdk.internal.heartbeat.tracing import LogDecorator
+
+log = logging.getLogger(__name__)
+
+
+class PingFrontendTest(HeartbeatBaseTest):
+    """
+    A simple test that pings the frontend to check if it started when deployed using helm
+    """
+
+    def __init__(self, config: Config):
+        super().__init__(config)
+        self.success_statuses = [200, 202, 204]
+        self.url = config.control_api_url
+
+    @LogDecorator(log)
+    def setup(self):
+        pass
+
+    @LogDecorator(log)
+    def clean_up(self):
+        pass
+
+    @LogDecorator(log)
+    def execute_test(self):
+        status = None
+        try:
+            response = requests.get(self.url)
+            status = response.status_code
+        except Exception as e:
+            raise AssertionError(f"Request to {self.url} failed to complete")
+
+        if status not in self.success_statuses:
+            raise AssertionError(
+                f"Request to {self.url} failed with status {status}"
+                "Could not detect that frontend is running"
+            )


### PR DESCRIPTION
Note: I'll add the test to the CI in a separate PR

## Why

The frontend is packaged in the quickstart-vdk helm chart. Adding a
smoke test to check if the frontend starts correctly provides
an additional layer of release confidence.

## What

Split test templates into HeartbeatTest inherits from HeartbeatBaseTest
HeartbeatBaseTest has the setup, execute_test and clean_up methods.
Its run_test method sets up, executes and cleans up on errors

HeartBeatTest does the same, but in addtion, it

- Creates a Data Job using VDK CLI for managing jobs
- Deploys the data job using the same Versatile Data Kit SDK
- Run database test to verify the job works correctly in cloud runtime.
- Deletes the Data Job using VDK CLI

Test templates now have run_test methods. Run_test methods contain the logic, which
was previously in heartbeat.py for HeartbeatTest and plain logic, which
does not include data job creation for HeartbeatBaseTest

Add a test that does a simple get request to the
frontend URL and expects a success status

## How was this tested

Tested locally by running the quickstart-vdk and running the
trino test against a local instance of trinodb

Tested locally by running the ping frontend test against
a local instance of the frontend

Ran tests included in heartbeat-vdk

CI

## What kind of change is this

Feature, breaking