### PR TITLE
vdk-control-cli: add vdk secrets command

### DIFF
--- a/projects/vdk-control-cli/requirements.txt
+++ b/projects/vdk-control-cli/requirements.txt
@@ -27,4 +27,4 @@ tabulate
 urllib3>=1.26.5
 vdk-control-api-auth
 
-vdk-control-service-api==1.0.10
+vdk-control-service-api==1.0.11

--- a/projects/vdk-control-cli/setup.cfg
+++ b/projects/vdk-control-cli/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     requests>=2.25
     setuptools>=47.0
     pluggy
-    vdk-control-service-api==1.0.10
+    vdk-control-service-api==1.0.11
     tabulate
     requests_oauthlib>=1.0
     urllib3>=1.26.5

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/secrets.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/secrets.py
@@ -1,0 +1,324 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import _io
+import json
+import logging
+from enum import Enum
+from enum import unique
+from typing import Any
+from typing import Dict
+from typing import Tuple
+from typing import Type
+
+import click
+from vdk.internal.control.configuration.defaults_config import load_default_team_name
+from vdk.internal.control.exception.vdk_exception import VDKException
+from vdk.internal.control.rest_lib.factory import ApiClientFactory
+from vdk.internal.control.rest_lib.rest_client_errors import ApiClientErrorDecorator
+from vdk.internal.control.utils import cli_utils
+from vdk.internal.control.utils import output_printer
+from vdk.internal.control.utils.output_printer import OutputFormat
+
+log = logging.getLogger(__name__)
+
+
+@unique
+class SecretOperation(Enum):
+    """
+    An enum used to store the types of secrets operations
+    """
+
+    SET = "set"
+    GET = "get"
+
+
+class JobSecrets:
+    def __init__(
+        self,
+        rest_api_url: str,
+        job_name: str,
+        team: str,
+        output_format: OutputFormat,
+    ):
+        self.__secrets_api = ApiClientFactory(rest_api_url).get_secrets_api()
+        self.__output = output_format
+        self.__printer = output_printer.create_printer(output_format)
+        self.__job_name = job_name
+        self.__team = team
+        self.__deployment_id = "TODO"
+
+    def __get_all_remote_secrets(self) -> Dict[str, Any]:
+        return self.__secrets_api.data_job_secrets_read(
+            team_name=self.__team,
+            job_name=self.__job_name,
+            deployment_id=self.__deployment_id,
+        )
+
+    def __list_secrets(self, remote_secrets: Dict[str, Any]) -> None:
+        self.__printer.print_dict(remote_secrets)
+
+    @staticmethod
+    def _to_bool(value: str) -> bool:
+        if value == "true" or value == "True":
+            return True
+        if value == "false" or value == "False":
+            return False
+        raise ValueError("bool cast accept only True/true/False/false values.")
+
+    @staticmethod
+    def __cast(key: str, new_value: str, value_type: Type) -> Any:
+        try:
+            log.debug(f"Cast {key} to type {value_type}")
+            if value_type == bool:
+                return JobSecrets._to_bool(new_value)
+            if value_type == list or value_type == dict:
+                raise ValueError(
+                    "Updating Secrets which are set to list or dict is not supported through CLI."
+                )
+            else:
+                return value_type(new_value)
+        except Exception as e:
+            raise VDKException(
+                f"The value of the passed secret with key {key} is not an expected type",
+                f"We detect existing value for secret with key '{key}' has type {value_type}. "
+                f"But we could not convert the value '{new_value}' to that type. Error is {e}",
+                f"In order to ensure that we do not overwrite with bad value the secrets, "
+                f"the operation aborts and no secret will be updated.",
+                f"If the key value is correct, you can first delete the key (with --delete)"
+                f" and then use the cli to set it again. "
+                f"Or you can use VDK job_input.set_all_secrets to overwrite them.",
+            )
+
+    def __merge_secrets(
+        self, new_secrets: Dict[str, str], remote_secrets: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Merge secrets between those already persisted (remote_secrets) and new key value pairs passed by user.
+        Merge algorithm attempts to preserve original type if possible and if not detects type from the passed value.
+
+        :param new_secrets: the passed key values pairs
+        :param remote_secrets: the secrets that are persisted on the remote server
+        :return: the new merged secrets
+        """
+        merged = remote_secrets
+        for new_key, new_value in new_secrets.items():
+            if new_key in remote_secrets:
+                remote_value_type = type(remote_secrets[new_key])
+                merged[new_key] = self.__cast(new_key, new_value, remote_value_type)
+            else:
+                merged[new_key] = new_value
+
+        return merged
+
+    @ApiClientErrorDecorator()
+    def get(self, key: str) -> None:
+        remote_secrets = self.__get_all_remote_secrets()
+        if key in remote_secrets:
+            self.__list_secrets({key: remote_secrets[key]})
+        else:
+            self.__list_secrets({})
+
+    @ApiClientErrorDecorator()
+    def list(self) -> None:
+        remote_secrets = self.__get_all_remote_secrets()
+        self.__list_secrets(remote_secrets)
+
+    @ApiClientErrorDecorator()
+    def update_secrets(self, new_secrets: Dict[str, str]) -> None:
+        remote_secrets = self.__get_all_remote_secrets()
+        merged_secrets = self.__merge_secrets(new_secrets, remote_secrets)
+        self.__secrets_api.data_job_secrets_update(
+            team_name=self.__team,
+            job_name=self.__job_name,
+            deployment_id=self.__deployment_id,
+            request_body=merged_secrets,
+        )
+
+    @ApiClientErrorDecorator()
+    def overwrite_secrets(self, new_secrets: Dict[str, str]) -> None:
+        self.__secrets_api.data_job_secrets_update(
+            team_name=self.__team,
+            job_name=self.__job_name,
+            deployment_id=self.__deployment_id,
+            request_body=new_secrets,
+        )
+
+    @ApiClientErrorDecorator()
+    def delete_keys(self, delete_keys: Tuple[str]) -> None:
+        secrets = self.__get_all_remote_secrets()
+        for key in delete_keys:
+            secrets.pop(key)
+        self.__secrets_api.data_job_secrets_update(
+            team_name=self.__team,
+            job_name=self.__job_name,
+            deployment_id=self.__deployment_id,
+            request_body=secrets,
+        )
+
+    @ApiClientErrorDecorator()
+    def delete_all_job_secrets(self) -> None:
+        self.__secrets_api.data_job_secrets_update(
+            team_name=self.__team,
+            job_name=self.__job_name,
+            deployment_id=self.__deployment_id,
+            request_body={},
+        )
+
+
+# Below is the definition of the CLI API/UX users will be interacting
+# Above is the actual implementation of the operations
+
+
+@click.command(
+    name="secrets",
+    help="Secrets are key value pairs that can be set per data job. "
+    """
+         Job secrets are used to store credentials/tokens/sensitive data securely.
+
+     Examples:
+
+     \b
+     # Set single secret with key "my-key" and value "my-value". If no value is passed
+     you'll get prompted so it's not printed on the screen.
+     vdk secrets --set my-key "my-value"
+
+     \b
+     # Update multiple secrets at once.
+     vdk secrets --set "key1" "value1" --set "key2" "value2" --set "secret1" --set "secret2"
+
+     \b
+     # Use backslash \\ to set them on multiple lines
+     vdk secrets \\
+        --set "key1" "value1" \\
+        --set "key2" "value2"
+
+     \b
+     # Return the value associated with the given key "my-key"
+     vdk secrets --get "my-key"
+
+     \b
+     # Delete a secrets with key "my-key"
+     vdk secrets --delete "my-key"
+
+     \b
+     # List all secrets
+     vdk secrets --list
+
+                    """,
+)
+@click.option(
+    "-n", "--name", prompt="Job Name", type=click.STRING, help="The job name."
+)
+@click.option(
+    "-t",
+    "--team",
+    type=click.STRING,
+    default=load_default_team_name(),
+    required=True,
+    prompt="Job Team",
+    help="The team name to which the job belongs to.",
+)
+@click.option(
+    "--set",
+    nargs=2,
+    type=click.STRING,
+    multiple=True,
+    help="Set key value secret. "
+    "If secret with same key exists we will override it but we will try to preserve the type."
+    "Entirely new secrets will be set with string type"
+    "You can set multiple secrets by using --set multiple times",
+)
+@click.option(
+    "--delete",
+    nargs=1,
+    type=click.STRING,
+    multiple=True,
+    help="Delete a secret with the given key. "
+    "You can delete multiple secrets by using --delete multiple times",
+)
+@click.option(
+    "--delete-all-job-secrets",
+    is_flag=True,
+    default=False,
+    help="Delete all secrets for the given data job. ",
+)
+@click.option(
+    "--overwrite-all-job-secrets",
+    type=click.File("rb"),
+    help="Pass JSON file that will overwrite all secrets for the passed data job. "
+    "No sanity checks are performed. It will completely overwrite all secrets."
+    "Use with care - with great power comes great responsibility."
+    "The option accepts '-' which will read the file input from the standard input (stdin)",
+)
+@click.option("--get", type=click.STRING, help="Get secret with a given key. ")
+@click.option("--list", is_flag=True, help="List all secrets for the data job ")
+@cli_utils.rest_api_url_option()
+@cli_utils.output_option()
+@cli_utils.check_required_parameters
+def secrets_command(
+    name: str,
+    team: str,
+    set: Tuple[str, str],
+    delete: Tuple[str],
+    delete_all_job_secrets: bool,
+    overwrite_all_job_secrets: _io.BufferedReader,
+    get: str,
+    list: bool,
+    rest_api_url: str,
+    output: OutputFormat,
+):
+    if (set or delete) and (get or list):
+        raise VDKException(
+            what="Invalid arguments",
+            why="Wrong input. Cannot pass --get or --list at the same time as --set and --delete.",
+            consequence="Command will abort with error.",
+            countermeasure="Fix passed arguments such that get/list are not passed in the same time as set/delete.",
+        )
+    if get and list:
+        raise VDKException(
+            what="Invalid arguments",
+            why="Wrong input. Cannot pass --get at the same time as --list. Choose one of the two.",
+            consequence="Command will abort with error",
+            countermeasure="Fix passed arguments such that only --list or only --get are used.",
+        )
+    log.debug(
+        f"secrets passed options: name: {name}, team: {team}, "
+        f"set: {set}, get: {get}, list: {list}, delete: {delete} "
+        f"rest_api_url: {rest_api_url}, output: {output}"
+    )
+    key_value_pairs = _get_key_value_pairs(set)
+    cmd = JobSecrets(rest_api_url, name, team, output)
+    if key_value_pairs:
+        cmd.update_secrets(key_value_pairs)
+    if delete:
+        cmd.delete_keys(delete)
+    if delete_all_job_secrets:
+        cmd.delete_all_job_secrets()
+    if get:
+        cmd.get(get)
+    if list:
+        cmd.list()
+    if overwrite_all_job_secrets:
+        json_secrets_string = overwrite_all_job_secrets.read().decode("utf-8")
+        try:
+            json_secrets = json.loads(json_secrets_string)
+            cmd.overwrite_secrets(json_secrets)
+        except Exception as e:
+            raise VDKException(
+                "Expected valid json for secrets overwrite.",
+                "JSON was not valid; error is " + str(e),
+                "Operation is aborted. Nothing has been changed.",
+                "Fix the file to be a valid json and re-try again.",
+            )
+
+
+def _get_key_value_pairs(set):
+    key_value_pairs = {}
+    if set:
+        for key, value in set:
+            if value:
+                key_value_pairs[key] = value
+            else:
+                value = click.prompt(f"{key}", hide_input=True)
+                key_value_pairs[key] = value
+    return key_value_pairs

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/secrets.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/secrets.py
@@ -96,7 +96,7 @@ class JobSecrets:
         Merge secrets between those already persisted (remote_secrets) and new key value pairs passed by user.
         Merge algorithm attempts to preserve original type if possible and if not detects type from the passed value.
 
-        :param new_secrets: the passed key values pairs
+        :param new_secrets: the passed key value pairs
         :param remote_secrets: the secrets that are persisted on the remote server
         :return: the new merged secrets
         """

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/secrets.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/secrets.py
@@ -82,11 +82,11 @@ class JobSecrets:
                 f"The value of the passed secret with key {key} is not an expected type",
                 f"We detect existing value for secret with key '{key}' has type {value_type}. "
                 f"But we could not convert the value '{new_value}' to that type. Error is {e}",
-                f"In order to ensure that we do not overwrite with bad value the secrets, "
-                f"the operation aborts and no secret will be updated.",
-                f"If the key value is correct, you can first delete the key (with --delete)"
-                f" and then use the cli to set it again. "
-                f"Or you can use VDK job_input.set_all_secrets to overwrite them.",
+                "In order to ensure that we do not overwrite with bad value the secrets, "
+                "the operation aborts and no secret will be updated.",
+                "If the key value is correct, you can first delete the key (with --delete)"
+                " and then use the cli to set it again. "
+                "Or you can use VDK job_input.set_all_secrets to overwrite them.",
             )
 
     def __merge_secrets(
@@ -258,12 +258,12 @@ class JobSecrets:
 def secrets_command(
     name: str,
     team: str,
-    set: Tuple[str, str],
+    set: Tuple[str, str],  # pylint: disable=redefined-builtin
     delete: Tuple[str],
     delete_all_job_secrets: bool,
     overwrite_all_job_secrets: _io.BufferedReader,
     get: str,
-    list: bool,
+    list: bool,  # pylint: disable=redefined-builtin
     rest_api_url: str,
     output: OutputFormat,
 ):
@@ -312,7 +312,7 @@ def secrets_command(
             )
 
 
-def _get_key_value_pairs(set):
+def _get_key_value_pairs(set):  # pylint: disable=redefined-builtin
     key_value_pairs = {}
     if set:
         for key, value in set:

--- a/projects/vdk-control-cli/src/vdk/internal/control/main.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/main.py
@@ -17,6 +17,7 @@ from vdk.internal.control.command_groups.job.download_key import download_key
 from vdk.internal.control.command_groups.job.execute import execute
 from vdk.internal.control.command_groups.job.list import list_command
 from vdk.internal.control.command_groups.job.properties import properties_command
+from vdk.internal.control.command_groups.job.secrets import secrets_command
 from vdk.internal.control.command_groups.job.show import show_command
 from vdk.internal.control.command_groups.login_group.login import login
 from vdk.internal.control.command_groups.logout_group.logout import logout
@@ -92,6 +93,7 @@ def run():
     cli.add_command(download_job)
     cli.add_command(show_command)
     cli.add_command(properties_command)
+    cli.add_command(secrets_command)
     cli.add_command(info)
 
     cli()

--- a/projects/vdk-control-cli/src/vdk/internal/control/rest_lib/factory.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/rest_lib/factory.py
@@ -8,6 +8,7 @@ from taurus_datajob_api import DataJobsApi
 from taurus_datajob_api import DataJobsDeploymentApi
 from taurus_datajob_api import DataJobsExecutionApi
 from taurus_datajob_api import DataJobsPropertiesApi
+from taurus_datajob_api import DataJobsSecretsApi
 from taurus_datajob_api import DataJobsServiceApi
 from taurus_datajob_api import DataJobsSourcesApi
 from urllib3 import Retry
@@ -67,6 +68,9 @@ class ApiClientFactory:
 
     def get_properties_api(self) -> DataJobsPropertiesApi:
         return DataJobsPropertiesApi(self._new_api_client())
+
+    def get_secrets_api(self) -> DataJobsSecretsApi:
+        return DataJobsSecretsApi(self._new_api_client())
 
     def get_service_api(self) -> DataJobsServiceApi:
         return DataJobsServiceApi(self._new_api_client())

--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_secrets.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_secrets.py
@@ -19,7 +19,9 @@ job_name = "test-job"
 deployment_id = "TODO"
 
 
-def _run_secrets_command(rest_api_url: str, args: List[str], input=None):
+def _run_secrets_command(
+    rest_api_url: str, args: List[str], input=None
+):  # pylint: disable=redefined-builtin
     runner = CliRunner()
     result = runner.invoke(
         secrets_command,

--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_secrets.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_secrets.py
@@ -1,0 +1,263 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import json
+import pathlib
+from typing import List
+
+from click.testing import CliRunner
+from py._path.local import LocalPath
+from pytest_httpserver.pytest_plugin import PluginHTTPServer
+from vdk.internal import test_utils
+from vdk.internal.control.command_groups.job.secrets import secrets_command
+from werkzeug.wrappers import Request
+from werkzeug.wrappers import Response
+
+test_utils.disable_vdk_authentication()
+
+team_name = "test-team"
+job_name = "test-job"
+deployment_id = "TODO"
+
+
+def _run_secrets_command(rest_api_url: str, args: List[str], input=None):
+    runner = CliRunner()
+    result = runner.invoke(
+        secrets_command,
+        args + ["-n", "test-job"] + ["-t", "test-team"] + ["-u", rest_api_url],
+        input=input,
+    )
+    return result
+
+
+def test_secrets_list_empty(httpserver: PluginHTTPServer):
+    rest_api_url = httpserver.url_for("")
+
+    httpserver.expect_request(
+        uri=f"/data-jobs/for-team/{team_name}/jobs/{job_name}/deployments/{deployment_id}/secrets"
+    ).respond_with_json({})
+
+    result = _run_secrets_command(rest_api_url, ["--list", "-o", "json"])
+    test_utils.assert_click_status(result, 0)
+    assert result.output.strip() == "{}"
+
+
+def test_secrets_list(httpserver: PluginHTTPServer):
+    rest_api_url = httpserver.url_for("")
+
+    # TODO:
+    # response = {"a": "b", "nested": {"inner": "inner_value"}, "int_value": 1}
+    response = {"aaaaa": "bbbbb", "nested": {"inner": "inner_value"}, "int_value": "1"}
+
+    httpserver.expect_request(
+        uri=f"/data-jobs/for-team/{team_name}/jobs/{job_name}/deployments/{deployment_id}/secrets"
+    ).respond_with_json(response)
+
+    result = _run_secrets_command(rest_api_url, ["--list", "-o", "json"])
+    test_utils.assert_click_status(result, 0)
+    assert json.loads(result.output) == response
+
+    result = _run_secrets_command(rest_api_url, ["--list", "-o", "text"])
+    test_utils.assert_click_status(result, 0)
+    # we do not impose strict contact on the table presentaiton
+    # we just verify the value on the expected row.
+    assert "aaaaa" in str(result.output).splitlines()[2]
+    assert "nested" in str(result.output).splitlines()[3]
+    assert "int_value" in str(result.output).splitlines()[4]
+
+
+def test_secrets_get_set(httpserver: PluginHTTPServer):
+    rest_api_url = _mock_secrets_server(httpserver)
+
+    result = _run_secrets_command(rest_api_url, ["--set", "my-key", "my-value"])
+    test_utils.assert_click_status(result, 0)
+
+    result = _run_secrets_command(rest_api_url, ["--get", "my-key", "-o", "json"])
+    test_utils.assert_click_status(result, 0)
+    assert result.output.strip() == '{"my-key": "my-value"}'
+
+
+def test_secrets_set_secret_prompt(httpserver: PluginHTTPServer):
+    rest_api_url = _mock_secrets_server(httpserver)
+
+    result = _run_secrets_command(
+        rest_api_url, ["--set", "secret", ""], input="my-secret-value"
+    )
+    test_utils.assert_click_status(result, 0)
+
+    result = _run_secrets_command(rest_api_url, ["--get", "secret", "-o", "json"])
+    test_utils.assert_click_status(result, 0)
+    assert result.output.strip() == '{"secret": "my-secret-value"}'
+
+
+def test_secrets_get_set_multiple(httpserver: PluginHTTPServer):
+    rest_api_url = _mock_secrets_server(httpserver)
+
+    result = _run_secrets_command(rest_api_url, ["--set", "key_1", "value-1"])
+    test_utils.assert_click_status(result, 0)
+
+    result = _run_secrets_command(
+        rest_api_url,
+        ["--set", "key_2", "value-2"]
+        + ["--set", "key_3", "value-3"]
+        + ["--set", "", "empty"],
+    )
+    test_utils.assert_click_status(result, 0)
+
+    result = _run_secrets_command(rest_api_url, ["--list", "-o", "json"])
+    test_utils.assert_click_status(result, 0)
+    assert (
+        result.output.strip()
+        == '{"key_1": "value-1", "key_2": "value-2", "key_3": "value-3", "": "empty"}'
+    )
+
+
+def test_secrets_get_set_preserve_value_types(httpserver: PluginHTTPServer):
+    rest_api_url = _mock_secrets_server(
+        httpserver,
+        {
+            "key_str": "string_value",
+            "key_int": 123,
+            "key_float": 3.1415,
+            "key_bool": True,
+        },
+    )
+
+    result = _run_secrets_command(
+        rest_api_url,
+        ["--set", "key_str", "new_string_value"]
+        + ["--set", "key_int", "456"]
+        + ["--set", "key_float", "6.2831"]
+        + ["--set", "key_bool", "False"],
+    )
+    test_utils.assert_click_status(result, 0)
+
+    result = _run_secrets_command(rest_api_url, ["--list", "-o", "json"])
+    test_utils.assert_click_status(result, 0)
+    assert (
+        result.output.strip()
+        == '{"key_str": "new_string_value", "key_int": 456, "key_float": 6.2831, "key_bool": false}'
+    )
+
+    result = _run_secrets_command(
+        rest_api_url, ["--set", "key_int", "string_value_cannot_be_cast_to_int"]
+    )
+    # we fail because we cannot cast to int
+    test_utils.assert_click_status(result, 2)
+
+
+def test_secrets_get_set_preserve_value_types_list_dict(
+    httpserver: PluginHTTPServer,
+):
+    rest_api_url = _mock_secrets_server(
+        httpserver,
+        {"key_list": ["a", "b", "c"], "key_dict": dict(a="b")},
+    )
+
+    result = _run_secrets_command(rest_api_url, ["--set", "key_list", "not,a,list"])
+    test_utils.assert_click_status(result, 2)
+
+    result = _run_secrets_command(rest_api_url, ["--set", "key_dict", "not_a:dict"])
+    test_utils.assert_click_status(result, 2)
+
+
+def test_secrets_delete(httpserver: PluginHTTPServer):
+    rest_api_url = _mock_secrets_server(
+        httpserver, {"key1": "value1", "key2": "value2", "key3": 3}
+    )
+
+    result = _run_secrets_command(
+        rest_api_url, ["--delete", "key1", "--delete", "key3"]
+    )
+    test_utils.assert_click_status(result, 0)
+
+    result = _run_secrets_command(rest_api_url, ["--list", "-o", "json"])
+    test_utils.assert_click_status(result, 0)
+    assert result.output.strip() == '{"key2": "value2"}'
+
+
+def test_secrets_get_set_lots_of_values(httpserver: PluginHTTPServer):
+    rest_api_url = _mock_secrets_server(
+        httpserver,
+        {str(i): i for i in range(1, 1000)},
+    )
+
+    result = _run_secrets_command(
+        rest_api_url, ["--set", "key_str", "new_string_value"] + ["--set", "foo", "456"]
+    )
+    test_utils.assert_click_status(result, 0)
+
+    result = _run_secrets_command(rest_api_url, ["--list", "-o", "json"])
+    test_utils.assert_click_status(result, 0)
+
+
+def test_secrets_delete_all(httpserver: PluginHTTPServer):
+    rest_api_url = _mock_secrets_server(
+        httpserver, {"key1": "value1", "key2": "value2", "key3": 3}
+    )
+
+    result = _run_secrets_command(rest_api_url, ["--delete-all-job-secrets"])
+    test_utils.assert_click_status(result, 0)
+
+    result = _run_secrets_command(rest_api_url, ["--list", "-o", "json"])
+    test_utils.assert_click_status(result, 0)
+    assert result.output.strip() == "{}"
+
+
+def test_secrets_overwrite_all(httpserver: PluginHTTPServer, tmpdir: LocalPath):
+    rest_api_url = _mock_secrets_server(
+        httpserver, {"key1": "value1", "key2": "value2", "key3": 3}
+    )
+
+    temp_file = pathlib.Path(tmpdir).joinpath("temp-file.json")
+    new_json = {"new_key": 1, "new_new_key": "new_value"}
+    temp_file.write_text(json.dumps(new_json))
+
+    result = _run_secrets_command(
+        rest_api_url, ["--overwrite-all-job-secrets", str(temp_file)]
+    )
+    test_utils.assert_click_status(result, 0)
+
+    result = _run_secrets_command(rest_api_url, ["--list", "-o", "json"])
+    test_utils.assert_click_status(result, 0)
+    assert result.output.strip() == json.dumps(new_json)
+
+
+def test_secrets_overwrite_all_not_valid_josn(
+    httpserver: PluginHTTPServer, tmpdir: LocalPath
+):
+    rest_api_url = _mock_secrets_server(
+        httpserver, {"key1": "value1", "key2": "value2", "key3": 3}
+    )
+
+    temp_file = pathlib.Path(tmpdir).joinpath("temp-file.json")
+    temp_file.write_text("{not-valid-josn;}")
+
+    result = _run_secrets_command(
+        rest_api_url, ["--overwrite-all-job-secrets", str(temp_file)]
+    )
+    test_utils.assert_click_status(result, 2)
+
+
+def _mock_secrets_server(httpserver, initial_secrets=None):
+    rest_api_url = httpserver.url_for("")
+    secrets_cache = {job_name: json.dumps(initial_secrets) if initial_secrets else "{}"}
+
+    def save_secrets(r: Request):
+        job_name = r.path.split("/")[5]
+        secrets_cache[job_name] = r.data
+        return Response(status=200)
+
+    def get_secrets(r: Request):
+        job_name = r.path.split("/")[5]
+        data = secrets_cache.get(job_name, "{}")
+        return Response(data, 200, content_type="application/json")
+
+    httpserver.expect_request(
+        method="PUT",
+        uri=f"/data-jobs/for-team/{team_name}/jobs/{job_name}/deployments/{deployment_id}/secrets",
+    ).respond_with_handler(save_secrets)
+    httpserver.expect_request(
+        method="GET",
+        uri=f"/data-jobs/for-team/{team_name}/jobs/{job_name}/deployments/{deployment_id}/secrets",
+    ).respond_with_handler(get_secrets)
+    return rest_api_url


### PR DESCRIPTION
Incremental change for adding "secrets" command to the cli.
Also adopting the latest version of the control service client api.

I'm aware of the code duplication and I'll refactor once I get this running end-to-end.