### PR TITLE
control-service: data jobs points to correct namespace

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesServiceConfiguration.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesServiceConfiguration.java
@@ -64,12 +64,6 @@ public class KubernetesServiceConfiguration {
     return new BatchV1Api(apiClient);
   }
 
-  @Bean
-  public BatchV1beta1Api controlBatchV1beta1Api(
-      @Qualifier("controlApiClient") ApiClient apiClient) {
-    return new BatchV1beta1Api(apiClient);
-  }
-
   @NotNull
   private ApiClient getClient(String kubeconfig) throws IOException {
     final ApiClient client;

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/ControlKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/ControlKubernetesService.java
@@ -9,7 +9,6 @@ import com.vmware.taurus.service.KubernetesService;
 import com.vmware.taurus.service.deploy.JobCommandProvider;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
-import io.kubernetes.client.openapi.apis.BatchV1beta1Api;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,13 +29,6 @@ public class ControlKubernetesService extends KubernetesService {
       @Qualifier("controlApiClient") ApiClient client,
       @Qualifier("controlBatchV1Api") BatchV1Api batchV1Api,
       JobCommandProvider jobCommandProvider) {
-    super(
-        namespace,
-        k8sSupportsV1CronJob,
-        log,
-        client,
-        batchV1Api,
-        null,
-        jobCommandProvider);
+    super(namespace, k8sSupportsV1CronJob, log, client, batchV1Api, null, jobCommandProvider);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/ControlKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/ControlKubernetesService.java
@@ -29,7 +29,6 @@ public class ControlKubernetesService extends KubernetesService {
       @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob,
       @Qualifier("controlApiClient") ApiClient client,
       @Qualifier("controlBatchV1Api") BatchV1Api batchV1Api,
-      @Qualifier("controlBatchV1beta1Api") BatchV1beta1Api batchV1beta1Api,
       JobCommandProvider jobCommandProvider) {
     super(
         namespace,
@@ -37,7 +36,7 @@ public class ControlKubernetesService extends KubernetesService {
         log,
         client,
         batchV1Api,
-        batchV1beta1Api,
+        null,
         jobCommandProvider);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
@@ -28,8 +28,8 @@ public class DataJobsKubernetesService extends KubernetesService {
       @Value("${datajobs.deployment.k8s.namespace:}") String namespace,
       @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob,
       @Qualifier("deploymentApiClient") ApiClient client,
-      @Qualifier("controlBatchV1Api") BatchV1Api batchV1Api,
-      @Qualifier("controlBatchV1beta1Api") BatchV1beta1Api batchV1beta1Api,
+      @Qualifier("deploymentBatchV1Api") BatchV1Api batchV1Api,
+      @Qualifier("deploymentBatchV1beta1Api") BatchV1beta1Api batchV1beta1Api,
       JobCommandProvider jobCommandProvider) {
     super(
         namespace,


### PR DESCRIPTION
# Why
BUG FIX: in a recent PR I made a change which points the data jobs deployer to the contrl namespace. 
I need to merge the fix asap. 


I will add a test shortly.  But I want to merge without a test to fix this ASAP. 



Signed-off-by: murphp15 <murphp15@tcd.ie>