### PR TITLE
versatile-data-kit: ignore patch updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,13 @@ updates:
     directory: "/projects/control-service/projects" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: "gradle"
     directory: "/projects/control-service/projects/pipelines_control_service" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Some libraries tend to have patch releases very often - like com.amazonaws:aws-java-sdk-sts latest patch upgrade is from 1.12.494 to 1.12.495

This is unnecessary. It's better to upgrade just on minor version automatically