### PR TITLE
control-service: increase CICD deployment resources

### DIFF
--- a/projects/control-service/cicd/deploy-testing-pipelines-service.sh
+++ b/projects/control-service/cicd/deploy-testing-pipelines-service.sh
@@ -18,6 +18,8 @@ export RELEASE_NAME=${RELEASE_NAME:-cicd-control-service}
 export VDK_OPTIONS=${VDK_OPTIONS:-"$SCRIPT_DIR/vdk-options.ini"}
 export TPCS_CHART=${TPCS_CHART:-"$SCRIPT_DIR/../projects/helm_charts/pipelines-control-service"}
 export VDK_DOCKER_REGISTRY_URL=${VDK_DOCKER_REGISTRY_URL:-"registry.hub.docker.com/versatiledatakit"}
+export TESTING_PIPELINES_SERVICE_VALUES_FILE=${TESTING_PIPELINES_SERVICE_VALUES_FILE:-"$SCRIPT_DIR/testing-pipelines-service-values.yaml"}
+
 
 RUN_ENVIRONMENT_SETUP=${RUN_ENVIRONMENT_SETUP:-'n'}
 
@@ -86,8 +88,8 @@ fi
 # image.tag is fixed during release. It is set here to deploy using latest change in source code.
 # We are using here embedded database, and we need to set the storageclass since in our test k8s no default storage class is not set.
 helm upgrade --install --debug --wait --timeout 10m0s $RELEASE_NAME . \
+      -f "$TESTING_PIPELINES_SERVICE_VALUES_FILE" \
       --set image.tag="$TAG" \
-      --set resources.limits.memory=2G \
       --set credentials.repository="EMPTY" \
       --set-file vdkOptions=$VDK_OPTIONS_SUBSTITUTED \
       --set deploymentGitUrl="$CICD_GIT_URI" \

--- a/projects/control-service/cicd/testing-pipelines-service-values.yaml
+++ b/projects/control-service/cicd/testing-pipelines-service-values.yaml
@@ -1,0 +1,10 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+resources:
+  limits:
+    cpu: 2000m
+    memory: 4000Mi
+  requests:
+    cpu: 1000m
+    memory: 2000Mi


### PR DESCRIPTION
This change increases the CPU and memory resource limits and requests for the test deployment of the Control Service .

The previous configuration with CPU and memory limits of 2000m and 500Mi respectively, and equal requests, has been changed. 
The new configuration sets the CPU limit to 2000m (2 cores), the memory limit to 4000Mi (approximately 4 GB), the CPU request to 1000m (1 core), and the memory request to 1000Mi (approximately 1 GB).

This change aims to improve the performance and stability of the test environment