### PR TITLE
vdk-control-cli, vdk-jupyter: Allow for creating a job with a notebook step

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/create.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/create.py
@@ -30,7 +30,13 @@ class JobCreate:
 
     @ApiClientErrorDecorator()
     def create_job(
-        self, name: str, team: str, path: str, cloud: bool, local: bool
+        self,
+        name: str,
+        team: str,
+        path: str,
+        cloud: bool,
+        local: bool,
+        is_jupyter: bool = False,
     ) -> None:
         self.__validate_job_name(name)
         if local:
@@ -40,7 +46,7 @@ class JobCreate:
             self.__create_cloud_job(team, name)
         if local:
             job_path = self.__get_job_path(path, name)
-            self.__create_local_job(team, name, job_path)
+            self.__create_local_job(team, name, job_path, is_jupyter)
             if cloud:
                 self.__download_key(team, name, path)
 
@@ -63,8 +69,13 @@ class JobCreate:
             f"Data Job with name {name} created and registered in cloud runtime by Control Service."
         )
 
-    def __create_local_job(self, team: str, name: str, job_path: str) -> None:
-        sample_job = self.__vdk_config.sample_job_directory
+    def __create_local_job(
+        self, team: str, name: str, job_path: str, is_jupyter: bool
+    ) -> None:
+        if is_jupyter:
+            sample_job = self.__vdk_config.jupyter_sample_job_directory
+        else:
+            sample_job = self.__vdk_config.sample_job_directory
         log.debug(f"Create sample job from directory: {sample_job} into {job_path}")
         cli_utils.copy_directory(sample_job, job_path)
         local_config = JobConfig(job_path)

--- a/projects/vdk-control-cli/src/vdk/internal/control/configuration/vdk_config.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/configuration/vdk_config.py
@@ -137,6 +137,18 @@ class VDKConfig:
             sample_job_dir = os.path.abspath(template_module_path)
         return sample_job_dir
 
