### PR TITLE
control-service: use real class when testing instead of mock

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -54,7 +54,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-
 /**
  * A facade over Kubernetes (https://en.wikipedia.org/wiki/Facade_pattern) (not complete see
  * JobImageDeployer)

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -354,8 +354,7 @@ public class KubernetesServiceTest {
       V1CronJob internalCronjobTemplate = (V1CronJob) loadInternalV1CronjobTemplate.invoke(service);
       // Prepare the 'v1checkForMissingEntries' method.
       Method checkForMissingEntries =
-          KubernetesService.class.getDeclaredMethod(
-              "v1checkForMissingEntries", V1CronJob.class);
+          KubernetesService.class.getDeclaredMethod("v1checkForMissingEntries", V1CronJob.class);
       if (checkForMissingEntries == null) {
         Assertions.fail("The method 'v1checkForMissingEntries' does not exist.");
       }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -398,7 +398,7 @@ public class KubernetesServiceTest {
 
       Assertions.assertNotNull(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
       // Step 3 - create and check the actual cronjob.
-      Method[] methods = DataJobsKubernetesService.class.getDeclaredMethods();
+      Method[] methods = KubernetesService.class.getDeclaredMethods();
       // This is much easier than describing the whole method signature.
       Optional<Method> method =
           Arrays.stream(methods)

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -38,52 +38,52 @@ public class KubernetesServiceTest {
   public void testCreateVDKContainer() {
 
     var vdkCommand =
-            List.of(
-                    "/bin/bash",
-                    "-c",
-                    "cp -r /usr/local/lib/python3.7/site-packages /vdk/. && cp /usr/local/bin/vdk /vdk/.");
+        List.of(
+            "/bin/bash",
+            "-c",
+            "cp -r /usr/local/lib/python3.7/site-packages /vdk/. && cp /usr/local/bin/vdk /vdk/.");
 
     var volumeMount = KubernetesService.volumeMount("vdk-volume", "/vdk", false);
 
     var expectedVDKContainer =
-            new V1ContainerBuilder()
-                    .withName("vdk")
-                    .withImage("vdk:latest")
-                    .withVolumeMounts(
-                            new V1VolumeMount().name("vdk-volume").mountPath("/vdk").readOnly(false))
-                    .withImagePullPolicy("Always")
-                    .withSecurityContext(
-                            new V1SecurityContextBuilder()
-                                    .withPrivileged(false)
-                                    .withReadOnlyRootFilesystem(false)
-                                    .build())
-                    .withCommand(vdkCommand)
-                    .withArgs(List.of())
-                    .withEnvFrom(
-                            new V1EnvFromSource()
-                                    .secretRef(new V1SecretEnvSource().name("builder-secrets").optional(true)))
-                    .withEnv(List.of())
-                    .withResources(
-                            new V1ResourceRequirementsBuilder()
-                                    .withRequests(Map.of("cpu", new Quantity("500m"), "memory", new Quantity("1G")))
-                                    .withLimits(Map.of("cpu", new Quantity("2000m"), "memory", new Quantity("1G")))
-                                    .build())
-                    .build();
+        new V1ContainerBuilder()
+            .withName("vdk")
+            .withImage("vdk:latest")
+            .withVolumeMounts(
+                new V1VolumeMount().name("vdk-volume").mountPath("/vdk").readOnly(false))
+            .withImagePullPolicy("Always")
+            .withSecurityContext(
+                new V1SecurityContextBuilder()
+                    .withPrivileged(false)
+                    .withReadOnlyRootFilesystem(false)
+                    .build())
+            .withCommand(vdkCommand)
+            .withArgs(List.of())
+            .withEnvFrom(
+                new V1EnvFromSource()
+                    .secretRef(new V1SecretEnvSource().name("builder-secrets").optional(true)))
+            .withEnv(List.of())
+            .withResources(
+                new V1ResourceRequirementsBuilder()
+                    .withRequests(Map.of("cpu", new Quantity("500m"), "memory", new Quantity("1G")))
+                    .withLimits(Map.of("cpu", new Quantity("2000m"), "memory", new Quantity("1G")))
+                    .build())
+            .build();
 
     var actualVDKContainer =
-            KubernetesService.container(
-                    "vdk",
-                    "vdk:latest",
-                    false,
-                    false,
-                    Map.of(),
-                    List.of(),
-                    List.of(volumeMount),
-                    "Always",
-                    new KubernetesService.Resources("500m", "1G"),
-                    new KubernetesService.Resources("2000m", "1G"),
-                    null,
-                    vdkCommand);
+        KubernetesService.container(
+            "vdk",
+            "vdk:latest",
+            false,
+            false,
+            Map.of(),
+            List.of(),
+            List.of(volumeMount),
+            "Always",
+            new KubernetesService.Resources("500m", "1G"),
+            new KubernetesService.Resources("2000m", "1G"),
+            null,
+            vdkCommand);
 
     Assertions.assertEquals(expectedVDKContainer, actualVDKContainer);
   }
@@ -94,10 +94,10 @@ public class KubernetesServiceTest {
     var mock = Mockito.mock(KubernetesService.class);
     Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
     Mockito.when(mock.getTerminationStatus(v1Job))
-            .thenReturn(ImmutablePair.of(Optional.empty(), Optional.empty()));
+        .thenReturn(ImmutablePair.of(Optional.empty(), Optional.empty()));
     Mockito.when(mock.getJobExecutionStatus(v1Job, null)).thenCallRealMethod();
     Optional<KubernetesService.JobExecution> actualJobExecutionStatusOptional =
-            mock.getJobExecutionStatus(v1Job, null);
+        mock.getJobExecutionStatus(v1Job, null);
 
     Assertions.assertTrue(actualJobExecutionStatusOptional.isPresent());
 
@@ -137,60 +137,60 @@ public class KubernetesServiceTest {
     Integer succeeded = 1;
 
     V1Job expectedJob =
-            new V1Job()
-                    .metadata(
-                            new V1ObjectMeta()
-                                    .name(kubernetesJobName)
-                                    .putLabelsItem(JobLabel.VERSION.getValue(), jobVersion)
-                                    .putLabelsItem(JobLabel.NAME.getValue(), dataJobName)
-                                    .putAnnotationsItem(JobAnnotation.DEPLOYED_DATE.getValue(), deployedDate)
-                                    .putAnnotationsItem(JobAnnotation.DEPLOYED_BY.getValue(), deployedBy)
-                                    .putAnnotationsItem(JobAnnotation.EXECUTION_TYPE.getValue(), executionType)
-                                    .putAnnotationsItem(JobAnnotation.OP_ID.getValue(), opId)
-                                    .putAnnotationsItem(JobAnnotation.PYTHON_VERSION.getValue(), jobPythonVersion))
-                    .spec(
-                            new V1JobSpec()
-                                    .template(
-                                            new V1PodTemplateSpec()
-                                                    .spec(
-                                                            new V1PodSpec()
-                                                                    .addContainersItem(
-                                                                            new V1Container()
-                                                                                    .name(dataJobName)
-                                                                                    .resources(
-                                                                                            new V1ResourceRequirements()
-                                                                                                    .putRequestsItem(
-                                                                                                            "cpu", new Quantity(cpuRequest))
-                                                                                                    .putRequestsItem(
-                                                                                                            "memory",
-                                                                                                            new Quantity(
-                                                                                                                    Integer.toString(
-                                                                                                                            memoryRequest * 1000 * 1000)))
-                                                                                                    .putLimitsItem("cpu", new Quantity(cpuLimit))
-                                                                                                    .putLimitsItem(
-                                                                                                            "memory",
-                                                                                                            new Quantity(
-                                                                                                                    Integer.toString(
-                                                                                                                            memoryLimit * 1000 * 1000))))))))
-                    .status(
-                            new V1JobStatus()
-                                    .startTime(startTime)
-                                    .completionTime(endTime)
-                                    .succeeded(succeeded));
+        new V1Job()
+            .metadata(
+                new V1ObjectMeta()
+                    .name(kubernetesJobName)
+                    .putLabelsItem(JobLabel.VERSION.getValue(), jobVersion)
+                    .putLabelsItem(JobLabel.NAME.getValue(), dataJobName)
+                    .putAnnotationsItem(JobAnnotation.DEPLOYED_DATE.getValue(), deployedDate)
+                    .putAnnotationsItem(JobAnnotation.DEPLOYED_BY.getValue(), deployedBy)
+                    .putAnnotationsItem(JobAnnotation.EXECUTION_TYPE.getValue(), executionType)
+                    .putAnnotationsItem(JobAnnotation.OP_ID.getValue(), opId)
+                    .putAnnotationsItem(JobAnnotation.PYTHON_VERSION.getValue(), jobPythonVersion))
+            .spec(
+                new V1JobSpec()
+                    .template(
+                        new V1PodTemplateSpec()
+                            .spec(
+                                new V1PodSpec()
+                                    .addContainersItem(
+                                        new V1Container()
+                                            .name(dataJobName)
+                                            .resources(
+                                                new V1ResourceRequirements()
+                                                    .putRequestsItem(
+                                                        "cpu", new Quantity(cpuRequest))
+                                                    .putRequestsItem(
+                                                        "memory",
+                                                        new Quantity(
+                                                            Integer.toString(
+                                                                memoryRequest * 1000 * 1000)))
+                                                    .putLimitsItem("cpu", new Quantity(cpuLimit))
+                                                    .putLimitsItem(
+                                                        "memory",
+                                                        new Quantity(
+                                                            Integer.toString(
+                                                                memoryLimit * 1000 * 1000))))))))
+            .status(
+                new V1JobStatus()
+                    .startTime(startTime)
+                    .completionTime(endTime)
+                    .succeeded(succeeded));
     KubernetesService.JobStatusCondition condition =
-            new KubernetesService.JobStatusCondition(
-                    true, "type", "reason", "message", endTime.toInstant().toEpochMilli());
+        new KubernetesService.JobStatusCondition(
+            true, "type", "reason", "message", endTime.toInstant().toEpochMilli());
 
     KubernetesService mock = Mockito.mock(KubernetesService.class);
     Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(false);
     Mockito.when(mock.getTerminationStatus(expectedJob))
-            .thenReturn(
-                    ImmutablePair.of(
-                            Optional.ofNullable(new V1ContainerStateTerminated().reason("test")),
-                            Optional.ofNullable(new V1ContainerStateTerminated().reason("test"))));
+        .thenReturn(
+            ImmutablePair.of(
+                Optional.ofNullable(new V1ContainerStateTerminated().reason("test")),
+                Optional.ofNullable(new V1ContainerStateTerminated().reason("test"))));
     Mockito.when(mock.getJobExecutionStatus(expectedJob, condition)).thenCallRealMethod();
     Optional<KubernetesService.JobExecution> actualJobExecutionStatusOptional =
-            mock.getJobExecutionStatus(expectedJob, condition);
+        mock.getJobExecutionStatus(expectedJob, condition);
 
     Assertions.assertTrue(actualJobExecutionStatusOptional.isPresent());
 
@@ -200,7 +200,7 @@ public class KubernetesServiceTest {
     Assertions.assertEquals(jobVersion, actualJobExecution.getJobVersion());
     Assertions.assertEquals(jobPythonVersion, actualJobExecution.getJobPythonVersion());
     Assertions.assertEquals(
-            OffsetDateTime.parse(deployedDate), actualJobExecution.getDeployedDate());
+        OffsetDateTime.parse(deployedDate), actualJobExecution.getDeployedDate());
     Assertions.assertEquals(executionType, actualJobExecution.getExecutionType());
     Assertions.assertEquals(opId, actualJobExecution.getOpId());
     Assertions.assertEquals(Float.valueOf(cpuRequest), actualJobExecution.getResourcesCpuRequest());
@@ -208,13 +208,13 @@ public class KubernetesServiceTest {
     Assertions.assertEquals(memoryRequest, actualJobExecution.getResourcesMemoryRequest());
     Assertions.assertEquals(memoryLimit, actualJobExecution.getResourcesMemoryLimit());
     Assertions.assertEquals(
-            OffsetDateTime.ofInstant(
-                    Instant.ofEpochMilli(startTime.toInstant().toEpochMilli()), ZoneOffset.UTC),
-            actualJobExecution.getStartTime());
+        OffsetDateTime.ofInstant(
+            Instant.ofEpochMilli(startTime.toInstant().toEpochMilli()), ZoneOffset.UTC),
+        actualJobExecution.getStartTime());
     Assertions.assertEquals(
-            OffsetDateTime.ofInstant(
-                    Instant.ofEpochMilli(endTime.toInstant().toEpochMilli()), ZoneOffset.UTC),
-            actualJobExecution.getEndTime());
+        OffsetDateTime.ofInstant(
+            Instant.ofEpochMilli(endTime.toInstant().toEpochMilli()), ZoneOffset.UTC),
+        actualJobExecution.getEndTime());
     Assertions.assertTrue(actualJobExecution.getSucceeded());
   }
 
@@ -231,23 +231,23 @@ public class KubernetesServiceTest {
       //          with corresponding entries from the internal cronjob template.
       // First we load the internal cronjob template.
       Method loadInternalV1beta1CronjobTemplate =
-              DataJobsKubernetesService.class.getDeclaredMethod("loadInternalV1beta1CronjobTemplate");
+          DataJobsKubernetesService.class.getDeclaredMethod("loadInternalV1beta1CronjobTemplate");
       if (loadInternalV1beta1CronjobTemplate == null) {
         Assertions.fail("The method 'loadInternalV1beta1CronjobTemplate' does not exist.");
       }
       loadInternalV1beta1CronjobTemplate.setAccessible(true);
       V1beta1CronJob internalCronjobTemplate =
-              (V1beta1CronJob) loadInternalV1beta1CronjobTemplate.invoke(service);
+          (V1beta1CronJob) loadInternalV1beta1CronjobTemplate.invoke(service);
       // Prepare the 'v1beta1checkForMissingEntries' method.
       Method checkForMissingEntries =
-              DataJobsKubernetesService.class.getDeclaredMethod(
-                      "v1beta1checkForMissingEntries", V1beta1CronJob.class);
+          DataJobsKubernetesService.class.getDeclaredMethod(
+              "v1beta1checkForMissingEntries", V1beta1CronJob.class);
       if (checkForMissingEntries == null) {
         Assertions.fail("The method 'v1beta1checkForMissingEntries' does not exist.");
       }
       checkForMissingEntries.setAccessible(true);
       V1beta1CronJob emptyCronjobToBeFixed =
-              new V1beta1CronJob(); // Worst case scenario to test - empty cronjob.
+          new V1beta1CronJob(); // Worst case scenario to test - empty cronjob.
       checkForMissingEntries.invoke(service, emptyCronjobToBeFixed);
       // We can't rely on equality check on root metadata/spec level, because if the internal
       // template
@@ -256,67 +256,67 @@ public class KubernetesServiceTest {
       Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata());
       Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata().getAnnotations());
       Assertions.assertEquals(
-              internalCronjobTemplate.getMetadata().getAnnotations(),
-              emptyCronjobToBeFixed.getMetadata().getAnnotations());
+          internalCronjobTemplate.getMetadata().getAnnotations(),
+          emptyCronjobToBeFixed.getMetadata().getAnnotations());
       Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec());
       Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate());
       Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec());
       Assertions.assertNotNull(
-              emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate());
+          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate());
       Assertions.assertNotNull(
-              emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
+          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
       Assertions.assertNotNull(
-              emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata());
+          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata());
       Assertions.assertEquals(
-              internalCronjobTemplate
-                      .getSpec()
-                      .getJobTemplate()
-                      .getSpec()
-                      .getTemplate()
-                      .getMetadata()
-                      .getLabels(),
-              emptyCronjobToBeFixed
-                      .getSpec()
-                      .getJobTemplate()
-                      .getSpec()
-                      .getTemplate()
-                      .getMetadata()
-                      .getLabels());
+          internalCronjobTemplate
+              .getSpec()
+              .getJobTemplate()
+              .getSpec()
+              .getTemplate()
+              .getMetadata()
+              .getLabels(),
+          emptyCronjobToBeFixed
+              .getSpec()
+              .getJobTemplate()
+              .getSpec()
+              .getTemplate()
+              .getMetadata()
+              .getLabels());
 
       Assertions.assertNotNull(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
       // Step 3 - create and check the actual cronjob.
       Method[] methods = DataJobsKubernetesService.class.getDeclaredMethods();
       // This is much easier than describing the whole method signature.
       Optional<Method> method =
-              Arrays.stream(methods)
-                      .filter(m -> m.getName().equals("v1beta1CronJobFromTemplate"))
-                      .findFirst();
+          Arrays.stream(methods)
+              .filter(m -> m.getName().equals("v1beta1CronJobFromTemplate"))
+              .findFirst();
       if (method.isEmpty()) {
         Assertions.fail("The method 'v1beta1cronJobFromTemplate' does not exist.");
       }
       method.get().setAccessible(true);
       V1beta1CronJob cronjob =
-              (V1beta1CronJob)
-                      method
-                              .get()
-                              .invoke(
-                                      service,
-                                      "test-job-name",
-                                      "test-job-schedule",
-                                      true,
-                                      null,
-                                      null,
-                                      null,
-                                      Collections.EMPTY_MAP,
-                                      Collections.EMPTY_MAP,
-                                      List.of(""));
+          (V1beta1CronJob)
+              method
+                  .get()
+                  .invoke(
+                      service,
+                      "test-job-name",
+                      "test-job-schedule",
+                      true,
+                      null,
+                      null,
+                      null,
+                      Collections.EMPTY_MAP,
+                      Collections.EMPTY_MAP,
+                      List.of(""));
       Assertions.assertEquals("test-job-name", cronjob.getMetadata().getName());
       Assertions.assertEquals("test-job-schedule", cronjob.getSpec().getSchedule());
       Assertions.assertEquals(true, cronjob.getSpec().getSuspend());
       Assertions.assertEquals(
-              Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getLabels());
+          Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getLabels());
       Assertions.assertEquals(
-              Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations());
+          Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations());
 
     } catch (Exception e) {
       e.printStackTrace();
@@ -327,13 +327,13 @@ public class KubernetesServiceTest {
   @NotNull
   private static DataJobsKubernetesService newDataJobKubernetesService() {
     return Mockito.spy(
-            new DataJobsKubernetesService(
-                    "default",
-                    false,
-                    new ApiClient(),
-                    new BatchV1Api(),
-                    new BatchV1beta1Api(),
-                    new JobCommandProvider()));
+        new DataJobsKubernetesService(
+            "default",
+            false,
+            new ApiClient(),
+            new BatchV1Api(),
+            new BatchV1beta1Api(),
+            new JobCommandProvider()));
   }
 
   @Test
@@ -346,7 +346,7 @@ public class KubernetesServiceTest {
       //          with corresponding entries from the internal cronjob template.
       // First we load the internal cronjob template.
       Method loadInternalV1CronjobTemplate =
-              DataJobsKubernetesService.class.getDeclaredMethod("loadInternalV1CronjobTemplate");
+          DataJobsKubernetesService.class.getDeclaredMethod("loadInternalV1CronjobTemplate");
       if (loadInternalV1CronjobTemplate == null) {
         Assertions.fail("The method 'loadInternalV1CronjobTemplate' does not exist.");
       }
@@ -354,14 +354,14 @@ public class KubernetesServiceTest {
       V1CronJob internalCronjobTemplate = (V1CronJob) loadInternalV1CronjobTemplate.invoke(service);
       // Prepare the 'v1checkForMissingEntries' method.
       Method checkForMissingEntries =
-              DataJobsKubernetesService.class.getDeclaredMethod(
-                      "v1checkForMissingEntries", V1CronJob.class);
+          DataJobsKubernetesService.class.getDeclaredMethod(
+              "v1checkForMissingEntries", V1CronJob.class);
       if (checkForMissingEntries == null) {
         Assertions.fail("The method 'v1checkForMissingEntries' does not exist.");
       }
       checkForMissingEntries.setAccessible(true);
       V1CronJob emptyCronjobToBeFixed =
-              new V1CronJob(); // Worst case scenario to test - empty cronjob.
+          new V1CronJob(); // Worst case scenario to test - empty cronjob.
       checkForMissingEntries.invoke(service, emptyCronjobToBeFixed);
       // We can't rely on equality check on root metadata/spec level, because if the internal
       // template
@@ -370,67 +370,67 @@ public class KubernetesServiceTest {
       Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata());
       Assertions.assertNotNull(emptyCronjobToBeFixed.getMetadata().getAnnotations());
       Assertions.assertEquals(
-              internalCronjobTemplate.getMetadata().getAnnotations(),
-              emptyCronjobToBeFixed.getMetadata().getAnnotations());
+          internalCronjobTemplate.getMetadata().getAnnotations(),
+          emptyCronjobToBeFixed.getMetadata().getAnnotations());
       Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec());
       Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate());
       Assertions.assertNotNull(emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec());
       Assertions.assertNotNull(
-              emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate());
+          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate());
       Assertions.assertNotNull(
-              emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
+          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
       Assertions.assertNotNull(
-              emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata());
+          emptyCronjobToBeFixed.getSpec().getJobTemplate().getSpec().getTemplate().getMetadata());
       Assertions.assertEquals(
-              internalCronjobTemplate
-                      .getSpec()
-                      .getJobTemplate()
-                      .getSpec()
-                      .getTemplate()
-                      .getMetadata()
-                      .getLabels(),
-              emptyCronjobToBeFixed
-                      .getSpec()
-                      .getJobTemplate()
-                      .getSpec()
-                      .getTemplate()
-                      .getMetadata()
-                      .getLabels());
+          internalCronjobTemplate
+              .getSpec()
+              .getJobTemplate()
+              .getSpec()
+              .getTemplate()
+              .getMetadata()
+              .getLabels(),
+          emptyCronjobToBeFixed
+              .getSpec()
+              .getJobTemplate()
+              .getSpec()
+              .getTemplate()
+              .getMetadata()
+              .getLabels());
 
       Assertions.assertNotNull(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
       // Step 3 - create and check the actual cronjob.
       Method[] methods = DataJobsKubernetesService.class.getDeclaredMethods();
       // This is much easier than describing the whole method signature.
       Optional<Method> method =
-              Arrays.stream(methods)
-                      .filter(m -> m.getName().equals("v1CronJobFromTemplate"))
-                      .findFirst();
+          Arrays.stream(methods)
+              .filter(m -> m.getName().equals("v1CronJobFromTemplate"))
+              .findFirst();
       if (method.isEmpty()) {
         Assertions.fail("The method 'v1cronJobFromTemplate' does not exist.");
       }
       method.get().setAccessible(true);
       V1CronJob cronjob =
-              (V1CronJob)
-                      method
-                              .get()
-                              .invoke(
-                                      service,
-                                      "test-job-name",
-                                      "test-job-schedule",
-                                      true,
-                                      null,
-                                      null,
-                                      null,
-                                      Collections.EMPTY_MAP,
-                                      Collections.EMPTY_MAP,
-                                      List.of(""));
+          (V1CronJob)
+              method
+                  .get()
+                  .invoke(
+                      service,
+                      "test-job-name",
+                      "test-job-schedule",
+                      true,
+                      null,
+                      null,
+                      null,
+                      Collections.EMPTY_MAP,
+                      Collections.EMPTY_MAP,
+                      List.of(""));
       Assertions.assertEquals("test-job-name", cronjob.getMetadata().getName());
       Assertions.assertEquals("test-job-schedule", cronjob.getSpec().getSchedule());
       Assertions.assertEquals(true, cronjob.getSpec().getSuspend());
       Assertions.assertEquals(
-              Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getLabels());
+          Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getLabels());
       Assertions.assertEquals(
-              Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations());
+          Collections.EMPTY_MAP, cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations());
 
     } catch (Exception e) {
       e.printStackTrace();
@@ -457,7 +457,7 @@ public class KubernetesServiceTest {
     v1TestList.add(v1DeploymentStatus);
 
     var mergedTestLists =
-            Stream.concat(v1TestList.stream(), v1BetaTestList.stream()).collect(Collectors.toList());
+        Stream.concat(v1TestList.stream(), v1BetaTestList.stream()).collect(Collectors.toList());
 
     Mockito.when(mock.getK8sSupportsV1CronJob()).thenReturn(true);
     Mockito.when(mock.readV1CronJobDeploymentStatuses()).thenReturn(v1TestList);
@@ -467,7 +467,6 @@ public class KubernetesServiceTest {
 
     Assertions.assertEquals(mergedTestLists, resultStatuses);
   }
-
 
   @Test
   public void testReadCronJob_readV1CronJobShouldReturnStatus() {
@@ -484,7 +483,7 @@ public class KubernetesServiceTest {
 
     Assertions.assertNotNull(mock.readCronJob(testCronjobName));
     Assertions.assertEquals(
-            testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
+        testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
     verify(mock, times(2)).readV1beta1CronJob(testCronjobName);
     verify(mock, times(2)).readV1CronJob(testCronjobName);
   }
@@ -500,12 +499,12 @@ public class KubernetesServiceTest {
     testDeploymentStatus.setCronJobName(testCronjobName);
 
     Mockito.when(mock.readV1beta1CronJob(testCronjobName))
-            .thenReturn(Optional.of(testDeploymentStatus));
+        .thenReturn(Optional.of(testDeploymentStatus));
     Mockito.when(mock.readV1CronJob(testCronjobName)).thenReturn(Optional.empty());
 
     Assertions.assertNotNull(mock.readCronJob(testCronjobName));
     Assertions.assertEquals(
-            testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
+        testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
     verify(mock, times(2)).readV1beta1CronJob(testCronjobName);
     verify(mock, times(0)).readV1CronJob(testCronjobName);
   }
@@ -547,127 +546,127 @@ public class KubernetesServiceTest {
   public void testV1beta1CronJobFromTemplate_emptyImagePullSecretsList() {
     KubernetesService mock = newDataJobKubernetesService();
     V1beta1CronJob v1beta1CronJob =
-            mock.v1beta1CronJobFromTemplate(
-                    "",
-                    "",
-                    true,
-                    null,
-                    null,
-                    null,
-                    Collections.emptyMap(),
-                    Collections.emptyMap(),
-                    Collections.emptyList());
+        mock.v1beta1CronJobFromTemplate(
+            "",
+            "",
+            true,
+            null,
+            null,
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyList());
 
     Assertions.assertNull(
-            v1beta1CronJob
-                    .getSpec()
-                    .getJobTemplate()
-                    .getSpec()
-                    .getTemplate()
-                    .getSpec()
-                    .getImagePullSecrets());
+        v1beta1CronJob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .getImagePullSecrets());
   }
 
   @Test
   public void testV1CronJobFromTemplate_emptyImagePullSecretsList() {
     KubernetesService mock = newDataJobKubernetesService();
     V1CronJob v1CronJob =
-            mock.v1CronJobFromTemplate(
-                    "",
-                    "",
-                    true,
-                    null,
-                    null,
-                    null,
-                    Collections.emptyMap(),
-                    Collections.emptyMap(),
-                    Collections.emptyList());
+        mock.v1CronJobFromTemplate(
+            "",
+            "",
+            true,
+            null,
+            null,
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyList());
 
     Assertions.assertNull(
-            v1CronJob
-                    .getSpec()
-                    .getJobTemplate()
-                    .getSpec()
-                    .getTemplate()
-                    .getSpec()
-                    .getImagePullSecrets());
+        v1CronJob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .getImagePullSecrets());
   }
 
   @Test
   public void testV1beta1CronJobFromTemplate_imagePullSecretsListWithEmptyValues() {
     KubernetesService mock = newDataJobKubernetesService();
     V1beta1CronJob v1beta1CronJob =
-            mock.v1beta1CronJobFromTemplate(
-                    "",
-                    "",
-                    true,
-                    null,
-                    null,
-                    null,
-                    Collections.emptyMap(),
-                    Collections.emptyMap(),
-                    List.of("", ""));
+        mock.v1beta1CronJobFromTemplate(
+            "",
+            "",
+            true,
+            null,
+            null,
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            List.of("", ""));
 
     Assertions.assertNull(
-            v1beta1CronJob
-                    .getSpec()
-                    .getJobTemplate()
-                    .getSpec()
-                    .getTemplate()
-                    .getSpec()
-                    .getImagePullSecrets());
+        v1beta1CronJob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .getImagePullSecrets());
   }
 
   @Test
   public void testV1CronJobFromTemplate_imagePullSecretsListWithEmptyValues() {
     KubernetesService mock = newDataJobKubernetesService();
     V1CronJob v1CronJob =
-            mock.v1CronJobFromTemplate(
-                    "",
-                    "",
-                    true,
-                    null,
-                    null,
-                    null,
-                    Collections.emptyMap(),
-                    Collections.emptyMap(),
-                    List.of("", ""));
+        mock.v1CronJobFromTemplate(
+            "",
+            "",
+            true,
+            null,
+            null,
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            List.of("", ""));
 
     Assertions.assertNull(
-            v1CronJob
-                    .getSpec()
-                    .getJobTemplate()
-                    .getSpec()
-                    .getTemplate()
-                    .getSpec()
-                    .getImagePullSecrets());
+        v1CronJob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .getImagePullSecrets());
   }
 
   @Test
   public void
-  testV1beta1CronJobFromTemplate_imagePullSecretsListWithOneNonEmptyValueAndOneEmptyValue() {
+      testV1beta1CronJobFromTemplate_imagePullSecretsListWithOneNonEmptyValueAndOneEmptyValue() {
     KubernetesService mock = newDataJobKubernetesService();
     String secretName = "test_secret_name";
     V1beta1CronJob v1beta1CronJob =
-            mock.v1beta1CronJobFromTemplate(
-                    "",
-                    "",
-                    true,
-                    null,
-                    null,
-                    null,
-                    Collections.emptyMap(),
-                    Collections.emptyMap(),
-                    List.of("", secretName));
+        mock.v1beta1CronJobFromTemplate(
+            "",
+            "",
+            true,
+            null,
+            null,
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            List.of("", secretName));
 
     List<V1LocalObjectReference> actualImagePullSecrets =
-            v1beta1CronJob
-                    .getSpec()
-                    .getJobTemplate()
-                    .getSpec()
-                    .getTemplate()
-                    .getSpec()
-                    .getImagePullSecrets();
+        v1beta1CronJob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .getImagePullSecrets();
 
     Assertions.assertNotNull(actualImagePullSecrets);
     Assertions.assertEquals(1, actualImagePullSecrets.size());
@@ -679,25 +678,25 @@ public class KubernetesServiceTest {
     KubernetesService mock = newDataJobKubernetesService();
     String secretName = "test_secret_name";
     V1CronJob v1CronJob =
-            mock.v1CronJobFromTemplate(
-                    "",
-                    "",
-                    true,
-                    null,
-                    null,
-                    null,
-                    Collections.emptyMap(),
-                    Collections.emptyMap(),
-                    List.of("", secretName));
+        mock.v1CronJobFromTemplate(
+            "",
+            "",
+            true,
+            null,
+            null,
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            List.of("", secretName));
 
     List<V1LocalObjectReference> actualImagePullSecrets =
-            v1CronJob
-                    .getSpec()
-                    .getJobTemplate()
-                    .getSpec()
-                    .getTemplate()
-                    .getSpec()
-                    .getImagePullSecrets();
+        v1CronJob
+            .getSpec()
+            .getJobTemplate()
+            .getSpec()
+            .getTemplate()
+            .getSpec()
+            .getImagePullSecrets();
 
     Assertions.assertNotNull(actualImagePullSecrets);
     Assertions.assertEquals(1, actualImagePullSecrets.size());
@@ -709,6 +708,4 @@ public class KubernetesServiceTest {
     var actual = KubernetesService.convertMemoryToMBs(q);
     Assertions.assertEquals(expectedMb, actual);
   }
-
-
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -231,7 +231,7 @@ public class KubernetesServiceTest {
       //          with corresponding entries from the internal cronjob template.
       // First we load the internal cronjob template.
       Method loadInternalV1beta1CronjobTemplate =
-          DataJobsKubernetesService.class.getDeclaredMethod("loadInternalV1beta1CronjobTemplate");
+          KubernetesService.class.getDeclaredMethod("loadInternalV1beta1CronjobTemplate");
       if (loadInternalV1beta1CronjobTemplate == null) {
         Assertions.fail("The method 'loadInternalV1beta1CronjobTemplate' does not exist.");
       }
@@ -240,7 +240,7 @@ public class KubernetesServiceTest {
           (V1beta1CronJob) loadInternalV1beta1CronjobTemplate.invoke(service);
       // Prepare the 'v1beta1checkForMissingEntries' method.
       Method checkForMissingEntries =
-          DataJobsKubernetesService.class.getDeclaredMethod(
+          KubernetesService.class.getDeclaredMethod(
               "v1beta1checkForMissingEntries", V1beta1CronJob.class);
       if (checkForMissingEntries == null) {
         Assertions.fail("The method 'v1beta1checkForMissingEntries' does not exist.");
@@ -285,7 +285,7 @@ public class KubernetesServiceTest {
 
       Assertions.assertNotNull(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
       // Step 3 - create and check the actual cronjob.
-      Method[] methods = DataJobsKubernetesService.class.getDeclaredMethods();
+      Method[] methods = KubernetesService.class.getDeclaredMethods();
       // This is much easier than describing the whole method signature.
       Optional<Method> method =
           Arrays.stream(methods)
@@ -346,7 +346,7 @@ public class KubernetesServiceTest {
       //          with corresponding entries from the internal cronjob template.
       // First we load the internal cronjob template.
       Method loadInternalV1CronjobTemplate =
-          DataJobsKubernetesService.class.getDeclaredMethod("loadInternalV1CronjobTemplate");
+          KubernetesService.class.getDeclaredMethod("loadInternalV1CronjobTemplate");
       if (loadInternalV1CronjobTemplate == null) {
         Assertions.fail("The method 'loadInternalV1CronjobTemplate' does not exist.");
       }
@@ -354,7 +354,7 @@ public class KubernetesServiceTest {
       V1CronJob internalCronjobTemplate = (V1CronJob) loadInternalV1CronjobTemplate.invoke(service);
       // Prepare the 'v1checkForMissingEntries' method.
       Method checkForMissingEntries =
-          DataJobsKubernetesService.class.getDeclaredMethod(
+          KubernetesService.class.getDeclaredMethod(
               "v1checkForMissingEntries", V1CronJob.class);
       if (checkForMissingEntries == null) {
         Assertions.fail("The method 'v1checkForMissingEntries' does not exist.");


### PR DESCRIPTION
# Why 
We were creating a mock just to tell it to call the real methods. 
This is pointless. 
# What
Use a real instance instead.
It results in less code. 
We are testing the product closer to how it will actually be used and it is easier for debugging. 

# How was this tested
Locally
