### PR TITLE
control-service: Clean up old data job configurations

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/_helpers.tpl
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/_helpers.tpl
@@ -133,54 +133,6 @@ Also, we can't use a single if because lazy evaluation is not an option
 {{- end -}}
 {{- end -}}
 
-{{/*
-Return the proper Control Service data jobs base image where data job run in.
-*/}}
-{{- define "pipelines-control-service.deploymentDataJobBaseImage" -}}
-{{- $globalRegistryOverrideName := .Values.deploymentDataJobBaseImage.globalRegistryOverride -}}
-{{- $registryName := .Values.deploymentDataJobBaseImage.registry -}}
-{{- $repositoryName := .Values.deploymentDataJobBaseImage.repository -}}
-{{- $tag := .Values.deploymentDataJobBaseImage.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if $globalRegistryOverrideName }}
-    {{- printf "%s/%s:%s" $globalRegistryOverrideName $repositoryName $tag -}}
-{{- else if .Values.global.imageRegistry }}
-    {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the proper Control Service vdk image where the vdk (sdk) is installed and used during data job runs.
-*/}}
-{{- define "pipelines-control-service.deploymentVdkDistributionImageRepository" -}}
-    {{- $globalRegistryOverrideName := .Values.deploymentVdkDistributionImage.globalRegistryOverride -}}
-    {{- $registryName := .Values.deploymentVdkDistributionImage.registry -}}
-    {{- $repositoryName := .Values.deploymentVdkDistributionImage.repository -}}
-
-    {{/*
-    Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-    but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-    Also, we can't use a single if because lazy evaluation is not an option
-    */}}
-    {{- if $globalRegistryOverrideName }}
-        {{- printf "%s/%s" $globalRegistryOverrideName $repositoryName -}}
-    {{- else if .Values.global.imageRegistry }}
-        {{- printf "%s/%s" .Values.global.imageRegistry $repositoryName -}}
-    {{- else -}}
-        {{- printf "%s/%s" $registryName $repositoryName -}}
-    {{- end -}}
-{{- end -}}
-
-{{- define "pipelines-control-service.deploymentVdkDistributionImage" -}}
-    {{- $tag := .Values.deploymentVdkDistributionImage.tag | toString -}}
-    {{- printf "%s:%s" (include "pipelines-control-service.deploymentVdkDistributionImageRepository" .) $tag -}}
-{{- end -}}
 
 {{/*
 Create the name of the deployment Kubernetes namespace used by Data Jobs
@@ -273,8 +225,4 @@ Image Pull Secret in json format
 
 {{- define "builderPullSecretJson" }}
     {{ include "buildImagePullSecretJson" (list .Values.deploymentBuilderImage.registry .Values.deploymentBuilderImage.username .Values.deploymentBuilderImage.password) }}
-{{- end }}
-
-{{- define "basePullSecretJson" }}
-    {{ include "buildImagePullSecretJson" (list .Values.deploymentDataJobBaseImage.registry .Values.deploymentDataJobBaseImage.username .Values.deploymentDataJobBaseImage.password) }}
 {{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -111,12 +111,8 @@ spec:
             {{- end }}
             - name: DOCKER_REPOSITORY_URL
               value: "{{ .Values.deploymentDockerRepository }}"
-            - name: DOCKER_VDK_BASE_IMAGE
-              value: {{ template "pipelines-control-service.deploymentVdkDistributionImage" . }}
             - name: DATAJOBS_BUILDER_IMAGE
               value: {{ template "pipelines-control-service.deploymentBuilderImage" . }}
-            - name: DATAJOBS_DEPLOYMENT_DATAJOBBASEIMAGE
-              value: {{ template "pipelines-control-service.deploymentDataJobBaseImage" . }}
             - name: SERVER_MAX_HTTP_HEADER_SIZE
               value: "{{ .Values.server.maxHttpHeaderSize }}"
             - name: DB_JDBC_URL

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -252,6 +252,7 @@ deploymentDockerRegistryPasswordReadOnly: ""
 
 ## The registry and associated credentials needed to pull the vdk sdk image.
 ## These are stored in a kubernetes secret.
+## IMPORTANT: The registry should be the same as the one specified in the deploymentSupportedPythonVersions
 deploymentVdkDistributionImage:
   registry: registry.hub.docker.com/versatiledatakit
 
@@ -269,6 +270,7 @@ deploymentVdkDistributionImage:
 
 ## The registry URL and associated credentials needed to pull the data job base image.
 ## These are stored in a kubernetes secret.
+## IMPORTANT: The registry should be the same as the one specified in the deploymentSupportedPythonVersions
 deploymentDataJobBaseImage:
   registry: registry.hub.docker.com/versatiledatakit
   username:

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -249,13 +249,9 @@ deploymentDockerRegistryPassword: ""
 deploymentDockerRegistryUsernameReadOnly: ""
 deploymentDockerRegistryPasswordReadOnly: ""
 
-## Image name of VDK which will be used to run the data jobs.
-## It is recommended to use image with same tag (e.g release or latest)
-## As it will be pulled before any execution thus making sure all jobs use the same and latest version of VDK.
-## The image should contain installation of VDK (vdk) which will be used to run the data jobs (vdk run command)
-## Only the installed python modules (vdk and its dependencies) will be used from the image.
-## Everything else is effectively discarded since another image is used as base during execution.
-## Override if you build VDK SDK yourself instead of using one provided by default.
+
+## The registry and associated credentials needed to pull the vdk sdk image.
+## These are stored in a kubernetes secret.
 deploymentVdkDistributionImage:
   registry: registry.hub.docker.com/versatiledatakit
 
@@ -270,19 +266,11 @@ deploymentVdkDistributionImage:
   registryUsernameReadOnly: ""
   registryPasswordReadOnly: ""
 
-  repository: quickstart-vdk
-  tag: "release"
 
-
-# The base image which will be used to create the image where data job would be run.
-# On top of it the job source and its dependencies are installed for each job.
-# It can be customized further by installing other native dependencies necessary to run different kinds of libraries
-# For example the below default image adds support for Oracle client on top of standard python image.
-# The SDK (vdk) is installed separate image (to enable zero time upgrades) see deploymentVdkDistributionImage
+## The registry URL and associated credentials needed to pull the data job base image.
+## These are stored in a kubernetes secret.
 deploymentDataJobBaseImage:
   registry: registry.hub.docker.com/versatiledatakit
-  repository: data-job-base-python-3.7
-  tag: "latest"
   username:
   password:
 
@@ -307,13 +295,16 @@ deploymentDataJobBaseImage:
 ##   3.7:
 ##     baseImage: "registry.hub.docker.com/versatiledatakit/data-job-base-python-3.7:latest"
 ##     vdkImage: "registry.hub.docker.com/versatiledatakit/quickstart-vdk:release"
-deploymentSupportedPythonVersions: {}
+deploymentSupportedPythonVersions:
+  3.9:
+    baseImage: "registry.hub.docker.com/versatiledatakit/data-job-base-python-3.9:latest"
+    vdkImage: "registry.hub.docker.com/versatiledatakit/quickstart-vdk:release"
 
 
 ## Default python version to be used for data job deployments. The value should be a string and would be
 ## used when a user has not provided a specific python_version for their data job's deployment.
 ## Example: "3.9"
-deploymentDefaultPythonVersion: ""
+deploymentDefaultPythonVersion: "3.9"
 
 ## ini formatted options that provides default and per-job VDK options.
 ## Allows to provide VDK configuration via environment variables.

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/TestJobImageBuilderDynamicVdkImageIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/TestJobImageBuilderDynamicVdkImageIT.java
@@ -46,8 +46,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @TestPropertySource(
     properties = {
       "datajobs.control.k8s.k8sSupportsV1CronJob=true",
-      "datajobs.vdk.image=",
-      "datajobs.deployment.dataJobBaseImage="
     })
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-test.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-test.properties
@@ -10,7 +10,6 @@ datajobs.aws.secretAccessKey=
 # Path to an ini config file that contains vdk runtime options
 # src/main/resources/vdk_options.ini can be used for testing
 datajobs.vdk_options_ini=
-datajobs.vdk.image=registry.hub.docker.com/versatiledatakit/quickstart-vdk:release
 
 datajobs.deployment.k8s.kubeconfig=${DEPLOYMENT_K8S_KUBECONFIG:}
 datajobs.deployment.k8s.namespace=${DEPLOYMENT_K8S_NAMESPACE:default}
@@ -59,7 +58,6 @@ datajobs.builder.registrySecret=${DATAJOBS_BUILDER_REGISTRY_SECRET:}
 
 datajobs.builder.image=ghcr.io/versatile-data-kit-dev/versatiledatakit/job-builder:1.3.3
 datajobs.proxy.repositoryUrl=${DOCKER_REGISTRY_URL}
-datajobs.deployment.dataJobBaseImage=versatiledatakit/data-job-base-python-3.7:latest
 
 datajobs.deployment.builder.extraArgs=--force
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
@@ -56,9 +56,6 @@ public class JobImageBuilder {
   @Value("${datajobs.docker.registryPassword:}")
   private String registryPassword;
 
-  @Value("${datajobs.deployment.dataJobBaseImage:python:3.9-slim}")
-  private String deploymentDataJobBaseImage;
-
   @Value("${datajobs.deployment.builder.extraArgs:}")
   private String builderJobExtraArgs;
 
@@ -138,10 +135,9 @@ public class JobImageBuilder {
       }
     }
 
-    // TODO: Remove when deploymentDataJobBaseImage deprecated.
-    if (jobDeployment.getPythonVersion() == null && deploymentDataJobBaseImage == null) {
+    if (jobDeployment.getPythonVersion() == null) {
       log.warn(
-          "Missing pythonVersion and deploymentDataJobBaseImage. Data Job cannot be deployed.");
+          "Missing pythonVersion. Data Job cannot be deployed.");
       return false;
     }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
@@ -136,8 +136,7 @@ public class JobImageBuilder {
     }
 
     if (jobDeployment.getPythonVersion() == null) {
-      log.warn(
-          "Missing pythonVersion. Data Job cannot be deployed.");
+      log.warn("Missing pythonVersion. Data Job cannot be deployed.");
       return false;
     }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
@@ -33,11 +33,6 @@ import java.util.*;
 @Slf4j
 public class JobImageDeployer {
 
-  // TODO: Out of the image we pick only the python vdk module. Remove when property deprecated
-  // It may make sense to just pass the module name as argument instead of an image ???
-  @Value("${datajobs.vdk.image}")
-  private String vdkImage;
-
   @Value("${datajobs.docker.registrySecret:}")
   private String dockerRegistrySecret = "";
 
@@ -312,17 +307,14 @@ public class JobImageDeployer {
   }
 
   private String getJobVdkImage(JobDeployment jobDeployment) {
-    // TODO: Refactor when vdkImage is deprecated.
     if (!supportedPythonVersions.getSupportedPythonVersions().isEmpty()
         && supportedPythonVersions.isPythonVersionSupported(jobDeployment.getPythonVersion())) {
       return supportedPythonVersions.getVdkImage(jobDeployment.getPythonVersion());
     } else {
-      if (StringUtils.isNotBlank(jobDeployment.getVdkVersion())
-          && StringUtils.isNotBlank(vdkImage)) {
-        return DockerImageName.updateImageWithTag(vdkImage, jobDeployment.getVdkVersion());
-      } else {
-        return vdkImage;
-      }
+      log.warn(
+              "An issue with the job deployment's pythonVersion or supportedPythonVersions configuration has"
+                      + " occurred. Returning default vdk image");
+      return supportedPythonVersions.getDefaultVdkImage();
     }
   }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
@@ -253,7 +253,7 @@ public class JobImageDeployer {
             "-c",
             "cp -r $(python -c \"from distutils.sysconfig import get_python_lib;"
                 + " print(get_python_lib())\") /vdk/. && cp /usr/local/bin/vdk /vdk/.");
-    var jobVdkImage = getJobVdkImage(jobDeployment);
+    var jobVdkImage = supportedPythonVersions.getVdkImage(jobDeployment.getPythonVersion());
     var jobInitContainer =
         KubernetesService.container(
             "vdk",
@@ -303,18 +303,6 @@ public class JobImageDeployer {
           jobAnnotations,
           jobLabels,
           List.of(dockerRegistrySecret, vdkSdkDockerRegistrySecret));
-    }
-  }
-
-  private String getJobVdkImage(JobDeployment jobDeployment) {
-    if (!supportedPythonVersions.getSupportedPythonVersions().isEmpty()
-        && supportedPythonVersions.isPythonVersionSupported(jobDeployment.getPythonVersion())) {
-      return supportedPythonVersions.getVdkImage(jobDeployment.getPythonVersion());
-    } else {
-      log.warn(
-          "An issue with the job deployment's pythonVersion or supportedPythonVersions"
-              + " configuration has occurred. Returning default vdk image");
-      return supportedPythonVersions.getDefaultVdkImage();
     }
   }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
@@ -312,8 +312,8 @@ public class JobImageDeployer {
       return supportedPythonVersions.getVdkImage(jobDeployment.getPythonVersion());
     } else {
       log.warn(
-              "An issue with the job deployment's pythonVersion or supportedPythonVersions configuration has"
-                      + " occurred. Returning default vdk image");
+          "An issue with the job deployment's pythonVersion or supportedPythonVersions"
+              + " configuration has occurred. Returning default vdk image");
       return supportedPythonVersions.getDefaultVdkImage();
     }
   }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/SupportedPythonVersions.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/SupportedPythonVersions.java
@@ -33,7 +33,6 @@ public class SupportedPythonVersions {
   @Value("${datajobs.deployment.defaultPythonVersion}")
   private String defaultPythonVersion;
 
-
   /**
    * Check if the pythonVersion passed by the user is supported by the Control Service.
    *

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/SupportedPythonVersions.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/SupportedPythonVersions.java
@@ -33,9 +33,6 @@ public class SupportedPythonVersions {
   @Value("${datajobs.deployment.defaultPythonVersion}")
   private String defaultPythonVersion;
 
-  // TODO: Remove when property is deprecated.
-  @Value("${datajobs.deployment.dataJobBaseImage:python:3.9-slim}")
-  private String deploymentDataJobBaseImage;
 
   /**
    * Check if the pythonVersion passed by the user is supported by the Control Service.
@@ -72,8 +69,6 @@ public class SupportedPythonVersions {
   public String getJobBaseImage(String pythonVersion) {
     if (supportedPythonVersions != null && isPythonVersionSupported(pythonVersion)) {
       return supportedPythonVersions.get(pythonVersion).get(BASE_IMAGE);
-    } else if (deploymentDataJobBaseImage != null && !deploymentDataJobBaseImage.isBlank()) {
-      return deploymentDataJobBaseImage;
     } else {
       log.warn(
           "An issue with the passed pythonVersion or supportedPythonVersions configuration has"

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application-prod.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application-prod.properties
@@ -37,7 +37,6 @@ datajobs.aws.region=${AWS_REGION}
 datajobs.aws.accessKeyId=${AWS_ACCESS_KEY_ID}
 datajobs.aws.secretAccessKey=${AWS_ACCESS_KEY_SECRET}
 datajobs.docker.repositoryUrl=${DOCKER_REPOSITORY_URL}
-datajobs.vdk.image=${DOCKER_VDK_BASE_IMAGE}
 datajobs.docker.registryType=${DOCKER_REGISTRY_TYPE}
 datajobs.docker.registryUsername=${DOCKER_REGISTRY_USERNAME}
 datajobs.docker.registryPassword=${DOCKER_REGISTRY_PASSWORD}
@@ -57,7 +56,6 @@ datajobs.kadmin_password=${KADMIN_PASSWORD}
 
 # This is the full image name of the data job builder
 datajobs.builder.image=registry.hub.docker.com/versatiledatakit/job-builder:1.3.3
-datajobs.deployment.dataJobBaseImage=registry.hub.docker.com/versatiledatakit/data-job-base-python-3.7:latest
 
 # Path to an ini config file that contains vdk runtime options
 datajobs.vdk_options_ini=${VDK_OPTIONS_INI}

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -126,10 +126,10 @@ datajobs.deployment.dataJobBaseImage=python:3.9-slim
 
 # The map of python version and respective data job base and vdk images that would be
 # used for data job deployments
-datajobs.deployment.supportedPythonVersions=${DATAJOBS_DEPLOYMENT_SUPPORTED_PYTHON_VERSIONS:{}}
+datajobs.deployment.supportedPythonVersions=${DATAJOBS_DEPLOYMENT_SUPPORTED_PYTHON_VERSIONS:{3.9: {vdkImage: 'registry.hub.docker.com/versatiledatakit/quickstart-vdk:release', baseImage: 'python:3.9-slim'}}}
 # The default python version, which is to be used when selecting the vdk and job base images from
 # the supportedPythonVersions for data job deployments
-datajobs.deployment.defaultPythonVersion=${DATAJOBS_DEPLOYMENT_DEFAULT_PYTHON_VERSION:#{null}}
+datajobs.deployment.defaultPythonVersion=${DATAJOBS_DEPLOYMENT_DEFAULT_PYTHON_VERSION:3.9}
 
 #Configuration variables used for data job execution cleanup
 #This is a spring cron expression, used to schedule the clean up job / default is every 3 hours

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/SupportedPythonVersionsTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/SupportedPythonVersionsTest.java
@@ -21,7 +21,6 @@ public class SupportedPythonVersionsTest {
   private static final String BASE_IMAGE = "baseImage";
   private static final String VDK_IMAGE = "vdkImage";
   private static final String DEFAULT_PYTHON_VERSION = "defaultPythonVersion";
-  private static final String DEPLOYMENT_DATA_JOB_BASE_IMAGE = "deploymentDataJobBaseImage";
 
   @InjectMocks private SupportedPythonVersions supportedPythonVersions;
 
@@ -92,19 +91,6 @@ public class SupportedPythonVersionsTest {
     final String resultBaseImg = "python:3.8-slim";
     ReflectionTestUtils.setField(
         supportedPythonVersions, SUPPORTED_PYTHON_VERSIONS, supportedVersions);
-
-    Assertions.assertEquals(resultBaseImg, supportedPythonVersions.getJobBaseImage("3.8"));
-  }
-
-  @Test
-  public void getJobBaseImage_shouldIgnoreDeploymentDataJobBaseImage() {
-    var supportedVersions = generateSupportedPythonVersionsConf();
-
-    final String resultBaseImg = "python:3.8-slim";
-    ReflectionTestUtils.setField(
-        supportedPythonVersions, SUPPORTED_PYTHON_VERSIONS, supportedVersions);
-    ReflectionTestUtils.setField(
-        supportedPythonVersions, DEPLOYMENT_DATA_JOB_BASE_IMAGE, "python:3.9-slim");
 
     Assertions.assertEquals(resultBaseImg, supportedPythonVersions.getJobBaseImage("3.8"));
   }


### PR DESCRIPTION
As part of the initiative to support multiple python versions for data job deployments, we introduced new configurations through the `datajobs.deployment.supportedPythonVersions` and `datajobs.deployment.defaultPythonVersion` properties. This new configuration renders the old configurations through `datajobs.vdk.image` and `datajobs.deployment.dataJobBaseImage` essentially useless, as these are no longer used.

This change cleans up the old configurations and related code and tests, so that only the new configurations remain. A more descriptive list of the changes is as follows:
* The `DOCKER_VDK_BASE_IMAGE` and `DATAJOBS_DEPLOYMENT_DATAJOBBASEIMAGE` environment variables are removed, as they are not needed anymore.
* The templates associated with the above-mentioned env vars, projects/control-service/projects/helm_charts/pipelines-control-service/templates/_helpers.tpl, is also removed.
* The JobImageDeployer, projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java, logic related to the stand-alone vdk image configuration is also cleaned up to use only the `supportedPythonVersions` functionality. Tests associated with the cleaned up logic are also removed.

The new configurations were introduced in https://github.com/vmware/versatile-data-kit/pull/2022 and https://github.com/vmware/versatile-data-kit/pull/1935

Testing Done: CI/CD