### PR TITLE
vdk-jupyter: fix broken server in one use case

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/handlers.py
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/handlers.py
@@ -65,8 +65,7 @@ class DeleteJobHandler(APIHandler):
         input_data = self.get_json_body()
         try:
             status = VdkUI.delete_job(
-                input_data[VdkOption.NAME.value],
-                input_data[VdkOption.TEAM.value]
+                input_data[VdkOption.NAME.value], input_data[VdkOption.TEAM.value]
             )
             self.finish(json.dumps({"message": f"{status}", "error": ""}))
         except Exception as e:

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/handlers.py
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/handlers.py
@@ -12,24 +12,6 @@ from .vdk_options.vdk_options import VdkOption
 from .vdk_ui import VdkUI
 
 
-class HandlerConfiguration:
-    def __init__(self):
-        self._rest_api_url = os.environ["REST_API_URL"]
-        if not self._rest_api_url:
-            raise ValueError(
-                "What happened: Missing environment variable REST_API_URL.\n"
-                "Why it happened: This is probably caused by a corrupt environment.\n"
-                "Consequences: The current environment cannot work as it cannot connect to the VDK Control Service.\n"
-                "Countermeasures: Please alert your support team; alternatively, try restarting your environment."
-            )
-
-    def get_rest_api_url(self):
-        return self._rest_api_url
-
-
-handler_config = HandlerConfiguration()
-
-
 class LoadJobDataHandler(APIHandler):
     """
     Class responsible for handling POST request for retrieving data(full path, job's name and team)
@@ -84,8 +66,7 @@ class DeleteJobHandler(APIHandler):
         try:
             status = VdkUI.delete_job(
                 input_data[VdkOption.NAME.value],
-                input_data[VdkOption.TEAM.value],
-                handler_config.get_rest_api_url(),
+                input_data[VdkOption.TEAM.value]
             )
             self.finish(json.dumps({"message": f"{status}", "error": ""}))
         except Exception as e:
@@ -108,7 +89,6 @@ class DownloadJobHandler(APIHandler):
             status = VdkUI.download_job(
                 input_data[VdkOption.NAME.value],
                 input_data[VdkOption.TEAM.value],
-                handler_config.get_rest_api_url(),
                 input_data[VdkOption.PATH.value],
             )
             self.finish(json.dumps({"message": f"{status}", "error": ""}))
@@ -133,7 +113,6 @@ class CreateJobHandler(APIHandler):
             status = VdkUI.create_job(
                 input_data[VdkOption.NAME.value],
                 input_data[VdkOption.TEAM.value],
-                handler_config.get_rest_api_url(),
                 input_data[VdkOption.PATH.value],
                 bool(input_data[VdkOption.LOCAL.value]),
                 bool(input_data[VdkOption.CLOUD.value]),
@@ -159,7 +138,6 @@ class CreateDeploymentHandler(APIHandler):
             status = VdkUI.create_deployment(
                 input_data[VdkOption.NAME.value],
                 input_data[VdkOption.TEAM.value],
-                handler_config.get_rest_api_url(),
                 input_data[VdkOption.PATH.value],
                 input_data[VdkOption.DEPLOYMENT_REASON.value],
                 input_data[VdkOption.DEPLOY_ENABLE.value],

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/vdk_ui.py
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/vdk_ui.py
@@ -117,9 +117,7 @@ class VdkUI:
 
     # TODO: make it work with notebook jobs
     @staticmethod
-    def create_job(
-        name: str, team: str, path: str, local: bool, cloud: bool
-    ):
+    def create_job(name: str, team: str, path: str, local: bool, cloud: bool):
         """
         Execute `create job`.
         :param name: the name of the data job that will be created
@@ -140,9 +138,7 @@ class VdkUI:
         return f"Job with name {name} was created."
 
     @staticmethod
-    def create_deployment(
-        name: str, team: str, path: str, reason: str, enabled: bool
-    ):
+    def create_deployment(name: str, team: str, path: str, reason: str, enabled: bool):
         """
         Execute `Deploy job`.
         :param name: the name of the data job that will be deployed

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/vdk_ui.py
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/vdk_ui.py
@@ -15,6 +15,21 @@ from vdk.internal.control.utils import cli_utils
 from vdk.internal.control.utils.cli_utils import get_or_prompt
 
 
+class RestApiUrlConfiguration:
+    @staticmethod
+    def get_rest_api_url():
+        try:
+            rest_api_url = os.environ["REST_API_URL"]
+        except Exception as e:
+            raise ValueError(
+                "What happened: Missing environment variable REST_API_URL.\n"
+                "Why it happened: This is probably caused by a corrupt environment.\n"
+                "Consequences: The current environment cannot work as it cannot connect to the VDK Control Service.\n"
+                "Countermeasures: Please alert your support team; alternatively, try restarting your environment."
+            )
+        return rest_api_url
+
+
 class VdkUI:
     """
     A single parent class containing all the individual VDK methods in it.
