### PR TITLE
vdk-heartbeat: fix python3.7 issue

### DIFF
--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/hearbeat.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/hearbeat.py
@@ -21,14 +21,13 @@ class Heartbeat:
     """
 
     def __init__(self, config: Config):
-        self._config = config
+        self.config = config
 
     @TestDecorator()
     def run(self):
-        create_test_instance(self._config).run_test()
+        create_test_instance(self.config).run_test()
 
 
-@staticmethod
 def create_test_instance(config: Config) -> HeartbeatBaseTest:
     import importlib
 

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/heartbeat_base_test.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/heartbeat_base_test.py
@@ -53,7 +53,7 @@ class HeartbeatBaseTest(ABC):
             self.execute_test()
         except:
             log.info("Heartbeat has failed.")
-            if self._config.clean_up_on_failure:
+            if self.config.clean_up_on_failure:
                 log.info("Heartbeat clean up on failure.")
                 self.clean_up()
             raise

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/heartbeat_test.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/heartbeat_test.py
@@ -49,7 +49,7 @@ class HeartbeatTest(HeartbeatBaseTest):
 
             self.__job_controller.disable_deployment()
 
-            if self._config.check_manual_job_execution:
+            if self.config.check_manual_job_execution:
                 self.__job_controller.check_job_execution_finished()
                 self.__job_controller.start_job_execution()
                 self.__job_controller.check_job_execution_finished()
@@ -60,7 +60,7 @@ class HeartbeatTest(HeartbeatBaseTest):
             log.info("Heartbeat has failed.")
             self.__job_controller.show_job_details()
             self.__job_controller.show_last_job_execution_logs()
-            if self._config.clean_up_on_failure:
+            if self.config.clean_up_on_failure:
                 log.info("Heartbeat clean up on failure.")
                 self.clean()
             raise


### PR DESCRIPTION
## Why

A recent test run in CI broke with an error related to the staticmethod decorator https://gitlab.com/vmware-analytics/versatile-data-kit/-/jobs/4325250349

The latest heartbeat changes were tested on python3.11 They turned out not to be compatible with python 3.7

## What

Remove the @staticmethod decorator from the test instantiation method (we're not using this method outside the runner)
Rename config memeber field of test classes to _config

## How was this tested

Locally, in virtual environment using python 3.7

## What kind of change is this

Bugfix