### PR TITLE
frontend: add null checks for optional configs

### DIFF
--- a/projects/frontend/data-pipelines/gui/projects/ui/src/app/app-config.service.ts
+++ b/projects/frontend/data-pipelines/gui/projects/ui/src/app/app-config.service.ts
@@ -25,10 +25,12 @@ export class AppConfigService {
         return firstValueFrom(this.httpClient.get<AppConfig>('/assets/data/appConfig.json')).then((data) => {
             this.appConfig = data;
             try {
-                const localRoutes = routes.filter((route: { path: string }) => {
-                    return !data.ignoreRoutes.includes(route.path);
-                });
-                this.router.resetConfig(localRoutes);
+                if (data.ignoreRoutes) {
+                    const localRoutes = routes.filter((route: { path: string }) => {
+                        return !data.ignoreRoutes.includes(route.path);
+                    });
+                    this.router.resetConfig(localRoutes);
+                }
             } catch (e) {
                 console.error('Failed to reset Router config');
                 throw e;

--- a/projects/frontend/data-pipelines/gui/projects/ui/src/app/app.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/ui/src/app/app.component.ts
@@ -64,7 +64,8 @@ export class AppComponent implements OnInit {
     }
 
     get explorePageVisible(): boolean {
-        return !this.appConfigService.getConfig().ignoreComponents.includes('explorePage');
+        const ignoreComponents = this.appConfigService.getConfig().ignoreComponents;
+        return !(ignoreComponents && ignoreComponents.includes('explorePage'));
     }
 
     /**

--- a/projects/frontend/data-pipelines/gui/projects/ui/src/app/getting-started/getting-started.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/ui/src/app/getting-started/getting-started.component.ts
@@ -17,6 +17,7 @@ export class GettingStartedComponent {
     }
 
     get widgetsVisible(): boolean {
-        return !this.appConfigService.getConfig().ignoreComponents.includes('widgetsComponent');
+        const ignoreComponents = this.appConfigService.getConfig().ignoreComponents;
+        return !(ignoreComponents && ignoreComponents.includes('widgetsComponent'));
     }
 }


### PR DESCRIPTION
## Why

Missing configs cause the UI to fail on startup

## What

Add null checks for the ignoreComponents and
ignoreRoutes configs

## How has this been tested

Locally

## What kind of change is this

Feature, non-breaking