### PR TITLE
control-service: handle null started by value

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-private-builder.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-private-builder.properties
@@ -1,4 +1,4 @@
 datajobs.builder.registrySecret=integration-test-docker-pull-secret
 datajobs.builder.registrySecret.content.testOnly=${BUILDER_TEST_REGISTRY_SECRET}
-datajobs.builder.image=${DOCKER_REGISTRY_URL}/versatiledatakit/job-builder:1.3.3
+datajobs.builder.image=${DOCKER_REGISTRY_URL}/versatiledatakit/job-builder-private:1.3.3
 datajobs.deployment.dataJobBaseImage=ghcr.io/versatile-data-kit-dev/dp/versatiledatakit/data-job-base-python-3.7:latest

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-private-builder.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-private-builder.properties
@@ -1,4 +1,4 @@
 datajobs.builder.registrySecret=integration-test-docker-pull-secret
 datajobs.builder.registrySecret.content.testOnly=${BUILDER_TEST_REGISTRY_SECRET}
-datajobs.builder.image=${DOCKER_REGISTRY_URL}/versatiledatakit/job-builder-private:1.3.3
+datajobs.builder.image=${DOCKER_REGISTRY_URL}/versatiledatakit/job-builder:1.3.3
 datajobs.deployment.dataJobBaseImage=ghcr.io/versatile-data-kit-dev/dp/versatiledatakit/data-job-base-python-3.7:latest

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
@@ -109,8 +109,8 @@ public class JobExecutionService {
       // We default to 'manual'; this also served for the purposes of backwards compatibility
       annotations.put(
           JobAnnotation.EXECUTION_TYPE.getValue(),
-              jobExecutionRequest.getStartedBy() != null &&
-          jobExecutionRequest.getStartedBy().contains("scheduled")
+          jobExecutionRequest.getStartedBy() != null
+                  && jobExecutionRequest.getStartedBy().contains("scheduled")
               ? ExecutionType.SCHEDULED.getValue()
               : ExecutionType.MANUAL.getValue());
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionService.java
@@ -109,6 +109,7 @@ public class JobExecutionService {
       // We default to 'manual'; this also served for the purposes of backwards compatibility
       annotations.put(
           JobAnnotation.EXECUTION_TYPE.getValue(),
+              jobExecutionRequest.getStartedBy() != null &&
           jobExecutionRequest.getStartedBy().contains("scheduled")
               ? ExecutionType.SCHEDULED.getValue()
               : ExecutionType.MANUAL.getValue());

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceStartExecutionIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceStartExecutionIT.java
@@ -143,10 +143,8 @@ public class JobExecutionServiceStartExecutionIT {
     Assertions.assertEquals(startedBy, actualDataJobExecution.getStartedBy());
   }
 
-
   @Test
-  public void testNullValueOfStartedByIsWellHandled()
-          throws ApiException {
+  public void testNullValueOfStartedByIsWellHandled() throws ApiException {
     String opId = "test-op-id";
     String cronJobName = "test-cron-job";
 
@@ -155,37 +153,37 @@ public class JobExecutionServiceStartExecutionIT {
     JobDeploymentStatus jobDeploymentStatus = new JobDeploymentStatus();
     jobDeploymentStatus.setCronJobName(cronJobName);
     Mockito.when(deploymentService.readDeployment(Mockito.eq(actualDataJob.getName())))
-            .thenReturn(Optional.of(jobDeploymentStatus));
+        .thenReturn(Optional.of(jobDeploymentStatus));
     Mockito.when(operationContext.getOpId()).thenReturn(opId);
     Mockito.when(dataJobsKubernetesService.isRunningJob(Mockito.eq(actualDataJob.getName())))
-            .thenReturn(false);
+        .thenReturn(false);
 
     final Map<String, String> annotations = new LinkedHashMap<>();
     annotations.put(JobAnnotation.OP_ID.getValue(), opId);
     annotations.put(JobAnnotation.STARTED_BY.getValue(), null);
     annotations.put(
-            JobAnnotation.EXECUTION_TYPE.getValue(),
-            JobExecutionService.ExecutionType.MANUAL.getValue());
+        JobAnnotation.EXECUTION_TYPE.getValue(),
+        JobExecutionService.ExecutionType.MANUAL.getValue());
 
     Map<String, String> envs = Map.of(JobEnvVar.VDK_OP_ID.getValue(), opId);
 
     String executionId =
-            jobExecutionService.startDataJobExecution(
-                    actualDataJob.getJobConfig().getTeam(),
-                    actualDataJob.getName(),
-                    "",
-                    new DataJobExecutionRequest());
+        jobExecutionService.startDataJobExecution(
+            actualDataJob.getJobConfig().getTeam(),
+            actualDataJob.getName(),
+            "",
+            new DataJobExecutionRequest());
     Mockito.verify(dataJobsKubernetesService)
-            .startNewCronJobExecution(
-                    Mockito.eq(cronJobName),
-                    Mockito.eq(executionId),
-                    Mockito.eq(annotations),
-                    Mockito.eq(envs),
-                    Mockito.any(),
-                    Mockito.any());
+        .startNewCronJobExecution(
+            Mockito.eq(cronJobName),
+            Mockito.eq(executionId),
+            Mockito.eq(annotations),
+            Mockito.eq(envs),
+            Mockito.any(),
+            Mockito.any());
 
     Optional<DataJobExecution> actualDataJobExecutionOptional =
-            jobExecutionRepository.findById(executionId);
+        jobExecutionRepository.findById(executionId);
     Assertions.assertTrue(actualDataJobExecutionOptional.isPresent());
     DataJobExecution actualDataJobExecution = actualDataJobExecutionOptional.get();
     Assertions.assertEquals(executionId, actualDataJobExecution.getId());

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceStartExecutionIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionServiceStartExecutionIT.java
@@ -142,4 +142,57 @@ public class JobExecutionServiceStartExecutionIT {
     Assertions.assertEquals(opId, actualDataJobExecution.getOpId());
     Assertions.assertEquals(startedBy, actualDataJobExecution.getStartedBy());
   }
+
+
+  @Test
+  public void testNullValueOfStartedByIsWellHandled()
+          throws ApiException {
+    String opId = "test-op-id";
+    String cronJobName = "test-cron-job";
+
+    DataJob actualDataJob = RepositoryUtil.createDataJob(jobsRepository);
+
+    JobDeploymentStatus jobDeploymentStatus = new JobDeploymentStatus();
+    jobDeploymentStatus.setCronJobName(cronJobName);
+    Mockito.when(deploymentService.readDeployment(Mockito.eq(actualDataJob.getName())))
+            .thenReturn(Optional.of(jobDeploymentStatus));
+    Mockito.when(operationContext.getOpId()).thenReturn(opId);
+    Mockito.when(dataJobsKubernetesService.isRunningJob(Mockito.eq(actualDataJob.getName())))
+            .thenReturn(false);
+
+    final Map<String, String> annotations = new LinkedHashMap<>();
+    annotations.put(JobAnnotation.OP_ID.getValue(), opId);
+    annotations.put(JobAnnotation.STARTED_BY.getValue(), null);
+    annotations.put(
+            JobAnnotation.EXECUTION_TYPE.getValue(),
+            JobExecutionService.ExecutionType.MANUAL.getValue());
+
+    Map<String, String> envs = Map.of(JobEnvVar.VDK_OP_ID.getValue(), opId);
+
+    String executionId =
+            jobExecutionService.startDataJobExecution(
+                    actualDataJob.getJobConfig().getTeam(),
+                    actualDataJob.getName(),
+                    "",
+                    new DataJobExecutionRequest());
+    Mockito.verify(dataJobsKubernetesService)
+            .startNewCronJobExecution(
+                    Mockito.eq(cronJobName),
+                    Mockito.eq(executionId),
+                    Mockito.eq(annotations),
+                    Mockito.eq(envs),
+                    Mockito.any(),
+                    Mockito.any());
+
+    Optional<DataJobExecution> actualDataJobExecutionOptional =
+            jobExecutionRepository.findById(executionId);
+    Assertions.assertTrue(actualDataJobExecutionOptional.isPresent());
+    DataJobExecution actualDataJobExecution = actualDataJobExecutionOptional.get();
+    Assertions.assertEquals(executionId, actualDataJobExecution.getId());
+    Assertions.assertEquals(actualDataJob, actualDataJobExecution.getDataJob());
+    Assertions.assertEquals(ExecutionStatus.SUBMITTED, actualDataJobExecution.getStatus());
+    Assertions.assertEquals(ExecutionType.MANUAL, actualDataJobExecution.getType());
+    Assertions.assertEquals(opId, actualDataJobExecution.getOpId());
+    Assertions.assertNull(actualDataJobExecution.getStartedBy());
+  }
 }


### PR DESCRIPTION
# Why
We are seeing errors when the UI when using the latest version of control service
# What
Write a test to check null values for startedby are supported. Also support null startedBy
# How was this tested
Locally 