### PR TITLE
vdk-airflow: fix failing tests

### DIFF
--- a/projects/vdk-plugins/airflow-provider-vdk/tests/hooks/test_vdkhook.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/tests/hooks/test_vdkhook.py
@@ -16,7 +16,7 @@ class PatchedAuth(Authentication):
     def read_access_token(self) -> str:
         return "test1token"
 
-class DummyResponse:
+class DummyStatusResponse:
     status = 200
     data = b"ddf"
     def getheader(self, str):
@@ -58,7 +58,7 @@ class TestVDKHook(unittest.TestCase):
     def test_cancel_job_execution(self, mocked_api_client_request):
         request_url = "https://www.vdk-endpoint.org/data-jobs/for-team/test_team/jobs/test_job/executions/test_execution_id"
 
-        mocked_api_client_request.return_value = DummyResponse()
+        mocked_api_client_request.return_value = DummyStatusResponse()
 
         self.hook.cancel_job_execution("test_execution_id")
 
@@ -68,7 +68,7 @@ class TestVDKHook(unittest.TestCase):
     @mock.patch("taurus_datajob_api.api_client.ApiClient.request")
     def test_get_job_execution_status(self, mocked_api_client_request, _):
         request_url = "https://www.vdk-endpoint.org/data-jobs/for-team/test_team/jobs/test_job/executions/test_execution_id"
-        mocked_api_client_request.return_value = DummyResponse()
+        mocked_api_client_request.return_value = DummyStatusResponse()
         self.hook.get_job_execution_status("test_execution_id")
 
         assert mocked_api_client_request.call_args_list[0][0] == ("GET", request_url)
@@ -78,7 +78,7 @@ class TestVDKHook(unittest.TestCase):
     def test_get_job_execution_log(self, mocked_api_client_request, _):
         request_url = "https://www.vdk-endpoint.org/data-jobs/for-team/test_team/jobs/test_job/executions/test_execution_id/logs"
 
-        mocked_api_client_request.return_value = DummyResponse()
+        mocked_api_client_request.return_value = DummyStatusResponse()
         self.hook.get_job_execution_log("test_execution_id")
 
         assert mocked_api_client_request.call_args_list[0][0] == ("GET", request_url)

--- a/projects/vdk-plugins/airflow-provider-vdk/tests/hooks/test_vdkhook.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/tests/hooks/test_vdkhook.py
@@ -16,6 +16,11 @@ class PatchedAuth(Authentication):
     def read_access_token(self) -> str:
         return "test1token"
 
+class DummyResponse:
+    status = 200
+    data = b"ddf"
+    def getheader(self, str):
+        return "json"
 
 class TestVDKHook(unittest.TestCase):
     @mock.patch.dict(
@@ -47,9 +52,13 @@ class TestVDKHook(unittest.TestCase):
             }
         )
 
+
+
     @mock.patch("taurus_datajob_api.api_client.ApiClient.request")
     def test_cancel_job_execution(self, mocked_api_client_request):
         request_url = "https://www.vdk-endpoint.org/data-jobs/for-team/test_team/jobs/test_job/executions/test_execution_id"
+
+        mocked_api_client_request.return_value = DummyResponse()
 
         self.hook.cancel_job_execution("test_execution_id")
 
@@ -59,7 +68,7 @@ class TestVDKHook(unittest.TestCase):
     @mock.patch("taurus_datajob_api.api_client.ApiClient.request")
     def test_get_job_execution_status(self, mocked_api_client_request, _):
         request_url = "https://www.vdk-endpoint.org/data-jobs/for-team/test_team/jobs/test_job/executions/test_execution_id"
-
+        mocked_api_client_request.return_value = DummyResponse()
         self.hook.get_job_execution_status("test_execution_id")
 
         assert mocked_api_client_request.call_args_list[0][0] == ("GET", request_url)
@@ -69,6 +78,7 @@ class TestVDKHook(unittest.TestCase):
     def test_get_job_execution_log(self, mocked_api_client_request, _):
         request_url = "https://www.vdk-endpoint.org/data-jobs/for-team/test_team/jobs/test_job/executions/test_execution_id/logs"
 
+        mocked_api_client_request.return_value = DummyResponse()
         self.hook.get_job_execution_log("test_execution_id")
 
         assert mocked_api_client_request.call_args_list[0][0] == ("GET", request_url)

