### PR TITLE
control-service: better error logging and pull private image in private test

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudIT.java
@@ -106,26 +106,27 @@ public class DataJobDeploymentCrudIT extends BaseIT {
         .andExpect(status().isUnauthorized());
 
     // Execute job upload with proper user
-    var jobUploadResult = mockMvc
+    var jobUploadResult =
+        mockMvc
             .perform(
-                    post(String.format(
-                            "/data-jobs/for-team/%s/jobs/%s/sources", TEST_TEAM_NAME, testJobName))
-                            .with(user("user"))
-                            .content(jobZipBinary)
-                            .contentType(MediaType.APPLICATION_OCTET_STREAM))
-            .andReturn().getResponse();
+                post(String.format(
+                        "/data-jobs/for-team/%s/jobs/%s/sources", TEST_TEAM_NAME, testJobName))
+                    .with(user("user"))
+                    .content(jobZipBinary)
+                    .contentType(MediaType.APPLICATION_OCTET_STREAM))
+            .andReturn()
+            .getResponse();
 
-    if(jobUploadResult.getStatus() != 200){
+    if (jobUploadResult.getStatus() != 200) {
       throw new Exception(
-              "status is "
-                      + jobUploadResult.getStatus()
-                      + "\nbody is "
-                      + jobUploadResult.getContentAsString());
+          "status is "
+              + jobUploadResult.getStatus()
+              + "\nbody is "
+              + jobUploadResult.getContentAsString());
     }
 
     DataJobVersion testDataJobVersion =
-        new ObjectMapper()
-            .readValue(jobUploadResult.getContentAsString(), DataJobVersion.class);
+        new ObjectMapper().readValue(jobUploadResult.getContentAsString(), DataJobVersion.class);
     Assertions.assertNotNull(testDataJobVersion);
 
     String testJobVersionSha = testDataJobVersion.getVersionSha();

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudIT.java
@@ -106,20 +106,26 @@ public class DataJobDeploymentCrudIT extends BaseIT {
         .andExpect(status().isUnauthorized());
 
     // Execute job upload with proper user
-    MvcResult jobUploadResult =
-        mockMvc
+    var jobUploadResult = mockMvc
             .perform(
-                post(String.format(
-                        "/data-jobs/for-team/%s/jobs/%s/sources", TEST_TEAM_NAME, testJobName))
-                    .with(user("user"))
-                    .content(jobZipBinary)
-                    .contentType(MediaType.APPLICATION_OCTET_STREAM))
-            .andExpect(status().isOk())
-            .andReturn();
+                    post(String.format(
+                            "/data-jobs/for-team/%s/jobs/%s/sources", TEST_TEAM_NAME, testJobName))
+                            .with(user("user"))
+                            .content(jobZipBinary)
+                            .contentType(MediaType.APPLICATION_OCTET_STREAM))
+            .andReturn().getResponse();
+
+    if(jobUploadResult.getStatus() != 200){
+      throw new Exception(
+              "status is "
+                      + jobUploadResult.getStatus()
+                      + "\nbody is "
+                      + jobUploadResult.getContentAsString());
+    }
 
     DataJobVersion testDataJobVersion =
         new ObjectMapper()
-            .readValue(jobUploadResult.getResponse().getContentAsString(), DataJobVersion.class);
+            .readValue(jobUploadResult.getContentAsString(), DataJobVersion.class);
     Assertions.assertNotNull(testDataJobVersion);
 
     String testJobVersionSha = testDataJobVersion.getVersionSha();

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-private-builder.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-private-builder.properties
@@ -1,4 +1,4 @@
 datajobs.builder.registrySecret=integration-test-docker-pull-secret
 datajobs.builder.registrySecret.content.testOnly=${BUILDER_TEST_REGISTRY_SECRET}
-datajobs.builder.image=${DOCKER_REGISTRY_URL}/versatiledatakit/job-builder:1.3.3
+datajobs.builder.image=${DOCKER_REGISTRY_URL}/versatiledatakit/job-builder-private:1.3.3
 datajobs.deployment.dataJobBaseImage=ghcr.io/versatile-data-kit-dev/dp/versatiledatakit/data-job-base-python-3.7:latest


### PR DESCRIPTION
# Why
1. When the job fails we want to know the reason and not just the status
2. We are now using github to pull public images from to avoid docker hub throttling. In doing this the private image test was no longer using a private image. Now it is using a private image again. 

# What
1. If the status code is not 200 log the response body
2. pull a private image
