### PR TITLE
add vdk info command

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/info_group/info.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/info_group/info.py
@@ -1,0 +1,57 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+import click
+from vdk.internal.control.configuration.defaults_config import load_default_team_name
+from vdk.internal.control.rest_lib.factory import ApiClientFactory
+from vdk.internal.control.rest_lib.rest_client_errors import ApiClientErrorDecorator
+from vdk.internal.control.utils import cli_utils
+
+log = logging.getLogger(__name__)
+#
+#
+# # TODO: handle errors messages more gracefully (do not show stacktrace, show http body access_token_request_response)
+#
+#
+# class JobDelete:
+#     def __init__(self, rest_api_url: str):
+#         self.jobs_api = ApiClientFactory(rest_api_url).get_jobs_api()
+#
+#     @ApiClientErrorDecorator()
+#     def delete_job(self, name: str, team: str):
+#         log.debug(f"Delete data job {name} of team {team}")
+#         self.jobs_api.data_job_delete(team_name=team, job_name=name)
+#         log.info(
+#             f"Deleted Data Job {name} and all its deployments successfully."
+#             f" The job's folder may still be present on your local file system."
+#         )
+#
+#
+# # Below is the definition of the CLI API/UX users will be interacting
+# # Above is the actual implementation of the operations
+#
+
+
+@click.command(
+    help="Get Control Service Information. "
+    "Get the current version of the Control Service and the supported python versions."
+)
+@click.option(
+    "-t",
+    "--team",
+    type=click.STRING,
+    default=load_default_team_name(),
+    required=True,
+    prompt="Job Team",
+    help="The team name to which the job belong to.",
+)
+@cli_utils.rest_api_url_option()
+@cli_utils.check_required_parameters
+def info(team: str, rest_api_url: str):
+    # cmd = JobDelete(rest_api_url)
+    print("---- IT WORKSS ----")
+    # cmd.delete_job(name, team)
+    service_api = ApiClientFactory(rest_api_url).get_service_api()
+    result = service_api.info(team_name=team)
+    print(f"result:{result}")

--- a/projects/vdk-control-cli/src/vdk/internal/control/main.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/main.py
@@ -8,6 +8,7 @@ from vdk.internal.control.command_groups.common_group.default import (
     reset_default_command,
 )
 from vdk.internal.control.command_groups.common_group.default import set_default_command
+from vdk.internal.control.command_groups.info_group.info import info
 from vdk.internal.control.command_groups.job.create import create
 from vdk.internal.control.command_groups.job.delete import delete
 from vdk.internal.control.command_groups.job.deploy_cli import deploy
@@ -91,6 +92,7 @@ def run():
     cli.add_command(download_job)
     cli.add_command(show_command)
     cli.add_command(properties_command)
+    cli.add_command(info)
 
     cli()
 

--- a/projects/vdk-control-cli/src/vdk/internal/control/rest_lib/factory.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/rest_lib/factory.py
@@ -8,6 +8,7 @@ from taurus_datajob_api import DataJobsApi
 from taurus_datajob_api import DataJobsDeploymentApi
 from taurus_datajob_api import DataJobsExecutionApi
 from taurus_datajob_api import DataJobsPropertiesApi
+from taurus_datajob_api import DataJobsServiceApi
 from taurus_datajob_api import DataJobsSourcesApi
 from urllib3 import Retry
 from vdk.internal.control.configuration.vdk_config import VDKConfig
@@ -66,3 +67,6 @@ class ApiClientFactory:
 
     def get_properties_api(self) -> DataJobsPropertiesApi:
         return DataJobsPropertiesApi(self._new_api_client())
+
+    def get_service_api(self) -> DataJobsServiceApi:
+        return DataJobsServiceApi(self._new_api_client())