--- a/projects/vdk-plugins/airflow-provider-vdk/tests/hooks/test_vdkhook.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/tests/hooks/test_vdkhook.py
@@ -16,11 +16,14 @@ class PatchedAuth(Authentication):
     def read_access_token(self) -> str:
         return "test1token"
 
+
 class DummyStatusResponse:
     status = 200
     data = b"ddf"
+
     def getheader(self, str):
         return "json"
+
 
 class TestVDKHook(unittest.TestCase):
     @mock.patch.dict(
@@ -51,8 +54,6 @@ class TestVDKHook(unittest.TestCase):
                 "deployment_id": "production",
             }
         )
-
-
 
     @mock.patch("taurus_datajob_api.api_client.ApiClient.request")
     def test_cancel_job_execution(self, mocked_api_client_request):

--- a/projects/vdk-plugins/airflow-provider-vdk/tests/sensors/test_vdksensor.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/tests/sensors/test_vdksensor.py
@@ -9,7 +9,7 @@ from vdk_provider.hooks.vdk import VDKJobExecutionException
 from vdk_provider.sensors.vdk import VDKSensor
 
 
-class DummyResponse:
+class DummyLogsResponse:
     status = 200
     data = b"ddf"
     def getheader(self, str):
@@ -68,7 +68,7 @@ class TestVDKSensor(TestCase):
         mock_get_job_execution_status.return_value = DataJobExecution(
             status="succeeded"
         )
-        mock_request.return_value = DummyResponse()
+        mock_request.return_value = DummyLogsResponse()
 
         self.assertEqual(self.sensor.poke(context={}), True)
         mock_access_token.assert_called_once()
@@ -116,7 +116,7 @@ class TestVDKSensor(TestCase):
             status="user_error"
         )
 
-        mock_request.return_value = DummyResponse()
+        mock_request.return_value = DummyLogsResponse()
 
         with self.assertRaises(VDKJobExecutionException) as e:
             self.sensor.poke(context={})
@@ -138,7 +138,7 @@ class TestVDKSensor(TestCase):
             status="platform_error"
         )
 
-        mock_request.return_value = DummyResponse()
+        mock_request.return_value = DummyLogsResponse()
 
         with self.assertRaises(VDKJobExecutionException) as e:
             self.sensor.poke(context={})

--- a/projects/vdk-plugins/airflow-provider-vdk/tests/sensors/test_vdksensor.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/tests/sensors/test_vdksensor.py
@@ -12,8 +12,10 @@ from vdk_provider.sensors.vdk import VDKSensor
 class DummyLogsResponse:
     status = 200
     data = b"ddf"
+
     def getheader(self, str):
         return "json"
+
 
 @mock.patch.dict(
     "os.environ", AIRFLOW_CONN_TEST_CONN_ID="http://https%3A%2F%2Fwww.vdk-endpoint.org"

--- a/projects/vdk-plugins/airflow-provider-vdk/tests/sensors/test_vdksensor.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/tests/sensors/test_vdksensor.py
@@ -9,6 +9,12 @@ from vdk_provider.hooks.vdk import VDKJobExecutionException
 from vdk_provider.sensors.vdk import VDKSensor
 
 
+class DummyResponse:
+    status = 200
+    data = b"ddf"
+    def getheader(self, str):
+        return "json"
+
 @mock.patch.dict(
     "os.environ", AIRFLOW_CONN_TEST_CONN_ID="http://https%3A%2F%2Fwww.vdk-endpoint.org"
 )
@@ -62,6 +68,7 @@ class TestVDKSensor(TestCase):
         mock_get_job_execution_status.return_value = DataJobExecution(
             status="succeeded"
         )
+        mock_request.return_value = DummyResponse()
 
         self.assertEqual(self.sensor.poke(context={}), True)
         mock_access_token.assert_called_once()
@@ -109,6 +116,8 @@ class TestVDKSensor(TestCase):
             status="user_error"
         )
 
+        mock_request.return_value = DummyResponse()
+
         with self.assertRaises(VDKJobExecutionException) as e:
             self.sensor.poke(context={})
 
@@ -128,6 +137,8 @@ class TestVDKSensor(TestCase):
         mock_get_job_execution_status.return_value = DataJobExecution(
             status="platform_error"
         )
+
+        mock_request.return_value = DummyResponse()
 
         with self.assertRaises(VDKJobExecutionException) as e:
             self.sensor.poke(context={})


### PR DESCRIPTION
# Why
on the newest python api client we are getting failing test because we check more of the properties in the mock response. 
# What
Return a dummy response. 
The dummy response which has the required properties. 
# How has this been tested
ran tests locally

