### PR TITLE
control-service: better error message

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/DataJobDeploymentExtension.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/DataJobDeploymentExtension.java
@@ -197,7 +197,7 @@ public class DataJobDeploymentExtension
       // Verify that the job deployment was created
       String jobDeploymentName = JobImageDeployer.getCronJobName(jobName);
       await()
-          .atMost(420, TimeUnit.SECONDS)
+          .atMost(240, TimeUnit.SECONDS)
           .with()
           .pollInterval(10, TimeUnit.SECONDS)
           .until(() -> dataJobsKubernetesService.readCronJob(jobDeploymentName).isPresent());

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/DataJobDeploymentExtension.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/DataJobDeploymentExtension.java
@@ -62,183 +62,197 @@ import com.vmware.taurus.service.model.JobDeploymentStatus;
  * this may affect other tests.</b>
  */
 public class DataJobDeploymentExtension
-    implements BeforeEachCallback, AfterAllCallback, ParameterResolver {
+        implements BeforeEachCallback, AfterAllCallback, ParameterResolver {
 
-  private static final String JOB_NOTIFIED_EMAIL = "versatiledatakit@vmware.com";
-  private static final String JOB_SCHEDULE = "*/20 * * * *";
-  private static final String USER_NAME = "user";
-  private static final String DEPLOYMENT_ID = "NOT_USED";
-  private static final String TEAM_NAME = "test-team";
+    private static final String JOB_NOTIFIED_EMAIL = "versatiledatakit@vmware.com";
+    private static final String JOB_SCHEDULE = "*/20 * * * *";
+    private static final String USER_NAME = "user";
+    private static final String DEPLOYMENT_ID = "NOT_USED";
+    private static final String TEAM_NAME = "test-team";
 
-  private static final String JOB_SOURCE_PATH = "data_jobs/";
+    private static final String JOB_SOURCE_PATH = "data_jobs/";
 
-  protected final ObjectMapper MAPPER = new ObjectMapper();
+    protected final ObjectMapper MAPPER = new ObjectMapper();
 
-  private String jobName =
-      JobExecutionUtil.JOB_NAME_PREFIX + UUID.randomUUID().toString().substring(0, 8);
+    private String jobName =
+            JobExecutionUtil.JOB_NAME_PREFIX + UUID.randomUUID().toString().substring(0, 8);
 
-  private String jobSource = "simple_job.zip";
+    private String jobSource = "simple_job.zip";
 
-  private boolean initialized = false;
+    private boolean initialized = false;
 
-  private final Map<String, Object> SUPPORTED_PARAMETERS =
-      Map.of(
-          "jobName",
-          jobName,
-          "username",
-          USER_NAME,
-          "deploymentId",
-          DEPLOYMENT_ID,
-          "teamName",
-          TEAM_NAME);
+    private final Map<String, Object> SUPPORTED_PARAMETERS =
+            Map.of(
+                    "jobName",
+                    jobName,
+                    "username",
+                    USER_NAME,
+                    "deploymentId",
+                    DEPLOYMENT_ID,
+                    "teamName",
+                    TEAM_NAME);
 
-  public DataJobDeploymentExtension() {}
-
-  public DataJobDeploymentExtension(String jobSource) {
-    this.jobSource = jobSource;
-  }
-
-  @Override
-  public void beforeEach(ExtensionContext context) throws Exception {
-    MockMvc mockMvc = SpringExtension.getApplicationContext(context).getBean(MockMvc.class);
-    DataJobsKubernetesService dataJobsKubernetesService =
-        SpringExtension.getApplicationContext(context).getBean(DataJobsKubernetesService.class);
-
-    // Setup
-    String dataJobRequestBody = BaseIT.getDataJobRequestBody(TEAM_NAME, jobName);
-    // Create the data job
-    mockMvc
-        .perform(
-            post(String.format("/data-jobs/for-team/%s/jobs", TEAM_NAME))
-                .with(user("user"))
-                .content(dataJobRequestBody)
-                .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isCreated())
-        .andExpect(
-            header()
-                .string(
-                    HttpHeaders.LOCATION,
-                    BaseIT.lambdaMatcher(
-                        s ->
-                            s.endsWith(
-                                String.format(
-                                    "/data-jobs/for-team/%s/jobs/%s", TEAM_NAME, jobName)))));
-
-    if (!initialized) {
-      byte[] jobZipBinary =
-          IOUtils.toByteArray(
-              getClass().getClassLoader().getResourceAsStream(JOB_SOURCE_PATH + jobSource));
-
-      // Upload the data job
-      MvcResult uploadResult =
-          mockMvc
-              .perform(
-                  post(String.format("/data-jobs/for-team/%s/jobs/%s/sources", TEAM_NAME, jobName))
-                      .with(user(USER_NAME))
-                      .content(jobZipBinary)
-                      .contentType(MediaType.APPLICATION_OCTET_STREAM))
-              .andExpect(status().isOk())
-              .andReturn();
-      DataJobVersion dataJobVersion =
-          MAPPER.readValue(uploadResult.getResponse().getContentAsString(), DataJobVersion.class);
-
-      // Update the data job configuration
-      var dataJob =
-          new com.vmware.taurus.controlplane.model.data.DataJob()
-              .jobName(jobName)
-              .team(TEAM_NAME)
-              .config(
-                  new DataJobConfig()
-                      .enableExecutionNotifications(false)
-                      .contacts(
-                          new DataJobContacts()
-                              .addNotifiedOnJobSuccessItem(JOB_NOTIFIED_EMAIL)
-                              .addNotifiedOnJobDeployItem(JOB_NOTIFIED_EMAIL)
-                              .addNotifiedOnJobFailurePlatformErrorItem(JOB_NOTIFIED_EMAIL)
-                              .addNotifiedOnJobFailureUserErrorItem(JOB_NOTIFIED_EMAIL))
-                      .schedule(new DataJobSchedule().scheduleCron(JOB_SCHEDULE)));
-      mockMvc.perform(
-          put(String.format("/data-jobs/for-team/%s/jobs/%s", TEAM_NAME, jobName))
-              .with(user(USER_NAME))
-              .content(MAPPER.writeValueAsString(dataJob))
-              .contentType(MediaType.APPLICATION_JSON));
-
-      // Deploy the data job
-      var dataJobDeployment =
-          new DataJobDeployment()
-              .jobVersion(dataJobVersion.getVersionSha())
-              .mode(DataJobMode.RELEASE)
-              .enabled(true);
-      mockMvc
-          .perform(
-              post(String.format("/data-jobs/for-team/%s/jobs/%s/deployments", TEAM_NAME, jobName))
-                  .with(user(USER_NAME))
-                  .content(MAPPER.writeValueAsString(dataJobDeployment))
-                  .contentType(MediaType.APPLICATION_JSON))
-          .andExpect(status().isAccepted())
-          .andReturn();
-
-      // Verify that the job deployment was created
-      String jobDeploymentName = JobImageDeployer.getCronJobName(jobName);
-      await()
-          .atMost(360, TimeUnit.SECONDS)
-          .with()
-          .pollInterval(10, TimeUnit.SECONDS)
-          .until(() -> dataJobsKubernetesService.readCronJob(jobDeploymentName).isPresent());
-
-      Optional<JobDeploymentStatus> cronJobOptional =
-          dataJobsKubernetesService.readCronJob(jobDeploymentName);
-      assertTrue(cronJobOptional.isPresent());
-      JobDeploymentStatus cronJob = cronJobOptional.get();
-      assertEquals(dataJobVersion.getVersionSha(), cronJob.getGitCommitSha());
-      assertEquals(DataJobMode.RELEASE.toString(), cronJob.getMode());
-      assertEquals(true, cronJob.getEnabled());
-      assertTrue(cronJob.getImageName().endsWith(dataJobVersion.getVersionSha()));
-      assertEquals(USER_NAME, cronJob.getLastDeployedBy());
-
-      initialized = true;
+    public DataJobDeploymentExtension() {
     }
-  }
 
-  @Override
-  public void afterAll(ExtensionContext context) throws Exception {
-    MockMvc mockMvc = SpringExtension.getApplicationContext(context).getBean(MockMvc.class);
-    DataJobsKubernetesService dataJobsKubernetesService =
-        SpringExtension.getApplicationContext(context).getBean(DataJobsKubernetesService.class);
+    public DataJobDeploymentExtension(String jobSource) {
+        this.jobSource = jobSource;
+    }
 
-    mockMvc
-        .perform(
-            delete(String.format("/data-jobs/for-team/%s/jobs/%s", TEAM_NAME, jobName))
-                .with(user(USER_NAME))
-                .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk());
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        MockMvc mockMvc = SpringExtension.getApplicationContext(context).getBean(MockMvc.class);
+        DataJobsKubernetesService dataJobsKubernetesService =
+                SpringExtension.getApplicationContext(context).getBean(DataJobsKubernetesService.class);
 
-    // Finally, delete the K8s jobs to avoid them messing up subsequent runs of the same test
-    dataJobsKubernetesService.listJobs().stream()
-        .filter(jobName -> jobName.startsWith(this.jobName))
-        .forEach(
-            s -> {
-              try {
-                dataJobsKubernetesService.deleteJob(s);
-              } catch (ApiException e) {
-                e.printStackTrace();
-              }
-            });
-  }
+        // Setup
+        String dataJobRequestBody = BaseIT.getDataJobRequestBody(TEAM_NAME, jobName);
+        // Create the data job
+        mockMvc
+                .perform(
+                        post(String.format("/data-jobs/for-team/%s/jobs", TEAM_NAME))
+                                .with(user("user"))
+                                .content(dataJobRequestBody)
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(
+                        header()
+                                .string(
+                                        HttpHeaders.LOCATION,
+                                        BaseIT.lambdaMatcher(
+                                                s ->
+                                                        s.endsWith(
+                                                                String.format(
+                                                                        "/data-jobs/for-team/%s/jobs/%s", TEAM_NAME, jobName)))));
 
-  @Override
-  public boolean supportsParameter(
-      ParameterContext parameterContext, ExtensionContext extensionContext)
-      throws ParameterResolutionException {
-    Parameter parameter = parameterContext.getParameter();
-    return String.class.equals(parameter.getType())
-        && SUPPORTED_PARAMETERS.containsKey(parameter.getName());
-  }
+        if (!initialized) {
+            byte[] jobZipBinary =
+                    IOUtils.toByteArray(
+                            getClass().getClassLoader().getResourceAsStream(JOB_SOURCE_PATH + jobSource));
 
-  @Override
-  public Object resolveParameter(
-      ParameterContext parameterContext, ExtensionContext extensionContext)
-      throws ParameterResolutionException {
-    return SUPPORTED_PARAMETERS.getOrDefault(parameterContext.getParameter().getName(), null);
-  }
+            // Upload the data job
+            MvcResult uploadResult =
+                    mockMvc
+                            .perform(
+                                    post(String.format("/data-jobs/for-team/%s/jobs/%s/sources", TEAM_NAME, jobName))
+                                            .with(user(USER_NAME))
+                                            .content(jobZipBinary)
+                                            .contentType(MediaType.APPLICATION_OCTET_STREAM))
+                            .andExpect(status().isOk())
+                            .andReturn();
+            DataJobVersion dataJobVersion =
+                    MAPPER.readValue(uploadResult.getResponse().getContentAsString(), DataJobVersion.class);
+
+            // Update the data job configuration
+            var dataJob =
+                    new com.vmware.taurus.controlplane.model.data.DataJob()
+                            .jobName(jobName)
+                            .team(TEAM_NAME)
+                            .config(
+                                    new DataJobConfig()
+                                            .enableExecutionNotifications(false)
+                                            .contacts(
+                                                    new DataJobContacts()
+                                                            .addNotifiedOnJobSuccessItem(JOB_NOTIFIED_EMAIL)
+                                                            .addNotifiedOnJobDeployItem(JOB_NOTIFIED_EMAIL)
+                                                            .addNotifiedOnJobFailurePlatformErrorItem(JOB_NOTIFIED_EMAIL)
+                                                            .addNotifiedOnJobFailureUserErrorItem(JOB_NOTIFIED_EMAIL))
+                                            .schedule(new DataJobSchedule().scheduleCron(JOB_SCHEDULE)));
+            mockMvc.perform(
+                    put(String.format("/data-jobs/for-team/%s/jobs/%s", TEAM_NAME, jobName))
+                            .with(user(USER_NAME))
+                            .content(MAPPER.writeValueAsString(dataJob))
+                            .contentType(MediaType.APPLICATION_JSON));
+
+            // Deploy the data job
+            var dataJobDeployment =
+                    new DataJobDeployment()
+                            .jobVersion(dataJobVersion.getVersionSha())
+                            .mode(DataJobMode.RELEASE)
+                            .enabled(true);
+            mockMvc
+                    .perform(
+                            post(String.format("/data-jobs/for-team/%s/jobs/%s/deployments", TEAM_NAME, jobName))
+                                    .with(user(USER_NAME))
+                                    .content(MAPPER.writeValueAsString(dataJobDeployment))
+                                    .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isAccepted())
+                    .andReturn();
+
+            await()
+                    .atMost(120, TimeUnit.SECONDS)
+                    .with()
+                    .pollDelay(20, TimeUnit.SECONDS)
+                    .pollInterval(2, TimeUnit.SECONDS)
+                    .failFast(() -> {
+                        if(dataJobsKubernetesService.getPod("builder-" + jobName)
+                                .map(a -> a.getStatus().getPhase().equals("Failed")).orElse(false)) {
+                            throw new Exception(dataJobsKubernetesService.getPodLogs("builder-" + jobName));
+                        }
+                    })
+                    .until(() -> dataJobsKubernetesService.getPod("builder-" + jobName).isEmpty());
+
+            // Verify that the job deployment was created
+            String jobDeploymentName = JobImageDeployer.getCronJobName(jobName);
+            await()
+                    .atMost(420, TimeUnit.SECONDS)
+                    .with()
+                    .pollInterval(10, TimeUnit.SECONDS)
+                    .until(() -> dataJobsKubernetesService.readCronJob(jobDeploymentName).isPresent());
+
+            Optional<JobDeploymentStatus> cronJobOptional =
+                    dataJobsKubernetesService.readCronJob(jobDeploymentName);
+            assertTrue(cronJobOptional.isPresent());
+            JobDeploymentStatus cronJob = cronJobOptional.get();
+            assertEquals(dataJobVersion.getVersionSha(), cronJob.getGitCommitSha());
+            assertEquals(DataJobMode.RELEASE.toString(), cronJob.getMode());
+            assertEquals(true, cronJob.getEnabled());
+            assertTrue(cronJob.getImageName().endsWith(dataJobVersion.getVersionSha()));
+            assertEquals(USER_NAME, cronJob.getLastDeployedBy());
+
+            initialized = true;
+        }
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+        MockMvc mockMvc = SpringExtension.getApplicationContext(context).getBean(MockMvc.class);
+        DataJobsKubernetesService dataJobsKubernetesService =
+                SpringExtension.getApplicationContext(context).getBean(DataJobsKubernetesService.class);
+
+        mockMvc
+                .perform(
+                        delete(String.format("/data-jobs/for-team/%s/jobs/%s", TEAM_NAME, jobName))
+                                .with(user(USER_NAME))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        // Finally, delete the K8s jobs to avoid them messing up subsequent runs of the same test
+        dataJobsKubernetesService.listJobs().stream()
+                .filter(jobName -> jobName.startsWith(this.jobName))
+                .forEach(
+                        s -> {
+                            try {
+                                dataJobsKubernetesService.deleteJob(s);
+                            } catch (ApiException e) {
+                                e.printStackTrace();
+                            }
+                        });
+    }
+
+    @Override
+    public boolean supportsParameter(
+            ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        Parameter parameter = parameterContext.getParameter();
+        return String.class.equals(parameter.getType())
+                && SUPPORTED_PARAMETERS.containsKey(parameter.getName());
+    }
+
+    @Override
+    public Object resolveParameter(
+            ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        return SUPPORTED_PARAMETERS.getOrDefault(parameterContext.getParameter().getName(), null);
+    }
 }


### PR DESCRIPTION
# Why
At the moment if a test fails to setup correctly it is almost impossible to figure out why it failed when investigating even 5 minutes later. 

# What 
With this PR I add a new assertion. instead of checking if a cron job for a data job is deployed I first check that the builder job completed successfully. 
If the builder fails, I include the logs in the stacktrace which means it is very easy to understand the root cause at a later date. 


# How was this tested 
Locally 


# Example stacktrace when builder fails. 

```
error building image: GET https://registry.hub.docker.com/v2/versatiledatakit/data-job-base-python-3.9/manifests/latest: TOOMANYREQUESTS: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
org.awaitility.core.TerminalFailureException: AWS_REGION=
DOCKER_REGISTRY=ghcr.io/murphp15
GIT_REPOSITORY=github.com/murphp15/test
REGISTRY_TYPE=generic
Cloning into './data-jobs'...
HEAD is now at cac5451 Update data job: integration-test-74e7e0d9
INFO[0000] Retrieving image manifest registry.hub.docker.com/versatiledatakit/data-job-base-python-3.9:latest 
INFO[0000] Retrieving image registry.hub.docker.com/versatiledatakit/data-job-base-python-3.9:latest from registry registry.hub.docker.com 
error building image: GET https://registry.hub.docker.com/v2/versatiledatakit/data-job-base-python-3.9/manifests/latest: TOOMANYREQUESTS: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
	at app//org.awaitility.core.ConditionAwaiter.executeFailFastConditionIfDefined(ConditionAwaiter.java:202)
	at app//org.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:97)
	at app//org.awaitility.core.CallableCondition.await(CallableCondition.java:78)
	at app//org.awaitility.core.CallableCondition.await(CallableCondition.java:26)
	at app//org.awaitility.core.ConditionFactory.until(ConditionFactory.java:985)
	at app//org.awaitility.core.ConditionFactory.until(ConditionFactory.java:954)
	at app//com.vmware.taurus.datajobs.it.common.DataJobDeploymentExtension.beforeEach(DataJobDeploymentExtension.java:196)
	at app//org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeBeforeEachCallbacks$2(TestMethodTestDescriptor.java:166)
	at app//org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeBeforeMethodsOrCallbacksUntilExceptionOccurs$6(TestMethodTestDescriptor.java:202)
	at app//org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at app//org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeBeforeMethodsOrCallbacksUntilExceptionOccurs(TestMethodTestDescriptor.java:202)
	at app//org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeBeforeEachCallbacks(TestMethodTestDescriptor.java:165)
	at app//org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:132)
	at app//org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:68)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
	at app//org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at app//org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at app//org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base@19.0.1/java.util.ArrayList.forEach(ArrayList.java:1511)
	at app//org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at app//org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at app//org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at app//org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base@19.0.1/java.util.ArrayList.forEach(ArrayList.java:1511)
	at app//org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at app//org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at app//org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at app//org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at app//org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at app//org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at app//org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:107)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:53)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:99)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:79)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:75)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:62)
	at java.base@19.0.1/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base@19.0.1/java.lang.reflect.Method.invoke(Method.java:578)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at jdk.proxy2/jdk.proxy2.$Proxy5.stop(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:193)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:113)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:65)
	at app//worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at app//worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
Caused by: java.lang.Exception: AWS_REGION=
DOCKER_REGISTRY=ghcr.io/murphp15
GIT_REPOSITORY=github.com/murphp15/test
REGISTRY_TYPE=generic
Cloning into './data-jobs'...
HEAD is now at cac5451 Update data job: integration-test-74e7e0d9
INFO[0000] Retrieving image manifest registry.hub.docker.com/versatiledatakit/data-job-base-python-3.9:latest 
INFO[0000] Retrieving image registry.hub.docker.com/versatiledatakit/data-job-base-python-3.9:latest from registry registry.hub.docker.com 
error building image: GET https://registry.hub.docker.com/v2/versatiledatakit/data-job-base-python-3.9/manifests/latest: TOOMANYREQUESTS: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
	at com.vmware.taurus.datajobs.it.common.DataJobDeploymentExtension.lambda$beforeEach$2(DataJobDeploymentExtension.java:193)
	at org.awaitility.core.ConditionAwaiter.executeFailFastConditionIfDefined(ConditionAwaiter.java:199)
	... 73 more


```

