### PR TITLE
vdk-core: Add python_version configuration to config-help

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/vdk_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/vdk_config.py
@@ -25,6 +25,7 @@ ATTEMPT_ID = "ATTEMPT_ID"
 EXECUTION_ID = "EXECUTION_ID"
 OP_ID = "OP_ID"
 TEMPORARY_WRITE_DIRECTORY = "TEMPORARY_WRITE_DIRECTORY"
+PYTHON_VERSION = "PYTHON_VERSION"
 
 log = logging.getLogger(__name__)
 
@@ -202,6 +203,23 @@ It can be overridden by environment variables configuration (set by operators in
             default_value="always_enabled",
             description=description,
         )
+        config_builder.add(
+            key=PYTHON_VERSION,
+            default_value=None,
+            show_default_value=False,
+            description="The python version, which is to be used for the data job deployment."
+            " This configuration is to only be set in the [job] section of the config"
+            ".ini file, and will be ignored if set in any other way (e.g., as an environment"
+            " variable). As the configuration is optional, if not set, the default python version"
+            " set by the Control Service would be used. To see what python versions"
+            " are supported by a Versatile Data Kit deployment, use the `vdk info` command.\n"
+            " EXAMPLE USAGE:\n"
+            " --------------\n"
+            "[job]\n"
+            "schedule_cron = */50 * * * *\n"
+            "python_version = 3.9",
+        )
+
         if (
             self.__job_path
             and self.__job_path.exists()
@@ -230,6 +248,10 @@ It can be overridden by environment variables configuration (set by operators in
             config_builder.set_value(
                 JobConfigKeys.ENABLE_ATTEMPT_NOTIFICATIONS.value,
                 job_config.get_enable_attempt_notifications(),
+            )
+            config_builder.set_value(
+                JobConfigKeys.PYTHON_VERSION.value,
+                job_config.get_python_version(),
             )
 
             for key, value in job_config.get_vdk_options().items():


### PR DESCRIPTION
As part of the initiative to support multiple python versions for data job deployments, a new configuration property, `python_version` was introduced. This configuration, however, was not initially added to the output of the `vdk config-help` command.

This change adds the `python_version` configuration to the JobConfigIniPlugin, as it is related to the config.ini file setup.

Testing Done:
Tested locally by running `vdk config-help` and verifying that the configuration is present in the output.