### PR TITLE
control-service: introduce latest and stable tags for docker images

### DIFF
--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -255,6 +255,7 @@ control_service_deploy_testing_data_pipelines:
   script:
     - apk --no-cache add bash openssl curl git gettext zip py-pip
     - pip install --upgrade pip && pip install awscli
+    - export FRONTEND_TAG=latest
     - export DESIRED_VERSION=v3.12.0 # helm version
     - curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
     - bash -ex ./projects/control-service/cicd/deploy-testing-pipelines-service.sh
@@ -291,7 +292,7 @@ control_service_post_deployment_test:
       changes: *control_service_helm_change_locations
 
 control_service_release:
-  image: docker:23.0.1
+  extends: .images:dind
   stage: release
   script:
     - apk --no-cache add bash openssl curl git
@@ -304,6 +305,8 @@ control_service_release:
     - helm plugin install https://github.com/thynquest/helm-pack --version 0.2.2
     - cd projects/control-service/projects/helm_charts
     - bash -ex ../../cicd/release-pipelines-service.sh
+    - docker login $VDK_DOCKER_REGISTRY_URL --username $VDK_DOCKER_REGISTRY_USERNAME --password $VDK_DOCKER_REGISTRY_PASSWORD
+    - bash -ex ../../cicd/tag_image_dockerhub.sh pipelines-control-service $IMAGE_TAG stable
   retry: !reference [.control_service_retry, retry_options]
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'

--- a/projects/control-service/cicd/deploy-testing-pipelines-service.sh
+++ b/projects/control-service/cicd/deploy-testing-pipelines-service.sh
@@ -14,6 +14,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 
 export TAG=${TAG:-$(git rev-parse --short HEAD)}
+export FRONTEND_TAG=${FRONTEND_TAG:-$(git rev-parse --short HEAD)}
 export RELEASE_NAME=${RELEASE_NAME:-cicd-control-service}
 export VDK_OPTIONS=${VDK_OPTIONS:-"$SCRIPT_DIR/vdk-options.ini"}
 export TPCS_CHART=${TPCS_CHART:-"$SCRIPT_DIR/../projects/helm_charts/pipelines-control-service"}
@@ -90,6 +91,7 @@ fi
 helm upgrade --install --debug --wait --timeout 10m0s $RELEASE_NAME . \
       -f "$TESTING_PIPELINES_SERVICE_VALUES_FILE" \
       --set image.tag="$TAG" \
+      --set operationsUi.image.tag="$FRONTEND_TAG" \
       --set credentials.repository="EMPTY" \
       --set-file vdkOptions=$VDK_OPTIONS_SUBSTITUTED \
       --set deploymentGitUrl="$CICD_GIT_URI" \

--- a/projects/control-service/cicd/tag_image_dockerhub.sh
+++ b/projects/control-service/cicd/tag_image_dockerhub.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+VDK_DOCKER_REGISTRY_URL=${VDK_DOCKER_REGISTRY_URL:-"registry.hub.docker.com/versatiledatakit"}
+
+[ $# -eq 0 ] && echo "ERROR: No argument for docker image name provided." && exit 1
+[ $# -eq 1 ] && echo "ERROR: No argument for docker image tag." && exit 1
+[ $# -eq 2 ] && echo "ERROR: No argument for docker image new tag." && exit 1
+
+
+name="$1"
+current_tag="$2"
+new_tag="$3"
+
+old_image="$VDK_DOCKER_REGISTRY_URL/$name:$current_tag"
+new_image="$VDK_DOCKER_REGISTRY_URL/$name:$new_tag"
+
+docker pull $old_image
+docker tag $old_image $new_image
+docker push $new_image

--- a/projects/control-service/projects/pipelines_control_service/build.gradle
+++ b/projects/control-service/projects/pipelines_control_service/build.gradle
@@ -150,6 +150,7 @@ docker {
     dependsOn bootJar
     files bootJar.archiveFile
     name "${dockerProject}/pipelines-control-service:${version}"
+    tags "latest"
     buildArgs([
             JAR_NAME                : "${project.name}-${version}.jar",
             DATAJOBS_GIT_COMMIT_HASH: gitVersion()


### PR DESCRIPTION
## Why

Re-deploying the helm chart from a CI pipeline that is not related to control service, e.g. frontend, requires a way to track control service docker images other than commit hashes.

## What

Introduce latest and stable tags for control service docker images. Each docker image is tagged with latest in the publish_artifacts stage. Once the image is deployed in the test environment and tests have run, it is tagged with stable.

## How was this tested

Ran new and changed scripts locally.
CI https://gitlab.com/vmware-analytics/versatile-data-kit/-/pipelines/882279167

## What type of change are you making

Breaking change to CI