### PR TITLE
vdk-dag: update VEP about the execution type propagation

### DIFF
--- a/specs/vep-1243-vdk-dag/README.md
+++ b/specs/vep-1243-vdk-dag/README.md
@@ -221,6 +221,11 @@ The DAG is executed as follows:
 3. Finished jobs are marked as completed and removed from the execution queue.
 
 The algorithm continues executing jobs until all jobs in the DAG are completed.
+The execution type of the DAG is being inherited by its orchestrated jobs.
+Upon sending the execution request for each job, the "started_by" parameter is set to "EXEC-TYPE/DAG-NAME"
+(e.g. "manual/dag-job"), where:
+* EXEC-TYPE = "manual" or "scheduled";
+* DAG-NAME = the name of the DAG Job.
 
 ### Capacity Estimation and Constraints
 


### PR DESCRIPTION
What: Update VEP with information about the recently added functionality of execution type propagation - if the DAG job is executed manually, then its execution type is "manual" and consequently, all its orcehstrated jobs' type would be set to "manual". Same applies for "scheduled" executions.

Testing Done: Just update the VEP

Signed-off-by: Yoan Salambashev <ysalambashev@vmware.com>