### PR TITLE
control-service: Swagger UI quickstart-vdk server config

### DIFF
--- a/projects/control-service/projects/model/apidefs/datajob-api/api.yaml
+++ b/projects/control-service/projects/model/apidefs/datajob-api/api.yaml
@@ -2,6 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 openapi: 3.0.3
+
+servers:
+  - url: http://localhost:8092
+    description: quickstart-vdk default local setup
+
 info:
   title: Versatile Data Kit Control Service API
   version: '1.0'


### PR DESCRIPTION
org.openapi.generator was not configured with quickstart-vdk server.

Adding url and description for quickstart-vdk default local setup.

Tesing done: cicd