### PR TITLE
vdk-jupyter: UI failing cell marks enhancement

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/run-job-component.spec.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/run-job-component.spec.tsx
@@ -2,7 +2,7 @@
  * Copyright 2023-2023 VMware, Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-import RunJobDialog, { findFailingCellId, handleErrorsProducedByNotebookCell } from '../components/RunJob';
+import RunJobDialog, { findFailingCellId, getCellInputAreaPromp, handleErrorsProducedByNotebookCell } from '../components/RunJob';
 import { render, fireEvent } from '@testing-library/react';
 import { jobData } from '../jobData';
 import { VdkOption } from '../vdkOptions/vdk_options';
@@ -137,4 +137,42 @@ describe('handleErrorsProducedByNotebookCell', () => {
     expect(result).toBe(true);
   });
 
+});
+
+describe('getCellInputAreaPromp', () => {
+  test('returns the prompt element when it exists', () => {
+    const mockPromptElement = document.createElement('div');
+    mockPromptElement.classList.add('jp-InputArea-prompt');
+
+    const mockCellInputArea = document.createElement('div');
+    mockCellInputArea.classList.add('jp-Cell-inputArea');
+    mockCellInputArea.appendChild(mockPromptElement);
+
+    const mockCellInputWrapper = document.createElement('div');
+    mockCellInputWrapper.classList.add('jp-Cell-inputWrapper');
+    mockCellInputWrapper.appendChild(mockCellInputArea);
+
+    const mockFailinCell = document.createElement('div');
+    mockFailinCell.appendChild(mockCellInputWrapper);
+
+    const result = getCellInputAreaPromp(mockFailinCell);
+
+    expect(result).toBe(mockPromptElement);
+  });
+
+  test('returns undefined when prompt element does not exist', () => {
+    const mockCellInputArea = document.createElement('div');
+    mockCellInputArea.classList.add('jp-Cell-inputArea');
+
+    const mockCellInputWrapper = document.createElement('div');
+    mockCellInputWrapper.classList.add('jp-Cell-inputWrapper');
+    mockCellInputWrapper.appendChild(mockCellInputArea);
+
+    const mockFailinCell = document.createElement('div');
+    mockFailinCell.appendChild(mockCellInputWrapper);
+
+    const result = getCellInputAreaPromp(mockFailinCell);
+
+    expect(result).toBeUndefined();
+  });
 });

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/RunJob.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/RunJob.tsx
@@ -123,7 +123,23 @@ export const findFailingCellId = (message: String): string => {
   return '';
 };
 
+export const getCellInputAreaPromp = (failinCell: Element): Element | undefined => {
+  const cellInputWrappers = failinCell.getElementsByClassName('jp-Cell-inputWrapper');
+  for (let i = 0; i < cellInputWrappers.length; i++) {
+    const cellAreas = cellInputWrappers[i].getElementsByClassName('jp-Cell-inputArea');
+    if (cellAreas.length > 0) {
+      const cellInputArea = cellAreas[0];
+      const promptElements = cellInputArea.getElementsByClassName('jp-InputArea-prompt');
+      if (promptElements.length > 0) {
+        return promptElements[0];
+      }
+    }
+  }
+};
+
 const switchToFailingCell = (failingCell: Element) => {
+  let prompt = getCellInputAreaPromp(failingCell);
+  prompt?.classList.add('jp-vdk-failing-cell-prompt');
   failingCell.scrollIntoView();
   failingCell.classList.add('jp-vdk-failing-cell');
   // Delete previous fail numbering
@@ -160,9 +176,13 @@ export const findFailingCellInNotebookCells = async (
     });
   } else {
     for (let i = 0; i < cells.length; i++) {
-      i === failingCellIndex
-        ? switchToFailingCell(cells[i])
-        : cells[i].classList.remove('jp-vdk-failing-cell');
+      if (i === failingCellIndex) {
+        switchToFailingCell(cells[i]);
+      } else {
+        cells[i].classList.remove('jp-vdk-failing-cell');
+        let cellPropt = getCellInputAreaPromp(cells[i]);
+        cellPropt?.classList.remove('jp-vdk-failing-cell-prompt')
+      }
     }
   }
 };

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/RunJob.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/RunJob.tsx
@@ -138,7 +138,7 @@ export const getCellInputAreaPromp = (failinCell: Element): Element | undefined 
 };
 
 const switchToFailingCell = (failingCell: Element) => {
-  let prompt = getCellInputAreaPromp(failingCell);
+  const prompt = getCellInputAreaPromp(failingCell);
   prompt?.classList.add('jp-vdk-failing-cell-prompt');
   failingCell.scrollIntoView();
   failingCell.classList.add('jp-vdk-failing-cell');
@@ -180,7 +180,7 @@ export const findFailingCellInNotebookCells = async (
         switchToFailingCell(cells[i]);
       } else {
         cells[i].classList.remove('jp-vdk-failing-cell');
-        let cellPropt = getCellInputAreaPromp(cells[i]);
+        const cellPropt = getCellInputAreaPromp(cells[i]);
         cellPropt?.classList.remove('jp-vdk-failing-cell-prompt')
       }
     }

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/RunJob.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/RunJob.tsx
@@ -123,13 +123,25 @@ export const findFailingCellId = (message: String): string => {
   return '';
 };
 
