### PR TITLE
frontend: disable stable tagging for ui docker images

### DIFF
--- a/projects/frontend/cicd/.gitlab-ci.yml
+++ b/projects/frontend/cicd/.gitlab-ci.yml
@@ -124,23 +124,23 @@ frontend_publish_ui_image:
       changes: *frontend_data_pipelines_locations
   extends: .frontend_publish_docker_image
 
-frontend_tag_ui_image_stable:
-  stage: release
-  before_script:
-    - cd projects/frontend
-  script:
-    - apk --no-cache add bash git
-    - export IMAGE_TAG="$(git rev-parse --short HEAD)"
-    - docker login --username "${VDK_DOCKER_REGISTRY_USERNAME}" --password "${VDK_DOCKER_REGISTRY_PASSWORD}" "${VDK_DOCKER_REGISTRY_URL}"
-    - bash -ex ../../projects/control-service/cicd/tag_image_dockerhub.sh vdk-operations-ui $IMAGE_TAG stable
-  rules:
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
-      when: never
-    - if: '$CI_COMMIT_BRANCH == "main"'
-      changes: *frontend_shared_components_locations
-    - if: '$CI_COMMIT_BRANCH == "main"'
-      changes: *frontend_data_pipelines_locations
-  extends: .frontend_publish_docker_image
+# frontend_tag_ui_image_stable:
+#   stage: release
+#   before_script:
+#     - cd projects/frontend
+#   script:
+#     - apk --no-cache add bash git
+#     - export IMAGE_TAG="$(git rev-parse --short HEAD)"
+#     - docker login --username "${VDK_DOCKER_REGISTRY_USERNAME}" --password "${VDK_DOCKER_REGISTRY_PASSWORD}" "${VDK_DOCKER_REGISTRY_URL}"
+#     - bash -ex ../../projects/control-service/cicd/tag_image_dockerhub.sh vdk-operations-ui $IMAGE_TAG stable
+#   rules:
+#     - if: '$CI_PIPELINE_SOURCE == "schedule"'
+#       when: never
+#     - if: '$CI_COMMIT_BRANCH == "main"'
+#       changes: *frontend_shared_components_locations
+#     - if: '$CI_COMMIT_BRANCH == "main"'
+#       changes: *frontend_data_pipelines_locations
+#   extends: .frontend_publish_docker_image
 
 frontend_deploy_testing_data_pipelines:
   stage: pre_release_test


### PR DESCRIPTION
## Why

Building shared-components and data-pipelines simultaneously in CI causes the UI docker image to break.

More info https://jira.eng.vmware.com/browse/TAUR-6084

## What

Disable the CI job that tags UI docker images as stable. quickstart-vdk uses the stable tag. Disabling tagging until the issue is solved makes sure that quickstart-vdk will not break because of changes we introduce in the meantime

## How was this tested

n/a

## What kind of change is this

Temporary bug mitigation