--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/info_group/test_info.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/info_group/test_info.py
@@ -20,7 +20,7 @@ def get_data_job_query_response(jobs: List[Any]):
 def get_example_info_response():
     return {
         "api_version": "PipelinesControlService/1.6.855638094/v0.13-30-g23b0851 (root@vdk-cs-dep-6f88c4bff-rzbbl Linux/amd64/amd64)",
-        "supported_python_versions": ["3.7", "3.8"],
+        "supported_python_versions": ["3.7", "3.8", "3.9"],
     }
 
 

--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/info_group/test_info.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/info_group/test_info.py
@@ -20,7 +20,7 @@ def get_data_job_query_response(jobs: List[Any]):
 def get_example_info_response():
     return {
         "api_version": "PipelinesControlService/1.6.855638094/v0.13-30-g23b0851 (root@vdk-cs-dep-6f88c4bff-rzbbl Linux/amd64/amd64)",
-        "supported_python_versions": ["3.7", "3.8", "3.9"],
+        "supported_python_versions": ["3.7", "3.8", "3.9", "3.10"],
     }
 
 

--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/info_group/test_info.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/info_group/test_info.py
@@ -20,7 +20,7 @@ def get_data_job_query_response(jobs: List[Any]):
 def get_example_info_response():
     return {
         "api_version": "PipelinesControlService/1.6.855638094/v0.13-30-g23b0851 (root@vdk-cs-dep-6f88c4bff-rzbbl Linux/amd64/amd64)",
-        "supported_python_versions": ["3.7", "3.8", "3.9", "3.10"],
+        "supported_python_versions": ["python3.7", "python3.8", "python3.9"],
     }
 
 
@@ -38,7 +38,7 @@ def test_info(httpserver: PluginHTTPServer, tmpdir: LocalPath):
     assert_click_status(result, 0)
     assert (
         "PipelinesControlService/1.6.855638094/v0.13-30-g23b0851" in result.output
-        and "3.7" in result.output
+        and "python3.7" in result.output
     ), f"expected data not found in output: {result.output} "
 
 

--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/info_group/test_info.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/info_group/test_info.py
@@ -1,0 +1,49 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from typing import Any
+from typing import List
+
+from click.testing import CliRunner
+from py._path.local import LocalPath
+from pytest_httpserver.pytest_plugin import PluginHTTPServer
+from vdk.internal import test_utils
+from vdk.internal.control.command_groups.info_group.info import info
+from vdk.internal.test_utils import assert_click_status
+
+test_utils.disable_vdk_authentication()
+
+
+def get_data_job_query_response(jobs: List[Any]):
+    return dict(data=dict(content=jobs, errors=[]))
+
+
+def get_example_info_response():
+    return {
+        "api_version": "PipelinesControlService/1.6.855638094/v0.13-30-g23b0851 (root@vdk-cs-dep-6f88c4bff-rzbbl Linux/amd64/amd64)",
+        "supported_python_versions": ["3.7", "3.8"],
+    }
+
+
+def test_info(httpserver: PluginHTTPServer, tmpdir: LocalPath):
+    rest_api_url = httpserver.url_for("")
+
+    response = get_example_info_response()
+
+    httpserver.expect_request(
+        uri="/data-jobs/for-team/test-team/info"
+    ).respond_with_json(response)
+
+    runner = CliRunner()
+    result = runner.invoke(info, ["-t", "test-team", "-u", rest_api_url])
+    assert_click_status(result, 0)
+    assert (
+        "PipelinesControlService/1.6.855638094/v0.13-30-g23b0851" in result.output
+        and "3.7" in result.output
+    ), f"expected data not found in output: {result.output} "
+
+
+def test_info_without_url(httpserver: PluginHTTPServer, tmpdir: LocalPath):
+    runner = CliRunner()
+    result = runner.invoke(info, ["-t", "test-team"])
+    assert_click_status(result, 2)
+    assert "what" in result.output and "why" in result.output


### PR DESCRIPTION
vdk-control-cli: add vdk info command

Add the vdk info command to show CS version and supported
python versions.

Signed-off-by: Dako Dakov <ddakov@vmware.com>