### PR TITLE
vdk-control-cli: Allow extensions to specify a sample job

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/create.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/create.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import pathlib
+from types import ModuleType
 from typing import Optional
 from typing import Tuple
 
@@ -36,7 +37,7 @@ class JobCreate:
         path: str,
         cloud: bool,
         local: bool,
-        sample_job_directory=None,
+        sample_job_directory: ModuleType = None,
     ) -> None:
         self.__validate_job_name(name)
         if local:
@@ -70,7 +71,7 @@ class JobCreate:
         )
 
     def __create_local_job(
-        self, team: str, name: str, job_path: str, sample_job_directory
+        self, team: str, name: str, job_path: str, sample_job_directory: ModuleType
     ) -> None:
         sample_job = self.__create_sample_job_dir(sample_job_directory)
         log.debug(f"Create sample job from directory: {sample_job} into {job_path}")
@@ -80,18 +81,18 @@ class JobCreate:
             log.warning(f"Failed to write Data Job team {team} in config.ini.")
         log.info(f"Data Job with name {name} created locally in {job_path}.")
 
-    def __create_sample_job_dir(self, sample_job_directory):
+    def __create_sample_job_dir(self, sample_job_directory: ModuleType):
         """
         This method generates the directory for the sample job which will be created when invoking `vdk create`.
         Its control flow is as follows:
          - if the configuration variable VDK_CONTROL_SAMPLE_JOB_DIRECTORY is set, it takes precedent over
          everything else
-         - next, if a sample_job_module is passed to the method by its invoking class, it takes precedent next; the
+         - next, if a sample_job_directory is passed to the method by its invoking class, it takes precedent next; the
          purpose of this is to allow plugins and extensions to set a new default sample job, but still not overwrite
          one which was set by the user
          - finally, the default sample job is used
 
-        :param sample_job_module: a Python module containing the files for a sample job
+        :param sample_job_directory: a Python module containing the files for a sample job
         :return: an absolute path in the current environment where the sample job is so the files located there can
         be copied over to the target directory when creating a new job
         """

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/create.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/create.py
@@ -30,7 +30,13 @@ class JobCreate:
 
     @ApiClientErrorDecorator()
     def create_job(
-        self, name: str, team: str, path: str, cloud: bool, local: bool
+        self,
+        name: str,
+        team: str,
+        path: str,
+        cloud: bool,
+        local: bool,
+        sample_job_directory=None,
     ) -> None:
         self.__validate_job_name(name)
         if local:
@@ -40,7 +46,7 @@ class JobCreate:
             self.__create_cloud_job(team, name)
         if local:
             job_path = self.__get_job_path(path, name)
-            self.__create_local_job(team, name, job_path)
+            self.__create_local_job(team, name, job_path, sample_job_directory)
             if cloud:
                 self.__download_key(team, name, path)
 
@@ -63,14 +69,44 @@ class JobCreate:
             f"Data Job with name {name} created and registered in cloud runtime by Control Service."
         )
 
-    def __create_local_job(self, team: str, name: str, job_path: str) -> None:
-        sample_job = self.__vdk_config.sample_job_directory
+    def __create_local_job(
+        self, team: str, name: str, job_path: str, sample_job_directory
+    ) -> None:
+        sample_job = self.__create_sample_job_dir(sample_job_directory)
         log.debug(f"Create sample job from directory: {sample_job} into {job_path}")
         cli_utils.copy_directory(sample_job, job_path)
         local_config = JobConfig(job_path)
         if not local_config.set_team_if_exists(team):
             log.warning(f"Failed to write Data Job team {team} in config.ini.")
         log.info(f"Data Job with name {name} created locally in {job_path}.")
