### PR TITLE
control-service: remove unneeded methods

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/PrivateBuilderDockerRepoIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/PrivateBuilderDockerRepoIT.java
@@ -11,6 +11,7 @@ import com.vmware.taurus.datajobs.it.common.BaseIT;
 import com.vmware.taurus.datajobs.it.common.DataJobDeploymentExtension;
 import com.vmware.taurus.datajobs.it.common.DockerConfigJsonUtils;
 import com.vmware.taurus.datajobs.it.common.JobExecutionUtil;
+import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1SecretBuilder;
@@ -18,6 +19,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -40,12 +43,17 @@ public class PrivateBuilderDockerRepoIT extends BaseIT {
   @Value("${datajobs.builder.image}")
   private String builderImage;
 
+
+  @Autowired
+  @Qualifier("controlApiClient")
+  private ApiClient client;
+
   @RegisterExtension
   static DataJobDeploymentExtension dataJobDeploymentExtension = new DataJobDeploymentExtension();
 
   private void createBuilderImagePullSecret(String namespaceName) throws Exception {
     try {
-      new CoreV1Api(controlKubernetesService.getClient())
+      new CoreV1Api(client)
           .createNamespacedSecret(
               namespaceName,
               new V1SecretBuilder()

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/PrivateBuilderDockerRepoIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/PrivateBuilderDockerRepoIT.java
@@ -43,7 +43,6 @@ public class PrivateBuilderDockerRepoIT extends BaseIT {
   @Value("${datajobs.builder.image}")
   private String builderImage;
 
-
   @Autowired
   @Qualifier("controlApiClient")
   private ApiClient client;

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -325,23 +325,6 @@ public abstract class KubernetesService {
     return cronjobTemplate;
   }
 
-  private String getCurrentNamespace() {
-    return getNamespaceFileContents().stream()
-        .filter(not(String::isBlank))
-        .findFirst()
-        .map(String::strip)
-        .orElse(null);
-  }
-
-  private List<String> getNamespaceFileContents() {
-    try {
-      String namespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
-      return Files.readAllLines(Paths.get(namespaceFile));
-    } catch (IOException e) {
-      return Collections.emptyList();
-    }
-  }
-
   public Pair<Boolean, String> health() {
     try {
       var info = new VersionApi(client).getCode();
@@ -2309,10 +2292,5 @@ public abstract class KubernetesService {
       divider = BigInteger.valueOf(1000);
     }
     return quantity.getNumber().toBigInteger().divide(divider.multiply(divider)).intValue();
-  }
-
-  @VisibleForTesting
-  public ApiClient getClient() {
-    return client;
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -6,7 +6,6 @@
 package com.vmware.taurus.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Iterables;
 import com.google.gson.JsonSyntaxException;
@@ -46,7 +45,6 @@ import org.springframework.util.CollectionUtils;
 import java.io.*;
 import java.math.BigInteger;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -56,7 +54,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.util.function.Predicate.not;
 
 /**
  * A facade over Kubernetes (https://en.wikipedia.org/wiki/Facade_pattern) (not complete see


### PR DESCRIPTION
# Why
The KubernetesService class is massive. 
It is important to keep it clean and remove unneeded functions. 

# What
delete functions that are not needed. 
# How was this tested
CICD