### PR TITLE
control-service: allow more time to reach a complete state

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/JobExecutionUtil.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/common/JobExecutionUtil.java
@@ -186,7 +186,7 @@ public class JobExecutionUtil {
 
     var result =
         await()
-            .atMost(5, TimeUnit.MINUTES)
+            .atMost(10, TimeUnit.MINUTES)
             .with()
             .pollInterval(15, TimeUnit.SECONDS)
             .failFast(

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-private-builder.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-private-builder.properties
@@ -1,4 +1,4 @@
 datajobs.builder.registrySecret=integration-test-docker-pull-secret
 datajobs.builder.registrySecret.content.testOnly=${BUILDER_TEST_REGISTRY_SECRET}
-datajobs.builder.image=${DOCKER_REGISTRY_URL}/versatiledatakit/job-builder:1.3.3
+datajobs.builder.image=${DOCKER_REGISTRY_URL}/versatiledatakit/job-builder-private:1.3.3
 datajobs.deployment.dataJobBaseImage=ghcr.io/versatile-data-kit-dev/dp/versatiledatakit/data-job-base-python-3.7:latest

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-private-builder.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-private-builder.properties
@@ -1,4 +1,4 @@
 datajobs.builder.registrySecret=integration-test-docker-pull-secret
 datajobs.builder.registrySecret.content.testOnly=${BUILDER_TEST_REGISTRY_SECRET}
-datajobs.builder.image=${DOCKER_REGISTRY_URL}/versatiledatakit/job-builder-private:1.3.3
+datajobs.builder.image=${DOCKER_REGISTRY_URL}/versatiledatakit/job-builder:1.3.3
 datajobs.deployment.dataJobBaseImage=ghcr.io/versatile-data-kit-dev/dp/versatiledatakit/data-job-base-python-3.7:latest


### PR DESCRIPTION
# Why
when the system is under load jobs often take a little over 5 minutes. 
Because we fail fast we won't waste needless time if the job goes into a failed state. 

# What
Wait longer to get into a successful state 

# How was this tested
CICD pipeline

