### PR TITLE
quickstart-vdk: ignore explore page and widgets in frontend

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -43,7 +43,7 @@ operationsUi:
     requests:
       memory: 250Mi
       cpu: 25m
-  config: '{"auth": {"skipAuth": true}}'
+  config: '{"auth": {"skipAuth": true}, "ignoreComponents": ["explorePage", "widgetsComponent"], "ignoreRoutes": ["explore/data-jobs", "explore/data-jobs/:team/:job"]}'
 
 
 # The image configuration for builder jobs used during deployment of data jobs.


### PR DESCRIPTION
## Why?

The explore page and widgets are not relevant to users outside of VMWare This also fixes the bug where the frontend does not load on running quickstart-vdk due to missing configuration

## What?

Ignore the explore page and widgets in the control service helm chart

## How has this been tested?

Configuration tested locally
Helm chart tested in CI

## What type of change are you making?

Bug fix (non-breaking change which fixes an issue) or a cosmetic change/minor improvement