### PR TITLE
vdk-jupyter: Pick up REST API URL from the env

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/create-job-component.spec.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/create-job-component.spec.ts
@@ -82,15 +82,6 @@ describe('#onTeamChange', () => {
   });
 });
 
-describe('#onRestApiUrlChange', () => {
-  it('should change the rest api url in jobData', () => {
-    const component = render(new CreateJobDialog(defaultProps).render());
-    const input = component.getByPlaceholderText('http://my_vdk_instance');
-    fireEvent.change(input, { target: { value: 'random-url' } });
-    expect(jobData.get(VdkOption.REST_API_URL)).toEqual('random-url');
-  });
-});
-
 describe('#onPathChange', () => {
   it('should change the path in jobData', () => {
     const component = render(new CreateJobDialog(defaultProps).render());

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/delete-job-component.spec.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/delete-job-component.spec.ts
@@ -46,12 +46,3 @@ describe('#onTeamChange', () => {
     expect(jobData.get(VdkOption.TEAM)).toEqual('second-team');
   });
 });
-
-describe('#onRestApiUrlChange', () => {
-  it('should change the rest api url in jobData', () => {
-    const component = render(new DeleteJobDialog(defaultProps).render());
-    const input = component.getByPlaceholderText('http://my_vdk_instance');
-    fireEvent.change(input, { target: { value: 'random-url' } });
-    expect(jobData.get(VdkOption.REST_API_URL)).toEqual('random-url');
-  });
-});

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/deploy-job-component.spec.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/deploy-job-component.spec.ts
@@ -69,15 +69,6 @@ describe('#onTeamChange', () => {
   });
 });
 
