### PR TITLE
control-service: disable authorization on test/cicd deployment

### DIFF
--- a/projects/control-service/cicd/deploy-testing-pipelines-service.sh
+++ b/projects/control-service/cicd/deploy-testing-pipelines-service.sh
@@ -103,7 +103,6 @@ helm upgrade --install --debug --wait --timeout 10m0s $RELEASE_NAME . \
       --set security.enabled=true \
       --set security.oauth2.jwtJwkSetUri=https://console-stg.cloud.vmware.com/csp/gateway/am/api/auth/token-public-key?format=jwks \
       --set security.oauth2.jwtIssuerUrl=https://gaz-preview.csp-vidm-prod.com \
-      --set security.authorizationEnabled=true \
-      --set security.authorization.webhookUri=https://httpbin.org/post \
+      --set security.authorizationEnabled=false \
       --set extraEnvVars.LOGGING_LEVEL_COM_VMWARE_TAURUS=DEBUG \
       --set extraEnvVars.DATAJOBS_TELEMETRY_WEBHOOK_ENDPOINT="https://vcsa.vmware.com/ph-stg/api/hyper/send?_c=taurus.v0&_i=cicd-control-service"


### PR DESCRIPTION

At present, we employ an authorization webhook in our CICD repository, directing to https://httpbin.org/post, which is designed to consistently return a 200 status. However, we've observed a high degree of instability in this arrangement, as documented in https://github.com/vmware/versatile-data-kit/issues/2081.

While it's advantageous to exercise this pathway during the VDK heartbeat process, it isn't essential. This coverage is sufficiently provided through our integration and unit tests, thereby reducing the necessity of the authorization webhook's stability.