### PR TITLE
vdk-jupyter: pin npm packages to previous version

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package.json
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package.json
@@ -65,9 +65,10 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
-    "@cfaester/enzyme-adapter-react-18": "^0.6.0",
     "@jupyterlab/builder": "^3.1.0",
+    "@jupyterlab/rendermime-interfaces": "3.6.3",
     "@jupyterlab/testutils": "^3.0.0",
+    "@lumino/widgets": "^2.1.1",
     "@testing-library/react": "12.1.5",
     "@types/enzyme": "^3.10.12",
     "@types/jest": "^26.0.0",


### PR DESCRIPTION
What:
Pinned rendermime-interfaces to 3.6.3.
Also removed "@cfaester/enzyme-adapter-react-18": "^0.6.0" which is not used and caused not frequent build errors.
Why:
Because jupyterlab 4 is released some days ago, and it bumps the latest version of rendermime-interface to 3.8.0, which is not compatible with lumino 1.x
This caused Build issues: 
![Screenshot 2023-05-18 at 15 29 27](https://github.com/vmware/versatile-data-kit/assets/87015481/9407ae37-519b-4224-b16c-776d62bd2374)


Signed-off-by: Duygu Hasan [hduygu@vmware.com](mailto:hduygu@vmware.com)