-describe('#onRestApiUrlChange', () => {
-  it('should change the rest api url in jobData', () => {
-    const component = render(new DeployJobDialog(defaultProps).render());
-    const input = component.getByPlaceholderText('http://my_vdk_instance');
-    fireEvent.change(input, { target: { value: 'random-url' } });
-    expect(jobData.get(VdkOption.REST_API_URL)).toEqual('random-url');
-  });
-});
-
 describe('#onPathChange', () => {
   it('should change the path in jobData', () => {
     const component = render(new DeployJobDialog(defaultProps).render());

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/download-job-component.spec.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/download-job-component.spec.ts
@@ -54,15 +54,6 @@ describe('#onTeamChange', () => {
   });
 });
 
-describe('#onRestApiUrlChange', () => {
-  it('should change the rest api url in jobData', () => {
-    const component = render(new DownloadJobDialog(defaultProps).render());
-    const input = component.getByPlaceholderText('http://my_vdk_instance');
-    fireEvent.change(input, { target: { value: 'random-url' } });
-    expect(jobData.get(VdkOption.REST_API_URL)).toEqual('random-url');
-  });
-});
-
 describe('#onPathChange', () => {
   it('should change the path in jobData', () => {
     const component = render(new DownloadJobDialog(defaultProps).render());

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/CreateJob.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/CreateJob.tsx
@@ -62,11 +62,6 @@ export default class CreateJobDialog extends Component<(IJobFullProps)> {
           label="Job Team:"
         ></VDKTextInput>
         <VDKTextInput
-          option={VdkOption.REST_API_URL}
-          value="http://my_vdk_instance"
-          label="Rest API URL:"
-        ></VDKTextInput>
-        <VDKTextInput
           option={VdkOption.PATH}
           value={this.props.jobPath}
           label="Path to job directory:"
@@ -79,7 +74,7 @@ export default class CreateJobDialog extends Component<(IJobFullProps)> {
    */
   private _onLocalClick() {
     return (event: React.MouseEvent) => {
-      this.setJobFlags('Local', 'jobPath');
+      this.setJobFlags('Local');
     };
   }
   /**
@@ -87,18 +82,16 @@ export default class CreateJobDialog extends Component<(IJobFullProps)> {
    */
   private _onCloudClick() {
     return (event: React.MouseEvent) => {
-      this.setJobFlags('Cloud', 'jobRestApiUrl');
+      this.setJobFlags('Cloud');
     };
   }
   /**
    * Function that sets job's cloud/local flags
    */
-  private setJobFlags(flag: string, inputId: string) {
+  private setJobFlags(flag: string) {
     let checkbox = document.getElementById(flag);
-    let input = document.getElementById(inputId);
     if (checkbox?.classList.contains('checked')) {
       checkbox.classList.remove('checked');
-      input?.parentElement?.classList.add('hidden');
       if (flag === 'Cloud') {
         jobData.set(VdkOption.CLOUD, '');
       } else {
@@ -111,7 +104,6 @@ export default class CreateJobDialog extends Component<(IJobFullProps)> {
       } else {
         jobData.set(VdkOption.LOCAL, '1');
       }
-      input?.parentElement?.classList.remove('hidden');
     }
   }
 }

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/DeleteJob.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/DeleteJob.tsx
@@ -35,11 +35,6 @@ export default class DeleteJobDialog extends Component<IJobNameAndTeamProps> {
           value={this.props.jobTeam}
           label="Job Team:"
         ></VDKTextInput>
-        <VDKTextInput
-          option={VdkOption.REST_API_URL}
-          value="http://my_vdk_instance"
-          label="Rest API URL:"
-        ></VDKTextInput>
       </>
     );
   }
@@ -63,8 +58,6 @@ export async function showDeleteJobDialog() {
         body:
           'Do you really want to delete the job with name ' +
           jobData.get(VdkOption.NAME) +
-          ' from ' +
-          jobData.get(VdkOption.REST_API_URL) +
           '?',
         buttons: [
           Dialog.cancelButton({ label: 'Cancel' }),

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/DeployJob.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/DeployJob.tsx
@@ -36,11 +36,6 @@ export default class DeployJobDialog extends Component<(IJobFullProps)> {
           label="Job Team:"
         ></VDKTextInput>
         <VDKTextInput
-          option={VdkOption.REST_API_URL}
-          value="http://my_vdk_instance"
-          label="Rest API URL:"
-        ></VDKTextInput>
-        <VDKTextInput
           option={VdkOption.PATH}
           value={this.props.jobPath}
           label="Path to job directory:"
@@ -113,7 +108,7 @@ export async function showCreateDeploymentDialog() {
           }
         } else {
           showErrorMessage(
-            'Encauntered an error while running the job!',
+            'Encоuntered an error while running the job!',
             message,
             [Dialog.okButton()]
           );

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/DownloadJob.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/DownloadJob.tsx
@@ -36,11 +36,6 @@ export default class DownloadJobDialog extends Component<IJobPathProp> {
           label="Job Team:"
         ></VDKTextInput>
         <VDKTextInput
-          option={VdkOption.REST_API_URL}
-          value="http://my_vdk_instance"
-          label="Rest API URL:"
-        ></VDKTextInput>
-        <VDKTextInput
           option={VdkOption.PATH}
           value={this.props.jobPath}
           label="Path to job directory:"

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/handlers.py
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/handlers.py
@@ -1,6 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 import json
+import os
 
 import tornado
 from jupyter_server.base.handlers import APIHandler
@@ -66,7 +67,7 @@ class DeleteJobHandler(APIHandler):
             status = VdkUI.delete_job(
                 input_data[VdkOption.NAME.value],
                 input_data[VdkOption.TEAM.value],
-                input_data[VdkOption.REST_API_URL.value],
+                os.environ["REST_API_URL"],
             )
             self.finish(json.dumps({"message": f"{status}", "error": ""}))
         except Exception as e:
@@ -89,7 +90,7 @@ class DownloadJobHandler(APIHandler):
             status = VdkUI.download_job(
                 input_data[VdkOption.NAME.value],
                 input_data[VdkOption.TEAM.value],
-                input_data[VdkOption.REST_API_URL.value],
+                os.environ["REST_API_URL"],
                 input_data[VdkOption.PATH.value],
             )
             self.finish(json.dumps({"message": f"{status}", "error": ""}))
@@ -114,7 +115,7 @@ class CreateJobHandler(APIHandler):
             status = VdkUI.create_job(
                 input_data[VdkOption.NAME.value],
                 input_data[VdkOption.TEAM.value],
-                input_data[VdkOption.REST_API_URL.value],
+                os.environ["REST_API_URL"],
                 input_data[VdkOption.PATH.value],
                 bool(input_data[VdkOption.LOCAL.value]),
                 bool(input_data[VdkOption.CLOUD.value]),
@@ -140,7 +141,7 @@ class CreateDeploymentHandler(APIHandler):
             status = VdkUI.create_deployment(
                 input_data[VdkOption.NAME.value],
                 input_data[VdkOption.TEAM.value],
-                input_data[VdkOption.REST_API_URL.value],
+                os.environ["REST_API_URL"],
                 input_data[VdkOption.PATH.value],
                 input_data[VdkOption.DEPLOYMENT_REASON.value],
                 input_data[VdkOption.DEPLOY_ENABLE.value],


### PR DESCRIPTION
Currently, users are expected to configure the REST API URL manually, which is a bad practice. After this change, the REST API URL will be picked up from the environment, which means it will be configured when deploying the docker image.

Testing done: pipelines