### PR TITLE
control-service: add helm template for alertmanager

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/alertmanager.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/alertmanager.yaml
@@ -3,32 +3,34 @@
   SPDX-License-Identifier: Apache-2.0
  */}}
 
-{{- if .Values.alertmanager.enabled }}
-apiVersion: v1
-kind: List
-items:
-  - apiVersion: monitoring.coreos.com/v1alpha1
-    kind: AlertmanagerConfig
-      labels:
-        role: {{ .Values.alertmanager.items.labels.role }}
-      name: {{ .Values.alertmanager.items.name }}
-      namespace: {{ .Values.alertmanager.items.namespace }}
-    spec:
-      receivers:
-        route: |
-          {{ toYaml .Values.alertmanager.items.spec.receivers.route | indent 4 }}
-      emailConfigs: |
-        {{ toYaml .Values.alertmanager.items.spec.emailConfigs | indent 4 }}
-        authPassword: {{- with secret .Values.alertmanager.authentication.secretName -}}
-              {{ .Data.authPassword | b64dec }}
-            {{- end }}
-        authSecret: {{- with secret .Values.alertmanager.authentication.secretName -}}
-              {{ .Data.authSecret | b64dec }}
-            {{- end }}
-        authSecretKey: {{- with secret .Values.alertmanager.authentication.secretName -}}
-              {{ .Data.authSecretKey | b64dec }}
-            {{- end }}
-        authIdentity: {{- with secret .Values.alertmanager.authentication.secretName -}}
-              {{ .Data.authIdentity | b64dec }}
-            {{- end }}
-{{- end }}
+{{ - /*
+      Copyright 2021-2023 VMware, Inc.
+    SPDX-License-Identifier: Apache-2.0
+      */ }}
+
+{{ - if .Values.alertmanager.enabled }}
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+  labels: {{ - include "pipelines-control-service.labels" . | nindent 4 }}
+    {{ - range $key, $value := .Values.alertmanager.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{ - end }}
+  name: {{ .Values.alertmanager.name }}
+  namespace: {{ .Values.alertmanager.namespace }}
+  spec:
+    receivers:
+      route: {{ toYaml .Values.alertmanager.spec.receivers.route | nindent 8 }}
+    emailConfigs: {{ toYaml .Values.alertmanager.spec.emailConfigs | nindent 6 }}
+      authPassword: {{ - with secret .Values.alertmanager.authentication.secretName - }}
+        {{ .Data.authPassword | b64dec }}
+        {{ - end }}
+      authSecret: {{ - with secret .Values.alertmanager.authentication.secretName - }}
+        {{ .Data.authSecret | b64dec }}
+        {{ - end }}
+      authSecretKey: {{ - with secret .Values.alertmanager.authentication.secretName - }}
+        {{ .Data.authSecretKey | b64dec }}
+        {{ - end }}
+      authIdentity: {{ - with secret .Values.alertmanager.authentication.secretName - }}
+        {{ .Data.authIdentity | b64dec }}
+        {{ - end }}
+  {{ - end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/alertmanager.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/alertmanager.yaml
@@ -1,0 +1,53 @@
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
+
+{{- if .Values.alertmanager.enabled }}
+apiVersion: v1
+kind: List
+metadata:
+  resourceVersion: ""
+items:
+  - apiVersion: monitoring.coreos.com/v1alpha1
+    kind: AlertmanagerConfig
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/last-applied-: ""
+      generation: 6
+      labels:
+        role: infra
+      name: dp-notifications
+      namespace: {{ .Values.alertmanager.items.namespace }}
+
+    spec:
+      receivers:
+        - emailConfigs:
+            - from: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.from }}
+              headers:
+                - key: subject
+                  value: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.headers.value }}
+              hello: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.hello }}
+              html: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.html }}
+              requireTLS: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.requireTLS }}
+              sendResolved: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.sendResolved }}
+              smarthost: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.smarthost }}
+              to: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.to }}
+              authUsername: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.authUsername }}
+              authPassword: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.authPassword }}
+              authSecret: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.authSecret }}
+              authSecretKey: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.authSecretKey }}
+              authIdentity: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.authIdentity }}
+          name: dp-receiver
+      route:
+        groupBy:
+          - alertname
+          - execution_id
+        groupInterval: 1m
+        groupWait: 0s
+        matchers:
+          - name: source
+            value: data-pipelines
+        receiver: dp-receiver
+        repeatInterval: 30d
+{{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/alertmanager.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/alertmanager.yaml
@@ -3,34 +3,29 @@
   SPDX-License-Identifier: Apache-2.0
  */}}
 
