### PR TITLE
vdk-control-cli: upgrade python client

### DIFF
--- a/projects/vdk-control-cli/requirements.txt
+++ b/projects/vdk-control-cli/requirements.txt
@@ -27,4 +27,4 @@ tabulate
 urllib3>=1.26.5
 vdk-control-api-auth
 
-vdk-control-service-api==1.0.9
+vdk-control-service-api==1.0.10

--- a/projects/vdk-control-cli/setup.cfg
+++ b/projects/vdk-control-cli/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     requests>=2.25
     setuptools>=47.0
     pluggy
-    vdk-control-service-api==1.0.9
+    vdk-control-service-api==1.0.10
     tabulate
     requests_oauthlib>=1.0
     urllib3>=1.26.5

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/download_job.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/download_job.py
@@ -5,7 +5,7 @@ import os
 
 import click
 import click_spinner
-from urllib3 import HTTPResponse
+from taurus_datajob_api import ApiResponse
 from vdk.internal.control.configuration.defaults_config import load_default_team_name
 from vdk.internal.control.exception.vdk_exception import VDKException
 from vdk.internal.control.job.job_archive import JobArchive
@@ -29,7 +29,7 @@ class JobDownloadSource:
         try:
             log.info(f"Downloading data job {name} in {path}/{name} ...")
             with click_spinner.spinner():
-                response: HTTPResponse = self.sources_api.data_job_sources_download(
+                response = self.sources_api.data_job_sources_download_with_http_info(
                     team_name=team, job_name=name, _preload_content=False
                 )
                 self.__write_response_to_archive(job_archive_path, response)
@@ -42,10 +42,10 @@ class JobDownloadSource:
             self.__cleanup_archive(job_archive_path)
 
     @staticmethod
-    def __write_response_to_archive(job_archive_path: str, response: HTTPResponse):
+    def __write_response_to_archive(job_archive_path: str, response: ApiResponse):
         log.debug(f"Write data job source to {job_archive_path}")
         with open(job_archive_path, "wb") as w:
-            w.write(response.data)
+            w.write(response.raw_data)
 
     @staticmethod
     def __validate_job_path(path: str, name: str):

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/download_key.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/download_key.py
@@ -20,11 +20,11 @@ class JobDownloadKey:
     @ApiClientErrorDecorator()
     def download(self, team: str, name: str, path: str):
         keytab_file_path = os.path.join(path, f"{name}.keytab")
-        response: HTTPResponse = self.jobs_api.data_job_keytab_download(
+        response = self.jobs_api.data_job_keytab_download_with_http_info(
             team_name=team, job_name=name, _preload_content=False
         )
         with open(keytab_file_path, "wb") as w:
-            w.write(response.data)
+            w.write(response.raw_data)
         log.info(f"Saved keytab in {keytab_file_path}")
 
 

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/execute.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/execute.py
@@ -83,12 +83,12 @@ class JobExecute:
             args=self.__validate_and_parse_args(arguments),
         )
         log.debug(f"Starting job with request {execution_request}")
-        _, _, headers = self.__execution_api.data_job_execution_start_with_http_info(
+        headers = self.__execution_api.data_job_execution_start_with_http_info(
             team_name=team,
             job_name=name,
             deployment_id="production",  # TODO
             data_job_execution_request=execution_request,
-        )
+        ).headers
         log.debug(f"Received headers: {headers}")
 
         location = headers["Location"]


### PR DESCRIPTION
# Why
We were using a version of the python client generator that had a few bugs in it. I opened tickets and they have fixed the bugs. in this PR https://github.com/vmware/versatile-data-kit/pull/2076 I released the new version. 

# What
Make a few small changes to make it compatible with the latest version

# How has this been tested
ran tests locally