### PR TITLE
vdk-core: Update JobConfig to match vdk-control-cli JobConfig

### DIFF
--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_job_config.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_job_config.py
@@ -72,7 +72,7 @@ class TestJobConfig:
 
     def test_defaults(self, tmpdir):
         empty_file_dir = tmpdir.mkdir("foo")
-        empty_file = os.path.join(empty_file_dir, "empty.ini")
+        empty_file = os.path.join(empty_file_dir, "config.ini")
         open(empty_file, "a").close()
         cfg = JobConfig(pathlib.Path(empty_file_dir))
 


### PR DESCRIPTION
Currently, there is code duplication between the vdk-core's JobConfig and vdk-control-cli's JobConfig. This is not sustainable, as when a change in one component is made, this change would need to be ported to the other component.

This change updates the vdk-core's JobConfig, as vdk-core is the main component of the Versatile Data Kit SDK. In a separate PR, the JobConfig of vdk-control-cli will be removed to remove the code duplication.

Testing Done: CI/CD