### PR TITLE
control-service: fail tests fast

### DIFF
--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -90,7 +90,7 @@ control_service_integration_test:
     - cp $KUBECONFIG ~/.kube/config
     - ./gradlew -v
     - ./gradlew projects --info
-    - ./gradlew -Djdk.tls.client.protocols=TLSv1.2 :pipelines_control_service:integrationTest --info --stacktrace
+    - ./gradlew -Djdk.tls.client.protocols=TLSv1.2 :pipelines_control_service:integrationTest --info --stacktrace --fail-fast
   retry: !reference [.control_service_retry, retry_options]
   artifacts:
     when: always


### PR DESCRIPTION
# Why
we want faster feedback when a test fails and we want to use less resources in the cicd cluster
# What
integration tests kill themselves if they have a single failure
# How was this tested
locally

 