### PR TITLE
control-service: upgrade python client

### DIFF
--- a/projects/control-service/projects/model/apidefs/build.gradle
+++ b/projects/control-service/projects/model/apidefs/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.openapi.generator' version '6.5.0'
+    id 'org.openapi.generator' version '6.6.0'
 }
 
 subprojects {
@@ -51,29 +51,6 @@ subprojects {
         inputSpec = "$projectDir/api.yaml"
         outputDir = "$projectDir/build/python"
         configFile = "$projectDir/config-python.json"
-        doLast {
-
-            fileTree("$projectDir/build/python/taurus_datajob_api/api") {
-            }.each { File propFile ->
-                if(propFile.getName().endsWith("data_jobs_sources_api.py")) {
-                    // Everything in this section can be removed when the ticket(https://github.com/OpenAPITools/openapi-generator/issues/15327) is closed
-                    String content = propFile.getText()
-                    content = content
-                            .replace(
-                                    'def sources_upload(self, team_name : Annotated[StrictStr, Field(..., description="Team Name")], job_name : Annotated[StrictStr, Field(..., description="Data Job Name.")], body : StrictStr, reason : Annotated[Optional[StrictStr], Field(description="The reason for executing the request")] = None, **kwargs) -> DataJobVersion:  # noqa: E501',
-                                    'def sources_upload(self, team_name : Annotated[StrictStr, Field(..., description="Team Name")], job_name : Annotated[StrictStr, Field(..., description="Data Job Name.")], body : bytes, reason : Annotated[Optional[StrictStr], Field(description="The reason for executing the request")] = None, **kwargs) -> DataJobVersion:  # noqa: E501').
-                            replace('def sources_upload_with_http_info(self, team_name : Annotated[StrictStr, Field(..., description="Team Name")], job_name : Annotated[StrictStr, Field(..., description="Data Job Name.")], body : StrictStr, reason : Annotated[Optional[StrictStr], Field(description="The reason for executing the request")] = None, **kwargs):  # noqa: E501',
-                                    'def sources_upload_with_http_info(self, team_name : Annotated[StrictStr, Field(..., description="Team Name")], job_name : Annotated[StrictStr, Field(..., description="Data Job Name.")], body : bytes, reason : Annotated[Optional[StrictStr], Field(description="The reason for executing the request")] = None, **kwargs):  # noqa: E501')
-                    propFile.setText(content)
-                }else if(propFile.getName().endsWith("data_jobs_properties_api.py")) {
-                    // Everything in this section can be removed when the ticket(https://github.com/OpenAPITools/openapi-generator/issues/15328) is closed
-                    String content = propFile.getText()
-                    content = content.
-                            replace("if _params['request_body']:", "if _params['request_body'] is not None:")
-                    propFile.setText(content)
-                }
-            }
-        }
     }
     cleanUpUnwantedGeneratedFiles.dependsOn 'openApiGenerate'
     compileJava.dependsOn 'openApiGenerate' //generate Java from openapi specs

--- a/projects/control-service/projects/model/apidefs/datajob-api/config-python.json
+++ b/projects/control-service/projects/model/apidefs/datajob-api/config-python.json
@@ -1,5 +1,5 @@
 {
   "packageName": "taurus_datajob_api",
   "projectName": "vdk-control-service-api",
-  "packageVersion": "1.0.9"
+  "packageVersion": "1.0.10"
 }


### PR DESCRIPTION
# Why
We were using a version of the python client generator that had a few bugs in it. I opened tickets and they have fixed the bugs
# What
Upgrade the gradle plugin version and remove the hacks in the gradle codebase to workaround the existing issues.

# How has this been tested 
I made a release of it locally and ran the vdk-control-cli tests using the newest python client library. 
 