+    @property
+    def jupyter_sample_job_directory(self) -> str:
+        jupyter_sample_job_dir = os.getenv("VDK_CONTROL_SAMPLE_JOB_DIRECTORY", None)
+        if not jupyter_sample_job_dir:
+            import vdk.internal.control.job.jupyter_sample_job
+
+            template_module_path = (
+                vdk.internal.control.job.jupyter_sample_job.__path__._path[0]
+            )
+            jupyter_sample_job_dir = os.path.abspath(template_module_path)
+        return jupyter_sample_job_dir
+
 
 class VDKConfigFolder:
     """

--- a/projects/vdk-control-cli/src/vdk/internal/control/job/jupyter_sample_job/10_notebook.ipynb
+++ b/projects/vdk-control-cli/src/vdk/internal/control/job/jupyter_sample_job/10_notebook.ipynb
@@ -1,0 +1,36 @@
+{
+ "cells": [],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "source": [
+     "\n",
+     "\n"
+    ],
+    "metadata": {
+     "collapsed": false
+    }
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/projects/vdk-control-cli/src/vdk/internal/control/job/jupyter_sample_job/README.md
+++ b/projects/vdk-control-cli/src/vdk/internal/control/job/jupyter_sample_job/README.md
@@ -1,0 +1,33 @@
+# My shiny new job
+
+Versatile Data Kit feature allows you to implement automated pull ingestion and batch data processing.
+
+### Create the data job Files
+
+Data Job directory can contain any files, however there are some files that are treated in a specific way:
+
+* SQL files (.sql) - called SQL steps - are directly executed as queries against your configured database;
+* Python files (.py) - called Python steps - are Python scripts that define run function that takes as argument the job_input object;
+* config.ini is needed in order to configure the Job. This is the only file required to deploy a Data Job;
+* requirements.txt is an optional file needed when your Python steps use external python libraries.
+
+Delete all files you do not need and replace them with your own.
+
+### Data Job Code
+
+VDK supports having many Python and/or SQL steps in a single Data Job. Steps are executed in ascending alphabetical order based on file names.
+Prefixing file names with numbers makes it easy to have meaningful file names while maintaining the steps' execution order.
+
+Run the Data Job from a Terminal:
+* Make sure you have vdk installed. See Platform documentation on how to install it.
+```
+vdk run <path to Data Job directory>
+```
+
+### Deploy Data Job
+
+When a Job is ready to be deployed in a Versatile Data Kit runtime (cloud):
+Run the command below and follow its instructions (you can see its options with `vdk --help`)
+```python
+vdk deploy
+```

--- a/projects/vdk-control-cli/src/vdk/internal/control/job/jupyter_sample_job/config.ini
+++ b/projects/vdk-control-cli/src/vdk/internal/control/job/jupyter_sample_job/config.ini
@@ -1,0 +1,61 @@
+; Supported format: https://docs.python.org/3/library/configparser.html#supported-ini-file-structure
+
+; This is the only file required to deploy a Data Job.
+; Read more to understand what each option means:
+
+; Information about the owner of the Data Job
+[owner]
+
+; Team is a way to group Data Jobs that belonged to the same team.
+team =
+
+; Configuration related to running data jobs
+[job]
+; For format see https://en.wikipedia.org/wiki/Cron
+; The cron expression is evaluated in UTC time.
+; If it is time for a new job run and the previous job run hasn’t finished yet,
+; the cron job waits until the previous execution has finished.
+schedule_cron = 11 23 5 8 1
+
+; Who will be contacted and on what occasion
+[contacts]
+
+; Specifies the time interval (in minutes) that a job execution is allowed to be delayed
+; from its scheduled time before a notification email is sent. The default is 240.
+; notification_delay_period_minutes=240
+
+; Specifies whether to enable or disable the email notifications for each data job run attempt.
+; The default value is true.
+; enable_attempt_notifications=true
+
+; Specifies whether to enable or disable email notifications per data job execution and execution delays.
+; The default value is true.
+;enable_execution_notifications=true
+
+; The [contacts] properties below use semicolon-separated list of email addresses that will be notified with email message on a given condition.
+; You can also provide email address linked to your Slack account in order to receive Slack messages.
+;   To generate Slack linked email address follow the steps here:
+;   https://get.slack.help/hc/en-us/articles/206819278-Send-emails-to-Slack#connect-the-email-app-to-your-workspace
+
+; Semicolon-separated list of email addresses to be notified on job execution failure caused by user code or user configuration why.
+; For example: if the job contains an SQL script with syntax error.
+; notified_on_job_failure_user_error=example@vmware.com
+notified_on_job_failure_user_error=
+
+; Semicolon-separated list of email addresses to be notified on job execution failure caused by a platform why.
+; notified_on_job_failure_platform_error=example@example.com; example2@example.com
+notified_on_job_failure_platform_error=
+
+; Semicolon-separated list of email addresses to be notified on job execution success.
+notified_on_job_success=
+
+; Semicolon-separated list of email addresses to be notified of job deployment outcome.
+; Notice that if this file is malformed (file structure is not as per https://docs.python.org/3/library/configparser.html#supported-ini-file-structure),
+;   then an email notification will NOT be sent to the recipients specified here.
+notified_on_job_deploy=
+
+[vdk]
+; Key value pairs of any configuration options that can be passed to vdk.
+; For possible options in your vdk installation execute command vdk config-help
+db_default_type=SQLITE
+ingest_method_default=SQLITE

--- a/projects/vdk-control-cli/src/vdk/internal/control/job/jupyter_sample_job/requirements.txt
+++ b/projects/vdk-control-cli/src/vdk/internal/control/job/jupyter_sample_job/requirements.txt
@@ -1,0 +1,3 @@
+# Python jobs can specify extra library dependencies in requirements.txt file.
+# See https://pip.readthedocs.io/en/stable/user_guide/#requirements-files
+# The file is optional and can be deleted if no extra library dependencies are necessary.

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/vdk_ui.py
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/vdk_ui.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 
 from vdk.internal.control.command_groups.job.create import JobCreate
@@ -102,7 +103,6 @@ class VdkUI:
         cmd.download(team, name, path)
         return f"Downloaded the job with name {name} to {path}. "
 
-    # TODO: make it work with notebook jobs
     @staticmethod
     def create_job(
         name: str, team: str, rest_api_url: str, path: str, local: bool, cloud: bool
@@ -124,7 +124,7 @@ class VdkUI:
         if local:
             cmd.validate_job_path(path, name)
 
-        cmd.create_job(name, team, path, cloud, local)
+        cmd.create_job(name, team, path, cloud, local, is_jupyter=True)
         return f"Job with name {name} was created."
 
     @staticmethod


### PR DESCRIPTION
Currently, when creating a job through the jupyter UI, the created job
has a sql step and a python step. We'd like a job created that way to
have only a notebook inside, as steps will be contained within that notebook.

This required changes to both the control cli module, as well as the jupyter
python module. An alternative way was possible which left the control cli
untounched, however that path was not chosen since it would require patching
module namespaces during runtime, which is prone to bugs and is to be avoided
if possible.

This is currently a draft PR, next required work is documenting this in the VEP

Testing done: tested locally by creating a new job through jupyter UI and observing
the notebook step inside

Signed-off-by: Gabriel Georgiev <gageorgiev@vmware.com>