### PR TITLE
control-service: make kubernetes service easy  to test.

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -30,8 +30,6 @@ import io.kubernetes.client.openapi.apis.*;
 import io.kubernetes.client.custom.IntOrString;
 import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.openapi.models.*;
-import io.kubernetes.client.util.ClientBuilder;
-import io.kubernetes.client.util.KubeConfig;
 import io.kubernetes.client.util.Watch;
 import io.kubernetes.client.util.Yaml;
 import lombok.*;
@@ -40,7 +38,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
@@ -54,7 +51,6 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -375,9 +371,8 @@ public abstract class KubernetesService {
   public Set<String> listJobs() throws ApiException {
     log.debug("Listing k8s jobs");
     var jobs =
-        batchV1Api
-            .listNamespacedJob(
-                namespace, null, null, null, null, null, null, null, null, null, null);
+        batchV1Api.listNamespacedJob(
+            namespace, null, null, null, null, null, null, null, null, null, null);
     var set =
         jobs.getItems().stream().map(j -> j.getMetadata().getName()).collect(Collectors.toSet());
     log.debug("K8s jobs: {}", set);
@@ -451,9 +446,8 @@ public abstract class KubernetesService {
     V1beta1CronJobList cronJobs = null;
     try {
       cronJobs =
-          batchV1beta1Api
-              .listNamespacedCronJob(
-                  namespace, null, null, null, null, null, null, null, null, null, null);
+          batchV1beta1Api.listNamespacedCronJob(
+              namespace, null, null, null, null, null, null, null, null, null, null);
     } catch (ApiException e) {
       log.warn("Failed to read k8s cron jobs: ", new KubernetesException("", e));
     }
@@ -471,9 +465,8 @@ public abstract class KubernetesService {
     V1CronJobList cronJobs = null;
     try {
       cronJobs =
-          batchV1Api
-              .listNamespacedCronJob(
-                  namespace, null, null, null, null, null, null, null, null, null, null);
+          batchV1Api.listNamespacedCronJob(
+              namespace, null, null, null, null, null, null, null, null, null, null);
     } catch (ApiException e) {
       log.warn("Failed to read k8s cron jobs: ", new KubernetesException("", e));
     }
@@ -661,9 +654,8 @@ public abstract class KubernetesService {
         namespace);
     try {
       var operationResponse =
-          batchV1Api
-              .deleteNamespacedJobWithHttpInfo(
-                  executionId, namespace, null, null, null, null, "Foreground", null);
+          batchV1Api.deleteNamespacedJobWithHttpInfo(
+              executionId, namespace, null, null, null, null, "Foreground", null);
       // Status of the operation. One of: "Success" or "Failure"
       if (operationResponse == null || operationResponse.getStatusCode() == 404) {
         log.info(
@@ -723,9 +715,8 @@ public abstract class KubernetesService {
 
     try {
       var v1CronJobs =
-          batchV1Api
-              .listNamespacedCronJob(
-                  namespace, null, null, null, null, null, null, null, null, null, null);
+          batchV1Api.listNamespacedCronJob(
+              namespace, null, null, null, null, null, null, null, null, null, null);
       v1CronJobNames =
           v1CronJobs.getItems().stream()
               .map(j -> j.getMetadata().getName())
@@ -742,9 +733,8 @@ public abstract class KubernetesService {
     }
 
     var v1BetaCronJobs =
-        batchV1beta1Api
-            .listNamespacedCronJob(
-                namespace, null, null, null, null, null, null, null, null, null, null);
+        batchV1beta1Api.listNamespacedCronJob(
+            namespace, null, null, null, null, null, null, null, null, null, null);
     var v1BetaCronJobNames =
         v1BetaCronJobs.getItems().stream()
             .map(j -> j.getMetadata().getName())
@@ -820,8 +810,7 @@ public abstract class KubernetesService {
             jobLabels,
             imagePullSecrets);
     V1beta1CronJob nsJob =
-        batchV1beta1Api
-            .createNamespacedCronJob(namespace, cronJob, null, null, null, null);
+        batchV1beta1Api.createNamespacedCronJob(namespace, cronJob, null, null, null, null);
     log.debug("Created k8s V1beta1 cron job: {}", nsJob);
     log.debug(
         "Created k8s cron job name: {}, api_version:{}, uid:{}, link:{}",
@@ -858,7 +847,7 @@ public abstract class KubernetesService {
             jobLabels,
             imagePullSecrets);
     V1CronJob nsJob =
-      batchV1Api.createNamespacedCronJob(namespace, cronJob, null, null, null, null);
+        batchV1Api.createNamespacedCronJob(namespace, cronJob, null, null, null, null);
     log.debug("Created k8s V1 cron job: {}", nsJob);
     log.debug(
         "Created k8s cron job name: {}, api_version: {}, uid:{}, link:{}",
@@ -931,8 +920,7 @@ public abstract class KubernetesService {
             jobLabels,
             imagePullSecrets);
     V1beta1CronJob nsJob =
-        batchV1beta1Api
-            .replaceNamespacedCronJob(name, namespace, cronJob, null, null, null, null);
+        batchV1beta1Api.replaceNamespacedCronJob(name, namespace, cronJob, null, null, null, null);
     log.debug(
         "Updated k8s V1beta1 cron job status for name:{}, image:{}, uid:{}, link:{}",
         name,
@@ -965,8 +953,7 @@ public abstract class KubernetesService {
             jobLabels,
             imagePullSecrets);
     V1CronJob nsJob =
-        batchV1Api
-            .replaceNamespacedCronJob(name, namespace, cronJob, null, null, null, null);
+        batchV1Api.replaceNamespacedCronJob(name, namespace, cronJob, null, null, null, null);
     log.debug(
         "Updated k8s V1 cron job status for name:{}, image:{}, uid:{}, link:{}",
         name,
@@ -983,8 +970,7 @@ public abstract class KubernetesService {
     // with the V1Beta1 API, so we need to try again with the beta API.
     if (getK8sSupportsV1CronJob()) {
       try {
-        batchV1Api
-            .deleteNamespacedCronJob(name, namespace, null, null, null, null, null, null);
+        batchV1Api.deleteNamespacedCronJob(name, namespace, null, null, null, null, null, null);
         log.debug("Deleted k8s V1 cron job: {}", name);
         return;
       } catch (Exception e) {
@@ -993,8 +979,7 @@ public abstract class KubernetesService {
     }
 
     try {
-      batchV1beta1Api
-          .deleteNamespacedCronJob(name, namespace, null, null, null, null, null, null);
+      batchV1beta1Api.deleteNamespacedCronJob(name, namespace, null, null, null, null, null, null);
       log.debug("Deleted k8s V1beta1 cron job: {}", name);
     } catch (JsonSyntaxException e) {
       if (e.getCause() instanceof IllegalStateException) {
@@ -1085,8 +1070,7 @@ public abstract class KubernetesService {
             .withSpec(spec)
             .build();
 
-    V1Job nsJob =
-        batchV1Api.createNamespacedJob(namespace, job, null, null, null, null);
+    V1Job nsJob = batchV1Api.createNamespacedJob(namespace, job, null, null, null, null);
     log.debug("Created k8s job: {}", nsJob);
     log.debug(
         "Created k8s job name: {}, uid:{}, link:{}",
@@ -1124,9 +1108,8 @@ public abstract class KubernetesService {
     var labelsToSelect = Map.of(JobLabel.NAME.getValue(), dataJobName);
     String labelSelector = buildLabelSelector(labelsToSelect);
     V1JobList v1JobList =
-        batchV1Api
-            .listNamespacedJob(
-                namespace, null, null, null, null, labelSelector, null, null, null, null, null);
+        batchV1Api.listNamespacedJob(
+            namespace, null, null, null, null, labelSelector, null, null, null, null, null);
 
     // In this case we use getConditions() instead of getActive()
     // because if the job is in init state the active flag is zero.
@@ -1211,7 +1194,6 @@ public abstract class KubernetesService {
     return condition;
   }
 
-
   private JobStatusCondition watchJobInternal(
       String jobName, int timeoutSeconds, Consumer<JobStatus> watcher)
       throws IOException, ApiException {
@@ -1219,20 +1201,19 @@ public abstract class KubernetesService {
     try (Watch<V1Job> watch =
         Watch.createWatch(
             Configuration.getDefaultApiClient(),
-           batchV1Api
-                .listNamespacedJobCall(
-                    namespace,
-                    null,
-                    null,
-                    null,
-                    fieldSelector,
-                    null,
-                    null,
-                    null,
-                    null,
-                    timeoutSeconds,
-                    true,
-                    null),
+            batchV1Api.listNamespacedJobCall(
+                namespace,
+                null,
+                null,
+                null,
+                fieldSelector,
+                null,
+                null,
+                null,
+                null,
+                timeoutSeconds,
+                true,
+                null),
             new TypeToken<Watch.Response<V1Job>>() {}.getType())) {
       for (var response : watch) {
         log.debug("watch k8s response type: {}", response.type);
@@ -1320,11 +1301,7 @@ public abstract class KubernetesService {
 
     var lastMainTerminatedPodState =
         jobPods.stream()
-            .map(
-                v1Pod ->
-                    getTerminatedState(
-                        v1Pod,
-                            V1PodStatus::getContainerStatuses))
+            .map(v1Pod -> getTerminatedState(v1Pod, V1PodStatus::getContainerStatuses))
             .filter(Optional::isPresent)
             .map(Optional::get)
             .max(Comparator.comparing(V1ContainerStateTerminated::getFinishedAt));
@@ -1335,11 +1312,7 @@ public abstract class KubernetesService {
 
     var lastInitTerminatedPodState =
         jobPods.stream()
-            .map(
-                v1Pod ->
-                    getTerminatedState(
-                        v1Pod,
-                            V1PodStatus::getInitContainerStatuses))
+            .map(v1Pod -> getTerminatedState(v1Pod, V1PodStatus::getInitContainerStatuses))
             .filter(Optional::isPresent)
             .map(Optional::get)
             .max(Comparator.comparing(V1ContainerStateTerminated::getFinishedAt));
@@ -1574,19 +1547,8 @@ public abstract class KubernetesService {
     String resourceVersion;
     try {
       var jobList =
-          batchV1Api
-              .listNamespacedJob(
-                  namespace,
-                  "false",
-                  null,
-                  null,
-                  null,
-                  labelSelector,
-                  null,
-                  null,
-                  null,
-                  null,
-                  null);
+          batchV1Api.listNamespacedJob(
+              namespace, "false", null, null, null, labelSelector, null, null, null, null, null);
       List<String> runningExecutionIds = new ArrayList<>();
 
       jobList
@@ -1614,20 +1576,19 @@ public abstract class KubernetesService {
     try (Watch<V1Job> watch =
         Watch.createWatch(
             Configuration.getDefaultApiClient(),
-            batchV1Api
-                .listNamespacedJobCall(
-                    namespace,
-                    null,
-                    null,
-                    null,
-                    null,
-                    labelSelector,
-                    null,
-                    resourceVersion,
-                    null,
-                    timeoutSeconds,
-                    true,
-                    null),
+            batchV1Api.listNamespacedJobCall(
+                namespace,
+                null,
+                null,
+                null,
+                null,
+                labelSelector,
+                null,
+                resourceVersion,
+                null,
+                timeoutSeconds,
+                true,
+                null),
             new TypeToken<Watch.Response<V1Job>>() {}.getType())) {
       for (var response : watch) {
         if (response.status != null) {
@@ -1706,8 +1667,7 @@ public abstract class KubernetesService {
     log.debug("Deleting k8s job: {}", name);
     try {
       var status =
-          batchV1Api
-              .deleteNamespacedJob(name, namespace, null, null, null, null, null, null);
+          batchV1Api.deleteNamespacedJob(name, namespace, null, null, null, null, null, null);
       log.debug("Deleted k8s job: {}, status: {}", name, status);
     } catch (JsonSyntaxException e) {
       log.warn(
@@ -1765,9 +1725,8 @@ public abstract class KubernetesService {
     String fieldSelector = String.format("metadata.name=%s", jobName);
     try {
       var jobs =
-          batchV1Api
-              .listNamespacedJob(
-                  namespace, null, null, null, fieldSelector, null, null, null, null, null, null);
+          batchV1Api.listNamespacedJob(
+              namespace, null, null, null, fieldSelector, null, null, null, null, null, null);
       if (!jobs.getItems().isEmpty()) {
         return Optional.of(jobs.getItems().get(0));
       }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesServiceConfiguration.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesServiceConfiguration.java
@@ -28,69 +28,69 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 public class KubernetesServiceConfiguration {
 
-    private final UserAgentService userAgentService;
+  private final UserAgentService userAgentService;
 
-    @Autowired
-    public KubernetesServiceConfiguration(UserAgentService userAgentService) {
-        this.userAgentService = userAgentService;
+  @Autowired
+  public KubernetesServiceConfiguration(UserAgentService userAgentService) {
+    this.userAgentService = userAgentService;
+  }
+
+  @Bean
+  public BatchV1Api deploymentBatchV1Api(
+      @Qualifier("deploymentApiClient") ApiClient deploymentApiClient) {
+    return new BatchV1Api(deploymentApiClient);
+  }
+
+  @Bean
+  public BatchV1beta1Api deploymentBatchV1beta1Api(
+      @Qualifier("deploymentApiClient") ApiClient deploymentApiClient) {
+    return new BatchV1beta1Api(deploymentApiClient);
+  }
+
+  @Bean
+  public ApiClient deploymentApiClient(
+      @Value("${datajobs.deployment.k8s.kubeconfig:}") String kubeconfig) throws Exception {
+    return getClient(kubeconfig);
+  }
+
+  @Bean
+  public ApiClient controlApiClient(@Value("${datajobs.control.k8s.kubeconfig:}") String kubeconfig)
+      throws Exception {
+    return getClient(kubeconfig);
+  }
+
+  @Bean
+  public BatchV1Api controlBatchV1Api(@Qualifier("controlApiClient") ApiClient apiClient) {
+    return new BatchV1Api(apiClient);
+  }
+
+  @Bean
+  public BatchV1beta1Api controlBatchV1beta1Api(
+      @Qualifier("controlApiClient") ApiClient apiClient) {
+    return new BatchV1beta1Api(apiClient);
+  }
+
+  @NotNull
+  private ApiClient getClient(String kubeconfig) throws IOException {
+    final ApiClient client;
+    log.info("Configuration used: kubeconfig: {}", kubeconfig);
+    if (!StringUtils.isBlank(kubeconfig) && new File(kubeconfig).isFile()) {
+      log.info("Will use provided kubeconfig file from configuration: {}", kubeconfig);
+      KubeConfig kubeConfig = KubeConfig.loadKubeConfig(new FileReader(kubeconfig));
+      client = ClientBuilder.kubeconfig(kubeConfig).build();
+    } else {
+      log.info("Will use default client");
+      client = ClientBuilder.defaultClient();
+    }
+    if (userAgentService != null) {
+      client.setUserAgent(userAgentService.getUserAgent());
     }
 
-    @Bean
-    public BatchV1Api deploymentBatchV1Api(
-            @Qualifier("deploymentApiClient") ApiClient deploymentApiClient) {
-        return new BatchV1Api(deploymentApiClient);
-    }
-
-    @Bean
-    public BatchV1beta1Api deploymentBatchV1beta1Api(
-            @Qualifier("deploymentApiClient") ApiClient deploymentApiClient) {
-        return new BatchV1beta1Api(deploymentApiClient);
-    }
-
-    @Bean
-    public ApiClient deploymentApiClient(
-            @Value("${datajobs.deployment.k8s.kubeconfig:}") String kubeconfig) throws Exception {
-        return getClient(kubeconfig);
-    }
-
-    @Bean
-    public ApiClient controlApiClient(@Value("${datajobs.control.k8s.kubeconfig:}") String kubeconfig)
-            throws Exception {
-        return getClient(kubeconfig);
-    }
-
-    @Bean
-    public BatchV1Api controlBatchV1Api(@Qualifier("controlApiClient") ApiClient apiClient) {
-        return new BatchV1Api(apiClient);
-    }
-
-    @Bean
-    public BatchV1beta1Api controlBatchV1beta1Api(
-            @Qualifier("controlApiClient") ApiClient apiClient) {
-        return new BatchV1beta1Api(apiClient);
-    }
-
-    @NotNull
-    private ApiClient getClient(String kubeconfig) throws IOException {
-        final ApiClient client;
-        log.info("Configuration used: kubeconfig: {}", kubeconfig);
-        if (!StringUtils.isBlank(kubeconfig) && new File(kubeconfig).isFile()) {
-            log.info("Will use provided kubeconfig file from configuration: {}", kubeconfig);
-            KubeConfig kubeConfig = KubeConfig.loadKubeConfig(new FileReader(kubeconfig));
-            client = ClientBuilder.kubeconfig(kubeConfig).build();
-        } else {
-            log.info("Will use default client");
-            client = ClientBuilder.defaultClient();
-        }
-        if (userAgentService != null) {
-            client.setUserAgent(userAgentService.getUserAgent());
-        }
-
-        // Annoying error: Watch is incompatible with debugging mode active
-        // client.setDebugging(true);
-        client.setHttpClient(
-                client.getHttpClient().newBuilder().readTimeout(0, TimeUnit.SECONDS).build());
-        // client.getHttpClient().setReadTimeout(0, TimeUnit.SECONDS);
-        return client;
-    }
+    // Annoying error: Watch is incompatible with debugging mode active
+    // client.setDebugging(true);
+    client.setHttpClient(
+        client.getHttpClient().newBuilder().readTimeout(0, TimeUnit.SECONDS).build());
+    // client.getHttpClient().setReadTimeout(0, TimeUnit.SECONDS);
+    return client;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesServiceConfiguration.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesServiceConfiguration.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service;
+
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.apis.BatchV1Api;
+import io.kubernetes.client.openapi.apis.BatchV1beta1Api;
+import io.kubernetes.client.util.ClientBuilder;
+import io.kubernetes.client.util.KubeConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@Slf4j
+public class KubernetesServiceConfiguration {
+
+    private final UserAgentService userAgentService;
+
+    @Autowired
+    public KubernetesServiceConfiguration(UserAgentService userAgentService) {
+        this.userAgentService = userAgentService;
+    }
+
+    @Bean
+    public BatchV1Api deploymentBatchV1Api(
+            @Qualifier("deploymentApiClient") ApiClient deploymentApiClient) {
+        return new BatchV1Api(deploymentApiClient);
+    }
+
+    @Bean
+    public BatchV1beta1Api deploymentBatchV1beta1Api(
+            @Qualifier("deploymentApiClient") ApiClient deploymentApiClient) {
+        return new BatchV1beta1Api(deploymentApiClient);
+    }
+
+    @Bean
+    public ApiClient deploymentApiClient(
+            @Value("${datajobs.deployment.k8s.kubeconfig:}") String kubeconfig) throws Exception {
+        return getClient(kubeconfig);
+    }
+
+    @Bean
+    public ApiClient controlApiClient(@Value("${datajobs.control.k8s.kubeconfig:}") String kubeconfig)
+            throws Exception {
+        return getClient(kubeconfig);
+    }
+
+    @Bean
+    public BatchV1Api controlBatchV1Api(@Qualifier("controlApiClient") ApiClient apiClient) {
+        return new BatchV1Api(apiClient);
+    }
+
+    @Bean
+    public BatchV1beta1Api controlBatchV1beta1Api(
+            @Qualifier("controlApiClient") ApiClient apiClient) {
+        return new BatchV1beta1Api(apiClient);
+    }
+
+    @NotNull
+    private ApiClient getClient(String kubeconfig) throws IOException {
+        final ApiClient client;
+        log.info("Configuration used: kubeconfig: {}", kubeconfig);
+        if (!StringUtils.isBlank(kubeconfig) && new File(kubeconfig).isFile()) {
+            log.info("Will use provided kubeconfig file from configuration: {}", kubeconfig);
+            KubeConfig kubeConfig = KubeConfig.loadKubeConfig(new FileReader(kubeconfig));
+            client = ClientBuilder.kubeconfig(kubeConfig).build();
+        } else {
+            log.info("Will use default client");
+            client = ClientBuilder.defaultClient();
+        }
+        if (userAgentService != null) {
+            client.setUserAgent(userAgentService.getUserAgent());
+        }
+
+        // Annoying error: Watch is incompatible with debugging mode active
+        // client.setDebugging(true);
+        client.setHttpClient(
+                client.getHttpClient().newBuilder().readTimeout(0, TimeUnit.SECONDS).build());
+        // client.getHttpClient().setReadTimeout(0, TimeUnit.SECONDS);
+        return client;
+    }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/ControlKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/ControlKubernetesService.java
@@ -25,19 +25,19 @@ public class ControlKubernetesService extends KubernetesService {
 
   // those should be null/empty when Control service is deployed in k8s hence default is empty
   public ControlKubernetesService(
-          @Value("${datajobs.control.k8s.namespace:}") String namespace,
-          @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob,
-          @Qualifier("controlApiClient") ApiClient client,
-          @Qualifier("controlBatchV1Api") BatchV1Api batchV1Api,
-          @Qualifier("controlBatchV1beta1Api") BatchV1beta1Api batchV1beta1Api,
-          JobCommandProvider jobCommandProvider) {
+      @Value("${datajobs.control.k8s.namespace:}") String namespace,
+      @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob,
+      @Qualifier("controlApiClient") ApiClient client,
+      @Qualifier("controlBatchV1Api") BatchV1Api batchV1Api,
+      @Qualifier("controlBatchV1beta1Api") BatchV1beta1Api batchV1beta1Api,
+      JobCommandProvider jobCommandProvider) {
     super(
-            namespace,
-            k8sSupportsV1CronJob,
-            log,
-            client,
-            batchV1Api,
-            batchV1beta1Api,
-            jobCommandProvider);
+        namespace,
+        k8sSupportsV1CronJob,
+        log,
+        client,
+        batchV1Api,
+        batchV1beta1Api,
+        jobCommandProvider);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/ControlKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/ControlKubernetesService.java
@@ -6,7 +6,12 @@
 package com.vmware.taurus.service.kubernetes;
 
 import com.vmware.taurus.service.KubernetesService;
+import com.vmware.taurus.service.deploy.JobCommandProvider;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.apis.BatchV1Api;
+import io.kubernetes.client.openapi.apis.BatchV1beta1Api;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -20,9 +25,19 @@ public class ControlKubernetesService extends KubernetesService {
 
   // those should be null/empty when Control service is deployed in k8s hence default is empty
   public ControlKubernetesService(
-      @Value("${datajobs.control.k8s.namespace:}") String namespace,
-      @Value("${datajobs.control.k8s.kubeconfig:}") String kubeconfig,
-      @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob) {
-    super(namespace, kubeconfig, k8sSupportsV1CronJob, log);
+          @Value("${datajobs.control.k8s.namespace:}") String namespace,
+          @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob,
+          @Qualifier("controlApiClient") ApiClient client,
+          @Qualifier("controlBatchV1Api") BatchV1Api batchV1Api,
+          @Qualifier("controlBatchV1beta1Api") BatchV1beta1Api batchV1beta1Api,
+          JobCommandProvider jobCommandProvider) {
+    super(
+            namespace,
+            k8sSupportsV1CronJob,
+            log,
+            client,
+            batchV1Api,
+            batchV1beta1Api,
+            jobCommandProvider);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
@@ -25,19 +25,19 @@ import org.springframework.stereotype.Service;
 public class DataJobsKubernetesService extends KubernetesService {
 
   public DataJobsKubernetesService(
-          @Value("${datajobs.deployment.k8s.namespace:}") String namespace,
-          @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob,
-          @Qualifier("deploymentApiClient") ApiClient client,
-          @Qualifier("controlBatchV1Api") BatchV1Api batchV1Api,
-          @Qualifier("controlBatchV1beta1Api") BatchV1beta1Api batchV1beta1Api,
-          JobCommandProvider jobCommandProvider) {
+      @Value("${datajobs.deployment.k8s.namespace:}") String namespace,
+      @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob,
+      @Qualifier("deploymentApiClient") ApiClient client,
+      @Qualifier("controlBatchV1Api") BatchV1Api batchV1Api,
+      @Qualifier("controlBatchV1beta1Api") BatchV1beta1Api batchV1beta1Api,
+      JobCommandProvider jobCommandProvider) {
     super(
-            namespace,
-            k8sSupportsV1CronJob,
-            log,
-            client,
-            batchV1Api,
-            batchV1beta1Api,
-            jobCommandProvider);
+        namespace,
+        k8sSupportsV1CronJob,
+        log,
+        client,
+        batchV1Api,
+        batchV1beta1Api,
+        jobCommandProvider);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
@@ -6,12 +6,14 @@
 package com.vmware.taurus.service.kubernetes;
 
 import com.vmware.taurus.service.KubernetesService;
+import com.vmware.taurus.service.deploy.JobCommandProvider;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.apis.BatchV1Api;
+import io.kubernetes.client.openapi.apis.BatchV1beta1Api;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-
-import java.io.File;
 
 /**
  * Kubernetes service used for serving data jobs deployments. All deployed data jobs are executed in
@@ -23,16 +25,19 @@ import java.io.File;
 public class DataJobsKubernetesService extends KubernetesService {
 
   public DataJobsKubernetesService(
-      @Value("${datajobs.deployment.k8s.namespace:}") String namespace,
-      @Value("${datajobs.deployment.k8s.kubeconfig:}") String kubeconfig,
-      @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob) {
-    super(namespace, kubeconfig, k8sSupportsV1CronJob, log);
-    if (StringUtils.isBlank(kubeconfig) && !new File(kubeconfig).isFile()) {
-      log.warn(
-          "Data Jobs (Deployment) Kubernetes service may not have been correctly bootstrapped. {}"
-              + " file is missing Will try to use same cluster as control Plane. But this is not"
-              + " recommended in production.",
-          kubeconfig);
-    }
+          @Value("${datajobs.deployment.k8s.namespace:}") String namespace,
+          @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob,
+          @Qualifier("deploymentApiClient") ApiClient client,
+          @Qualifier("controlBatchV1Api") BatchV1Api batchV1Api,
+          @Qualifier("controlBatchV1beta1Api") BatchV1beta1Api batchV1beta1Api,
+          JobCommandProvider jobCommandProvider) {
+    super(
+            namespace,
+            k8sSupportsV1CronJob,
+            log,
+            client,
+            batchV1Api,
+            batchV1beta1Api,
+            jobCommandProvider);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
@@ -17,8 +17,6 @@ import io.kubernetes.client.openapi.models.V1StatusDetails;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.slf4j.Logger;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import com.vmware.taurus.exception.DataJobExecutionCannotBeCancelledException;
 import com.vmware.taurus.exception.KubernetesException;
@@ -99,11 +97,11 @@ public class KubernetesServiceCancelRunningCronJobTest {
         .thenReturn(response);
 
     return new DataJobsKubernetesService(
-            "default",
-            false,
-            new ApiClient(),
-            batchV1Api,
-            new BatchV1beta1Api(),
-            new JobCommandProvider());
+        "default",
+        false,
+        new ApiClient(),
+        batchV1Api,
+        new BatchV1beta1Api(),
+        new JobCommandProvider());
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
@@ -5,9 +5,13 @@
 
 package com.vmware.taurus.service;
 
+import com.vmware.taurus.service.deploy.JobCommandProvider;
+import com.vmware.taurus.service.kubernetes.DataJobsKubernetesService;
+import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.ApiResponse;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
+import io.kubernetes.client.openapi.apis.BatchV1beta1Api;
 import io.kubernetes.client.openapi.models.V1Status;
 import io.kubernetes.client.openapi.models.V1StatusDetails;
 import org.junit.jupiter.api.Assertions;
@@ -77,15 +81,6 @@ public class KubernetesServiceCancelRunningCronJobTest {
   }
 
   private KubernetesService mockKubernetesService(V1Status v1Status) throws ApiException {
-    var kubernetesService = Mockito.mock(KubernetesService.class);
-    ReflectionTestUtils.setField(
-        kubernetesService, // inject into this object
-        "log", // assign to this field
-        Mockito.mock(Logger.class)); // object to be injected
-    Mockito.doCallRealMethod()
-        .when(kubernetesService)
-        .cancelRunningCronJob(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
-
     ApiResponse<V1Status> response = Mockito.mock(ApiResponse.class);
     Mockito.when(response.getData()).thenReturn(v1Status);
     Mockito.when(response.getStatusCode()).thenReturn(v1Status == null ? 404 : v1Status.getCode());
@@ -94,7 +89,7 @@ public class KubernetesServiceCancelRunningCronJobTest {
     Mockito.when(
             batchV1Api.deleteNamespacedJobWithHttpInfo(
                 Mockito.anyString(),
-                Mockito.isNull(),
+                Mockito.anyString(),
                 Mockito.isNull(),
                 Mockito.isNull(),
                 Mockito.isNull(),
@@ -103,8 +98,12 @@ public class KubernetesServiceCancelRunningCronJobTest {
                 Mockito.isNull()))
         .thenReturn(response);
 
-    Mockito.when(kubernetesService.initBatchV1Api()).thenReturn(batchV1Api);
-
-    return kubernetesService;
+    return new DataJobsKubernetesService(
+            "default",
+            false,
+            new ApiClient(),
+            batchV1Api,
+            new BatchV1beta1Api(),
+            new JobCommandProvider());
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceIsRunningJobTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceIsRunningJobTest.java
@@ -95,13 +95,13 @@ public class KubernetesServiceIsRunningJobTest {
         .thenReturn(response);
 
     KubernetesService kubernetesService =
-            new DataJobsKubernetesService(
-                    "default",
-                    true,
-                    new ApiClient(),
-                    batchV1Api,
-                    new BatchV1beta1Api(),
-                    new JobCommandProvider());
+        new DataJobsKubernetesService(
+            "default",
+            true,
+            new ApiClient(),
+            batchV1Api,
+            new BatchV1beta1Api(),
+            new JobCommandProvider());
     boolean actualResult = kubernetesService.isRunningJob("test-job");
 
     Assertions.assertEquals(expectedResult, actualResult);

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceIsRunningJobTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceIsRunningJobTest.java
@@ -7,8 +7,12 @@ package com.vmware.taurus.service;
 
 import java.util.Collections;
 
+import com.vmware.taurus.service.deploy.JobCommandProvider;
+import com.vmware.taurus.service.kubernetes.DataJobsKubernetesService;
+import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
+import io.kubernetes.client.openapi.apis.BatchV1beta1Api;
 import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1JobCondition;
 import io.kubernetes.client.openapi.models.V1JobList;
@@ -73,13 +77,11 @@ public class KubernetesServiceIsRunningJobTest {
   }
 
   private void assertResponseValid(V1JobList response, boolean expectedResult) throws ApiException {
-    KubernetesService kubernetesService = Mockito.mock(KubernetesService.class);
-    Mockito.when(kubernetesService.isRunningJob(Mockito.anyString())).thenCallRealMethod();
 
     BatchV1Api batchV1Api = Mockito.mock(BatchV1Api.class);
     Mockito.when(
             batchV1Api.listNamespacedJob(
-                Mockito.isNull(),
+                Mockito.anyString(),
                 Mockito.isNull(),
                 Mockito.isNull(),
                 Mockito.isNull(),
@@ -92,7 +94,14 @@ public class KubernetesServiceIsRunningJobTest {
                 Mockito.isNull()))
         .thenReturn(response);
 
-    Mockito.when(kubernetesService.initBatchV1Api()).thenReturn(batchV1Api);
+    KubernetesService kubernetesService =
+            new DataJobsKubernetesService(
+                    "default",
+                    true,
+                    new ApiClient(),
+                    batchV1Api,
+                    new BatchV1beta1Api(),
+                    new JobCommandProvider());
     boolean actualResult = kubernetesService.isRunningJob("test-job");
 
     Assertions.assertEquals(expectedResult, actualResult);

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartJobWithArgumentsIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartJobWithArgumentsIT.java
@@ -36,27 +36,22 @@ public class KubernetesServiceStartJobWithArgumentsIT {
     BatchV1Api mockBatchV1 = Mockito.mock(BatchV1Api.class);
 
     kubernetesService =
-            new DataJobsKubernetesService(
-                    "default",
-                    false,
-                    new ApiClient(),
-                    mockBatchV1,
-                    mockBatch,
-                    new JobCommandProvider());
+        new DataJobsKubernetesService(
+            "default", false, new ApiClient(), mockBatchV1, mockBatch, new JobCommandProvider());
     V1beta1CronJob internalCronjobTemplate = getValidCronJobForVdkRunExtraArgsTests();
 
     kubernetesService =
-            Mockito.spy(
-                    new DataJobsKubernetesService(
-                            "default",
-                            false,
-                            new ApiClient(),
-                            mockBatchV1,
-                            mockBatch,
-                            new JobCommandProvider()));
+        Mockito.spy(
+            new DataJobsKubernetesService(
+                "default",
+                false,
+                new ApiClient(),
+                mockBatchV1,
+                mockBatch,
+                new JobCommandProvider()));
     Mockito.doNothing()
-            .when(kubernetesService)
-            .createNewJob(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+        .when(kubernetesService)
+        .createNewJob(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
 
     Mockito.when(mockBatch.readNamespacedCronJob(any(), any(), any()))
         .thenReturn(internalCronjobTemplate);
@@ -171,7 +166,8 @@ public class KubernetesServiceStartJobWithArgumentsIT {
   }
 
   private V1beta1CronJob getValidCronJobForVdkRunExtraArgsTests() throws Exception {
-    KubernetesService service = new DataJobsKubernetesService(
+    KubernetesService service =
+        new DataJobsKubernetesService(
             "default",
             false,
             new ApiClient(),

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartNewCronJobExecutionTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartNewCronJobExecutionTest.java
@@ -215,21 +215,21 @@ public class KubernetesServiceStartNewCronJobExecutionTest {
         .thenReturn(result);
 
     Mockito.when(
-                    batchV1beta1Api.readNamespacedCronJob(
-                            Mockito.eq(jobName), Mockito.anyString(), Mockito.isNull()))
-            .thenReturn(result);
+            batchV1beta1Api.readNamespacedCronJob(
+                Mockito.eq(jobName), Mockito.anyString(), Mockito.isNull()))
+        .thenReturn(result);
     DataJobsKubernetesService spy =
-            Mockito.spy(
-                    new DataJobsKubernetesService(
-                            "default",
-                            false,
-                            new ApiClient(),
-                            new BatchV1Api(),
-                            batchV1beta1Api,
-                            new JobCommandProvider()));
+        Mockito.spy(
+            new DataJobsKubernetesService(
+                "default",
+                false,
+                new ApiClient(),
+                new BatchV1Api(),
+                batchV1beta1Api,
+                new JobCommandProvider()));
     Mockito.doNothing()
-            .when(spy)
-            .createNewJob(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any());
+        .when(spy)
+        .createNewJob(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any());
     return spy;
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartNewCronJobExecutionTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartNewCronJobExecutionTest.java
@@ -5,9 +5,13 @@
 
 package com.vmware.taurus.service;
 
+import com.vmware.taurus.service.deploy.JobCommandProvider;
+import com.vmware.taurus.service.kubernetes.DataJobsKubernetesService;
 import com.vmware.taurus.service.model.JobAnnotation;
 import com.vmware.taurus.service.model.JobEnvVar;
+import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.BatchV1Api;
 import io.kubernetes.client.openapi.apis.BatchV1beta1Api;
 import io.kubernetes.client.openapi.models.*;
 import org.junit.jupiter.api.Test;
@@ -204,25 +208,28 @@ public class KubernetesServiceStartNewCronJobExecutionTest {
 
   private KubernetesService mockKubernetesService(String jobName, V1beta1CronJob result)
       throws ApiException {
-    var kubernetesService = Mockito.mock(KubernetesService.class);
-    Mockito.doCallRealMethod()
-        .when(kubernetesService)
-        .startNewCronJobExecution(
-            Mockito.anyString(),
-            Mockito.anyString(),
-            Mockito.anyMap(),
-            Mockito.anyMap(),
-            Mockito.anyMap(),
-            Mockito.any());
-
     BatchV1beta1Api batchV1beta1Api = Mockito.mock(BatchV1beta1Api.class);
     Mockito.when(
             batchV1beta1Api.readNamespacedCronJob(
                 Mockito.eq(jobName), Mockito.isNull(), Mockito.isNull()))
         .thenReturn(result);
 
-    Mockito.when(kubernetesService.initBatchV1beta1Api()).thenReturn(batchV1beta1Api);
-
-    return kubernetesService;
+    Mockito.when(
+                    batchV1beta1Api.readNamespacedCronJob(
+                            Mockito.eq(jobName), Mockito.anyString(), Mockito.isNull()))
+            .thenReturn(result);
+    DataJobsKubernetesService spy =
+            Mockito.spy(
+                    new DataJobsKubernetesService(
+                            "default",
+                            false,
+                            new ApiClient(),
+                            new BatchV1Api(),
+                            batchV1beta1Api,
+                            new JobCommandProvider()));
+    Mockito.doNothing()
+            .when(spy)
+            .createNewJob(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any());
+    return spy;
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -40,715 +40,715 @@ import java.util.stream.Stream;
 
 public class KubernetesServiceTest {
 
-    @Test
-    public void testCreateVDKContainer() {
+  @Test
+  public void testCreateVDKContainer() {
 
-        var vdkCommand =
-                List.of(
-                        "/bin/bash",
-                        "-c",
-                        "cp -r /usr/local/lib/python3.7/site-packages /vdk/. && cp /usr/local/bin/vdk /vdk/.");
+    var vdkCommand =
+        List.of(
+            "/bin/bash",
+            "-c",
+            "cp -r /usr/local/lib/python3.7/site-packages /vdk/. && cp /usr/local/bin/vdk /vdk/.");
 
-        var volumeMount = KubernetesService.volumeMount("vdk-volume", "/vdk", false);
+    var volumeMount = KubernetesService.volumeMount("vdk-volume", "/vdk", false);
 
-        var expectedVDKContainer =
-                new V1ContainerBuilder()
-                        .withName("vdk")
-                        .withImage("vdk:latest")
-                        .withVolumeMounts(
-                                new V1VolumeMount().name("vdk-volume").mountPath("/vdk").readOnly(false))
-                        .withImagePullPolicy("Always")
-                        .withSecurityContext(
-                                new V1SecurityContextBuilder()
-                                        .withPrivileged(false)
-                                        .withReadOnlyRootFilesystem(false)
-                                        .build())
-                        .withCommand(vdkCommand)
-                        .withArgs(List.of())
-                        .withEnvFrom(
-                                new V1EnvFromSource()
-                                        .secretRef(new V1SecretEnvSource().name("builder-secrets").optional(true)))
-                        .withEnv(List.of())
-                        .withResources(
-                                new V1ResourceRequirementsBuilder()
-                                        .withRequests(Map.of("cpu", new Quantity("500m"), "memory", new Quantity("1G")))
-                                        .withLimits(Map.of("cpu", new Quantity("2000m"), "memory", new Quantity("1G")))
-                                        .build())
-                        .build();
+    var expectedVDKContainer =
+        new V1ContainerBuilder()
+            .withName("vdk")
+            .withImage("vdk:latest")
+            .withVolumeMounts(
+                new V1VolumeMount().name("vdk-volume").mountPath("/vdk").readOnly(false))
+            .withImagePullPolicy("Always")
+            .withSecurityContext(
+                new V1SecurityContextBuilder()
+                    .withPrivileged(false)
+                    .withReadOnlyRootFilesystem(false)
+                    .build())
+            .withCommand(vdkCommand)
+            .withArgs(List.of())
+            .withEnvFrom(
+                new V1EnvFromSource()
+                    .secretRef(new V1SecretEnvSource().name("builder-secrets").optional(true)))
+            .withEnv(List.of())
+            .withResources(
+                new V1ResourceRequirementsBuilder()
+                    .withRequests(Map.of("cpu", new Quantity("500m"), "memory", new Quantity("1G")))
+                    .withLimits(Map.of("cpu", new Quantity("2000m"), "memory", new Quantity("1G")))
+                    .build())
+            .build();
 
-        var actualVDKContainer =
-                KubernetesService.container(
-                        "vdk",
-                        "vdk:latest",
-                        false,
-                        false,
-                        Map.of(),
-                        List.of(),
-                        List.of(volumeMount),
-                        "Always",
-                        new KubernetesService.Resources("500m", "1G"),
-                        new KubernetesService.Resources("2000m", "1G"),
-                        null,
-                        vdkCommand);
+    var actualVDKContainer =
+        KubernetesService.container(
+            "vdk",
+            "vdk:latest",
+            false,
+            false,
+            Map.of(),
+            List.of(),
+            List.of(volumeMount),
+            "Always",
+            new KubernetesService.Resources("500m", "1G"),
+            new KubernetesService.Resources("2000m", "1G"),
+            null,
+            vdkCommand);
 
-        Assertions.assertEquals(expectedVDKContainer, actualVDKContainer);
+    Assertions.assertEquals(expectedVDKContainer, actualVDKContainer);
+  }
+
+  @Test
+  public void testGetJobExecutionStatus_emptyJob_shouldReturnEmptyJobExecutionStatus() {
+    V1Job v1Job = new V1Job();
+    var mock = Mockito.mock(KubernetesService.class);
+    Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
+    Mockito.when(mock.getTerminationStatus(v1Job))
+        .thenReturn(ImmutablePair.of(Optional.empty(), Optional.empty()));
+    Mockito.when(mock.getJobExecutionStatus(v1Job, null)).thenCallRealMethod();
+    Optional<KubernetesService.JobExecution> actualJobExecutionStatusOptional =
+        mock.getJobExecutionStatus(v1Job, null);
+
+    Assertions.assertTrue(actualJobExecutionStatusOptional.isPresent());
+
+    KubernetesService.JobExecution actualJobExecution = actualJobExecutionStatusOptional.get();
+    Assertions.assertNull(actualJobExecution.getExecutionId());
+    Assertions.assertNull(actualJobExecution.getJobName());
+    Assertions.assertNull(actualJobExecution.getJobVersion());
+    Assertions.assertNull(actualJobExecution.getJobPythonVersion());
+    Assertions.assertNull(actualJobExecution.getDeployedDate());
+    Assertions.assertNull(actualJobExecution.getExecutionType());
+    Assertions.assertNull(actualJobExecution.getOpId());
+    Assertions.assertNull(actualJobExecution.getResourcesCpuRequest());
+    Assertions.assertNull(actualJobExecution.getResourcesCpuLimit());
+    Assertions.assertNull(actualJobExecution.getResourcesMemoryRequest());
+    Assertions.assertNull(actualJobExecution.getResourcesMemoryLimit());
+    Assertions.assertNull(actualJobExecution.getStartTime());
+    Assertions.assertNull(actualJobExecution.getEndTime());
+    Assertions.assertNull(actualJobExecution.getSucceeded());
+  }
+
+  @Test
+  public void testGetJobExecutionStatus_notEmptyJob_shouldReturnNotEmptyJobExecutionStatus() {
+    String dataJobName = "test-data-job";
+    String kubernetesJobName = "test-job";
+    String jobVersion = "1234";
+    String jobPythonVersion = "3.11";
+    String deployedDate = "2021-06-15T08:04:33.534787Z";
+    String deployedBy = "test-user";
+    String executionType = "manual";
+    String opId = "test-op-id";
+    String cpuRequest = "1";
+    String cpuLimit = "2";
+    Integer memoryRequest = 500;
+    Integer memoryLimit = 1000;
+    OffsetDateTime startTime = OffsetDateTime.now();
+    OffsetDateTime endTime = OffsetDateTime.now();
+    Integer succeeded = 1;
+
+    V1Job expectedJob =
+        new V1Job()
+            .metadata(
+                new V1ObjectMeta()
+                    .name(kubernetesJobName)
+                    .putLabelsItem(JobLabel.VERSION.getValue(), jobVersion)
+                    .putLabelsItem(JobLabel.NAME.getValue(), dataJobName)
+                    .putAnnotationsItem(JobAnnotation.DEPLOYED_DATE.getValue(), deployedDate)
+                    .putAnnotationsItem(JobAnnotation.DEPLOYED_BY.getValue(), deployedBy)
+                    .putAnnotationsItem(JobAnnotation.EXECUTION_TYPE.getValue(), executionType)
+                    .putAnnotationsItem(JobAnnotation.OP_ID.getValue(), opId)
+                    .putAnnotationsItem(JobAnnotation.PYTHON_VERSION.getValue(), jobPythonVersion))
+            .spec(
+                new V1JobSpec()
+                    .template(
+                        new V1PodTemplateSpec()
+                            .spec(
+                                new V1PodSpec()
+                                    .addContainersItem(
+                                        new V1Container()
+                                            .name(dataJobName)
+                                            .resources(
+                                                new V1ResourceRequirements()
+                                                    .putRequestsItem(
+                                                        "cpu", new Quantity(cpuRequest))
+                                                    .putRequestsItem(
+                                                        "memory",
+                                                        new Quantity(
+                                                            Integer.toString(
+                                                                memoryRequest * 1000 * 1000)))
+                                                    .putLimitsItem("cpu", new Quantity(cpuLimit))
+                                                    .putLimitsItem(
+                                                        "memory",
+                                                        new Quantity(
+                                                            Integer.toString(
+                                                                memoryLimit * 1000 * 1000))))))))
+            .status(
+                new V1JobStatus()
+                    .startTime(startTime)
+                    .completionTime(endTime)
+                    .succeeded(succeeded));
+    KubernetesService.JobStatusCondition condition =
+        new KubernetesService.JobStatusCondition(
+            true, "type", "reason", "message", endTime.toInstant().toEpochMilli());
+
+    KubernetesService mock = Mockito.mock(KubernetesService.class);
+    Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
+    Mockito.when(mock.getTerminationStatus(expectedJob))
+        .thenReturn(
+            ImmutablePair.of(
+                Optional.ofNullable(new V1ContainerStateTerminated().reason("test")),
+                Optional.ofNullable(new V1ContainerStateTerminated().reason("test"))));
+    Mockito.when(mock.getJobExecutionStatus(expectedJob, condition)).thenCallRealMethod();
+    Optional<KubernetesService.JobExecution> actualJobExecutionStatusOptional =
+        mock.getJobExecutionStatus(expectedJob, condition);
+
+    Assertions.assertTrue(actualJobExecutionStatusOptional.isPresent());
+
+    KubernetesService.JobExecution actualJobExecution = actualJobExecutionStatusOptional.get();
+    Assertions.assertEquals(kubernetesJobName, actualJobExecution.getExecutionId());
+    Assertions.assertEquals(dataJobName, actualJobExecution.getJobName());
+    Assertions.assertEquals(jobVersion, actualJobExecution.getJobVersion());
+    Assertions.assertEquals(jobPythonVersion, actualJobExecution.getJobPythonVersion());
+    Assertions.assertEquals(
+        OffsetDateTime.parse(deployedDate), actualJobExecution.getDeployedDate());
+    Assertions.assertEquals(executionType, actualJobExecution.getExecutionType());
+    Assertions.assertEquals(opId, actualJobExecution.getOpId());
+    Assertions.assertEquals(Float.valueOf(cpuRequest), actualJobExecution.getResourcesCpuRequest());
+    Assertions.assertEquals(Float.valueOf(cpuLimit), actualJobExecution.getResourcesCpuLimit());
+    Assertions.assertEquals(memoryRequest, actualJobExecution.getResourcesMemoryRequest());
+    Assertions.assertEquals(memoryLimit, actualJobExecution.getResourcesMemoryLimit());
+    Assertions.assertEquals(
+        OffsetDateTime.ofInstant(
+            Instant.ofEpochMilli(startTime.toInstant().toEpochMilli()), ZoneOffset.UTC),
+        actualJobExecution.getStartTime());
+    Assertions.assertEquals(
+        OffsetDateTime.ofInstant(
+            Instant.ofEpochMilli(endTime.toInstant().toEpochMilli()), ZoneOffset.UTC),
+        actualJobExecution.getEndTime());
+    Assertions.assertTrue(actualJobExecution.getSucceeded());
+  }
+
+  // Note that we are testing private functionality and mocking the surrounding methods
+  // won't do us any good. Better approach is to rely on integration tests where we can
+  // check the final outcome directly in the K8s environment.
+  @Test
+  public void testCreateV1beta1CronJobFromInternalResource() {
+    KubernetesService service = newDataJobKubernetesService();
+    try {
+      // At this point we know that the cronjob template is loaded successfully.
+
+      // Step 2 - check whether an empty V1beta1CronJob object is properly populated
+      //          with corresponding entries from the internal cronjob template.
+      // First we load the internal cronjob template.
+      Method loadInternalV1beta1CronjobTemplate =
+          KubernetesService.class.getDeclaredMethod("loadInternalV1beta1CronjobTemplate");
+      if (loadInternalV1beta1CronjobTemplate == null) {
+        Assertions.fail("The method 'loadInternalV1beta1CronjobTemplate' does not exist.");
+      }
+      loadInternalV1beta1CronjobTemplate.setAccessible(true);
+      V1beta1CronJob internalCronjobTemplate =
+          (V1beta1CronJob) loadInternalV1beta1CronjobTemplate.invoke(service);
+      // Prepare the 'v1beta1checkForMissingEntries' method.
+      Method checkForMissingEntries =
+          KubernetesService.class.getDeclaredMethod(
+              "v1beta1checkForMissingEntries", V1beta1CronJob.class);
+      if (checkForMissingEntries == null) {
+        Assertions.fail("The method 'v1beta1checkForMissingEntries' does not exist.");
+      }
+      checkForMissingEntries.setAccessible(true);
+      V1beta1CronJob emptyCronjobToBeFixed =
+          new V1beta1CronJob(); // Worst case scenario to test - empty cronjob.
+      checkForMissingEntries.invoke(service, emptyCronjobToBeFixed);
+      // We can't rely on equality check on root metadata/spec level, because if the internal
+      // template
+      // has missing elements, the equality check will miss them. Instead, we will check the most
+      // important elements one by one.
+      Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata());
+      Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata().getAnnotations());
+      Assertions.assertEquals(
+          internalCronjobTemplate.getMetadata().getAnnotations(),
+          emptyCronjobToBeFixed.getMetadata().getAnnotations());
+      Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec());
+      Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate());
+      Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec());
+      Assertions.assertNotNull(
+          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate());
+      Assertions.assertNotNull(
+          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
+      Assertions.assertNotNull(
+          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata());
+      Assertions.assertEquals(
+          internalCronjobTemplate
+              .getSpec()
+              .getJobTemplate()
+              .getSpec()
+              .getTemplate()
+              .getMetadata()
+              .getLabels(),
+          emptyCronjobToBeFixed
+              .getSpec()
+              .getJobTemplate()
+              .getSpec()
+              .getTemplate()
+              .getMetadata()
+              .getLabels());
+
+      Assertions.assertNotNull(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
+      // Step 3 - create and check the actual cronjob.
+      Method[] methods = KubernetesService.class.getDeclaredMethods();
+      // This is much easier than describing the whole method signature.
+      Optional<Method> method =
+          Arrays.stream(methods)
+              .filter(m -> m.getName().equals("v1beta1CronJobFromTemplate"))
+              .findFirst();
+      if (method.isEmpty()) {
+        Assertions.fail("The method 'v1beta1cronJobFromTemplate' does not exist.");
+      }
+      method.get().setAccessible(true);
+      V1beta1CronJob cronjob =
+          (V1beta1CronJob)
+              method
+                  .get()
+                  .invoke(
+                      service,
+                      "test-job-name",
+                      "test-job-schedule",
+                      true,
+                      null,
+                      null,
+                      null,
+                      Collections.EMPTY_MAP,
+                      Collections.EMPTY_MAP,
+                      List.of(""));
+      Assertions.assertEquals("test-job-name", cronjob.getMetadata().getName());
+      Assertions.assertEquals("test-job-schedule", cronjob.getSpec().getSchedule());
+      Assertions.assertEquals(true, cronjob.getSpec().getSuspend());
+      Assertions.assertEquals(
+          Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getLabels());
+      Assertions.assertEquals(
+          Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations());
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assertions.fail(e.getMessage());
     }
+  }
 
-    @Test
-    public void testGetJobExecutionStatus_emptyJob_shouldReturnEmptyJobExecutionStatus() {
-        V1Job v1Job = new V1Job();
-        var mock = Mockito.mock(KubernetesService.class);
-        Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
-        Mockito.when(mock.getTerminationStatus(v1Job))
-                .thenReturn(ImmutablePair.of(Optional.empty(), Optional.empty()));
-        Mockito.when(mock.getJobExecutionStatus(v1Job, null)).thenCallRealMethod();
-        Optional<KubernetesService.JobExecution> actualJobExecutionStatusOptional =
-                mock.getJobExecutionStatus(v1Job, null);
+  @NotNull
+  private static DataJobsKubernetesService newDataJobKubernetesService() {
+    return new DataJobsKubernetesService(
+        "default",
+        false,
+        new ApiClient(),
+        new BatchV1Api(),
+        new BatchV1beta1Api(),
+        new JobCommandProvider());
+  }
 
-        Assertions.assertTrue(actualJobExecutionStatusOptional.isPresent());
+  @Test
+  public void testCreateV1CronJobFromInternalResource() {
+    KubernetesService service = newDataJobKubernetesService();
+    try {
+      // At this point we know that the cronjob template is loaded successfully.
 
-        KubernetesService.JobExecution actualJobExecution = actualJobExecutionStatusOptional.get();
-        Assertions.assertNull(actualJobExecution.getExecutionId());
-        Assertions.assertNull(actualJobExecution.getJobName());
-        Assertions.assertNull(actualJobExecution.getJobVersion());
-        Assertions.assertNull(actualJobExecution.getJobPythonVersion());
-        Assertions.assertNull(actualJobExecution.getDeployedDate());
-        Assertions.assertNull(actualJobExecution.getExecutionType());
-        Assertions.assertNull(actualJobExecution.getOpId());
-        Assertions.assertNull(actualJobExecution.getResourcesCpuRequest());
-        Assertions.assertNull(actualJobExecution.getResourcesCpuLimit());
-        Assertions.assertNull(actualJobExecution.getResourcesMemoryRequest());
-        Assertions.assertNull(actualJobExecution.getResourcesMemoryLimit());
-        Assertions.assertNull(actualJobExecution.getStartTime());
-        Assertions.assertNull(actualJobExecution.getEndTime());
-        Assertions.assertNull(actualJobExecution.getSucceeded());
+      // Step 2 - check whether an empty V1CronJob object is properly populated
+      //          with corresponding entries from the internal cronjob template.
+      // First we load the internal cronjob template.
+      Method loadInternalV1CronjobTemplate =
+          KubernetesService.class.getDeclaredMethod("loadInternalV1CronjobTemplate");
+      if (loadInternalV1CronjobTemplate == null) {
+        Assertions.fail("The method 'loadInternalV1CronjobTemplate' does not exist.");
+      }
+      loadInternalV1CronjobTemplate.setAccessible(true);
+      V1CronJob internalCronjobTemplate = (V1CronJob) loadInternalV1CronjobTemplate.invoke(service);
+      // Prepare the 'v1checkForMissingEntries' method.
+      Method checkForMissingEntries =
+          KubernetesService.class.getDeclaredMethod("v1checkForMissingEntries", V1CronJob.class);
+      if (checkForMissingEntries == null) {
+        Assertions.fail("The method 'v1checkForMissingEntries' does not exist.");
+      }
+      checkForMissingEntries.setAccessible(true);
+      V1CronJob emptyCronjobToBeFixed =
+          new V1CronJob(); // Worst case scenario to test - empty cronjob.
+      checkForMissingEntries.invoke(service, emptyCronjobToBeFixed);
+      // We can't rely on equality check on root metadata/spec level, because if the internal
+      // template
+      // has missing elements, the equality check will miss them. Instead, we will check the most
+      // important elements one by one.
+      Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata());
+      Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata().getAnnotations());
+      Assertions.assertEquals(
+          internalCronjobTemplate.getMetadata().getAnnotations(),
+          emptyCronjobToBeFixed.getMetadata().getAnnotations());
+      Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec());
+      Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate());
+      Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec());
+      Assertions.assertNotNull(
+          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate());
+      Assertions.assertNotNull(
+          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
+      Assertions.assertNotNull(
+          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata());
+      Assertions.assertEquals(
+          internalCronjobTemplate
+              .getSpec()
+              .getJobTemplate()
+              .getSpec()
+              .getTemplate()
+              .getMetadata()
+              .getLabels(),
+          emptyCronjobToBeFixed
+              .getSpec()
+              .getJobTemplate()
+              .getSpec()
+              .getTemplate()
+              .getMetadata()
+              .getLabels());
+
+      Assertions.assertNotNull(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
+      // Step 3 - create and check the actual cronjob.
+      Method[] methods = KubernetesService.class.getDeclaredMethods();
+      // This is much easier than describing the whole method signature.
+      Optional<Method> method =
+          Arrays.stream(methods)
+              .filter(m -> m.getName().equals("v1CronJobFromTemplate"))
+              .findFirst();
+      if (method.isEmpty()) {
+        Assertions.fail("The method 'v1cronJobFromTemplate' does not exist.");
+      }
+      method.get().setAccessible(true);
+      V1CronJob cronjob =
+          (V1CronJob)
+              method
+                  .get()
+                  .invoke(
+                      service,
+                      "test-job-name",
+                      "test-job-schedule",
+                      true,
+                      null,
+                      null,
+                      null,
+                      Collections.EMPTY_MAP,
+                      Collections.EMPTY_MAP,
+                      List.of(""));
+      Assertions.assertEquals("test-job-name", cronjob.getMetadata().getName());
+      Assertions.assertEquals("test-job-schedule", cronjob.getSpec().getSchedule());
+      Assertions.assertEquals(true, cronjob.getSpec().getSuspend());
+      Assertions.assertEquals(
+          Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getLabels());
+      Assertions.assertEquals(
+          Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations());
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assertions.fail(e.getMessage());
     }
+  }
 
-    @Test
-    public void testGetJobExecutionStatus_notEmptyJob_shouldReturnNotEmptyJobExecutionStatus() {
-        String dataJobName = "test-data-job";
-        String kubernetesJobName = "test-job";
-        String jobVersion = "1234";
-        String jobPythonVersion = "3.11";
-        String deployedDate = "2021-06-15T08:04:33.534787Z";
-        String deployedBy = "test-user";
-        String executionType = "manual";
-        String opId = "test-op-id";
-        String cpuRequest = "1";
-        String cpuLimit = "2";
-        Integer memoryRequest = 500;
-        Integer memoryLimit = 1000;
-        OffsetDateTime startTime = OffsetDateTime.now();
-        OffsetDateTime endTime = OffsetDateTime.now();
-        Integer succeeded = 1;
+  @Test
+  public void testReadJobDeploymentStatuses() {
+    KubernetesService mock = Mockito.mock(KubernetesService.class);
+    List<JobDeploymentStatus> v1TestList = new ArrayList<>();
+    List<JobDeploymentStatus> v1BetaTestList = new ArrayList<>();
 
-        V1Job expectedJob =
-                new V1Job()
-                        .metadata(
-                                new V1ObjectMeta()
-                                        .name(kubernetesJobName)
-                                        .putLabelsItem(JobLabel.VERSION.getValue(), jobVersion)
-                                        .putLabelsItem(JobLabel.NAME.getValue(), dataJobName)
-                                        .putAnnotationsItem(JobAnnotation.DEPLOYED_DATE.getValue(), deployedDate)
-                                        .putAnnotationsItem(JobAnnotation.DEPLOYED_BY.getValue(), deployedBy)
-                                        .putAnnotationsItem(JobAnnotation.EXECUTION_TYPE.getValue(), executionType)
-                                        .putAnnotationsItem(JobAnnotation.OP_ID.getValue(), opId)
-                                        .putAnnotationsItem(JobAnnotation.PYTHON_VERSION.getValue(), jobPythonVersion))
-                        .spec(
-                                new V1JobSpec()
-                                        .template(
-                                                new V1PodTemplateSpec()
-                                                        .spec(
-                                                                new V1PodSpec()
-                                                                        .addContainersItem(
-                                                                                new V1Container()
-                                                                                        .name(dataJobName)
-                                                                                        .resources(
-                                                                                                new V1ResourceRequirements()
-                                                                                                        .putRequestsItem(
-                                                                                                                "cpu", new Quantity(cpuRequest))
-                                                                                                        .putRequestsItem(
-                                                                                                                "memory",
-                                                                                                                new Quantity(
-                                                                                                                        Integer.toString(
-                                                                                                                                memoryRequest * 1000 * 1000)))
-                                                                                                        .putLimitsItem("cpu", new Quantity(cpuLimit))
-                                                                                                        .putLimitsItem(
-                                                                                                                "memory",
-                                                                                                                new Quantity(
-                                                                                                                        Integer.toString(
-                                                                                                                                memoryLimit * 1000 * 1000))))))))
-                        .status(
-                                new V1JobStatus()
-                                        .startTime(startTime)
-                                        .completionTime(endTime)
-                                        .succeeded(succeeded));
-        KubernetesService.JobStatusCondition condition =
-                new KubernetesService.JobStatusCondition(
-                        true, "type", "reason", "message", endTime.toInstant().toEpochMilli());
+    JobDeploymentStatus v1BetaDeploymentStatus = new JobDeploymentStatus();
+    v1BetaDeploymentStatus.setEnabled(false);
+    v1BetaDeploymentStatus.setDataJobName("v1betaTestJob");
+    v1BetaDeploymentStatus.setCronJobName("v1betaTestJob");
+    v1BetaTestList.add(v1BetaDeploymentStatus);
 
-        KubernetesService mock = Mockito.mock(KubernetesService.class);
-        Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
-        Mockito.when(mock.getTerminationStatus(expectedJob))
-                .thenReturn(
-                        ImmutablePair.of(
-                                Optional.ofNullable(new V1ContainerStateTerminated().reason("test")),
-                                Optional.ofNullable(new V1ContainerStateTerminated().reason("test"))));
-        Mockito.when(mock.getJobExecutionStatus(expectedJob, condition)).thenCallRealMethod();
-        Optional<KubernetesService.JobExecution> actualJobExecutionStatusOptional =
-                mock.getJobExecutionStatus(expectedJob, condition);
+    JobDeploymentStatus v1DeploymentStatus = new JobDeploymentStatus();
+    v1DeploymentStatus.setEnabled(false);
+    v1DeploymentStatus.setDataJobName("v1TestJob");
+    v1DeploymentStatus.setCronJobName("v1TestJob");
+    v1TestList.add(v1DeploymentStatus);
 
-        Assertions.assertTrue(actualJobExecutionStatusOptional.isPresent());
+    var mergedTestLists =
+        Stream.concat(v1TestList.stream(), v1BetaTestList.stream()).collect(Collectors.toList());
 
-        KubernetesService.JobExecution actualJobExecution = actualJobExecutionStatusOptional.get();
-        Assertions.assertEquals(kubernetesJobName, actualJobExecution.getExecutionId());
-        Assertions.assertEquals(dataJobName, actualJobExecution.getJobName());
-        Assertions.assertEquals(jobVersion, actualJobExecution.getJobVersion());
-        Assertions.assertEquals(jobPythonVersion, actualJobExecution.getJobPythonVersion());
-        Assertions.assertEquals(
-                OffsetDateTime.parse(deployedDate), actualJobExecution.getDeployedDate());
-        Assertions.assertEquals(executionType, actualJobExecution.getExecutionType());
-        Assertions.assertEquals(opId, actualJobExecution.getOpId());
-        Assertions.assertEquals(Float.valueOf(cpuRequest), actualJobExecution.getResourcesCpuRequest());
-        Assertions.assertEquals(Float.valueOf(cpuLimit), actualJobExecution.getResourcesCpuLimit());
-        Assertions.assertEquals(memoryRequest, actualJobExecution.getResourcesMemoryRequest());
-        Assertions.assertEquals(memoryLimit, actualJobExecution.getResourcesMemoryLimit());
-        Assertions.assertEquals(
-                OffsetDateTime.ofInstant(
-                        Instant.ofEpochMilli(startTime.toInstant().toEpochMilli()), ZoneOffset.UTC),
-                actualJobExecution.getStartTime());
-        Assertions.assertEquals(
-                OffsetDateTime.ofInstant(
-                        Instant.ofEpochMilli(endTime.toInstant().toEpochMilli()), ZoneOffset.UTC),
-                actualJobExecution.getEndTime());
-        Assertions.assertTrue(actualJobExecution.getSucceeded());
-    }
+    Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(true);
+    Mockito.when(mock.readV1CronJobDeploymentStatuses()).thenReturn(v1TestList);
+    Mockito.when(mock.readV1beta1CronJobDeploymentStatuses()).thenReturn(v1BetaTestList);
+    Mockito.when(mock.readJobDeploymentStatuses()).thenCallRealMethod();
+    List<JobDeploymentStatus> resultStatuses = mock.readJobDeploymentStatuses();
 
-    // Note that we are testing private functionality and mocking the surrounding methods
-    // won't do us any good. Better approach is to rely on integration tests where we can
-    // check the final outcome directly in the K8s environment.
-    @Test
-    public void testCreateV1beta1CronJobFromInternalResource() {
-        KubernetesService service = newDataJobKubernetesService();
-        try {
-            // At this point we know that the cronjob template is loaded successfully.
+    Assertions.assertEquals(mergedTestLists, resultStatuses);
+  }
 
-            // Step 2 - check whether an empty V1beta1CronJob object is properly populated
-            //          with corresponding entries from the internal cronjob template.
-            // First we load the internal cronjob template.
-            Method loadInternalV1beta1CronjobTemplate =
-                    KubernetesService.class.getDeclaredMethod("loadInternalV1beta1CronjobTemplate");
-            if (loadInternalV1beta1CronjobTemplate == null) {
-                Assertions.fail("The method 'loadInternalV1beta1CronjobTemplate' does not exist.");
-            }
-            loadInternalV1beta1CronjobTemplate.setAccessible(true);
-            V1beta1CronJob internalCronjobTemplate =
-                    (V1beta1CronJob) loadInternalV1beta1CronjobTemplate.invoke(service);
-            // Prepare the 'v1beta1checkForMissingEntries' method.
-            Method checkForMissingEntries =
-                    KubernetesService.class.getDeclaredMethod(
-                            "v1beta1checkForMissingEntries", V1beta1CronJob.class);
-            if (checkForMissingEntries == null) {
-                Assertions.fail("The method 'v1beta1checkForMissingEntries' does not exist.");
-            }
-            checkForMissingEntries.setAccessible(true);
-            V1beta1CronJob emptyCronjobToBeFixed =
-                    new V1beta1CronJob(); // Worst case scenario to test - empty cronjob.
-            checkForMissingEntries.invoke(service, emptyCronjobToBeFixed);
-            // We can't rely on equality check on root metadata/spec level, because if the internal
-            // template
-            // has missing elements, the equality check will miss them. Instead, we will check the most
-            // important elements one by one.
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata());
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata().getAnnotations());
-            Assertions.assertEquals(
-                    internalCronjobTemplate.getMetadata().getAnnotations(),
-                    emptyCronjobToBeFixed.getMetadata().getAnnotations());
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec());
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate());
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec());
-            Assertions.assertNotNull(
-                    emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate());
-            Assertions.assertNotNull(
-                    emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
-            Assertions.assertNotNull(
-                    emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata());
-            Assertions.assertEquals(
-                    internalCronjobTemplate
-                            .getSpec()
-                            .getJobTemplate()
-                            .getSpec()
-                            .getTemplate()
-                            .getMetadata()
-                            .getLabels(),
-                    emptyCronjobToBeFixed
-                            .getSpec()
-                            .getJobTemplate()
-                            .getSpec()
-                            .getTemplate()
-                            .getMetadata()
-                            .getLabels());
+  @Test
+  public void testReadCronJob_readV1CronJobShouldReturnStatus() {
+    String testCronjobName = "testCronjob";
+    KubernetesService mock = Mockito.mock(KubernetesService.class);
 
-            Assertions.assertNotNull(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
-            // Step 3 - create and check the actual cronjob.
-            Method[] methods = KubernetesService.class.getDeclaredMethods();
-            // This is much easier than describing the whole method signature.
-            Optional<Method> method =
-                    Arrays.stream(methods)
-                            .filter(m -> m.getName().equals("v1beta1CronJobFromTemplate"))
-                            .findFirst();
-            if (method.isEmpty()) {
-                Assertions.fail("The method 'v1beta1cronJobFromTemplate' does not exist.");
-            }
-            method.get().setAccessible(true);
-            V1beta1CronJob cronjob =
-                    (V1beta1CronJob)
-                            method
-                                    .get()
-                                    .invoke(
-                                            service,
-                                            "test-job-name",
-                                            "test-job-schedule",
-                                            true,
-                                            null,
-                                            null,
-                                            null,
-                                            Collections.EMPTY_MAP,
-                                            Collections.EMPTY_MAP,
-                                            List.of(""));
-            Assertions.assertEquals("test-job-name", cronjob.getMetadata().getName());
-            Assertions.assertEquals("test-job-schedule", cronjob.getSpec().getSchedule());
-            Assertions.assertEquals(true, cronjob.getSpec().getSuspend());
-            Assertions.assertEquals(
-                    Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getLabels());
-            Assertions.assertEquals(
-                    Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations());
+    JobDeploymentStatus testDeploymentStatus = new JobDeploymentStatus();
+    testDeploymentStatus.setEnabled(false);
+    testDeploymentStatus.setDataJobName(testCronjobName);
+    testDeploymentStatus.setCronJobName(testCronjobName);
+    Mockito.when(mock.readCronJob(testCronjobName)).thenCallRealMethod();
 
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assertions.fail(e.getMessage());
-        }
-    }
+    Mockito.when(mock.readV1beta1CronJob(testCronjobName)).thenReturn(Optional.empty());
+    Mockito.when(mock.readV1CronJob(testCronjobName)).thenReturn(Optional.of(testDeploymentStatus));
 
-    @NotNull
-    private static DataJobsKubernetesService newDataJobKubernetesService() {
-        return new DataJobsKubernetesService(
-                "default",
-                false,
-                new ApiClient(),
-                new BatchV1Api(),
-                new BatchV1beta1Api(),
-                new JobCommandProvider());
-    }
+    Assertions.assertNotNull(mock.readCronJob(testCronjobName));
+    Assertions.assertEquals(
+        testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
+    verify(mock, times(2)).readV1beta1CronJob(testCronjobName);
+    verify(mock, times(2)).readV1CronJob(testCronjobName);
+  }
 
-    @Test
-    public void testCreateV1CronJobFromInternalResource() {
-        KubernetesService service = newDataJobKubernetesService();
-        try {
-            // At this point we know that the cronjob template is loaded successfully.
+  @Test
+  public void testReadCronJob_readV1beta1CronJobShouldReturnStatus() {
+    String testCronjobName = "testCronjob";
+    KubernetesService mock = Mockito.mock(KubernetesService.class);
 
-            // Step 2 - check whether an empty V1CronJob object is properly populated
-            //          with corresponding entries from the internal cronjob template.
-            // First we load the internal cronjob template.
-            Method loadInternalV1CronjobTemplate =
-                    KubernetesService.class.getDeclaredMethod("loadInternalV1CronjobTemplate");
-            if (loadInternalV1CronjobTemplate == null) {
-                Assertions.fail("The method 'loadInternalV1CronjobTemplate' does not exist.");
-            }
-            loadInternalV1CronjobTemplate.setAccessible(true);
-            V1CronJob internalCronjobTemplate = (V1CronJob) loadInternalV1CronjobTemplate.invoke(service);
-            // Prepare the 'v1checkForMissingEntries' method.
-            Method checkForMissingEntries =
-                    KubernetesService.class.getDeclaredMethod("v1checkForMissingEntries", V1CronJob.class);
-            if (checkForMissingEntries == null) {
-                Assertions.fail("The method 'v1checkForMissingEntries' does not exist.");
-            }
-            checkForMissingEntries.setAccessible(true);
-            V1CronJob emptyCronjobToBeFixed =
-                    new V1CronJob(); // Worst case scenario to test - empty cronjob.
-            checkForMissingEntries.invoke(service, emptyCronjobToBeFixed);
-            // We can't rely on equality check on root metadata/spec level, because if the internal
-            // template
-            // has missing elements, the equality check will miss them. Instead, we will check the most
-            // important elements one by one.
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata());
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata().getAnnotations());
-            Assertions.assertEquals(
-                    internalCronjobTemplate.getMetadata().getAnnotations(),
-                    emptyCronjobToBeFixed.getMetadata().getAnnotations());
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec());
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate());
-            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec());
-            Assertions.assertNotNull(
-                    emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate());
-            Assertions.assertNotNull(
-                    emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
-            Assertions.assertNotNull(
-                    emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata());
-            Assertions.assertEquals(
-                    internalCronjobTemplate
-                            .getSpec()
-                            .getJobTemplate()
-                            .getSpec()
-                            .getTemplate()
-                            .getMetadata()
-                            .getLabels(),
-                    emptyCronjobToBeFixed
-                            .getSpec()
-                            .getJobTemplate()
-                            .getSpec()
-                            .getTemplate()
-                            .getMetadata()
-                            .getLabels());
+    JobDeploymentStatus testDeploymentStatus = new JobDeploymentStatus();
+    testDeploymentStatus.setEnabled(false);
+    testDeploymentStatus.setDataJobName(testCronjobName);
+    testDeploymentStatus.setCronJobName(testCronjobName);
+    Mockito.when(mock.readCronJob(testCronjobName)).thenCallRealMethod();
 
-            Assertions.assertNotNull(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
-            // Step 3 - create and check the actual cronjob.
-            Method[] methods = KubernetesService.class.getDeclaredMethods();
-            // This is much easier than describing the whole method signature.
-            Optional<Method> method =
-                    Arrays.stream(methods)
-                            .filter(m -> m.getName().equals("v1CronJobFromTemplate"))
-                            .findFirst();
-            if (method.isEmpty()) {
-                Assertions.fail("The method 'v1cronJobFromTemplate' does not exist.");
-            }
-            method.get().setAccessible(true);
-            V1CronJob cronjob =
-                    (V1CronJob)
-                            method
-                                    .get()
-                                    .invoke(
-                                            service,
-                                            "test-job-name",
-                                            "test-job-schedule",
-                                            true,
-                                            null,
-                                            null,
-                                            null,
-                                            Collections.EMPTY_MAP,
-                                            Collections.EMPTY_MAP,
-                                            List.of(""));
-            Assertions.assertEquals("test-job-name", cronjob.getMetadata().getName());
-            Assertions.assertEquals("test-job-schedule", cronjob.getSpec().getSchedule());
-            Assertions.assertEquals(true, cronjob.getSpec().getSuspend());
-            Assertions.assertEquals(
-                    Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getLabels());
-            Assertions.assertEquals(
-                    Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations());
+    Mockito.when(mock.readV1beta1CronJob(testCronjobName))
+        .thenReturn(Optional.of(testDeploymentStatus));
+    Mockito.when(mock.readV1CronJob(testCronjobName)).thenReturn(Optional.empty());
 
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assertions.fail(e.getMessage());
-        }
-    }
+    Assertions.assertNotNull(mock.readCronJob(testCronjobName));
+    Assertions.assertEquals(
+        testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
+    verify(mock, times(2)).readV1beta1CronJob(testCronjobName);
+    verify(mock, times(0)).readV1CronJob(testCronjobName);
+  }
 
-    @Test
-    public void testReadJobDeploymentStatuses() {
-        KubernetesService mock = Mockito.mock(KubernetesService.class);
-        List<JobDeploymentStatus> v1TestList = new ArrayList<>();
-        List<JobDeploymentStatus> v1BetaTestList = new ArrayList<>();
+  @Test
+  public void testQuantityToMbConversionMegabytes() throws Exception {
+    var hundredMb = "100M";
+    testQuantityToMbConversion(100, hundredMb);
 
-        JobDeploymentStatus v1BetaDeploymentStatus = new JobDeploymentStatus();
-        v1BetaDeploymentStatus.setEnabled(false);
-        v1BetaDeploymentStatus.setDataJobName("v1betaTestJob");
-        v1BetaDeploymentStatus.setCronJobName("v1betaTestJob");
-        v1BetaTestList.add(v1BetaDeploymentStatus);
+    var thousandMb = "1000M";
+    testQuantityToMbConversion(1000, thousandMb);
+    // this should be enough for overflow errors on the method to manifest.
+    var tenThousandMb = "10000M";
+    testQuantityToMbConversion(10000, tenThousandMb);
 
-        JobDeploymentStatus v1DeploymentStatus = new JobDeploymentStatus();
-        v1DeploymentStatus.setEnabled(false);
-        v1DeploymentStatus.setDataJobName("v1TestJob");
-        v1DeploymentStatus.setCronJobName("v1TestJob");
-        v1TestList.add(v1DeploymentStatus);
+    var hundredThousandMb = "100000M";
+    testQuantityToMbConversion(100000, hundredThousandMb);
+  }
 
-        var mergedTestLists =
-                Stream.concat(v1TestList.stream(), v1BetaTestList.stream()).collect(Collectors.toList());
+  @Test
+  public void testQuantityConversionGigabytes() throws Exception {
+    var oneG = "1G";
+    testQuantityToMbConversion(1000, oneG);
 
-        Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(true);
-        Mockito.when(mock.readV1CronJobDeploymentStatuses()).thenReturn(v1TestList);
-        Mockito.when(mock.readV1beta1CronJobDeploymentStatuses()).thenReturn(v1BetaTestList);
-        Mockito.when(mock.readJobDeploymentStatuses()).thenCallRealMethod();
-        List<JobDeploymentStatus> resultStatuses = mock.readJobDeploymentStatuses();
+    var twoG = "2G";
+    testQuantityToMbConversion(2000, twoG);
+    // this should be enough for overflow errors on the method to manifest.
+    var threeG = "3G";
+    testQuantityToMbConversion(3000, threeG);
 
-        Assertions.assertEquals(mergedTestLists, resultStatuses);
-    }
+    var fourG = "4G";
+    testQuantityToMbConversion(4000, fourG);
 
-    @Test
-    public void testReadCronJob_readV1CronJobShouldReturnStatus() {
-        String testCronjobName = "testCronjob";
-        KubernetesService mock = Mockito.mock(KubernetesService.class);
+    var sixtyFourG = "64G";
+    testQuantityToMbConversion(64000, sixtyFourG);
+  }
 
-        JobDeploymentStatus testDeploymentStatus = new JobDeploymentStatus();
-        testDeploymentStatus.setEnabled(false);
-        testDeploymentStatus.setDataJobName(testCronjobName);
-        testDeploymentStatus.setCronJobName(testCronjobName);
-        Mockito.when(mock.readCronJob(testCronjobName)).thenCallRealMethod();
+  @Test
+  public void testV1beta1CronJobFromTemplate_emptyImagePullSecretsList() {
+    var mock = mockCronJobFromTemplate();
+    V1beta1CronJob v1beta1CronJob =
+        mock.v1beta1CronJobFromTemplate(
+            "",
+            "",
+            true,
+            null,
+            null,
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyList());
 
-        Mockito.when(mock.readV1beta1CronJob(testCronjobName)).thenReturn(Optional.empty());
-        Mockito.when(mock.readV1CronJob(testCronjobName)).thenReturn(Optional.of(testDeploymentStatus));
+    Assertions.assertNull(
+        v1beta1CronJob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .getImagePullSecrets());
+  }
 
-        Assertions.assertNotNull(mock.readCronJob(testCronjobName));
-        Assertions.assertEquals(
-                testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
-        verify(mock, times(2)).readV1beta1CronJob(testCronjobName);
-        verify(mock, times(2)).readV1CronJob(testCronjobName);
-    }
+  @Test
+  public void testV1CronJobFromTemplate_emptyImagePullSecretsList() {
+    var mock = mockCronJobFromTemplate();
+    V1CronJob v1CronJob =
+        mock.v1CronJobFromTemplate(
+            "",
+            "",
+            true,
+            null,
+            null,
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyList());
 
-    @Test
-    public void testReadCronJob_readV1beta1CronJobShouldReturnStatus() {
-        String testCronjobName = "testCronjob";
-        KubernetesService mock = Mockito.mock(KubernetesService.class);
+    Assertions.assertNull(
+        v1CronJob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .getImagePullSecrets());
+  }
 
-        JobDeploymentStatus testDeploymentStatus = new JobDeploymentStatus();
-        testDeploymentStatus.setEnabled(false);
-        testDeploymentStatus.setDataJobName(testCronjobName);
-        testDeploymentStatus.setCronJobName(testCronjobName);
-        Mockito.when(mock.readCronJob(testCronjobName)).thenCallRealMethod();
+  @Test
+  public void testV1beta1CronJobFromTemplate_imagePullSecretsListWithEmptyValues() {
+    var mock = mockCronJobFromTemplate();
+    V1beta1CronJob v1beta1CronJob =
+        mock.v1beta1CronJobFromTemplate(
+            "",
+            "",
+            true,
+            null,
+            null,
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            List.of("", ""));
 
-        Mockito.when(mock.readV1beta1CronJob(testCronjobName))
-                .thenReturn(Optional.of(testDeploymentStatus));
-        Mockito.when(mock.readV1CronJob(testCronjobName)).thenReturn(Optional.empty());
+    Assertions.assertNull(
+        v1beta1CronJob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .getImagePullSecrets());
+  }
 
-        Assertions.assertNotNull(mock.readCronJob(testCronjobName));
-        Assertions.assertEquals(
-                testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
-        verify(mock, times(2)).readV1beta1CronJob(testCronjobName);
-        verify(mock, times(0)).readV1CronJob(testCronjobName);
-    }
+  @Test
+  public void testV1CronJobFromTemplate_imagePullSecretsListWithEmptyValues() {
+    var mock = mockCronJobFromTemplate();
+    V1CronJob v1CronJob =
+        mock.v1CronJobFromTemplate(
+            "",
+            "",
+            true,
+            null,
+            null,
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            List.of("", ""));
 
-    @Test
-    public void testQuantityToMbConversionMegabytes() throws Exception {
-        var hundredMb = "100M";
-        testQuantityToMbConversion(100, hundredMb);
+    Assertions.assertNull(
+        v1CronJob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .getImagePullSecrets());
+  }
 
-        var thousandMb = "1000M";
-        testQuantityToMbConversion(1000, thousandMb);
-        // this should be enough for overflow errors on the method to manifest.
-        var tenThousandMb = "10000M";
-        testQuantityToMbConversion(10000, tenThousandMb);
+  @Test
+  public void
+      testV1beta1CronJobFromTemplate_imagePullSecretsListWithOneNonEmptyValueAndOneEmptyValue() {
+    var mock = mockCronJobFromTemplate();
+    String secretName = "test_secret_name";
+    V1beta1CronJob v1beta1CronJob =
+        mock.v1beta1CronJobFromTemplate(
+            "",
+            "",
+            true,
+            null,
+            null,
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            List.of("", secretName));
 
-        var hundredThousandMb = "100000M";
-        testQuantityToMbConversion(100000, hundredThousandMb);
-    }
+    List<V1LocalObjectReference> actualImagePullSecrets =
+        v1beta1CronJob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .getImagePullSecrets();
 
-    @Test
-    public void testQuantityConversionGigabytes() throws Exception {
-        var oneG = "1G";
-        testQuantityToMbConversion(1000, oneG);
+    Assertions.assertNotNull(actualImagePullSecrets);
+    Assertions.assertEquals(1, actualImagePullSecrets.size());
+    Assertions.assertEquals(secretName, actualImagePullSecrets.get(0).getName());
+  }
 
-        var twoG = "2G";
-        testQuantityToMbConversion(2000, twoG);
-        // this should be enough for overflow errors on the method to manifest.
-        var threeG = "3G";
-        testQuantityToMbConversion(3000, threeG);
+  @Test
+  public void testV1CronJobFromTemplate_imagePullSecretsListWithOneNonEmptyValueAndOneEmptyValue() {
+    var mock = mockCronJobFromTemplate();
+    String secretName = "test_secret_name";
+    V1CronJob v1CronJob =
+        mock.v1CronJobFromTemplate(
+            "",
+            "",
+            true,
+            null,
+            null,
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            List.of("", secretName));
 
-        var fourG = "4G";
-        testQuantityToMbConversion(4000, fourG);
+    List<V1LocalObjectReference> actualImagePullSecrets =
+        v1CronJob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .getImagePullSecrets();
 
-        var sixtyFourG = "64G";
-        testQuantityToMbConversion(64000, sixtyFourG);
-    }
+    Assertions.assertNotNull(actualImagePullSecrets);
+    Assertions.assertEquals(1, actualImagePullSecrets.size());
+    Assertions.assertEquals(secretName, actualImagePullSecrets.get(0).getName());
+  }
 
-    @Test
-    public void testV1beta1CronJobFromTemplate_emptyImagePullSecretsList() {
-        var mock = mockCronJobFromTemplate();
-        V1beta1CronJob v1beta1CronJob =
-                mock.v1beta1CronJobFromTemplate(
-                        "",
-                        "",
-                        true,
-                        null,
-                        null,
-                        null,
-                        Collections.emptyMap(),
-                        Collections.emptyMap(),
-                        Collections.emptyList());
+  public void testQuantityToMbConversion(int expectedMb, String providedResources)
+      throws Exception {
+    var q = Quantity.fromString(providedResources);
+    var actual = KubernetesService.convertMemoryToMBs(q);
+    Assertions.assertEquals(expectedMb, actual);
+  }
 
-        Assertions.assertNull(
-                v1beta1CronJob
-                        .getSpec()
-                        .getJobTemplate()
-                        .getSpec()
-                        .getTemplate()
-                        .getSpec()
-                        .getImagePullSecrets());
-    }
+  private KubernetesService mockCronJobFromTemplate() {
+    var mock = Mockito.mock(KubernetesService.class);
+    Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
+    Mockito.when(
+            mock.v1beta1CronJobFromTemplate(
+                anyString(),
+                anyString(),
+                anyBoolean(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                anyList()))
+        .thenCallRealMethod();
+    Mockito.when(
+            mock.v1CronJobFromTemplate(
+                anyString(),
+                anyString(),
+                anyBoolean(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                anyList()))
+        .thenCallRealMethod();
 
-    @Test
-    public void testV1CronJobFromTemplate_emptyImagePullSecretsList() {
-        var mock = mockCronJobFromTemplate();
-        V1CronJob v1CronJob =
-                mock.v1CronJobFromTemplate(
-                        "",
-                        "",
-                        true,
-                        null,
-                        null,
-                        null,
-                        Collections.emptyMap(),
-                        Collections.emptyMap(),
-                        Collections.emptyList());
+    ReflectionTestUtils.setField(
+        mock, // inject into this object
+        "log", // assign to this field
+        Mockito.mock(Logger.class)); // object to be injected
 
-        Assertions.assertNull(
-                v1CronJob
-                        .getSpec()
-                        .getJobTemplate()
-                        .getSpec()
-                        .getTemplate()
-                        .getSpec()
-                        .getImagePullSecrets());
-    }
-
-    @Test
-    public void testV1beta1CronJobFromTemplate_imagePullSecretsListWithEmptyValues() {
-        var mock = mockCronJobFromTemplate();
-        V1beta1CronJob v1beta1CronJob =
-                mock.v1beta1CronJobFromTemplate(
-                        "",
-                        "",
-                        true,
-                        null,
-                        null,
-                        null,
-                        Collections.emptyMap(),
-                        Collections.emptyMap(),
-                        List.of("", ""));
-
-        Assertions.assertNull(
-                v1beta1CronJob
-                        .getSpec()
-                        .getJobTemplate()
-                        .getSpec()
-                        .getTemplate()
-                        .getSpec()
-                        .getImagePullSecrets());
-    }
-
-    @Test
-    public void testV1CronJobFromTemplate_imagePullSecretsListWithEmptyValues() {
-        var mock = mockCronJobFromTemplate();
-        V1CronJob v1CronJob =
-                mock.v1CronJobFromTemplate(
-                        "",
-                        "",
-                        true,
-                        null,
-                        null,
-                        null,
-                        Collections.emptyMap(),
-                        Collections.emptyMap(),
-                        List.of("", ""));
-
-        Assertions.assertNull(
-                v1CronJob
-                        .getSpec()
-                        .getJobTemplate()
-                        .getSpec()
-                        .getTemplate()
-                        .getSpec()
-                        .getImagePullSecrets());
-    }
-
-    @Test
-    public void
-    testV1beta1CronJobFromTemplate_imagePullSecretsListWithOneNonEmptyValueAndOneEmptyValue() {
-        var mock = mockCronJobFromTemplate();
-        String secretName = "test_secret_name";
-        V1beta1CronJob v1beta1CronJob =
-                mock.v1beta1CronJobFromTemplate(
-                        "",
-                        "",
-                        true,
-                        null,
-                        null,
-                        null,
-                        Collections.emptyMap(),
-                        Collections.emptyMap(),
-                        List.of("", secretName));
-
-        List<V1LocalObjectReference> actualImagePullSecrets =
-                v1beta1CronJob
-                        .getSpec()
-                        .getJobTemplate()
-                        .getSpec()
-                        .getTemplate()
-                        .getSpec()
-                        .getImagePullSecrets();
-
-        Assertions.assertNotNull(actualImagePullSecrets);
-        Assertions.assertEquals(1, actualImagePullSecrets.size());
-        Assertions.assertEquals(secretName, actualImagePullSecrets.get(0).getName());
-    }
-
-    @Test
-    public void testV1CronJobFromTemplate_imagePullSecretsListWithOneNonEmptyValueAndOneEmptyValue() {
-        var mock = mockCronJobFromTemplate();
-        String secretName = "test_secret_name";
-        V1CronJob v1CronJob =
-                mock.v1CronJobFromTemplate(
-                        "",
-                        "",
-                        true,
-                        null,
-                        null,
-                        null,
-                        Collections.emptyMap(),
-                        Collections.emptyMap(),
-                        List.of("", secretName));
-
-        List<V1LocalObjectReference> actualImagePullSecrets =
-                v1CronJob
-                        .getSpec()
-                        .getJobTemplate()
-                        .getSpec()
-                        .getTemplate()
-                        .getSpec()
-                        .getImagePullSecrets();
-
-        Assertions.assertNotNull(actualImagePullSecrets);
-        Assertions.assertEquals(1, actualImagePullSecrets.size());
-        Assertions.assertEquals(secretName, actualImagePullSecrets.get(0).getName());
-    }
-
-    public void testQuantityToMbConversion(int expectedMb, String providedResources)
-            throws Exception {
-        var q = Quantity.fromString(providedResources);
-        var actual = KubernetesService.convertMemoryToMBs(q);
-        Assertions.assertEquals(expectedMb, actual);
-    }
-
-    private KubernetesService mockCronJobFromTemplate() {
-        var mock = Mockito.mock(KubernetesService.class);
-        Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
-        Mockito.when(
-                        mock.v1beta1CronJobFromTemplate(
-                                anyString(),
-                                anyString(),
-                                anyBoolean(),
-                                any(),
-                                any(),
-                                any(),
-                                any(),
-                                any(),
-                                anyList()))
-                .thenCallRealMethod();
-        Mockito.when(
-                        mock.v1CronJobFromTemplate(
-                                anyString(),
-                                anyString(),
-                                anyBoolean(),
-                                any(),
-                                any(),
-                                any(),
-                                any(),
-                                any(),
-                                anyList()))
-                .thenCallRealMethod();
-
-        ReflectionTestUtils.setField(
-                mock, // inject into this object
-                "log", // assign to this field
-                Mockito.mock(Logger.class)); // object to be injected
-
-        return mock;
-    }
+    return mock;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -12,13 +12,18 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.vmware.taurus.service.deploy.JobCommandProvider;
 import com.vmware.taurus.service.kubernetes.DataJobsKubernetesService;
 import com.vmware.taurus.service.model.JobAnnotation;
 import com.vmware.taurus.service.model.JobDeploymentStatus;
 import com.vmware.taurus.service.model.JobLabel;
 import io.kubernetes.client.custom.Quantity;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.apis.BatchV1Api;
+import io.kubernetes.client.openapi.apis.BatchV1beta1Api;
 import io.kubernetes.client.openapi.models.*;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -35,708 +40,715 @@ import java.util.stream.Stream;
 
 public class KubernetesServiceTest {
 
-  @Test
-  public void testCreateVDKContainer() {
+    @Test
+    public void testCreateVDKContainer() {
 
-    var vdkCommand =
-        List.of(
-            "/bin/bash",
-            "-c",
-            "cp -r /usr/local/lib/python3.7/site-packages /vdk/. && cp /usr/local/bin/vdk /vdk/.");
+        var vdkCommand =
+                List.of(
+                        "/bin/bash",
+                        "-c",
+                        "cp -r /usr/local/lib/python3.7/site-packages /vdk/. && cp /usr/local/bin/vdk /vdk/.");
 
-    var volumeMount = KubernetesService.volumeMount("vdk-volume", "/vdk", false);
+        var volumeMount = KubernetesService.volumeMount("vdk-volume", "/vdk", false);
 
-    var expectedVDKContainer =
-        new V1ContainerBuilder()
-            .withName("vdk")
-            .withImage("vdk:latest")
-            .withVolumeMounts(
-                new V1VolumeMount().name("vdk-volume").mountPath("/vdk").readOnly(false))
-            .withImagePullPolicy("Always")
-            .withSecurityContext(
-                new V1SecurityContextBuilder()
-                    .withPrivileged(false)
-                    .withReadOnlyRootFilesystem(false)
-                    .build())
-            .withCommand(vdkCommand)
-            .withArgs(List.of())
-            .withEnvFrom(
-                new V1EnvFromSource()
-                    .secretRef(new V1SecretEnvSource().name("builder-secrets").optional(true)))
-            .withEnv(List.of())
-            .withResources(
-                new V1ResourceRequirementsBuilder()
-                    .withRequests(Map.of("cpu", new Quantity("500m"), "memory", new Quantity("1G")))
-                    .withLimits(Map.of("cpu", new Quantity("2000m"), "memory", new Quantity("1G")))
-                    .build())
-            .build();
+        var expectedVDKContainer =
+                new V1ContainerBuilder()
+                        .withName("vdk")
+                        .withImage("vdk:latest")
+                        .withVolumeMounts(
+                                new V1VolumeMount().name("vdk-volume").mountPath("/vdk").readOnly(false))
+                        .withImagePullPolicy("Always")
+                        .withSecurityContext(
+                                new V1SecurityContextBuilder()
+                                        .withPrivileged(false)
+                                        .withReadOnlyRootFilesystem(false)
+                                        .build())
+                        .withCommand(vdkCommand)
+                        .withArgs(List.of())
+                        .withEnvFrom(
+                                new V1EnvFromSource()
+                                        .secretRef(new V1SecretEnvSource().name("builder-secrets").optional(true)))
+                        .withEnv(List.of())
+                        .withResources(
+                                new V1ResourceRequirementsBuilder()
+                                        .withRequests(Map.of("cpu", new Quantity("500m"), "memory", new Quantity("1G")))
+                                        .withLimits(Map.of("cpu", new Quantity("2000m"), "memory", new Quantity("1G")))
+                                        .build())
+                        .build();
 
-    var actualVDKContainer =
-        KubernetesService.container(
-            "vdk",
-            "vdk:latest",
-            false,
-            false,
-            Map.of(),
-            List.of(),
-            List.of(volumeMount),
-            "Always",
-            new KubernetesService.Resources("500m", "1G"),
-            new KubernetesService.Resources("2000m", "1G"),
-            null,
-            vdkCommand);
+        var actualVDKContainer =
+                KubernetesService.container(
+                        "vdk",
+                        "vdk:latest",
+                        false,
+                        false,
+                        Map.of(),
+                        List.of(),
+                        List.of(volumeMount),
+                        "Always",
+                        new KubernetesService.Resources("500m", "1G"),
+                        new KubernetesService.Resources("2000m", "1G"),
+                        null,
+                        vdkCommand);
 
-    Assertions.assertEquals(expectedVDKContainer, actualVDKContainer);
-  }
-
-  @Test
-  public void testGetJobExecutionStatus_emptyJob_shouldReturnEmptyJobExecutionStatus() {
-    V1Job v1Job = new V1Job();
-    var mock = Mockito.mock(KubernetesService.class);
-    Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
-    Mockito.when(mock.getTerminationStatus(v1Job))
-        .thenReturn(ImmutablePair.of(Optional.empty(), Optional.empty()));
-    Mockito.when(mock.getJobExecutionStatus(v1Job, null)).thenCallRealMethod();
-    Optional<KubernetesService.JobExecution> actualJobExecutionStatusOptional =
-        mock.getJobExecutionStatus(v1Job, null);
-
-    Assertions.assertTrue(actualJobExecutionStatusOptional.isPresent());
-
-    KubernetesService.JobExecution actualJobExecution = actualJobExecutionStatusOptional.get();
-    Assertions.assertNull(actualJobExecution.getExecutionId());
-    Assertions.assertNull(actualJobExecution.getJobName());
-    Assertions.assertNull(actualJobExecution.getJobVersion());
-    Assertions.assertNull(actualJobExecution.getJobPythonVersion());
-    Assertions.assertNull(actualJobExecution.getDeployedDate());
-    Assertions.assertNull(actualJobExecution.getExecutionType());
-    Assertions.assertNull(actualJobExecution.getOpId());
-    Assertions.assertNull(actualJobExecution.getResourcesCpuRequest());
-    Assertions.assertNull(actualJobExecution.getResourcesCpuLimit());
-    Assertions.assertNull(actualJobExecution.getResourcesMemoryRequest());
-    Assertions.assertNull(actualJobExecution.getResourcesMemoryLimit());
-    Assertions.assertNull(actualJobExecution.getStartTime());
-    Assertions.assertNull(actualJobExecution.getEndTime());
-    Assertions.assertNull(actualJobExecution.getSucceeded());
-  }
-
-  @Test
-  public void testGetJobExecutionStatus_notEmptyJob_shouldReturnNotEmptyJobExecutionStatus() {
-    String dataJobName = "test-data-job";
-    String kubernetesJobName = "test-job";
-    String jobVersion = "1234";
-    String jobPythonVersion = "3.11";
-    String deployedDate = "2021-06-15T08:04:33.534787Z";
-    String deployedBy = "test-user";
-    String executionType = "manual";
-    String opId = "test-op-id";
-    String cpuRequest = "1";
-    String cpuLimit = "2";
-    Integer memoryRequest = 500;
-    Integer memoryLimit = 1000;
-    OffsetDateTime startTime = OffsetDateTime.now();
-    OffsetDateTime endTime = OffsetDateTime.now();
-    Integer succeeded = 1;
-
-    V1Job expectedJob =
-        new V1Job()
-            .metadata(
-                new V1ObjectMeta()
-                    .name(kubernetesJobName)
-                    .putLabelsItem(JobLabel.VERSION.getValue(), jobVersion)
-                    .putLabelsItem(JobLabel.NAME.getValue(), dataJobName)
-                    .putAnnotationsItem(JobAnnotation.DEPLOYED_DATE.getValue(), deployedDate)
-                    .putAnnotationsItem(JobAnnotation.DEPLOYED_BY.getValue(), deployedBy)
-                    .putAnnotationsItem(JobAnnotation.EXECUTION_TYPE.getValue(), executionType)
-                    .putAnnotationsItem(JobAnnotation.OP_ID.getValue(), opId)
-                    .putAnnotationsItem(JobAnnotation.PYTHON_VERSION.getValue(), jobPythonVersion))
-            .spec(
-                new V1JobSpec()
-                    .template(
-                        new V1PodTemplateSpec()
-                            .spec(
-                                new V1PodSpec()
-                                    .addContainersItem(
-                                        new V1Container()
-                                            .name(dataJobName)
-                                            .resources(
-                                                new V1ResourceRequirements()
-                                                    .putRequestsItem(
-                                                        "cpu", new Quantity(cpuRequest))
-                                                    .putRequestsItem(
-                                                        "memory",
-                                                        new Quantity(
-                                                            Integer.toString(
-                                                                memoryRequest * 1000 * 1000)))
-                                                    .putLimitsItem("cpu", new Quantity(cpuLimit))
-                                                    .putLimitsItem(
-                                                        "memory",
-                                                        new Quantity(
-                                                            Integer.toString(
-                                                                memoryLimit * 1000 * 1000))))))))
-            .status(
-                new V1JobStatus()
-                    .startTime(startTime)
-                    .completionTime(endTime)
-                    .succeeded(succeeded));
-    KubernetesService.JobStatusCondition condition =
-        new KubernetesService.JobStatusCondition(
-            true, "type", "reason", "message", endTime.toInstant().toEpochMilli());
-
-    KubernetesService mock = Mockito.mock(KubernetesService.class);
-    Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
-    Mockito.when(mock.getTerminationStatus(expectedJob))
-        .thenReturn(
-            ImmutablePair.of(
-                Optional.ofNullable(new V1ContainerStateTerminated().reason("test")),
-                Optional.ofNullable(new V1ContainerStateTerminated().reason("test"))));
-    Mockito.when(mock.getJobExecutionStatus(expectedJob, condition)).thenCallRealMethod();
-    Optional<KubernetesService.JobExecution> actualJobExecutionStatusOptional =
-        mock.getJobExecutionStatus(expectedJob, condition);
-
-    Assertions.assertTrue(actualJobExecutionStatusOptional.isPresent());
-
-    KubernetesService.JobExecution actualJobExecution = actualJobExecutionStatusOptional.get();
-    Assertions.assertEquals(kubernetesJobName, actualJobExecution.getExecutionId());
-    Assertions.assertEquals(dataJobName, actualJobExecution.getJobName());
-    Assertions.assertEquals(jobVersion, actualJobExecution.getJobVersion());
-    Assertions.assertEquals(jobPythonVersion, actualJobExecution.getJobPythonVersion());
-    Assertions.assertEquals(
-        OffsetDateTime.parse(deployedDate), actualJobExecution.getDeployedDate());
-    Assertions.assertEquals(executionType, actualJobExecution.getExecutionType());
-    Assertions.assertEquals(opId, actualJobExecution.getOpId());
-    Assertions.assertEquals(Float.valueOf(cpuRequest), actualJobExecution.getResourcesCpuRequest());
-    Assertions.assertEquals(Float.valueOf(cpuLimit), actualJobExecution.getResourcesCpuLimit());
-    Assertions.assertEquals(memoryRequest, actualJobExecution.getResourcesMemoryRequest());
-    Assertions.assertEquals(memoryLimit, actualJobExecution.getResourcesMemoryLimit());
-    Assertions.assertEquals(
-        OffsetDateTime.ofInstant(
-            Instant.ofEpochMilli(startTime.toInstant().toEpochMilli()), ZoneOffset.UTC),
-        actualJobExecution.getStartTime());
-    Assertions.assertEquals(
-        OffsetDateTime.ofInstant(
-            Instant.ofEpochMilli(endTime.toInstant().toEpochMilli()), ZoneOffset.UTC),
-        actualJobExecution.getEndTime());
-    Assertions.assertTrue(actualJobExecution.getSucceeded());
-  }
-
-  // Note that we are testing private functionality and mocking the surrounding methods
-  // won't do us any good. Better approach is to rely on integration tests where we can
-  // check the final outcome directly in the K8s environment.
-  @Test
-  public void testCreateV1beta1CronJobFromInternalResource() {
-    KubernetesService service = new DataJobsKubernetesService("default", "someConfig", false);
-    try {
-      // Step 1 - load and check the internal cronjob template.
-      service.afterPropertiesSet();
-      // At this point we know that the cronjob template is loaded successfully.
-
-      // Step 2 - check whether an empty V1beta1CronJob object is properly populated
-      //          with corresponding entries from the internal cronjob template.
-      // First we load the internal cronjob template.
-      Method loadInternalV1beta1CronjobTemplate =
-          KubernetesService.class.getDeclaredMethod("loadInternalV1beta1CronjobTemplate");
-      if (loadInternalV1beta1CronjobTemplate == null) {
-        Assertions.fail("The method 'loadInternalV1beta1CronjobTemplate' does not exist.");
-      }
-      loadInternalV1beta1CronjobTemplate.setAccessible(true);
-      V1beta1CronJob internalCronjobTemplate =
-          (V1beta1CronJob) loadInternalV1beta1CronjobTemplate.invoke(service);
-      // Prepare the 'v1beta1checkForMissingEntries' method.
-      Method checkForMissingEntries =
-          KubernetesService.class.getDeclaredMethod(
-              "v1beta1checkForMissingEntries", V1beta1CronJob.class);
-      if (checkForMissingEntries == null) {
-        Assertions.fail("The method 'v1beta1checkForMissingEntries' does not exist.");
-      }
-      checkForMissingEntries.setAccessible(true);
-      V1beta1CronJob emptyCronjobToBeFixed =
-          new V1beta1CronJob(); // Worst case scenario to test - empty cronjob.
-      checkForMissingEntries.invoke(service, emptyCronjobToBeFixed);
-      // We can't rely on equality check on root metadata/spec level, because if the internal
-      // template
-      // has missing elements, the equality check will miss them. Instead, we will check the most
-      // important elements one by one.
-      Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata());
-      Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata().getAnnotations());
-      Assertions.assertEquals(
-          internalCronjobTemplate.getMetadata().getAnnotations(),
-          emptyCronjobToBeFixed.getMetadata().getAnnotations());
-      Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec());
-      Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate());
-      Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec());
-      Assertions.assertNotNull(
-          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate());
-      Assertions.assertNotNull(
-          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
-      Assertions.assertNotNull(
-          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata());
-      Assertions.assertEquals(
-          internalCronjobTemplate
-              .getSpec()
-              .getJobTemplate()
-              .getSpec()
-              .getTemplate()
-              .getMetadata()
-              .getLabels(),
-          emptyCronjobToBeFixed
-              .getSpec()
-              .getJobTemplate()
-              .getSpec()
-              .getTemplate()
-              .getMetadata()
-              .getLabels());
-
-      Assertions.assertNotNull(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
-      // Step 3 - create and check the actual cronjob.
-      Method[] methods = KubernetesService.class.getDeclaredMethods();
-      // This is much easier than describing the whole method signature.
-      Optional<Method> method =
-          Arrays.stream(methods)
-              .filter(m -> m.getName().equals("v1beta1CronJobFromTemplate"))
-              .findFirst();
-      if (method.isEmpty()) {
-        Assertions.fail("The method 'v1beta1cronJobFromTemplate' does not exist.");
-      }
-      method.get().setAccessible(true);
-      V1beta1CronJob cronjob =
-          (V1beta1CronJob)
-              method
-                  .get()
-                  .invoke(
-                      service,
-                      "test-job-name",
-                      "test-job-schedule",
-                      true,
-                      null,
-                      null,
-                      null,
-                      Collections.EMPTY_MAP,
-                      Collections.EMPTY_MAP,
-                      List.of(""));
-      Assertions.assertEquals("test-job-name", cronjob.getMetadata().getName());
-      Assertions.assertEquals("test-job-schedule", cronjob.getSpec().getSchedule());
-      Assertions.assertEquals(true, cronjob.getSpec().getSuspend());
-      Assertions.assertEquals(
-          Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getLabels());
-      Assertions.assertEquals(
-          Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations());
-
-    } catch (Exception e) {
-      e.printStackTrace();
-      Assertions.fail(e.getMessage());
+        Assertions.assertEquals(expectedVDKContainer, actualVDKContainer);
     }
-  }
 
-  @Test
-  public void testCreateV1CronJobFromInternalResource() {
-    KubernetesService service = new DataJobsKubernetesService("default", "someConfig", false);
-    try {
-      // Step 1 - load and check the internal cronjob template.
-      service.afterPropertiesSet();
-      // At this point we know that the cronjob template is loaded successfully.
+    @Test
+    public void testGetJobExecutionStatus_emptyJob_shouldReturnEmptyJobExecutionStatus() {
+        V1Job v1Job = new V1Job();
+        var mock = Mockito.mock(KubernetesService.class);
+        Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
+        Mockito.when(mock.getTerminationStatus(v1Job))
+                .thenReturn(ImmutablePair.of(Optional.empty(), Optional.empty()));
+        Mockito.when(mock.getJobExecutionStatus(v1Job, null)).thenCallRealMethod();
+        Optional<KubernetesService.JobExecution> actualJobExecutionStatusOptional =
+                mock.getJobExecutionStatus(v1Job, null);
 
-      // Step 2 - check whether an empty V1CronJob object is properly populated
-      //          with corresponding entries from the internal cronjob template.
-      // First we load the internal cronjob template.
-      Method loadInternalV1CronjobTemplate =
-          KubernetesService.class.getDeclaredMethod("loadInternalV1CronjobTemplate");
-      if (loadInternalV1CronjobTemplate == null) {
-        Assertions.fail("The method 'loadInternalV1CronjobTemplate' does not exist.");
-      }
-      loadInternalV1CronjobTemplate.setAccessible(true);
-      V1CronJob internalCronjobTemplate = (V1CronJob) loadInternalV1CronjobTemplate.invoke(service);
-      // Prepare the 'v1checkForMissingEntries' method.
-      Method checkForMissingEntries =
-          KubernetesService.class.getDeclaredMethod("v1checkForMissingEntries", V1CronJob.class);
-      if (checkForMissingEntries == null) {
-        Assertions.fail("The method 'v1checkForMissingEntries' does not exist.");
-      }
-      checkForMissingEntries.setAccessible(true);
-      V1CronJob emptyCronjobToBeFixed =
-          new V1CronJob(); // Worst case scenario to test - empty cronjob.
-      checkForMissingEntries.invoke(service, emptyCronjobToBeFixed);
-      // We can't rely on equality check on root metadata/spec level, because if the internal
-      // template
-      // has missing elements, the equality check will miss them. Instead, we will check the most
-      // important elements one by one.
-      Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata());
-      Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata().getAnnotations());
-      Assertions.assertEquals(
-          internalCronjobTemplate.getMetadata().getAnnotations(),
-          emptyCronjobToBeFixed.getMetadata().getAnnotations());
-      Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec());
-      Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate());
-      Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec());
-      Assertions.assertNotNull(
-          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate());
-      Assertions.assertNotNull(
-          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
-      Assertions.assertNotNull(
-          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata());
-      Assertions.assertEquals(
-          internalCronjobTemplate
-              .getSpec()
-              .getJobTemplate()
-              .getSpec()
-              .getTemplate()
-              .getMetadata()
-              .getLabels(),
-          emptyCronjobToBeFixed
-              .getSpec()
-              .getJobTemplate()
-              .getSpec()
-              .getTemplate()
-              .getMetadata()
-              .getLabels());
+        Assertions.assertTrue(actualJobExecutionStatusOptional.isPresent());
 
-      Assertions.assertNotNull(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
-      // Step 3 - create and check the actual cronjob.
-      Method[] methods = KubernetesService.class.getDeclaredMethods();
-      // This is much easier than describing the whole method signature.
-      Optional<Method> method =
-          Arrays.stream(methods)
-              .filter(m -> m.getName().equals("v1CronJobFromTemplate"))
-              .findFirst();
-      if (method.isEmpty()) {
-        Assertions.fail("The method 'v1cronJobFromTemplate' does not exist.");
-      }
-      method.get().setAccessible(true);
-      V1CronJob cronjob =
-          (V1CronJob)
-              method
-                  .get()
-                  .invoke(
-                      service,
-                      "test-job-name",
-                      "test-job-schedule",
-                      true,
-                      null,
-                      null,
-                      null,
-                      Collections.EMPTY_MAP,
-                      Collections.EMPTY_MAP,
-                      List.of(""));
-      Assertions.assertEquals("test-job-name", cronjob.getMetadata().getName());
-      Assertions.assertEquals("test-job-schedule", cronjob.getSpec().getSchedule());
-      Assertions.assertEquals(true, cronjob.getSpec().getSuspend());
-      Assertions.assertEquals(
-          Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getLabels());
-      Assertions.assertEquals(
-          Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations());
-
-    } catch (Exception e) {
-      e.printStackTrace();
-      Assertions.fail(e.getMessage());
+        KubernetesService.JobExecution actualJobExecution = actualJobExecutionStatusOptional.get();
+        Assertions.assertNull(actualJobExecution.getExecutionId());
+        Assertions.assertNull(actualJobExecution.getJobName());
+        Assertions.assertNull(actualJobExecution.getJobVersion());
+        Assertions.assertNull(actualJobExecution.getJobPythonVersion());
+        Assertions.assertNull(actualJobExecution.getDeployedDate());
+        Assertions.assertNull(actualJobExecution.getExecutionType());
+        Assertions.assertNull(actualJobExecution.getOpId());
+        Assertions.assertNull(actualJobExecution.getResourcesCpuRequest());
+        Assertions.assertNull(actualJobExecution.getResourcesCpuLimit());
+        Assertions.assertNull(actualJobExecution.getResourcesMemoryRequest());
+        Assertions.assertNull(actualJobExecution.getResourcesMemoryLimit());
+        Assertions.assertNull(actualJobExecution.getStartTime());
+        Assertions.assertNull(actualJobExecution.getEndTime());
+        Assertions.assertNull(actualJobExecution.getSucceeded());
     }
-  }
 
-  @Test
-  public void testReadJobDeploymentStatuses() {
-    KubernetesService mock = Mockito.mock(KubernetesService.class);
-    List<JobDeploymentStatus> v1TestList = new ArrayList<>();
-    List<JobDeploymentStatus> v1BetaTestList = new ArrayList<>();
+    @Test
+    public void testGetJobExecutionStatus_notEmptyJob_shouldReturnNotEmptyJobExecutionStatus() {
+        String dataJobName = "test-data-job";
+        String kubernetesJobName = "test-job";
+        String jobVersion = "1234";
+        String jobPythonVersion = "3.11";
+        String deployedDate = "2021-06-15T08:04:33.534787Z";
+        String deployedBy = "test-user";
+        String executionType = "manual";
+        String opId = "test-op-id";
+        String cpuRequest = "1";
+        String cpuLimit = "2";
+        Integer memoryRequest = 500;
+        Integer memoryLimit = 1000;
+        OffsetDateTime startTime = OffsetDateTime.now();
+        OffsetDateTime endTime = OffsetDateTime.now();
+        Integer succeeded = 1;
 
-    JobDeploymentStatus v1BetaDeploymentStatus = new JobDeploymentStatus();
-    v1BetaDeploymentStatus.setEnabled(false);
-    v1BetaDeploymentStatus.setDataJobName("v1betaTestJob");
-    v1BetaDeploymentStatus.setCronJobName("v1betaTestJob");
-    v1BetaTestList.add(v1BetaDeploymentStatus);
+        V1Job expectedJob =
+                new V1Job()
+                        .metadata(
+                                new V1ObjectMeta()
+                                        .name(kubernetesJobName)
+                                        .putLabelsItem(JobLabel.VERSION.getValue(), jobVersion)
+                                        .putLabelsItem(JobLabel.NAME.getValue(), dataJobName)
+                                        .putAnnotationsItem(JobAnnotation.DEPLOYED_DATE.getValue(), deployedDate)
+                                        .putAnnotationsItem(JobAnnotation.DEPLOYED_BY.getValue(), deployedBy)
+                                        .putAnnotationsItem(JobAnnotation.EXECUTION_TYPE.getValue(), executionType)
+                                        .putAnnotationsItem(JobAnnotation.OP_ID.getValue(), opId)
+                                        .putAnnotationsItem(JobAnnotation.PYTHON_VERSION.getValue(), jobPythonVersion))
+                        .spec(
+                                new V1JobSpec()
+                                        .template(
+                                                new V1PodTemplateSpec()
+                                                        .spec(
+                                                                new V1PodSpec()
+                                                                        .addContainersItem(
+                                                                                new V1Container()
+                                                                                        .name(dataJobName)
+                                                                                        .resources(
+                                                                                                new V1ResourceRequirements()
+                                                                                                        .putRequestsItem(
+                                                                                                                "cpu", new Quantity(cpuRequest))
+                                                                                                        .putRequestsItem(
+                                                                                                                "memory",
+                                                                                                                new Quantity(
+                                                                                                                        Integer.toString(
+                                                                                                                                memoryRequest * 1000 * 1000)))
+                                                                                                        .putLimitsItem("cpu", new Quantity(cpuLimit))
+                                                                                                        .putLimitsItem(
+                                                                                                                "memory",
+                                                                                                                new Quantity(
+                                                                                                                        Integer.toString(
+                                                                                                                                memoryLimit * 1000 * 1000))))))))
+                        .status(
+                                new V1JobStatus()
+                                        .startTime(startTime)
+                                        .completionTime(endTime)
+                                        .succeeded(succeeded));
+        KubernetesService.JobStatusCondition condition =
+                new KubernetesService.JobStatusCondition(
+                        true, "type", "reason", "message", endTime.toInstant().toEpochMilli());
 
-    JobDeploymentStatus v1DeploymentStatus = new JobDeploymentStatus();
-    v1DeploymentStatus.setEnabled(false);
-    v1DeploymentStatus.setDataJobName("v1TestJob");
-    v1DeploymentStatus.setCronJobName("v1TestJob");
-    v1TestList.add(v1DeploymentStatus);
+        KubernetesService mock = Mockito.mock(KubernetesService.class);
+        Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
+        Mockito.when(mock.getTerminationStatus(expectedJob))
+                .thenReturn(
+                        ImmutablePair.of(
+                                Optional.ofNullable(new V1ContainerStateTerminated().reason("test")),
+                                Optional.ofNullable(new V1ContainerStateTerminated().reason("test"))));
+        Mockito.when(mock.getJobExecutionStatus(expectedJob, condition)).thenCallRealMethod();
+        Optional<KubernetesService.JobExecution> actualJobExecutionStatusOptional =
+                mock.getJobExecutionStatus(expectedJob, condition);
 
-    var mergedTestLists =
-        Stream.concat(v1TestList.stream(), v1BetaTestList.stream()).collect(Collectors.toList());
+        Assertions.assertTrue(actualJobExecutionStatusOptional.isPresent());
 
-    Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(true);
-    Mockito.when(mock.readV1CronJobDeploymentStatuses()).thenReturn(v1TestList);
-    Mockito.when(mock.readV1beta1CronJobDeploymentStatuses()).thenReturn(v1BetaTestList);
-    Mockito.when(mock.readJobDeploymentStatuses()).thenCallRealMethod();
-    List<JobDeploymentStatus> resultStatuses = mock.readJobDeploymentStatuses();
+        KubernetesService.JobExecution actualJobExecution = actualJobExecutionStatusOptional.get();
+        Assertions.assertEquals(kubernetesJobName, actualJobExecution.getExecutionId());
+        Assertions.assertEquals(dataJobName, actualJobExecution.getJobName());
+        Assertions.assertEquals(jobVersion, actualJobExecution.getJobVersion());
+        Assertions.assertEquals(jobPythonVersion, actualJobExecution.getJobPythonVersion());
+        Assertions.assertEquals(
+                OffsetDateTime.parse(deployedDate), actualJobExecution.getDeployedDate());
+        Assertions.assertEquals(executionType, actualJobExecution.getExecutionType());
+        Assertions.assertEquals(opId, actualJobExecution.getOpId());
+        Assertions.assertEquals(Float.valueOf(cpuRequest), actualJobExecution.getResourcesCpuRequest());
+        Assertions.assertEquals(Float.valueOf(cpuLimit), actualJobExecution.getResourcesCpuLimit());
+        Assertions.assertEquals(memoryRequest, actualJobExecution.getResourcesMemoryRequest());
+        Assertions.assertEquals(memoryLimit, actualJobExecution.getResourcesMemoryLimit());
+        Assertions.assertEquals(
+                OffsetDateTime.ofInstant(
+                        Instant.ofEpochMilli(startTime.toInstant().toEpochMilli()), ZoneOffset.UTC),
+                actualJobExecution.getStartTime());
+        Assertions.assertEquals(
+                OffsetDateTime.ofInstant(
+                        Instant.ofEpochMilli(endTime.toInstant().toEpochMilli()), ZoneOffset.UTC),
+                actualJobExecution.getEndTime());
+        Assertions.assertTrue(actualJobExecution.getSucceeded());
+    }
 
-    Assertions.assertEquals(mergedTestLists, resultStatuses);
-  }
+    // Note that we are testing private functionality and mocking the surrounding methods
+    // won't do us any good. Better approach is to rely on integration tests where we can
+    // check the final outcome directly in the K8s environment.
+    @Test
+    public void testCreateV1beta1CronJobFromInternalResource() {
+        KubernetesService service = newDataJobKubernetesService();
+        try {
+            // At this point we know that the cronjob template is loaded successfully.
 
-  @Test
-  public void testReadCronJob_readV1CronJobShouldReturnStatus() {
-    String testCronjobName = "testCronjob";
-    KubernetesService mock = Mockito.mock(KubernetesService.class);
+            // Step 2 - check whether an empty V1beta1CronJob object is properly populated
+            //          with corresponding entries from the internal cronjob template.
+            // First we load the internal cronjob template.
+            Method loadInternalV1beta1CronjobTemplate =
+                    KubernetesService.class.getDeclaredMethod("loadInternalV1beta1CronjobTemplate");
+            if (loadInternalV1beta1CronjobTemplate == null) {
+                Assertions.fail("The method 'loadInternalV1beta1CronjobTemplate' does not exist.");
+            }
+            loadInternalV1beta1CronjobTemplate.setAccessible(true);
+            V1beta1CronJob internalCronjobTemplate =
+                    (V1beta1CronJob) loadInternalV1beta1CronjobTemplate.invoke(service);
+            // Prepare the 'v1beta1checkForMissingEntries' method.
+            Method checkForMissingEntries =
+                    KubernetesService.class.getDeclaredMethod(
+                            "v1beta1checkForMissingEntries", V1beta1CronJob.class);
+            if (checkForMissingEntries == null) {
+                Assertions.fail("The method 'v1beta1checkForMissingEntries' does not exist.");
+            }
+            checkForMissingEntries.setAccessible(true);
+            V1beta1CronJob emptyCronjobToBeFixed =
+                    new V1beta1CronJob(); // Worst case scenario to test - empty cronjob.
+            checkForMissingEntries.invoke(service, emptyCronjobToBeFixed);
+            // We can't rely on equality check on root metadata/spec level, because if the internal
+            // template
+            // has missing elements, the equality check will miss them. Instead, we will check the most
+            // important elements one by one.
+            Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata());
+            Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata().getAnnotations());
+            Assertions.assertEquals(
+                    internalCronjobTemplate.getMetadata().getAnnotations(),
+                    emptyCronjobToBeFixed.getMetadata().getAnnotations());
+            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec());
+            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate());
+            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec());
+            Assertions.assertNotNull(
+                    emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate());
+            Assertions.assertNotNull(
+                    emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
+            Assertions.assertNotNull(
+                    emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata());
+            Assertions.assertEquals(
+                    internalCronjobTemplate
+                            .getSpec()
+                            .getJobTemplate()
+                            .getSpec()
+                            .getTemplate()
+                            .getMetadata()
+                            .getLabels(),
+                    emptyCronjobToBeFixed
+                            .getSpec()
+                            .getJobTemplate()
+                            .getSpec()
+                            .getTemplate()
+                            .getMetadata()
+                            .getLabels());
 
-    JobDeploymentStatus testDeploymentStatus = new JobDeploymentStatus();
-    testDeploymentStatus.setEnabled(false);
-    testDeploymentStatus.setDataJobName(testCronjobName);
-    testDeploymentStatus.setCronJobName(testCronjobName);
-    Mockito.when(mock.readCronJob(testCronjobName)).thenCallRealMethod();
+            Assertions.assertNotNull(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
+            // Step 3 - create and check the actual cronjob.
+            Method[] methods = KubernetesService.class.getDeclaredMethods();
+            // This is much easier than describing the whole method signature.
+            Optional<Method> method =
+                    Arrays.stream(methods)
+                            .filter(m -> m.getName().equals("v1beta1CronJobFromTemplate"))
+                            .findFirst();
+            if (method.isEmpty()) {
+                Assertions.fail("The method 'v1beta1cronJobFromTemplate' does not exist.");
+            }
+            method.get().setAccessible(true);
+            V1beta1CronJob cronjob =
+                    (V1beta1CronJob)
+                            method
+                                    .get()
+                                    .invoke(
+                                            service,
+                                            "test-job-name",
+                                            "test-job-schedule",
+                                            true,
+                                            null,
+                                            null,
+                                            null,
+                                            Collections.EMPTY_MAP,
+                                            Collections.EMPTY_MAP,
+                                            List.of(""));
+            Assertions.assertEquals("test-job-name", cronjob.getMetadata().getName());
+            Assertions.assertEquals("test-job-schedule", cronjob.getSpec().getSchedule());
+            Assertions.assertEquals(true, cronjob.getSpec().getSuspend());
+            Assertions.assertEquals(
+                    Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getLabels());
+            Assertions.assertEquals(
+                    Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations());
 
-    Mockito.when(mock.readV1beta1CronJob(testCronjobName)).thenReturn(Optional.empty());
-    Mockito.when(mock.readV1CronJob(testCronjobName)).thenReturn(Optional.of(testDeploymentStatus));
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assertions.fail(e.getMessage());
+        }
+    }
 
-    Assertions.assertNotNull(mock.readCronJob(testCronjobName));
-    Assertions.assertEquals(
-        testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
-    verify(mock, times(2)).readV1beta1CronJob(testCronjobName);
-    verify(mock, times(2)).readV1CronJob(testCronjobName);
-  }
+    @NotNull
+    private static DataJobsKubernetesService newDataJobKubernetesService() {
+        return new DataJobsKubernetesService(
+                "default",
+                false,
+                new ApiClient(),
+                new BatchV1Api(),
+                new BatchV1beta1Api(),
+                new JobCommandProvider());
+    }
 
-  @Test
-  public void testReadCronJob_readV1beta1CronJobShouldReturnStatus() {
-    String testCronjobName = "testCronjob";
-    KubernetesService mock = Mockito.mock(KubernetesService.class);
+    @Test
+    public void testCreateV1CronJobFromInternalResource() {
+        KubernetesService service = newDataJobKubernetesService();
+        try {
+            // At this point we know that the cronjob template is loaded successfully.
 
-    JobDeploymentStatus testDeploymentStatus = new JobDeploymentStatus();
-    testDeploymentStatus.setEnabled(false);
-    testDeploymentStatus.setDataJobName(testCronjobName);
-    testDeploymentStatus.setCronJobName(testCronjobName);
-    Mockito.when(mock.readCronJob(testCronjobName)).thenCallRealMethod();
+            // Step 2 - check whether an empty V1CronJob object is properly populated
+            //          with corresponding entries from the internal cronjob template.
+            // First we load the internal cronjob template.
+            Method loadInternalV1CronjobTemplate =
+                    KubernetesService.class.getDeclaredMethod("loadInternalV1CronjobTemplate");
+            if (loadInternalV1CronjobTemplate == null) {
+                Assertions.fail("The method 'loadInternalV1CronjobTemplate' does not exist.");
+            }
+            loadInternalV1CronjobTemplate.setAccessible(true);
+            V1CronJob internalCronjobTemplate = (V1CronJob) loadInternalV1CronjobTemplate.invoke(service);
+            // Prepare the 'v1checkForMissingEntries' method.
+            Method checkForMissingEntries =
+                    KubernetesService.class.getDeclaredMethod("v1checkForMissingEntries", V1CronJob.class);
+            if (checkForMissingEntries == null) {
+                Assertions.fail("The method 'v1checkForMissingEntries' does not exist.");
+            }
+            checkForMissingEntries.setAccessible(true);
+            V1CronJob emptyCronjobToBeFixed =
+                    new V1CronJob(); // Worst case scenario to test - empty cronjob.
+            checkForMissingEntries.invoke(service, emptyCronjobToBeFixed);
+            // We can't rely on equality check on root metadata/spec level, because if the internal
+            // template
+            // has missing elements, the equality check will miss them. Instead, we will check the most
+            // important elements one by one.
+            Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata());
+            Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata().getAnnotations());
+            Assertions.assertEquals(
+                    internalCronjobTemplate.getMetadata().getAnnotations(),
+                    emptyCronjobToBeFixed.getMetadata().getAnnotations());
+            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec());
+            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate());
+            Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec());
+            Assertions.assertNotNull(
+                    emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate());
+            Assertions.assertNotNull(
+                    emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
+            Assertions.assertNotNull(
+                    emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata());
+            Assertions.assertEquals(
+                    internalCronjobTemplate
+                            .getSpec()
+                            .getJobTemplate()
+                            .getSpec()
+                            .getTemplate()
+                            .getMetadata()
+                            .getLabels(),
+                    emptyCronjobToBeFixed
+                            .getSpec()
+                            .getJobTemplate()
+                            .getSpec()
+                            .getTemplate()
+                            .getMetadata()
+                            .getLabels());
 
-    Mockito.when(mock.readV1beta1CronJob(testCronjobName))
-        .thenReturn(Optional.of(testDeploymentStatus));
-    Mockito.when(mock.readV1CronJob(testCronjobName)).thenReturn(Optional.empty());
+            Assertions.assertNotNull(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
+            // Step 3 - create and check the actual cronjob.
+            Method[] methods = KubernetesService.class.getDeclaredMethods();
+            // This is much easier than describing the whole method signature.
+            Optional<Method> method =
+                    Arrays.stream(methods)
+                            .filter(m -> m.getName().equals("v1CronJobFromTemplate"))
+                            .findFirst();
+            if (method.isEmpty()) {
+                Assertions.fail("The method 'v1cronJobFromTemplate' does not exist.");
+            }
+            method.get().setAccessible(true);
+            V1CronJob cronjob =
+                    (V1CronJob)
+                            method
+                                    .get()
+                                    .invoke(
+                                            service,
+                                            "test-job-name",
+                                            "test-job-schedule",
+                                            true,
+                                            null,
+                                            null,
+                                            null,
+                                            Collections.EMPTY_MAP,
+                                            Collections.EMPTY_MAP,
+                                            List.of(""));
+            Assertions.assertEquals("test-job-name", cronjob.getMetadata().getName());
+            Assertions.assertEquals("test-job-schedule", cronjob.getSpec().getSchedule());
+            Assertions.assertEquals(true, cronjob.getSpec().getSuspend());
+            Assertions.assertEquals(
+                    Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getLabels());
+            Assertions.assertEquals(
+                    Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations());
 
-    Assertions.assertNotNull(mock.readCronJob(testCronjobName));
-    Assertions.assertEquals(
-        testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
-    verify(mock, times(2)).readV1beta1CronJob(testCronjobName);
-    verify(mock, times(0)).readV1CronJob(testCronjobName);
-  }
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assertions.fail(e.getMessage());
+        }
+    }
 
-  @Test
-  public void testQuantityToMbConversionMegabytes() throws Exception {
-    var hundredMb = "100M";
-    testQuantityToMbConversion(100, hundredMb);
+    @Test
+    public void testReadJobDeploymentStatuses() {
+        KubernetesService mock = Mockito.mock(KubernetesService.class);
+        List<JobDeploymentStatus> v1TestList = new ArrayList<>();
+        List<JobDeploymentStatus> v1BetaTestList = new ArrayList<>();
 
-    var thousandMb = "1000M";
-    testQuantityToMbConversion(1000, thousandMb);
-    // this should be enough for overflow errors on the method to manifest.
-    var tenThousandMb = "10000M";
-    testQuantityToMbConversion(10000, tenThousandMb);
+        JobDeploymentStatus v1BetaDeploymentStatus = new JobDeploymentStatus();
+        v1BetaDeploymentStatus.setEnabled(false);
+        v1BetaDeploymentStatus.setDataJobName("v1betaTestJob");
+        v1BetaDeploymentStatus.setCronJobName("v1betaTestJob");
+        v1BetaTestList.add(v1BetaDeploymentStatus);
 
-    var hundredThousandMb = "100000M";
-    testQuantityToMbConversion(100000, hundredThousandMb);
-  }
+        JobDeploymentStatus v1DeploymentStatus = new JobDeploymentStatus();
+        v1DeploymentStatus.setEnabled(false);
+        v1DeploymentStatus.setDataJobName("v1TestJob");
+        v1DeploymentStatus.setCronJobName("v1TestJob");
+        v1TestList.add(v1DeploymentStatus);
 
-  @Test
-  public void testQuantityConversionGigabytes() throws Exception {
-    var oneG = "1G";
-    testQuantityToMbConversion(1000, oneG);
+        var mergedTestLists =
+                Stream.concat(v1TestList.stream(), v1BetaTestList.stream()).collect(Collectors.toList());
 
-    var twoG = "2G";
-    testQuantityToMbConversion(2000, twoG);
-    // this should be enough for overflow errors on the method to manifest.
-    var threeG = "3G";
-    testQuantityToMbConversion(3000, threeG);
+        Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(true);
+        Mockito.when(mock.readV1CronJobDeploymentStatuses()).thenReturn(v1TestList);
+        Mockito.when(mock.readV1beta1CronJobDeploymentStatuses()).thenReturn(v1BetaTestList);
+        Mockito.when(mock.readJobDeploymentStatuses()).thenCallRealMethod();
+        List<JobDeploymentStatus> resultStatuses = mock.readJobDeploymentStatuses();
 
-    var fourG = "4G";
-    testQuantityToMbConversion(4000, fourG);
+        Assertions.assertEquals(mergedTestLists, resultStatuses);
+    }
 
-    var sixtyFourG = "64G";
-    testQuantityToMbConversion(64000, sixtyFourG);
-  }
+    @Test
+    public void testReadCronJob_readV1CronJobShouldReturnStatus() {
+        String testCronjobName = "testCronjob";
+        KubernetesService mock = Mockito.mock(KubernetesService.class);
 
-  @Test
-  public void testV1beta1CronJobFromTemplate_emptyImagePullSecretsList() {
-    var mock = mockCronJobFromTemplate();
-    V1beta1CronJob v1beta1CronJob =
-        mock.v1beta1CronJobFromTemplate(
-            "",
-            "",
-            true,
-            null,
-            null,
-            null,
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            Collections.emptyList());
+        JobDeploymentStatus testDeploymentStatus = new JobDeploymentStatus();
+        testDeploymentStatus.setEnabled(false);
+        testDeploymentStatus.setDataJobName(testCronjobName);
+        testDeploymentStatus.setCronJobName(testCronjobName);
+        Mockito.when(mock.readCronJob(testCronjobName)).thenCallRealMethod();
 
-    Assertions.assertNull(
-        v1beta1CronJob
-            .getSpec()
-            .getJobTemplate()
-            .getSpec()
-            .getTemplate()
-            .getSpec()
-            .getImagePullSecrets());
-  }
+        Mockito.when(mock.readV1beta1CronJob(testCronjobName)).thenReturn(Optional.empty());
+        Mockito.when(mock.readV1CronJob(testCronjobName)).thenReturn(Optional.of(testDeploymentStatus));
 
-  @Test
-  public void testV1CronJobFromTemplate_emptyImagePullSecretsList() {
-    var mock = mockCronJobFromTemplate();
-    V1CronJob v1CronJob =
-        mock.v1CronJobFromTemplate(
-            "",
-            "",
-            true,
-            null,
-            null,
-            null,
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            Collections.emptyList());
+        Assertions.assertNotNull(mock.readCronJob(testCronjobName));
+        Assertions.assertEquals(
+                testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
+        verify(mock, times(2)).readV1beta1CronJob(testCronjobName);
+        verify(mock, times(2)).readV1CronJob(testCronjobName);
+    }
 
-    Assertions.assertNull(
-        v1CronJob
-            .getSpec()
-            .getJobTemplate()
-            .getSpec()
-            .getTemplate()
-            .getSpec()
-            .getImagePullSecrets());
-  }
+    @Test
+    public void testReadCronJob_readV1beta1CronJobShouldReturnStatus() {
+        String testCronjobName = "testCronjob";
+        KubernetesService mock = Mockito.mock(KubernetesService.class);
 
-  @Test
-  public void testV1beta1CronJobFromTemplate_imagePullSecretsListWithEmptyValues() {
-    var mock = mockCronJobFromTemplate();
-    V1beta1CronJob v1beta1CronJob =
-        mock.v1beta1CronJobFromTemplate(
-            "",
-            "",
-            true,
-            null,
-            null,
-            null,
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            List.of("", ""));
+        JobDeploymentStatus testDeploymentStatus = new JobDeploymentStatus();
+        testDeploymentStatus.setEnabled(false);
+        testDeploymentStatus.setDataJobName(testCronjobName);
+        testDeploymentStatus.setCronJobName(testCronjobName);
+        Mockito.when(mock.readCronJob(testCronjobName)).thenCallRealMethod();
 
-    Assertions.assertNull(
-        v1beta1CronJob
-            .getSpec()
-            .getJobTemplate()
-            .getSpec()
-            .getTemplate()
-            .getSpec()
-            .getImagePullSecrets());
-  }
+        Mockito.when(mock.readV1beta1CronJob(testCronjobName))
+                .thenReturn(Optional.of(testDeploymentStatus));
+        Mockito.when(mock.readV1CronJob(testCronjobName)).thenReturn(Optional.empty());
 
-  @Test
-  public void testV1CronJobFromTemplate_imagePullSecretsListWithEmptyValues() {
-    var mock = mockCronJobFromTemplate();
-    V1CronJob v1CronJob =
-        mock.v1CronJobFromTemplate(
-            "",
-            "",
-            true,
-            null,
-            null,
-            null,
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            List.of("", ""));
+        Assertions.assertNotNull(mock.readCronJob(testCronjobName));
+        Assertions.assertEquals(
+                testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
+        verify(mock, times(2)).readV1beta1CronJob(testCronjobName);
+        verify(mock, times(0)).readV1CronJob(testCronjobName);
+    }
 
-    Assertions.assertNull(
-        v1CronJob
-            .getSpec()
-            .getJobTemplate()
-            .getSpec()
-            .getTemplate()
-            .getSpec()
-            .getImagePullSecrets());
-  }
+    @Test
+    public void testQuantityToMbConversionMegabytes() throws Exception {
+        var hundredMb = "100M";
+        testQuantityToMbConversion(100, hundredMb);
 
-  @Test
-  public void
-      testV1beta1CronJobFromTemplate_imagePullSecretsListWithOneNonEmptyValueAndOneEmptyValue() {
-    var mock = mockCronJobFromTemplate();
-    String secretName = "test_secret_name";
-    V1beta1CronJob v1beta1CronJob =
-        mock.v1beta1CronJobFromTemplate(
-            "",
-            "",
-            true,
-            null,
-            null,
-            null,
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            List.of("", secretName));
+        var thousandMb = "1000M";
+        testQuantityToMbConversion(1000, thousandMb);
+        // this should be enough for overflow errors on the method to manifest.
+        var tenThousandMb = "10000M";
+        testQuantityToMbConversion(10000, tenThousandMb);
 
-    List<V1LocalObjectReference> actualImagePullSecrets =
-        v1beta1CronJob
-            .getSpec()
-            .getJobTemplate()
-            .getSpec()
-            .getTemplate()
-            .getSpec()
-            .getImagePullSecrets();
+        var hundredThousandMb = "100000M";
+        testQuantityToMbConversion(100000, hundredThousandMb);
+    }
 
-    Assertions.assertNotNull(actualImagePullSecrets);
-    Assertions.assertEquals(1, actualImagePullSecrets.size());
-    Assertions.assertEquals(secretName, actualImagePullSecrets.get(0).getName());
-  }
+    @Test
+    public void testQuantityConversionGigabytes() throws Exception {
+        var oneG = "1G";
+        testQuantityToMbConversion(1000, oneG);
 
-  @Test
-  public void testV1CronJobFromTemplate_imagePullSecretsListWithOneNonEmptyValueAndOneEmptyValue() {
-    var mock = mockCronJobFromTemplate();
-    String secretName = "test_secret_name";
-    V1CronJob v1CronJob =
-        mock.v1CronJobFromTemplate(
-            "",
-            "",
-            true,
-            null,
-            null,
-            null,
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            List.of("", secretName));
+        var twoG = "2G";
+        testQuantityToMbConversion(2000, twoG);
+        // this should be enough for overflow errors on the method to manifest.
+        var threeG = "3G";
+        testQuantityToMbConversion(3000, threeG);
 
-    List<V1LocalObjectReference> actualImagePullSecrets =
-        v1CronJob
-            .getSpec()
-            .getJobTemplate()
-            .getSpec()
-            .getTemplate()
-            .getSpec()
-            .getImagePullSecrets();
+        var fourG = "4G";
+        testQuantityToMbConversion(4000, fourG);
 
-    Assertions.assertNotNull(actualImagePullSecrets);
-    Assertions.assertEquals(1, actualImagePullSecrets.size());
-    Assertions.assertEquals(secretName, actualImagePullSecrets.get(0).getName());
-  }
+        var sixtyFourG = "64G";
+        testQuantityToMbConversion(64000, sixtyFourG);
+    }
 
-  public void testQuantityToMbConversion(int expectedMb, String providedResources)
-      throws Exception {
-    var q = Quantity.fromString(providedResources);
-    var actual = KubernetesService.convertMemoryToMBs(q);
-    Assertions.assertEquals(expectedMb, actual);
-  }
+    @Test
+    public void testV1beta1CronJobFromTemplate_emptyImagePullSecretsList() {
+        var mock = mockCronJobFromTemplate();
+        V1beta1CronJob v1beta1CronJob =
+                mock.v1beta1CronJobFromTemplate(
+                        "",
+                        "",
+                        true,
+                        null,
+                        null,
+                        null,
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Collections.emptyList());
 
-  private KubernetesService mockCronJobFromTemplate() {
-    var mock = Mockito.mock(KubernetesService.class);
-    Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
-    Mockito.when(
-            mock.v1beta1CronJobFromTemplate(
-                anyString(),
-                anyString(),
-                anyBoolean(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                anyList()))
-        .thenCallRealMethod();
-    Mockito.when(
-            mock.v1CronJobFromTemplate(
-                anyString(),
-                anyString(),
-                anyBoolean(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                anyList()))
-        .thenCallRealMethod();
+        Assertions.assertNull(
+                v1beta1CronJob
+                        .getSpec()
+                        .getJobTemplate()
+                        .getSpec()
+                        .getTemplate()
+                        .getSpec()
+                        .getImagePullSecrets());
+    }
 
-    ReflectionTestUtils.setField(
-        mock, // inject into this object
-        "log", // assign to this field
-        Mockito.mock(Logger.class)); // object to be injected
+    @Test
+    public void testV1CronJobFromTemplate_emptyImagePullSecretsList() {
+        var mock = mockCronJobFromTemplate();
+        V1CronJob v1CronJob =
+                mock.v1CronJobFromTemplate(
+                        "",
+                        "",
+                        true,
+                        null,
+                        null,
+                        null,
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Collections.emptyList());
 
-    return mock;
-  }
+        Assertions.assertNull(
+                v1CronJob
+                        .getSpec()
+                        .getJobTemplate()
+                        .getSpec()
+                        .getTemplate()
+                        .getSpec()
+                        .getImagePullSecrets());
+    }
+
+    @Test
+    public void testV1beta1CronJobFromTemplate_imagePullSecretsListWithEmptyValues() {
+        var mock = mockCronJobFromTemplate();
+        V1beta1CronJob v1beta1CronJob =
+                mock.v1beta1CronJobFromTemplate(
+                        "",
+                        "",
+                        true,
+                        null,
+                        null,
+                        null,
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        List.of("", ""));
+
+        Assertions.assertNull(
+                v1beta1CronJob
+                        .getSpec()
+                        .getJobTemplate()
+                        .getSpec()
+                        .getTemplate()
+                        .getSpec()
+                        .getImagePullSecrets());
+    }
+
+    @Test
+    public void testV1CronJobFromTemplate_imagePullSecretsListWithEmptyValues() {
+        var mock = mockCronJobFromTemplate();
+        V1CronJob v1CronJob =
+                mock.v1CronJobFromTemplate(
+                        "",
+                        "",
+                        true,
+                        null,
+                        null,
+                        null,
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        List.of("", ""));
+
+        Assertions.assertNull(
+                v1CronJob
+                        .getSpec()
+                        .getJobTemplate()
+                        .getSpec()
+                        .getTemplate()
+                        .getSpec()
+                        .getImagePullSecrets());
+    }
+
+    @Test
+    public void
+    testV1beta1CronJobFromTemplate_imagePullSecretsListWithOneNonEmptyValueAndOneEmptyValue() {
+        var mock = mockCronJobFromTemplate();
+        String secretName = "test_secret_name";
+        V1beta1CronJob v1beta1CronJob =
+                mock.v1beta1CronJobFromTemplate(
+                        "",
+                        "",
+                        true,
+                        null,
+                        null,
+                        null,
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        List.of("", secretName));
+
+        List<V1LocalObjectReference> actualImagePullSecrets =
+                v1beta1CronJob
+                        .getSpec()
+                        .getJobTemplate()
+                        .getSpec()
+                        .getTemplate()
+                        .getSpec()
+                        .getImagePullSecrets();
+
+        Assertions.assertNotNull(actualImagePullSecrets);
+        Assertions.assertEquals(1, actualImagePullSecrets.size());
+        Assertions.assertEquals(secretName, actualImagePullSecrets.get(0).getName());
+    }
+
+    @Test
+    public void testV1CronJobFromTemplate_imagePullSecretsListWithOneNonEmptyValueAndOneEmptyValue() {
+        var mock = mockCronJobFromTemplate();
+        String secretName = "test_secret_name";
+        V1CronJob v1CronJob =
+                mock.v1CronJobFromTemplate(
+                        "",
+                        "",
+                        true,
+                        null,
+                        null,
+                        null,
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        List.of("", secretName));
+
+        List<V1LocalObjectReference> actualImagePullSecrets =
+                v1CronJob
+                        .getSpec()
+                        .getJobTemplate()
+                        .getSpec()
+                        .getTemplate()
+                        .getSpec()
+                        .getImagePullSecrets();
+
+        Assertions.assertNotNull(actualImagePullSecrets);
+        Assertions.assertEquals(1, actualImagePullSecrets.size());
+        Assertions.assertEquals(secretName, actualImagePullSecrets.get(0).getName());
+    }
+
+    public void testQuantityToMbConversion(int expectedMb, String providedResources)
+            throws Exception {
+        var q = Quantity.fromString(providedResources);
+        var actual = KubernetesService.convertMemoryToMBs(q);
+        Assertions.assertEquals(expectedMb, actual);
+    }
+
+    private KubernetesService mockCronJobFromTemplate() {
+        var mock = Mockito.mock(KubernetesService.class);
+        Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
+        Mockito.when(
+                        mock.v1beta1CronJobFromTemplate(
+                                anyString(),
+                                anyString(),
+                                anyBoolean(),
+                                any(),
+                                any(),
+                                any(),
+                                any(),
+                                any(),
+                                anyList()))
+                .thenCallRealMethod();
+        Mockito.when(
+                        mock.v1CronJobFromTemplate(
+                                anyString(),
+                                anyString(),
+                                anyBoolean(),
+                                any(),
+                                any(),
+                                any(),
+                                any(),
+                                any(),
+                                anyList()))
+                .thenCallRealMethod();
+
+        ReflectionTestUtils.setField(
+                mock, // inject into this object
+                "log", // assign to this field
+                Mockito.mock(Logger.class)); // object to be injected
+
+        return mock;
+    }
 }


### PR DESCRIPTION
# What
The KubernetesService is by far the biggest class in control-plane. 

It has much too much responsibilities. 

It is responsible for initialing the class that it will use. 
For example it is responsible for creating the k8s client. 
This is against the spring model where each component should be setup with all the components it needs. 
But also it makes it hard to test, because we can't pass in mock clients. 

In this PR I create the client outside of the kuberentesService and autowire it into the service. 
I also do this for the batch clients. 


In a previous PR(https://github.com/vmware/versatile-data-kit/pull/2207#discussion_r1221372123) it was pointed out that there is a bug in the kubernetesService where 500s from the cluster are misclassified as the job not existing. 
To write a test for that bug is not easy because we are creating the clients within the class. 
After this PR is merged it will be much easier to test that bug. 




# How
I have taken the approach that more properties in kuberentes service should be final. 

In the PR it should be obvious that this change is better for tests and production code. 

In the old code we were calling initBatchV1Client() before every call to kuberentes just to create the client again which was totally needless because it should have been a singleton. 

Also in the tests we were often creating a mock to mock a single function to return another mock. All this noise is gone from the tests. 



# How how this tested? 
Local and CICD
