### PR TITLE
[Bug fix] vdk-core: Fix _get_contacts in JobConfig

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/job_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/job_config.py
@@ -5,6 +5,7 @@ import fileinput
 import logging
 import os
 import pathlib
+import re
 import sys
 from configparser import ConfigParser
 from configparser import MissingSectionHeaderError
@@ -174,9 +175,10 @@ class JobConfig:
 
     def _get_contacts(self, key):
         contacts_str = self._get_value("contacts", key).strip()
+        contacts = []
         if contacts_str:
-            return [x.strip() for x in contacts_str.split(";")]
-        return []
+            contacts = [x.strip() for x in re.split("[;,]", contacts_str)]
+        return contacts
 
     def _get_boolean(self, section, key, fallback=None) -> bool:
         return self._config_ini.getboolean(section, key, fallback=fallback)

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_job_config.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_job_config.py
@@ -1,17 +1,21 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import configparser
 import os
 import pathlib
 import shutil
 import tempfile
 
+import pytest
 from vdk.internal.builtin_plugins.config.job_config import JobConfig
+from vdk.internal.core.errors import VdkConfigurationError
 
 
 class TestJobConfig:
     def setup_method(self, method):
         # Create a temporary directory
         self._test_dir = pathlib.Path(tempfile.mkdtemp())
+        self._test_config_path = os.path.join(self._test_dir, "config.ini")
         cfg_string = """
    [owner]
      team = foo
@@ -92,6 +96,121 @@ class TestJobConfig:
         )
         cfg = JobConfig(self._test_dir)
         self.assertEqual({"a": "b"}, cfg.get_vdk_options())
+
+    def test_set_team(self):
+        self._perform_set_team_test("my_unique_team_name")
+
+    def test_set_empty_team(self):
+        self._perform_set_team_test("")
+
+    def test_set_team_with_spaces(self):
+        self._perform_set_team_test("my unique team name")
+
+    def test_set_team_with_no_team_in_config_ini(self):
+        # remove all contents of config.ini (including team option)
+        self._write_to_config_ini(
+            self._test_dir,
+            """
+            """,
+        )
+        cfg = JobConfig(self._test_dir)
+
+        assert not cfg.get_team(), f"empty config.ini file should not provide a team"
+
+        assert not cfg.set_team_if_exists(
+            "my unique team name"
+        ), f"set_team_if_exists was supposed to return False if there is no team option in config.ini"
+
+    def _perform_set_team_test(self, team_name):
+        assert self._cfg.set_team_if_exists(
+            team_name
+        ), f"team option was expected to be present in: {self._test_config_path}"
+
+        with open(self._test_config_path) as f:
+            assert (
+                team_name in f.read()
+            ), f"set_team_if_exists failed to write team {team_name} in: {self._test_config_path}"
+
+    def test_notification_delay_period_minutes(self):
+        self.__create_job_config_with_custom_contacts(
+            [("notification_delay_period_minutes", "100")],
+        )
+        job_config = JobConfig(self._test_dir)
+        assert job_config.get_notification_delay_period_minutes() == 100
+
+    def test_invalid_notification_delay_period_minutes(self):
+        self.__create_job_config_with_custom_contacts(
+            [("notification_delay_period_minutes", "invalid_value")],
+        )
+        job_config = JobConfig(self._test_dir)
+        with pytest.raises(VdkConfigurationError):
+            job_config.get_notification_delay_period_minutes()
+
+    def test_negative_notification_delay_period_minutes(self):
+        self.__create_job_config_with_custom_contacts(
+            [("notification_delay_period_minutes", "-100")],
+        )
+        job_config = JobConfig(self._test_dir)
+        with pytest.raises(VdkConfigurationError):
+            job_config.get_notification_delay_period_minutes()
+
+    def test_parse_notification_contacts(self):
+        self.__create_job_config_with_custom_contacts(
+            [
+                ("notified_on_job_deploy", "a@abv.bg; b@dir.bg,   c@abv.bg ; d@dir.bg"),
+                (
+                    "notified_on_job_success",
+                    "a@abv.bg; b@dir.bg,   c@abv.bg ; d@dir.bg",
+                ),
+                (
+                    "notified_on_job_failure_user_error",
+                    "a@abv.bg; b@dir.bg,   c@abv.bg ; d@dir.bg",
+                ),
+                (
+                    "notified_on_job_failure_platform_error",
+                    "a@abv.bg; b@dir.bg,   c@abv.bg ; d@dir.bg",
+                ),
+            ],
+        )
+        job_config = JobConfig(self._test_dir)
+        assert job_config.get_contacts_notified_on_job_deploy() == [
+            "a@abv.bg",
+            "b@dir.bg",
+            "c@abv.bg",
+            "d@dir.bg",
+        ]
+        assert job_config.get_contacts_notified_on_job_success() == [
+            "a@abv.bg",
+            "b@dir.bg",
+            "c@abv.bg",
+            "d@dir.bg",
+        ]
+        assert job_config.get_contacts_notified_on_job_failure_user_error() == [
+            "a@abv.bg",
+            "b@dir.bg",
+            "c@abv.bg",
+            "d@dir.bg",
+        ]
+        assert job_config.get_contacts_notified_on_job_failure_platform_error() == [
+            "a@abv.bg",
+            "b@dir.bg",
+            "c@abv.bg",
+            "d@dir.bg",
+        ]
+
+    def __create_job_config_with_custom_contacts(self, contacts):
+        # remove all contents of config.ini (including team option)
+        self._write_to_config_ini(
+            self._test_dir,
+            """
+            """,
+        )
+        config = configparser.ConfigParser()
+        config.add_section("contacts")
+        for k, v in contacts:
+            config.set("contacts", k, v)
+        with open(self._test_config_path, "w") as f:
+            config.write(f)
 
     @staticmethod
     def assertEqual(lhs, rhs):


### PR DESCRIPTION
When the logic from vdk-control-cli's JobConfig class was synced with the vdk-core's JobConfig, the `._get_contacts()` method logic was not properly ported, and this caused issues with config.ini files, where email addresses are not separated with `;`.

This change fixes the introduced bug. Additionally, the job config tests from the vdk-control-cli are  refactored and moved to the vdk-core.

Testing Done: New unit tests.