### PR TITLE
control-service: remove spammy logs 

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -1543,7 +1543,9 @@ public abstract class KubernetesService {
       runningJobExecutionsConsumer.accept(runningExecutionIds);
       resourceVersion = jobList.getMetadata().getResourceVersion();
     } catch (ApiException ex) {
-      log.info("Failed to list jobs for watching. Error was: {}", new KubernetesException("", ex).toString());
+      log.info(
+          "Failed to list jobs for watching. Error was: {}",
+          new KubernetesException("", ex).toString());
       return;
     }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -1514,7 +1514,6 @@ public abstract class KubernetesService {
       throws ApiException, IOException {
 
     Objects.requireNonNull(watcher, "The watcher cannot be null");
-    log.info("Start watching jobs with labels: {}", labelsToWatch);
 
     // Job change detection implementation:
     // https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes
@@ -1544,7 +1543,7 @@ public abstract class KubernetesService {
       runningJobExecutionsConsumer.accept(runningExecutionIds);
       resourceVersion = jobList.getMetadata().getResourceVersion();
     } catch (ApiException ex) {
-      log.info("Failed to list jobs for watching. Error was: {}", ex.getMessage());
+      log.info("Failed to list jobs for watching. Error was: {}", new KubernetesException("", ex).toString());
       return;
     }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMonitorCron.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMonitorCron.java
@@ -101,7 +101,7 @@ public class DataJobMonitorCron {
       lastWatchTime = Instant.now().minusMillis(ONE_MINUTE_MILLIS).toEpochMilli();
     } catch (IOException ioe) {
       log.info("Failed to watch jobs. Error was: {}", ioe.toString());
-    } catch(ApiException ae) {
+    } catch (ApiException ae) {
       log.info("Failed to watch jobs. Error was: {}", new KubernetesException("", ae).toString());
     }
   }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMonitorCron.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DataJobMonitorCron.java
@@ -5,6 +5,7 @@
 
 package com.vmware.taurus.service.monitoring;
 
+import com.vmware.taurus.exception.KubernetesException;
 import com.vmware.taurus.service.execution.JobExecutionService;
 import com.vmware.taurus.service.kubernetes.DataJobsKubernetesService;
 import com.vmware.taurus.service.model.JobLabel;
@@ -49,6 +50,7 @@ public class DataJobMonitorCron {
     this.jobExecutionService = jobExecutionService;
     this.dataJobMetrics = dataJobMetrics;
     this.dataJobMonitor = dataJobMonitor;
+    log.info("Data Job Monitor initialized to watch for jobs with labels: {}", labelsToWatch);
   }
 
   /**
@@ -97,8 +99,10 @@ public class DataJobMonitorCron {
       // Move the lastWatchTime one minute into the past to account for events that
       // could have happened after the watch has completed until now
       lastWatchTime = Instant.now().minusMillis(ONE_MINUTE_MILLIS).toEpochMilli();
-    } catch (IOException | ApiException e) {
-      log.info("Failed to watch jobs. Error was: {}", e.getMessage());
+    } catch (IOException ioe) {
+      log.info("Failed to watch jobs. Error was: {}", ioe.toString());
+    } catch(ApiException ae) {
+      log.info("Failed to watch jobs. Error was: {}", new KubernetesException("", ae).toString());
     }
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -34,6 +34,8 @@ spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.show_sql=false
 logging.level.org.hibernate.SQL=INFO
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=INFO
+logging.level.com.vmware.taurus.service.locks.CustomLockProvider=INFO
+
 
 spring.jpa.open-in-view=false
 


### PR DESCRIPTION
The Control Service has some pretty spammy logs that are making it
harder to pick the important things.

For example

```
?[30m2023-06-19 06:38:27,637?[0;39m ?[39mDEBUG?[0;39m [OpId:]
?[34mthread-3  ?[0;39m ?[33mc.v.t.s.locks.CustomLockProvider?[0;39m
Releasing lock watchJobs_schedulerLock
?[30m2023-06-19 06:38:27,637?[0;39m ?[39mDEBUG?[0;39m [OpId:]
?[34mthread-3  ?[0;39m ?[33mc.v.t.s.locks.CustomLockProvider?[0;39m Lock
watchJobs_schedulerLock is released
```

Those are not really needed in most cases . They still might be useful
if troubleshooting some issue with the locks so I am disabling them in
applicaiton.properties configuraiton (which can be overriden if needed)

```
?[30m2023-06-19 06:38:27,634?[0;39m ?[34mINFO ?[0;39m [OpId:]
?[34mthread-3  ?[0;39m ?[33m.t.s.k.DataJobsKubernetesService?[0;39m
Start watching jobs with labels: {com.vmware.taurus/type=DataJob}
```

Move the information from the log to when DataJobMonitor is initialized.
Not needed every time.

```
?[30m2023-06-19 06:38:27,637?[0;39m ?[34mINFO ?[0;39m [OpId:]
?[34mthread-3  ?[0;39m ?[33m.t.s.k.DataJobsKubernetesService?[0;39m
Failed to list jobs for watching. Error was:
```

This is spammy but for some reason the error is not printed. So I am trying
to use KubernetesException which provides more details.
Also `e.toString()` is prefered over `e.getMessage()` since the first
one prints at least the exception class (even if there's no message)

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>
