### PR TITLE
vdk-core: Accept string as job_path in JobConfig

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/job_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/job_config.py
@@ -11,6 +11,7 @@ from configparser import MissingSectionHeaderError
 from enum import Enum
 from typing import Dict
 from typing import List
+from typing import Union
 
 from vdk.internal.core.config import convert_value_to_type_of_default_type
 from vdk.internal.core.errors import ErrorMessage
@@ -40,7 +41,7 @@ class JobConfig:
     For more see the user wiki
     """
 
-    def __init__(self, data_job_path: pathlib.Path):
+    def __init__(self, data_job_path: Union[pathlib.Path, str]):
         self._config_ini = configparser.ConfigParser()
         self._config_file = os.path.join(data_job_path, "config.ini")
 


### PR DESCRIPTION
Currently, the JobConfig class accepts only pathlib.Path as data_job_path. This, however, causes unnecesary warnings when a string is passed as job path.

This change updates the type annotation of the init to support both pathlib.Path and string as data_job_path.

Testing Done: CI/CD