### PR TITLE
vdk-jupyter: pin jupyterlab to 3.6.3 in pyproject.toml

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/pyproject.toml
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.4.0", "jupyterlab>=3.4.7,<4.0.0", "hatch-nodejs-version"]
+requires = ["hatchling>=1.4.0", "jupyterlab==3.6.3", "hatch-nodejs-version"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
What:
pinned jupyterlab version to 3.6.3 in pyproject.toml

Why: not being pinned was cause of some installation issues since the npm package dependencies are pinned

Signed-off-by: Duygu Hasan [hduygu@vmware.com](mailto:hduygu@vmware.com)