+
+    def __create_sample_job_dir(self, sample_job_directory):
+        """
+        This method generates the directory for the sample job which will be created when invoking `vdk create`.
+        Its control flow is as follows:
+         - if the configuration variable VDK_CONTROL_SAMPLE_JOB_DIRECTORY is set, it takes precedent over
+         everything else
+         - next, if a sample_job_module is passed to the method by its invoking class, it takes precedent next; the
+         purpose of this is to allow plugins and extensions to set a new default sample job, but still not overwrite
+         one which was set by the user
+         - finally, the default sample job is used
+
+        :param sample_job_module: a Python module containing the files for a sample job
+        :return: an absolute path in the current environment where the sample job is so the files located there can
+        be copied over to the target directory when creating a new job
+        """
+        if self.__vdk_config.sample_job_directory:
+            return self.__vdk_config.sample_job_directory
+
+        if not sample_job_directory:
+            import vdk.internal.control.job.sample_job
+
+            template_module_path = vdk.internal.control.job.sample_job.__path__._path[0]
+            sample_job_dir = os.path.abspath(template_module_path)
+        else:
+            template_module_path = sample_job_directory.__path__._path[0]
+            sample_job_dir = os.path.abspath(template_module_path)
+        return sample_job_dir
 
     def __download_key(self, team, name, path):
         job_download_key = JobDownloadKey(self.__rest_api_url)

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/create.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/create.py
@@ -37,7 +37,7 @@ class JobCreate:
         path: str,
         cloud: bool,
         local: bool,
-        sample_job_directory: ModuleType = None,
+        sample_job_module: ModuleType = None,
     ) -> None:
         self.__validate_job_name(name)
         if local:
@@ -47,7 +47,7 @@ class JobCreate:
             self.__create_cloud_job(team, name)
         if local:
             job_path = self.__get_job_path(path, name)
-            self.__create_local_job(team, name, job_path, sample_job_directory)
+            self.__create_local_job(team, name, job_path, sample_job_module)
             if cloud:
                 self.__download_key(team, name, path)
 
@@ -71,9 +71,9 @@ class JobCreate:
         )
 
     def __create_local_job(
-        self, team: str, name: str, job_path: str, sample_job_directory: ModuleType
+        self, team: str, name: str, job_path: str, sample_job_module: ModuleType
     ) -> None:
-        sample_job = self.__create_sample_job_dir(sample_job_directory)
+        sample_job = self.__create_sample_job_dir(sample_job_module)
         log.debug(f"Create sample job from directory: {sample_job} into {job_path}")
         cli_utils.copy_directory(sample_job, job_path)
         local_config = JobConfig(job_path)
@@ -81,7 +81,7 @@ class JobCreate:
             log.warning(f"Failed to write Data Job team {team} in config.ini.")
         log.info(f"Data Job with name {name} created locally in {job_path}.")
 
