### PR TITLE
support: slack notification on pipeline failure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,3 +38,14 @@ end:
   only:
     refs:
       - external_pull_requests
+
+notify_failure:
+  stage: end
+  script:
+    - ./cicd/notify.sh "The pipeline for the $CI_COMMIT_BRANCH branch has failed.\nPlease take the necessary steps to fix it. https://gitlab.com/vmware-analytics/versatile-data-kit/-/pipelines/$CI_PIPELINE_ID" $VDK_SLACK_NOTIFICATION_HOOK
+  allow_failure: true
+  rules:
+    - if: '$CI_COMMIT_BRANCH != "main"'
+      when: never
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      when: on_failure

--- a/cicd/notify.sh
+++ b/cicd/notify.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+curl -X POST -H "Content-type: application/json" --data "{\"text\":\"$1\"}" $2


### PR DESCRIPTION
## Why?
    
In order to set up CI on-call for vdk, visible and reliable notifications are required.
The notifications should alert on pipeline failure and provide the necessary information for troubleshooting.
    
## What?
    
Call an incoming webhook for a custom slack application on pipeline failure. This sends a message to the corresponding channel.
    
## How was this tested?
    
Ran in pipeline and sent notification to debug channel.
Note that the env variable for the notification hook will have to be changed after this is merged.

https://gitlab.com/vmware-analytics/versatile-data-kit/-/pipelines/914912201

## What kind of change is this?

Feature/non-breaking