### PR TITLE
vdk-jupyter: pin tsc to specific version

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package-lock.json
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package-lock.json
@@ -50,7 +50,8 @@
         "stylelint-config-recommended": "6.0.0",
         "stylelint-config-standard": "24.0.0",
         "stylelint-prettier": "2.0.0",
-        "ts-jest": "27.1.4"
+        "ts-jest": "27.1.4",
+        "typescript": "4.1.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -15966,7 +15967,6 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
       "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -29394,8 +29394,7 @@
     "typescript": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
-      "peer": true
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg=="
     },
     "typestyle": {
       "version": "2.4.0",

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package.json
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package.json
@@ -85,7 +85,7 @@
     "@typescript-eslint/eslint-plugin": "4.8.1",
     "@typescript-eslint/parser": "4.8.1",
     "babel-jest": "27.5.1",
-    "eslint": "7.14.0",   
+    "eslint": "7.14.0",
     "eslint-config-prettier": "6.15.0",
     "eslint-plugin-prettier": "3.1.4",
     "jest": "27.0.6",

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package.json
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package.json
@@ -61,6 +61,7 @@
     "@jupyterlab/attachments": "3.6.3",
     "@jupyterlab/builder": "3.6.3",
     "@jupyterlab/cells": "3.6.3",
+    "@jupyterlab/codeeditor": "3.6.3",
     "@jupyterlab/coreutils": "5.6.0",
     "@jupyterlab/docmanager": "3.6.3",
     "@jupyterlab/docregistry": "3.6.3",
@@ -72,8 +73,7 @@
     "@jupyterlab/services": "6.5.3",
     "@jupyterlab/settingregistry": "3.1.0",
     "@jupyterlab/testutils": "3.6.3",
-    "@lumino/widgets": "1.33.0",
-    "@jupyterlab/codeeditor": "3.6.3"
+    "@lumino/widgets": "1.33.0"
   },
   "devDependencies": {
     "@babel/core": "7.8.0",
@@ -85,7 +85,7 @@
     "@typescript-eslint/eslint-plugin": "4.8.1",
     "@typescript-eslint/parser": "4.8.1",
     "babel-jest": "27.5.1",
-    "eslint": "7.14.0",
+    "eslint": "7.14.0",   
     "eslint-config-prettier": "6.15.0",
     "eslint-plugin-prettier": "3.1.4",
     "jest": "27.0.6",
@@ -98,7 +98,8 @@
     "stylelint-config-recommended": "6.0.0",
     "stylelint-config-standard": "24.0.0",
     "stylelint-prettier": "2.0.0",
-    "ts-jest": "27.1.4"
+    "ts-jest": "27.1.4",
+    "typescript": "4.1.3"
   },
   "sideEffects": [
     "style/*.css",


### PR DESCRIPTION
What:
Pinned typescript to an older version.
Why:
Some of the jupyterlab packages are not compatible with the newer versions.

Signed-off-by: Duygu Hasan [hduygu@vmware.com](mailto:hduygu@vmware.com)