-    def __create_sample_job_dir(self, sample_job_directory: ModuleType):
+    def __create_sample_job_dir(self, sample_job_module: ModuleType):
         """
         This method generates the directory for the sample job which will be created when invoking `vdk create`.
         Its control flow is as follows:
@@ -99,13 +99,13 @@ class JobCreate:
         if self.__vdk_config.sample_job_directory:
             return self.__vdk_config.sample_job_directory
 
-        if not sample_job_directory:
+        if not sample_job_module:
             import vdk.internal.control.job.sample_job
 
             template_module_path = vdk.internal.control.job.sample_job.__path__._path[0]
             sample_job_dir = os.path.abspath(template_module_path)
         else:
-            template_module_path = sample_job_directory.__path__._path[0]
+            template_module_path = sample_job_module.__path__._path[0]
             sample_job_dir = os.path.abspath(template_module_path)
         return sample_job_dir
 

--- a/projects/vdk-control-cli/src/vdk/internal/control/configuration/vdk_config.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/configuration/vdk_config.py
@@ -129,13 +129,7 @@ class VDKConfig:
 
     @property
     def sample_job_directory(self) -> str:
-        sample_job_dir = os.getenv("VDK_CONTROL_SAMPLE_JOB_DIRECTORY", None)
-        if not sample_job_dir:
-            import vdk.internal.control.job.sample_job
-
-            template_module_path = vdk.internal.control.job.sample_job.__path__._path[0]
-            sample_job_dir = os.path.abspath(template_module_path)
-        return sample_job_dir
+        return os.getenv("VDK_CONTROL_SAMPLE_JOB_DIRECTORY", None)
 
 
 class VDKConfigFolder:

--- a/projects/vdk-control-cli/tests/resources/sample_job_module/1_new_module_step.py
+++ b/projects/vdk-control-cli/tests/resources/sample_job_module/1_new_module_step.py
@@ -1,0 +1,6 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+
+def run(job_input):
+    pass

--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_create.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_create.py
@@ -126,9 +126,6 @@ def test_create_job_configurable_sample_job_module(
     jobs_dir, rest_api_url = setup_create(
         httpserver, tmpdir, 200, 200, job_name, team_name
     )
-    sample_dir = tmpdir.mkdir("sample")
-    sample_dir.join("foo").write("")
-    sample_dir.join("config.ini").write("")
 
     runner = CliRunner()
     result = runner.invoke(
@@ -140,7 +137,7 @@ def test_create_job_configurable_sample_job_module(
     assert_click_status(result, 0)
     assert os.path.isdir(job_dir)
     # foo file exists only in our sample job
-    assert os.path.isfile(os.path.join(job_dir, "foo"))
+    assert os.path.isfile(os.path.join(job_dir, "1_new_module_step.py"))
 
 
 def test_create_job_bad_format(httpserver: PluginHTTPServer, tmpdir: LocalPath):

--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_create.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_create.py
@@ -118,7 +118,12 @@ def test_create_job_configurable_sample_job_module(
         )
         cmd.validate_job_path(path, name)
 
-        cmd.create_job(name, team, path, False, True, sample_job_module)
+        template_module_path = sample_job_module.__path__._path[
+            0
+        ]  # get the path of the imported module
+        sample_job_dir = os.path.abspath(template_module_path)
+
+        cmd.create_job(name, team, path, False, True, sample_job_dir)
         pass
 
     team_name = "test-team"

--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_create.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_create.py
@@ -4,11 +4,14 @@ import os
 import traceback
 from unittest import mock
 
+import click
 from click.testing import CliRunner
 from py._path.local import LocalPath
 from pytest_httpserver.pytest_plugin import PluginHTTPServer
 from vdk.internal import test_utils
 from vdk.internal.control.command_groups.job.create import create
+from vdk.internal.control.command_groups.job.create import JobCreate
+from vdk.internal.control.utils import cli_utils
 from vdk.internal.test_utils import assert_click_status
 from werkzeug import Response
 
@@ -89,10 +92,7 @@ def test_create_job_configurable_sample_job(
 def test_create_job_configurable_sample_job_module(
     httpserver: PluginHTTPServer, tmpdir: LocalPath
 ):
-    import click
-    from vdk.internal.control.utils import cli_utils
-    from vdk.internal.control.command_groups.job.create import JobCreate
-
+    # importing the new sample job module which we will be instantiating
     from resources import sample_job_module
 
     @click.command()

--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_create.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_create.py
@@ -124,7 +124,6 @@ def test_create_job_configurable_sample_job_module(
         sample_job_dir = os.path.abspath(template_module_path)
 
         cmd.create_job(name, team, path, False, True, sample_job_dir)
-        pass
 
     team_name = "test-team"
     job_name = "test-job"


### PR DESCRIPTION
The purpose of this change is the following: some extensions to VDK might use vdk-control-cli as a dependency to create new jobs of a certain type through the JobCreate class. Currently, there is a way to specify what job is created, which is the VDK_CONTROL_SAMPLE_JOB_DIRECTORY, however this config variable is aimed at users which want to create a job template which is specific to their environment, and must be in the form of a path in their file system. An extension cannot use this to create a new sample job. This change allows for this by extending the JobCreate class' create method with a new parameter which can be passed when the method is called. This parameter must be a Python module which is to be included in the extension's source code and must contain the necessary job files which will be created when running creating a job.

Testing done: unit test