### PR TITLE
vdk-impala: add udf hive2server user error classification

### DIFF
--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_error_classifier.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_error_classifier.py
@@ -20,6 +20,7 @@ def is_impala_user_error(received_exception):
         or _is_quota_exceeded(received_exception)
         or _is_other_query_error(received_exception)
         or _is_property_unsupported_value_error(received_exception)
+        or _is_udf_hive_server2_error(received_exception)
     )
 
 
@@ -118,4 +119,12 @@ def _is_quota_exceeded(exception):
         exception,
         classname_with_package="impala.error.OperationalError",
         exception_message_matcher_regex=".*DiskSpace quota of .* is exceeded.*",
+    )
+
+
+def _is_udf_hive_server2_error(exception):
+    return errors.exception_matches(
+        exception,
+        classname_with_package="impala.error.HiveServer2Error",
+        exception_message_matcher_regex=".*UDF ERROR:.*",
     )

--- a/projects/vdk-plugins/vdk-impala/tests/test_error_classifier.py
+++ b/projects/vdk-plugins/vdk-impala/tests/test_error_classifier.py
@@ -92,3 +92,10 @@ class UserErrorClassification(unittest.TestCase):
                 )
             )
         )
+        self.assertTrue(
+            is_impala_user_error(
+                HiveServer2Error(
+                    "impala.error.HiveServer2Error: UDF ERROR: Decimal expression overflowed"
+                )
+            )
+        )


### PR DESCRIPTION
what: added a new error to be classified as user exception in the vdk-impala plugin

why: a use case came up where the following excerpt of an exception was classified as platform error:

`File "/vdk/site-packages/impala/hiveserver2.py", line 1397, in fetch
    resp = self._rpc('FetchResults', req, False)
  File "/vdk/site-packages/impala/hiveserver2.py", line 1085, in _rpc
    err_if_rpc_not_ok(response)
  File "/vdk/site-packages/impala/hiveserver2.py", line 781, in err_if_rpc_not_ok
    raise HiveServer2Error(resp.status.errorMessage)
impala.error.HiveServer2Error: UDF ERROR: Decimal expression overflowed


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/vdk/site-packages/vdk/internal/builtin_plugins/run/data_job.py", line 73, in run_step
    step_executed = step.runner_func(step, context.job_input)`

testing: added case to the unit test