-export const getCellInputAreaPromp = (failinCell: Element): Element | undefined => {
-  const cellInputWrappers = failinCell.getElementsByClassName('jp-Cell-inputWrapper');
+/**
+ * Returns a Element that is used for numarating cell executions on Jupyter (text with [] if not executed and  with [1], [2] if executed)
+ * @param failingCell - parent cell of that element
+ * @returns Element or undefined if the element could not be found
+ */
+export const getCellInputAreaPromp = (
+  failinCell: Element
+): Element | undefined => {
+  const cellInputWrappers = failinCell.getElementsByClassName(
+    'jp-Cell-inputWrapper'
+  );
   for (let i = 0; i < cellInputWrappers.length; i++) {
-    const cellAreas = cellInputWrappers[i].getElementsByClassName('jp-Cell-inputArea');
+    const cellAreas =
+      cellInputWrappers[i].getElementsByClassName('jp-Cell-inputArea');
     if (cellAreas.length > 0) {
       const cellInputArea = cellAreas[0];
-      const promptElements = cellInputArea.getElementsByClassName('jp-InputArea-prompt');
+      const promptElements = cellInputArea.getElementsByClassName(
+        'jp-InputArea-prompt'
+      );
       if (promptElements.length > 0) {
         return promptElements[0];
       }
@@ -150,6 +162,12 @@ const switchToFailingCell = (failingCell: Element) => {
     element.classList.remove('jp-vdk-failing-cell-num');
     element.classList.add('jp-vdk-cell-num');
   });
+};
+
+const unmarkOldFailingCells = (cell: Element) => {
+  cell.classList.remove('jp-vdk-failing-cell');
+  const cellPropt = getCellInputAreaPromp(cell);
+  cellPropt?.classList.remove('jp-vdk-failing-cell-prompt');
 };
 
 export const findFailingCellInNotebookCells = async (
@@ -176,13 +194,9 @@ export const findFailingCellInNotebookCells = async (
     });
   } else {
     for (let i = 0; i < cells.length; i++) {
-      if (i === failingCellIndex) {
-        switchToFailingCell(cells[i]);
-      } else {
-        cells[i].classList.remove('jp-vdk-failing-cell');
-        const cellPropt = getCellInputAreaPromp(cells[i]);
-        cellPropt?.classList.remove('jp-vdk-failing-cell-prompt')
-      }
+      i === failingCellIndex
+        ? switchToFailingCell(cells[i])
+        : unmarkOldFailingCells(cells[i]);
     }
   }
 };

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/base.css
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/base.css
@@ -46,3 +46,8 @@
   color: aliceblue;
   padding: 4px;
 }
+
+.jp-vdk-failing-cell-prompt {
+  --jp-cell-prompt-not-active-font-color: #8c1e1e;
+  --jp-cell-inprompt-font-color: #8c1e1e;
+}


### PR DESCRIPTION
What:
Added more colouring to the cell 
See the numbering on the left side:
Now:
<img width="1325" alt="Screenshot 2023-05-26 at 9 27 38" src="https://github.com/vmware/versatile-data-kit/assets/87015481/616077dd-e4d1-4abe-8757-6d10302510d0">
Then: 
<img width="1228" alt="Screenshot 2023-05-10 at 18 41 51" src="https://github.com/vmware/versatile-data-kit/assets/87015481/46c28739-354a-4bd6-8f7b-5b53ad5ed771">

Why: we received feedback form users that it would be more user-friendly to have that part of the cell coloured on fail, too

Signed-off-by: Duygu Hasan [hduygu@vmware.com](mailto:hduygu@vmware.com)