### PR TITLE
control-service: move cron jobs methods to the data jobs class

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -719,45 +719,6 @@ public abstract class KubernetesService {
         .collect(Collectors.toSet());
   }
 
-  public void createCronJob(
-      String name,
-      String image,
-      String schedule,
-      boolean enable,
-      V1Container jobContainer,
-      V1Container initContainer,
-      List<V1Volume> volumes,
-      Map<String, String> jobAnnotations,
-      Map<String, String> jobLabels,
-      List<String> imagePullSecrets)
-      throws ApiException {
-    if (getK8sSupportsV1CronJob()) {
-      createV1CronJob(
-          name,
-          image,
-          schedule,
-          enable,
-          jobContainer,
-          initContainer,
-          volumes,
-          jobAnnotations,
-          jobLabels,
-          imagePullSecrets);
-    } else {
-      createV1beta1CronJob(
-          name,
-          image,
-          schedule,
-          enable,
-          jobContainer,
-          initContainer,
-          volumes,
-          jobAnnotations,
-          jobLabels,
-          imagePullSecrets);
-    }
-  }
-
   // TODO:  container/volume args are breaking a bit abstraction of KubernetesService by leaking
   // impl. details
   public void createV1beta1CronJob(
@@ -830,45 +791,6 @@ public abstract class KubernetesService {
         nsJob.getApiVersion(),
         nsJob.getMetadata().getUid(),
         nsJob.getMetadata().getSelfLink());
-  }
-
-  public void updateCronJob(
-      String name,
-      String image,
-      String schedule,
-      boolean enable,
-      V1Container jobContainer,
-      V1Container initContainer,
-      List<V1Volume> volumes,
-      Map<String, String> jobAnnotations,
-      Map<String, String> jobLabels,
-      List<String> imagePullSecrets)
-      throws ApiException {
-    if (getK8sSupportsV1CronJob()) {
-      updateV1CronJob(
-          name,
-          image,
-          schedule,
-          enable,
-          jobContainer,
-          initContainer,
-          volumes,
-          jobAnnotations,
-          jobLabels,
-          imagePullSecrets);
-    } else {
-      updateV1beta1CronJob(
-          name,
-          image,
-          schedule,
-          enable,
-          jobContainer,
-          initContainer,
-          volumes,
-          jobAnnotations,
-          jobLabels,
-          imagePullSecrets);
-    }
   }
 
   public void updateV1beta1CronJob(

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
@@ -8,12 +8,18 @@ package com.vmware.taurus.service.kubernetes;
 import com.vmware.taurus.service.KubernetesService;
 import com.vmware.taurus.service.deploy.JobCommandProvider;
 import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
 import io.kubernetes.client.openapi.apis.BatchV1beta1Api;
+import io.kubernetes.client.openapi.models.V1Container;
+import io.kubernetes.client.openapi.models.V1Volume;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * Kubernetes service used for serving data jobs deployments. All deployed data jobs are executed in
@@ -40,4 +46,86 @@ public class DataJobsKubernetesService extends KubernetesService {
         batchV1beta1Api,
         jobCommandProvider);
   }
+
+
+  public void createCronJob(
+          String name,
+          String image,
+          String schedule,
+          boolean enable,
+          V1Container jobContainer,
+          V1Container initContainer,
+          List<V1Volume> volumes,
+          Map<String, String> jobAnnotations,
+          Map<String, String> jobLabels,
+          List<String> imagePullSecrets)
+          throws ApiException {
+    if (getK8sSupportsV1CronJob()) {
+      createV1CronJob(
+              name,
+              image,
+              schedule,
+              enable,
+              jobContainer,
+              initContainer,
+              volumes,
+              jobAnnotations,
+              jobLabels,
+              imagePullSecrets);
+    } else {
+      createV1beta1CronJob(
+              name,
+              image,
+              schedule,
+              enable,
+              jobContainer,
+              initContainer,
+              volumes,
+              jobAnnotations,
+              jobLabels,
+              imagePullSecrets);
+    }
+  }
+
+
+  public void updateCronJob(
+          String name,
+          String image,
+          String schedule,
+          boolean enable,
+          V1Container jobContainer,
+          V1Container initContainer,
+          List<V1Volume> volumes,
+          Map<String, String> jobAnnotations,
+          Map<String, String> jobLabels,
+          List<String> imagePullSecrets)
+          throws ApiException {
+    if (getK8sSupportsV1CronJob()) {
+      updateV1CronJob(
+              name,
+              image,
+              schedule,
+              enable,
+              jobContainer,
+              initContainer,
+              volumes,
+              jobAnnotations,
+              jobLabels,
+              imagePullSecrets);
+    } else {
+      updateV1beta1CronJob(
+              name,
+              image,
+              schedule,
+              enable,
+              jobContainer,
+              initContainer,
+              volumes,
+              jobAnnotations,
+              jobLabels,
+              imagePullSecrets);
+    }
+  }
+
+
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
@@ -47,85 +47,81 @@ public class DataJobsKubernetesService extends KubernetesService {
         jobCommandProvider);
   }
 