@@ -76,50 +91,47 @@ class VdkUI:
             return {"message": process.returncode}
 
     @staticmethod
-    def delete_job(name: str, team: str, rest_api_url: str):
+    def delete_job(name: str, team: str):
         """
         Execute `delete job`.
         :param name: the name of the data job that will be deleted
         :param team: the team of the data job that will be deleted
-        :param rest_api_url: The base REST API URL.
         :return: message that the job is deleted
         """
-        cmd = JobDelete(rest_api_url)
+        cmd = JobDelete(RestApiUrlConfiguration.get_rest_api_url())
         cmd.delete_job(name, team)
         return f"Deleted the job with name {name} from {team} team. "
 
     @staticmethod
-    def download_job(name: str, team: str, rest_api_url: str, path: str):
+    def download_job(name: str, team: str, path: str):
         """
         Execute `download job`.
         :param name: the name of the data job that will be downloaded
         :param team: the team of the data job that will be downloaded
-        :param rest_api_url: The base REST API URL
         :param path: the path to the directory where the job will be downloaded
         :return: message that the job is downloaded
         """
-        cmd = JobDownloadSource(rest_api_url)
+        cmd = JobDownloadSource(RestApiUrlConfiguration.get_rest_api_url())
         cmd.download(team, name, path)
         return f"Downloaded the job with name {name} to {path}. "
 
     # TODO: make it work with notebook jobs
     @staticmethod
     def create_job(
-        name: str, team: str, rest_api_url: str, path: str, local: bool, cloud: bool
+        name: str, team: str, path: str, local: bool, cloud: bool
     ):
         """
         Execute `create job`.
         :param name: the name of the data job that will be created
         :param team: the team of the data job that will be created
-        :param rest_api_url: The base REST API URL
         :param path: the path to the directory where the job will be created
         :param local: create sample job on local file system
         :param cloud: create job in the cloud
         :return: message that the job is created
         """
-        cmd = JobCreate(rest_api_url)
+        cmd = JobCreate(RestApiUrlConfiguration.get_rest_api_url())
         if cloud:
-            cli_utils.check_rest_api_url(rest_api_url)
+            cli_utils.check_rest_api_url(RestApiUrlConfiguration.get_rest_api_url())
 
         if local:
             cmd.validate_job_path(path, name)
@@ -129,20 +141,19 @@ class VdkUI:
 
     @staticmethod
     def create_deployment(
-        name: str, team: str, rest_api_url: str, path: str, reason: str, enabled: bool
+        name: str, team: str, path: str, reason: str, enabled: bool
     ):
         """
         Execute `Deploy job`.
         :param name: the name of the data job that will be deployed
-        :param team: the team of the data job that will be depployed
-        :param rest_api_url: The base REST API URL
+        :param team: the team of the data job that will be deployed
         :param path: the path to the job's directory
         :param reason: the reason of deployment
         :param enabled: flag whether the job is enabled (that will basically un-pause the job)
         :return: output string of the operation
         """
         output = ""
-        cmd = JobDeploy(rest_api_url, output)
+        cmd = JobDeploy(RestApiUrlConfiguration.get_rest_api_url(), output)
         path = get_or_prompt("Job Path", path)
         default_name = os.path.basename(path)
         name = get_or_prompt("Job Name", name, default_name)


### PR DESCRIPTION
What: currently the server is broken in the use case when a user uses the extension with no rest_api_url set as env variable
With this changes we only look for the rest_api_url in specific cases for download, create, etc and for run and local development we do not look for it
Also we remove the use of rest_api_url in the handlers and move all of it to vdk_ui

Why: broken server
This is what the users get currently: 
<img width="565" alt="Screenshot 2023-05-30 at 18 23 41" src="https://github.com/vmware/versatile-data-kit/assets/87015481/496c7a00-1a44-4858-a315-6b40a4b6c6ac">

