### PR TITLE
vdk-plugin-control-cli: better error logging

### DIFF
--- a/projects/vdk-plugins/vdk-plugin-control-cli/src/vdk/plugin/control_cli_plugin/execution_skip.py
+++ b/projects/vdk-plugins/vdk-plugin-control-cli/src/vdk/plugin/control_cli_plugin/execution_skip.py
@@ -127,7 +127,7 @@ def _skip_job_if_necessary(
             return 1  # All other branches return None
     except Exception as exc:
         log.warning(
-            f"Error while checking for another data job excecution: {str(exc)} "
+            f"Error while checking for another data job excecution: {str(exc)} ", exc_info=True
         )
         log.warning("Printing stack trace and proceeding with execution:")
     return None

--- a/projects/vdk-plugins/vdk-plugin-control-cli/src/vdk/plugin/control_cli_plugin/execution_skip.py
+++ b/projects/vdk-plugins/vdk-plugin-control-cli/src/vdk/plugin/control_cli_plugin/execution_skip.py
@@ -127,7 +127,8 @@ def _skip_job_if_necessary(
             return 1  # All other branches return None
     except Exception as exc:
         log.warning(
-            f"Error while checking for another data job excecution: {str(exc)} ", exc_info=True
+            f"Error while checking for another data job excecution: {str(exc)} ",
+            exc_info=True,
         )
         log.warning("Printing stack trace and proceeding with execution:")
     return None


### PR DESCRIPTION
# Why
If you look at this ticket(https://github.com/vmware/versatile-data-kit/issues/2176) we can see that the error the customer is reporting is 
```
execution_skip.py:129  _skip_job_if_nec[id:gdp-execution-id-example-1685547120-ftlwb]- Error while checking for another data job excecution: unsupported operand type(s) for +: 'NoneType' and 'str' 
```
However its impossible to tell which line or varialbe is actually to blame. 
We need a full stacktrace

# What
Print the full stacktrace when there is an error. 