-
   public void createCronJob(
-          String name,
-          String image,
-          String schedule,
-          boolean enable,
-          V1Container jobContainer,
-          V1Container initContainer,
-          List<V1Volume> volumes,
-          Map<String, String> jobAnnotations,
-          Map<String, String> jobLabels,
-          List<String> imagePullSecrets)
-          throws ApiException {
+      String name,
+      String image,
+      String schedule,
+      boolean enable,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobAnnotations,
+      Map<String, String> jobLabels,
+      List<String> imagePullSecrets)
+      throws ApiException {
     if (getK8sSupportsV1CronJob()) {
       createV1CronJob(
-              name,
-              image,
-              schedule,
-              enable,
-              jobContainer,
-              initContainer,
-              volumes,
-              jobAnnotations,
-              jobLabels,
-              imagePullSecrets);
+          name,
+          image,
+          schedule,
+          enable,
+          jobContainer,
+          initContainer,
+          volumes,
+          jobAnnotations,
+          jobLabels,
+          imagePullSecrets);
     } else {
       createV1beta1CronJob(
-              name,
-              image,
-              schedule,
-              enable,
-              jobContainer,
-              initContainer,
-              volumes,
-              jobAnnotations,
-              jobLabels,
-              imagePullSecrets);
+          name,
+          image,
+          schedule,
+          enable,
+          jobContainer,
+          initContainer,
+          volumes,
+          jobAnnotations,
+          jobLabels,
+          imagePullSecrets);
     }
   }
-
 
   public void updateCronJob(
-          String name,
-          String image,
-          String schedule,
-          boolean enable,
-          V1Container jobContainer,
-          V1Container initContainer,
-          List<V1Volume> volumes,
-          Map<String, String> jobAnnotations,
-          Map<String, String> jobLabels,
-          List<String> imagePullSecrets)
-          throws ApiException {
+      String name,
+      String image,
+      String schedule,
+      boolean enable,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobAnnotations,
+      Map<String, String> jobLabels,
+      List<String> imagePullSecrets)
+      throws ApiException {
     if (getK8sSupportsV1CronJob()) {
       updateV1CronJob(
-              name,
-              image,
-              schedule,
-              enable,
-              jobContainer,
-              initContainer,
-              volumes,
-              jobAnnotations,
-              jobLabels,
-              imagePullSecrets);
+          name,
+          image,
+          schedule,
+          enable,
+          jobContainer,
+          initContainer,
+          volumes,
+          jobAnnotations,
+          jobLabels,
+          imagePullSecrets);
     } else {
       updateV1beta1CronJob(
-              name,
-              image,
-              schedule,
-              enable,
-              jobContainer,
-              initContainer,
-              volumes,
-              jobAnnotations,
-              jobLabels,
-              imagePullSecrets);
+          name,
+          image,
+          schedule,
+          enable,
+          jobContainer,
+          initContainer,
+          volumes,
+          jobAnnotations,
+          jobLabels,
+          imagePullSecrets);
     }
   }
-
-
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/MockKubernetes.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/MockKubernetes.java
@@ -141,29 +141,29 @@ public class MockKubernetes {
     mockKubernetesService(mock);
   }
 
-
-  private void mockKubernetesService(KubernetesService mock) throws ApiException, IOException, InterruptedException {
+  private void mockKubernetesService(KubernetesService mock)
+      throws ApiException, IOException, InterruptedException {
 
     final Map<String, InvocationOnMock> jobs = new ConcurrentHashMap<>();
     doAnswer(inv -> jobs.put(inv.getArgument(0), inv))
-            .when(mock)
-            .createJob(
-                    anyString(),
-                    anyString(),
-                    anyBoolean(),
-                    anyBoolean(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    anyString(),
-                    any(),
-                    any(),
-                    anyLong(),
-                    anyLong(),
-                    anyLong(),
-                    anyString(),
-                    anyString());
+        .when(mock)
+        .createJob(
+            anyString(),
+            anyString(),
+            anyBoolean(),
+            anyBoolean(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyString(),
+            any(),
+            any(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyString(),
+            anyString());
     doAnswer(inv -> jobs.keySet()).when(mock).listCronJobs();
     doAnswer(inv -> jobs.remove(inv.getArgument(0))).when(mock).deleteJob(anyString());
 
@@ -173,16 +173,15 @@ public class MockKubernetes {
               if (jobs.containsKey(jobName)) {
                 if (jobName.startsWith("failure-")) {
                   return new KubernetesService.JobStatusCondition(
-                          false, "Status", "Job name starts with 'failure-'", "", 0);
+                      false, "Status", "Job name starts with 'failure-'", "", 0);
                 } else {
                   return new KubernetesService.JobStatusCondition(true, "Status", "", "", 0);
                 }
               }
               return new KubernetesService.JobStatusCondition(false, null, "No such job", "", 0);
             })
-            .when(mock)
-            .watchJob(anyString(), anyInt(), any());
-
+        .when(mock)
+        .watchJob(anyString(), anyInt(), any());
 
     doAnswer(inv -> "logs").when(mock).getJobLogs(anyString(), anyInt());
   }


### PR DESCRIPTION
# Why
At the moment the KubernetesService class as much to much responsibilities. 
It is extended by DataJobsKubernetesService and controlKubernetesService class.
However it includes the logic that is unique to those individual classes also. 
For example only the datajobsKS creates or deploys cron jobs.
So in this PR I move those external facing functions to the dataJobsclass and fix the tests. 


I have not move alot of the more private functions to the datajobs class yet because alot of other tests need to be changed to achieve this as they are being tested using reflection and I want to keep the PRs small. 

 
# How has this been tested?
Locally. 


Signed-off-by: murphp15 <murphp15@tcd.ie>