### PR TITLE
vdk-jupyter: pin lumino/widgets package to version 1

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package.json
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package.json
@@ -34,7 +34,7 @@
     "build:prod": "jlpm clean && jlpm build:lib && jlpm build:labextension",
     "build:labextension": "jupyter labextension build .",
     "build:labextension:dev": "jupyter labextension build --development True .",
-    "build:lib": "tsc",
+    "build:lib": "npm update && tsc",
     "build:interfaces": "pip install py-to-ts-interfaces && py-to-ts-interfaces vdk_jupyterlab_extension/vdk_options/ src/vdkOptions",
     "clean": "jlpm clean:lib",
     "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
@@ -53,7 +53,7 @@
     "stylelint:check": "stylelint --cache \"style/**/*.css\"",
     "test": "jest --coverage",
     "watch": "run-p watch:src watch:labextension",
-    "watch:src": "npm update && tsc -w",
+    "watch:src": "tsc -w",
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package.json
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package.json
@@ -118,6 +118,7 @@
     "hooks": {
       "before-build-npm": [
         "python -m pip install jupyterlab~=3.1",
+        "npm update",
         "jlpm"
       ],
       "before-build-python": [

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package.json
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package.json
@@ -68,7 +68,7 @@
     "@jupyterlab/builder": "^3.1.0",
     "@jupyterlab/rendermime-interfaces": "3.6.3",
     "@jupyterlab/testutils": "^3.0.0",
-    "@lumino/widgets": "^2.1.1",
+    "@lumino/widgets": "1.33.0",
     "@testing-library/react": "12.1.5",
     "@types/enzyme": "^3.10.12",
     "@types/jest": "^26.0.0",

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package.json
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package.json
@@ -53,7 +53,7 @@
     "stylelint:check": "stylelint --cache \"style/**/*.css\"",
     "test": "jest --coverage",
     "watch": "run-p watch:src watch:labextension",
-    "watch:src": "tsc -w",
+    "watch:src": "npm update && tsc -w",
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
@@ -118,7 +118,6 @@
     "hooks": {
       "before-build-npm": [
         "python -m pip install jupyterlab~=3.1",
-        "npm update",
         "jlpm"
       ],
       "before-build-python": [


### PR DESCRIPTION
What:
Pinned lumino/widgets to 1.33.0

Why:
Jupyterlab 4 is released some days ago, and it bumps the latest
version of rendermime-interface to 3.8.0, which is not compatible with
lumino 1.x
Because of that. we pinned render mime-interface to 3.6.3 which is best compatible with lumino 1.x and causes problems with lumina 2.x, I pinned the lumina to the lates stable 1.x version
This caused Build issues: 
![Screenshot 2023-05-18 at 15 29
27](https://github.com/vmware/versatile-data-kit/assets/87015481/9407ae37-519b-4224-b16c-776d62bd2374)


Signed-off-by: Duygu Hasan [hduygu@vmware.com](mailto:hduygu@vmware.com)