-{{ - /*
-      Copyright 2021-2023 VMware, Inc.
-    SPDX-License-Identifier: Apache-2.0
-      */ }}
-
-{{ - if .Values.alertmanager.enabled }}
+{{- if .Values.alertmanager.enabled }}
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: AlertmanagerConfig
-  labels: {{ - include "pipelines-control-service.labels" . | nindent 4 }}
-    {{ - range $key, $value := .Values.alertmanager.labels }}
+  labels: {{- include "pipelines-control-service.labels" . | nindent 4 }}
+    {{- range $key, $value := .Values.alertmanager.labels }}
     {{ $key }}: {{ $value | quote }}
-    {{ - end }}
+    {{- end }}
   name: {{ .Values.alertmanager.name }}
   namespace: {{ .Values.alertmanager.namespace }}
   spec:
     receivers:
       route: {{ toYaml .Values.alertmanager.spec.receivers.route | nindent 8 }}
     emailConfigs: {{ toYaml .Values.alertmanager.spec.emailConfigs | nindent 6 }}
-      authPassword: {{ - with secret .Values.alertmanager.authentication.secretName - }}
+      authPassword: {{` {{- with secret .Values.alertmanager.authentication.secretName -}}
         {{ .Data.authPassword | b64dec }}
-        {{ - end }}
-      authSecret: {{ - with secret .Values.alertmanager.authentication.secretName - }}
+        {{- end }} `}}
+      authSecret: {{` {{- with secret .Values.alertmanager.authentication.secretName -}}
         {{ .Data.authSecret | b64dec }}
-        {{ - end }}
-      authSecretKey: {{ - with secret .Values.alertmanager.authentication.secretName - }}
+        {{- end }} `}}
+      authSecretKey: {{` {{- with secret .Values.alertmanager.authentication.secretName -}}
         {{ .Data.authSecretKey | b64dec }}
-        {{ - end }}
-      authIdentity: {{ - with secret .Values.alertmanager.authentication.secretName - }}
+        {{- end }} `}}
+      authIdentity: {{` {{ - with secret .Values.alertmanager.authentication.secretName -}}
         {{ .Data.authIdentity | b64dec }}
-        {{ - end }}
-  {{ - end }}
+        {{- end }} `}}
+  {{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/alertmanager.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/alertmanager.yaml
@@ -6,48 +6,17 @@
 {{- if .Values.alertmanager.enabled }}
 apiVersion: v1
 kind: List
-metadata:
-  resourceVersion: ""
 items:
   - apiVersion: monitoring.coreos.com/v1alpha1
     kind: AlertmanagerConfig
-    metadata:
-      annotations:
-        kubectl.kubernetes.io/last-applied-: ""
-      generation: 6
       labels:
-        role: infra
-      name: dp-notifications
+        role: {{ .Values.alertmanager.items.labels.role }}
+      name: {{ .Values.alertmanager.items.name }}
       namespace: {{ .Values.alertmanager.items.namespace }}
-
     spec:
       receivers:
-        - emailConfigs:
-            - from: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.from }}
-              headers:
-                - key: subject
-                  value: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.headers.value }}
-              hello: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.hello }}
-              html: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.html }}
-              requireTLS: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.requireTLS }}
-              sendResolved: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.sendResolved }}
-              smarthost: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.smarthost }}
-              to: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.to }}
-              authUsername: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.authUsername }}
-              authPassword: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.authPassword }}
-              authSecret: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.authSecret }}
-              authSecretKey: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.authSecretKey }}
-              authIdentity: {{ .Values.alertmanager.items.spec.receivers.emailConfigs.authIdentity }}
-          name: dp-receiver
-      route:
-        groupBy:
-          - alertname
-          - execution_id
-        groupInterval: 1m
-        groupWait: 0s
-        matchers:
-          - name: source
-            value: data-pipelines
-        receiver: dp-receiver
-        repeatInterval: 30d
+        route:
+          {{ toYaml .Values.items.spec.receivers.route | indent 4 }}
+      emailConfigs:
+        {{ toYaml .Values.items.spec.emailConfigs | indent 4 }}
 {{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/alertmanager.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/alertmanager.yaml
@@ -15,8 +15,20 @@ items:
       namespace: {{ .Values.alertmanager.items.namespace }}
     spec:
       receivers:
-        route:
-          {{ toYaml .Values.items.spec.receivers.route | indent 4 }}
-      emailConfigs:
-        {{ toYaml .Values.items.spec.emailConfigs | indent 4 }}
+        route: |
+          {{ toYaml .Values.alertmanager.items.spec.receivers.route | indent 4 }}
+      emailConfigs: |
+        {{ toYaml .Values.alertmanager.items.spec.emailConfigs | indent 4 }}
+        authPassword: {{- with secret .Values.alertmanager.authentication.secretName -}}
+              {{ .Data.authPassword | b64dec }}
+            {{- end }}
+        authSecret: {{- with secret .Values.alertmanager.authentication.secretName -}}
+              {{ .Data.authSecret | b64dec }}
+            {{- end }}
+        authSecretKey: {{- with secret .Values.alertmanager.authentication.secretName -}}
+              {{ .Data.authSecretKey | b64dec }}
+            {{- end }}
+        authIdentity: {{- with secret .Values.alertmanager.authentication.secretName -}}
+              {{ .Data.authIdentity | b64dec }}
+            {{- end }}
 {{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/alertmanager.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/alertmanager.yaml
@@ -6,26 +6,20 @@
 {{- if .Values.alertmanager.enabled }}
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: AlertmanagerConfig
+metadata:
   labels: {{- include "pipelines-control-service.labels" . | nindent 4 }}
-    {{- range $key, $value := .Values.alertmanager.labels }}
+    {{- range $key, $value := .Values.alertmanager.metadata.labels }}
     {{ $key }}: {{ $value | quote }}
-    {{- end }}
-  name: {{ .Values.alertmanager.name }}
-  namespace: {{ .Values.alertmanager.namespace }}
-  spec:
-    receivers:
-      route: {{ toYaml .Values.alertmanager.spec.receivers.route | nindent 8 }}
-    emailConfigs: {{ toYaml .Values.alertmanager.spec.emailConfigs | nindent 6 }}
-      authPassword: {{` {{- with secret .Values.alertmanager.authentication.secretName -}}
-        {{ .Data.authPassword | b64dec }}
-        {{- end }} `}}
-      authSecret: {{` {{- with secret .Values.alertmanager.authentication.secretName -}}
-        {{ .Data.authSecret | b64dec }}
-        {{- end }} `}}
-      authSecretKey: {{` {{- with secret .Values.alertmanager.authentication.secretName -}}
-        {{ .Data.authSecretKey | b64dec }}
-        {{- end }} `}}
-      authIdentity: {{` {{ - with secret .Values.alertmanager.authentication.secretName -}}
-        {{ .Data.authIdentity | b64dec }}
-        {{- end }} `}}
   {{- end }}
+  name: {{ .Values.alertmanager.metadata.name }}
+  namespace: {{ .Values.alertmanager.metadata.namespace }}
+spec:
+  receivers:
+    - emailConfigs: {{ toYaml (index .Values.alertmanager.spec.receivers 0).emailConfigs | nindent 8 }}
+          authPassword:
+            key: authPassword
+            name: {{ .Values.alertmanager.authentication.secretName }}
+            optional: true
+      name: {{ (index .Values.alertmanager.spec.receivers 0).name }}
+  route: {{ toYaml .Values.alertmanager.spec.route | nindent 6 }}
+{{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_alertmanager.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_alertmanager.yaml
@@ -9,13 +9,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.alertmanager.authentication.secretName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.alertmanager.metadata.namespace }}
   labels: {{- include "pipelines-control-service.labels" . | nindent 4 }}
 type: Opaque
 data:
   authPassword: {{ default "" .Values.alertmanager.authentication.authPassword | b64enc | quote }}
-  authSecret: {{ default "" .Values.alertmanager.authentication.authSecret | b64enc | quote }}
-  authSecretKey: {{ default "" .Values.alertmanager.authentication.authSecretKey | b64enc | quote }}
-  authIdentity: {{ default "" .Values.alertmanager.authentication.authIdentity | b64enc | quote }}
-
 {{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_alertmanager.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_alertmanager.yaml
@@ -1,0 +1,18 @@
+{{- /*
+    Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+    */}}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-authentication-secret
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "pipelines-control-service.labels" . | nindent 4 }}
+type: Opaque
+data:
+  authUsername: {{ default "" .Values.credentials.kerberosKadminPassword | b64enc | quote }}
+  authPassword: {{ default "" .Values.deploymentK8sKubeconfig | b64enc | quote }}
+  authSecret: {{ default "" .Values.credentials.kerberosKrb5Conf | b64enc | quote }}
+  authSecretKey: {{ default "" .Values.vdkOptions | b64enc | quote }}
+  authIdentity: {{ default "" .Values.}}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_alertmanager.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/secret_alertmanager.yaml
@@ -3,16 +3,19 @@
   SPDX-License-Identifier: Apache-2.0
     */}}
 
+{{- if .Values.alertmanager.enabled }}
+
 apiVersion: v1
 kind: Secret
 metadata:
-  name: alertmanager-authentication-secret
+  name: {{ .Values.alertmanager.authentication.secretName }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "pipelines-control-service.labels" . | nindent 4 }}
 type: Opaque
 data:
-  authUsername: {{ default "" .Values.credentials.kerberosKadminPassword | b64enc | quote }}
-  authPassword: {{ default "" .Values.deploymentK8sKubeconfig | b64enc | quote }}
-  authSecret: {{ default "" .Values.credentials.kerberosKrb5Conf | b64enc | quote }}
-  authSecretKey: {{ default "" .Values.vdkOptions | b64enc | quote }}
-  authIdentity: {{ default "" .Values.}}
+  authPassword: {{ default "" .Values.alertmanager.authentication.authPassword | b64enc | quote }}
+  authSecret: {{ default "" .Values.alertmanager.authentication.authSecret | b64enc | quote }}
+  authSecretKey: {{ default "" .Values.alertmanager.authentication.authSecretKey | b64enc | quote }}
+  authIdentity: {{ default "" .Values.alertmanager.authentication.authIdentity | b64enc | quote }}
+
+{{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -1044,6 +1044,8 @@ mail:
 # (dp) k8s deployment.
 # More information on individual fileds can be found here:
 # https://docs.openshift.com/container-platform/4.10/rest_api/monitoring_apis/alertmanagerconfig-monitoring-coreos-com-v1alpha1.html#specification
+# Pre-requisites for the alertmanager is that prometheus-operator is installed:
+# helm install prometheus-operator prometheus-community/kube-prometheus-stack
 alertmanager:
   enabled: false
   # Authentication credentials are mounted into a k8s secret, that's why they are separate.

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -1061,18 +1061,18 @@ alertmanager:
   spec:
     receivers:
       - emailConfigs:
-          - from: ''
+          - from: ""
             headers:
               - key: subject
-                value: ''
+                value: ""
             hello: localhost
-            html: ''
+            html: ""
             requireTLS: false
             sendResolved: false
-            smarthost: smtp.vmware.com:25
-            to: ''
-            authUsername: ''
-        name: dp-receiver
+            smarthost: ""
+            to: ""
+            authUsername: ""
+        name: "data-pipelines-receiver"
     route:
       groupBy:
         - alertname
@@ -1081,6 +1081,6 @@ alertmanager:
       groupWait: 0s
       matchers:
         - name: source
-          value: data-pipelines
-      receiver: dp-receiver
+          value: ""
+      receiver: "data-pipelines-receiver"
       repeatInterval: 30d

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -1039,3 +1039,28 @@ mail:
     ssl:
       protocols: "TLSv1.2"
     port: 587
+
+# Alert manager email notification configuration.
+# More information on individual fileds can be found here:
+# https://prometheus.io/docs/alerting/latest/configuration/#email_config
+alertmanager:
+  enabled: false
+  items:
+    namespace: data-jobs
+    spec:
+      receivers:
+        - emailConfigs:
+            - from: '{{ .CommonAnnotations.email_from }}'
+              headers:
+                  value: '{{ .CommonAnnotations.subject | safeHtml }}'
+              hello: ""
+              html: '{{ .CommonAnnotations.content | safeHtml }}'
+              requireTLS: false
+              sendResolved: false
+              smarthost: ""
+              to: '{{ .CommonAnnotations.email_to }}'
+              authUsername: ""
+              authPassword: ""
+              authSecret: ""
+              authSecretKey: ""
+              authIdentity: ""

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -1053,28 +1053,17 @@ alertmanager:
     authSecret: ""
     authSecretKey: ""
     authIdentity: ""
-  items:
-    labels:
-      role: infra
-    namespace: data-jobs
-    name: dp-notifications # Data Pipelines notifications
-    spec:
-      receivers:
-        route:
-          groupBy:
-            alertname
-            execution_id
-            groupInterval: 1m
-            groupWait: 0s
-            matchers:
-              - name: source
-                value: data-pipelines
-            receiver: dp-receiver
-            repeatInterval: 30d
-        emailConfigs:
+  labels:
+    role: infra
+  namespace: data-jobs
+  name: dp-notifications # Data Pipelines notifications
+  spec:
+    receivers:
+      - emailConfigs:
           - from: '{{ .CommonAnnotations.email_from }}'
             headers:
-              value: '{{ .CommonAnnotations.subject | safeHtml }}'
+              - key : subject
+                value: '{{ .CommonAnnotations.subject | safeHtml }}'
             hello: ""
             html: '{{ .CommonAnnotations.content | safeHtml }}'
             requireTLS: false
@@ -1082,4 +1071,15 @@ alertmanager:
             smarthost: ""
             to: '{{ .CommonAnnotations.email_to }}'
             authUsername: ''
-          name: dp-receiver
+        name: dp-receiver
+    route:
+      groupBy:
+        - alertname
+        - execution_id
+      groupInterval: 1m
+      groupWait: 0s
+      matchers:
+        - name: source
+          value: data-pipelines
+      receiver: dp-receiver
+      repeatInterval: 30d

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -1043,7 +1043,7 @@ mail:
 # Alert manager email notification configuration for the Data-Pipelines/Data Jobs
 # (dp) k8s deployment.
 # More information on individual fileds can be found here:
-# https://prometheus.io/docs/alerting/latest/configuration/#email_config
+# https://docs.openshift.com/container-platform/4.10/rest_api/monitoring_apis/alertmanagerconfig-monitoring-coreos-com-v1alpha1.html#specification
 alertmanager:
   enabled: false
   # Authentication credentials are mounted into a k8s secret, that's why they are separate.
@@ -1053,23 +1053,24 @@ alertmanager:
     authSecret: ""
     authSecretKey: ""
     authIdentity: ""
-  labels:
-    role: infra
-  namespace: data-jobs
-  name: dp-notifications # Data Pipelines notifications
+  metadata:
+    labels:
+      role: infra
+    name: dp-notifications
+    namespace: default
   spec:
     receivers:
       - emailConfigs:
-          - from: '{{ .CommonAnnotations.email_from }}'
+          - from: ''
             headers:
-              - key : subject
-                value: '{{ .CommonAnnotations.subject | safeHtml }}'
-            hello: ""
-            html: '{{ .CommonAnnotations.content | safeHtml }}'
+              - key: subject
+                value: ''
+            hello: localhost
+            html: ''
             requireTLS: false
             sendResolved: false
-            smarthost: ""
-            to: '{{ .CommonAnnotations.email_to }}'
+            smarthost: smtp.vmware.com:25
+            to: ''
             authUsername: ''
         name: dp-receiver
     route:

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -1046,11 +1046,18 @@ mail:
 # https://prometheus.io/docs/alerting/latest/configuration/#email_config
 alertmanager:
   enabled: false
+  # Authentication credentials are mounted into a k8s secret, that's why they are separate.
+  authentication:
+    secretName: "alertmanager-authentication-secret"
+    authPassword: ""
+    authSecret: ""
+    authSecretKey: ""
+    authIdentity: ""
   items:
     labels:
       role: infra
     namespace: data-jobs
-    name: dp-notifications
+    name: dp-notifications # Data Pipelines notifications
     spec:
       receivers:
         route:
@@ -1075,8 +1082,4 @@ alertmanager:
             smarthost: ""
             to: '{{ .CommonAnnotations.email_to }}'
             authUsername: ''
-            authPassword: ''
-            authSecret: ''
-            authSecretKey: ''
-            authIdentity: ''
           name: dp-receiver

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -1040,27 +1040,43 @@ mail:
       protocols: "TLSv1.2"
     port: 587
 
-# Alert manager email notification configuration.
+# Alert manager email notification configuration for the Data-Pipelines/Data Jobs
+# (dp) k8s deployment.
 # More information on individual fileds can be found here:
 # https://prometheus.io/docs/alerting/latest/configuration/#email_config
 alertmanager:
   enabled: false
   items:
+    labels:
+      role: infra
     namespace: data-jobs
+    name: dp-notifications
     spec:
       receivers:
-        - emailConfigs:
-            - from: '{{ .CommonAnnotations.email_from }}'
-              headers:
-                  value: '{{ .CommonAnnotations.subject | safeHtml }}'
-              hello: ""
-              html: '{{ .CommonAnnotations.content | safeHtml }}'
-              requireTLS: false
-              sendResolved: false
-              smarthost: ""
-              to: '{{ .CommonAnnotations.email_to }}'
-              authUsername: ""
-              authPassword: ""
-              authSecret: ""
-              authSecretKey: ""
-              authIdentity: ""
+        route:
+          groupBy:
+            alertname
+            execution_id
+            groupInterval: 1m
+            groupWait: 0s
+            matchers:
+              - name: source
+                value: data-pipelines
+            receiver: dp-receiver
+            repeatInterval: 30d
+        emailConfigs:
+          - from: '{{ .CommonAnnotations.email_from }}'
+            headers:
+              value: '{{ .CommonAnnotations.subject | safeHtml }}'
+            hello: ""
+            html: '{{ .CommonAnnotations.content | safeHtml }}'
+            requireTLS: false
+            sendResolved: false
+            smarthost: ""
+            to: '{{ .CommonAnnotations.email_to }}'
+            authUsername: ''
+            authPassword: ''
+            authSecret: ''
+            authSecretKey: ''
+            authIdentity: ''
+          name: dp-receiver


### PR DESCRIPTION
what: added alertmanager.yaml to helm chart templates, added configurable properties in values.yaml that correspond to the alertmanager.yaml template.

why: users of control-service can configure Prometheus alert manager through a helm chart instead of manually in the k8s cluster. More information on configuration properties: https://docs.openshift.com/container-platform/4.10/rest_api/monitoring_apis/alertmanagerconfig-monitoring-coreos-com-v1alpha1.html#specification

testing: helm chart validations.
cd into the 'versatile-data-kit/projects/control-service/projects/helm_charts' folder and run the following commands (make sure prometheus-operator is installed on minikube cluster and you have updated the charts, and enabled alertmanager from values.yaml before doing so):

`minikube start`

`helm package pipelines-control-service`
`helm install tpcs ./pipelines-control-service-0.0.1-SNAPSHOT.tgz`
`kubectl get alertmanagerconfigs.monitoring.coreos.com -oyaml`

And we receive the following output:

```
apiVersion: v1
items:
- apiVersion: monitoring.coreos.com/v1alpha1
  kind: AlertmanagerConfig
  metadata:
    annotations:
      meta.helm.sh/release-name: tpcs
      meta.helm.sh/release-namespace: default
    creationTimestamp: "2023-07-13T09:06:50Z"
    generation: 1
    labels:
      app.kubernetes.io/component: tpcs-pipelines-control-service-dep
      app.kubernetes.io/instance: tpcs
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/name: tpcs-pipelines-control-service
      app.kubernetes.io/version: 0.0.1-SNAPSHOT
      helm.sh/chart: pipelines-control-service-0.0.1-SNAPSHOT
      role: infra
    name: dp-notifications
    namespace: default
    resourceVersion: "62522"
    uid: 902b6864-8912-4970-89b4-6f14644aefaa
  spec:
    receivers:
    - emailConfigs:
      - authPassword:
          key: authPassword
          name: alertmanager-authentication-secret
          optional: true
        authUsername: ""
        from: ""
        headers:
        - key: subject
          value: ""
        hello: localhost
        html: ""
        requireTLS: false
        sendResolved: false
        smarthost: smtp.vmware.com:25
        to: ""
      name: dp-receiver
    route:
      groupBy:
      - alertname
      - execution_id
      groupInterval: 1m
      groupWait: 0s
      matchers:
      - name: source
        value: data-pipelines
      receiver: dp-receiver
      repeatInterval: 30d
kind: List
metadata:
  resourceVersion: ""
```

