### PR TITLE
vdk-jupyter: add separator to the VDK menu

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/schema/plugin.json
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/schema/plugin.json
@@ -13,6 +13,9 @@
             "command": "jp-vdk:menu-run"
           },
           {
+            "type": "separator"
+          },
+          {
             "command": "jp-vdk:menu-create"
           },
           {


### PR DESCRIPTION
What:
Added a separator to the vdk menu:
Now:
<img width="193" alt="Screenshot 2023-05-23 at 13 57 10" src="https://github.com/vmware/versatile-data-kit/assets/87015481/d9461688-b4d0-4c8c-b393-b4f657272723">
Then:
<img width="174" alt="Screenshot 2023-05-23 at 13 57 17" src="https://github.com/vmware/versatile-data-kit/assets/87015481/7e42c35d-c4ad-4a7d-a67b-333d5d6587df">

Why: to group related menu items together


Signed-off-by: Duygu Hasan [hduygu@vmware.com](mailto:hduygu@vmware.com)