### PR TITLE
control-service: infer correct namespace if not set

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesServiceConfiguration.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesServiceConfiguration.java
@@ -20,9 +20,16 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import static java.util.function.Predicate.not;
 
 @Configuration
 @Slf4j
@@ -62,6 +69,47 @@ public class KubernetesServiceConfiguration {
   @Bean
   public BatchV1Api controlBatchV1Api(@Qualifier("controlApiClient") ApiClient apiClient) {
     return new BatchV1Api(apiClient);
+  }
+
+  @Bean
+  public String controlNamespace(@Value("${datajobs.control.k8s.kubeconfig:}") String kubeconfig,
+          @Value("${datajobs.control.k8s.namespace:}") String namespace) throws FileNotFoundException {
+    return getNamespace(kubeconfig, namespace);
+  }
+
+  @Bean
+  public String dataJobsNamespace(@Value("${datajobs.deployment.k8s.kubeconfig:}") String kubeconfig,
+          @Value("${datajobs.deployment.k8s.namespace:}") String namespace) throws FileNotFoundException {
+    return getNamespace(kubeconfig, namespace);
+  }
+
+  @NotNull
+  private static String getNamespace(String kubeconfig, String namespace) throws FileNotFoundException {
+    if (!StringUtils.isBlank(namespace))  {
+      return namespace;
+    } else if (!StringUtils.isBlank(kubeconfig) && new File(kubeconfig).isFile()) {
+      KubeConfig kubeConfig = KubeConfig.loadKubeConfig(new FileReader(kubeconfig));
+      return kubeConfig.getNamespace();
+    } else {
+      return getCurrentNamespace();
+    }
+  }
+
+  private static String getCurrentNamespace() {
+    return getNamespaceFileContents().stream()
+            .filter(not(String::isBlank))
+            .findFirst()
+            .map(String::strip)
+            .orElse(null);
+  }
+
+  private static List<String> getNamespaceFileContents() {
+    try {
+      String namespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
+      return Files.readAllLines(Paths.get(namespaceFile));
+    } catch (IOException e) {
+      return Collections.emptyList();
+    }
   }
 
   @NotNull

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesServiceConfiguration.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesServiceConfiguration.java
@@ -72,20 +72,25 @@ public class KubernetesServiceConfiguration {
   }
 
   @Bean
-  public String controlNamespace(@Value("${datajobs.control.k8s.kubeconfig:}") String kubeconfig,
-          @Value("${datajobs.control.k8s.namespace:}") String namespace) throws FileNotFoundException {
+  public String controlNamespace(
+      @Value("${datajobs.control.k8s.kubeconfig:}") String kubeconfig,
+      @Value("${datajobs.control.k8s.namespace:}") String namespace)
+      throws FileNotFoundException {
     return getNamespace(kubeconfig, namespace);
   }
 
   @Bean
-  public String dataJobsNamespace(@Value("${datajobs.deployment.k8s.kubeconfig:}") String kubeconfig,
-          @Value("${datajobs.deployment.k8s.namespace:}") String namespace) throws FileNotFoundException {
+  public String dataJobsNamespace(
+      @Value("${datajobs.deployment.k8s.kubeconfig:}") String kubeconfig,
+      @Value("${datajobs.deployment.k8s.namespace:}") String namespace)
+      throws FileNotFoundException {
     return getNamespace(kubeconfig, namespace);
   }
 
   @NotNull
-  private static String getNamespace(String kubeconfig, String namespace) throws FileNotFoundException {
-    if (!StringUtils.isBlank(namespace))  {
+  private static String getNamespace(String kubeconfig, String namespace)
+      throws FileNotFoundException {
+    if (!StringUtils.isBlank(namespace)) {
       return namespace;
     } else if (!StringUtils.isBlank(kubeconfig) && new File(kubeconfig).isFile()) {
       KubeConfig kubeConfig = KubeConfig.loadKubeConfig(new FileReader(kubeconfig));
@@ -97,10 +102,10 @@ public class KubernetesServiceConfiguration {
 
   private static String getCurrentNamespace() {
     return getNamespaceFileContents().stream()
-            .filter(not(String::isBlank))
-            .findFirst()
-            .map(String::strip)
-            .orElse(null);
+        .filter(not(String::isBlank))
+        .findFirst()
+        .map(String::strip)
+        .orElse(null);
   }
 
   private static List<String> getNamespaceFileContents() {

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/ControlKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/ControlKubernetesService.java
@@ -24,7 +24,7 @@ public class ControlKubernetesService extends KubernetesService {
 
   // those should be null/empty when Control service is deployed in k8s hence default is empty
   public ControlKubernetesService(
-      @Value("${datajobs.control.k8s.namespace:}") String namespace,
+      @Qualifier("controlNamespace") String namespace,
       @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob,
       @Qualifier("controlApiClient") ApiClient client,
       @Qualifier("controlBatchV1Api") BatchV1Api batchV1Api,

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Service;
 public class DataJobsKubernetesService extends KubernetesService {
 
   public DataJobsKubernetesService(
-      @Value("${datajobs.deployment.k8s.namespace:}") String namespace,
+          @Qualifier("dataJobsNamespace") String namespace,
       @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob,
       @Qualifier("deploymentApiClient") ApiClient client,
       @Qualifier("deploymentBatchV1Api") BatchV1Api batchV1Api,

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Service;
 public class DataJobsKubernetesService extends KubernetesService {
 
   public DataJobsKubernetesService(
-          @Qualifier("dataJobsNamespace") String namespace,
+      @Qualifier("dataJobsNamespace") String namespace,
       @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob,
       @Qualifier("deploymentApiClient") ApiClient client,
       @Qualifier("deploymentBatchV1Api") BatchV1Api batchV1Api,


### PR DESCRIPTION
to infer namespace if not set which is breaking the CICD since it tests
this logic.

Testing Done: locally ran the control service and saw correct values,
temporarily enabled deploy testing pipeline scripts on the branch and
saw it deployed the testing control service and the post deployment
test(vdk-heartbeat) succeeds (see https://gitlab.com/vmware-analytics/versatile-data-kit/-/pipelines/904026915)

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>
