### PR TITLE
control-service: add timestamps to helm chart

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -12,6 +12,7 @@ metadata:
   {{- if .Values.deploymentAdditionalLabels }}
   {{- include "common.tplvalues.render" (dict "value" .Values.deploymentAdditionalLabels "context" $) | nindent 4 }}
   {{- end }}
+    date: "{{ now | unixEpoch }}"
 spec:
   replicas: {{ .Values.replicas }}
   strategy:
@@ -28,6 +29,7 @@ spec:
       {{- if .Values.deploymentAdditionalLabels }}
       {{- include "common.tplvalues.render" (dict "value" .Values.deploymentAdditionalLabels "context" $) | nindent 8 }}
       {{- end }}
+        date: "{{ now | unixEpoch }}"
       annotations:
         # https://helm.sh/docs/howto/charts_tips_and_tricks Automatically Roll Deployments
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}


### PR DESCRIPTION
## Why?

When upgrading the vdk helm chart, helm will not pull the latest image when using a meta tag (latest, stable, etc.). Helm treats tags as first-class citizens and doesn't look at the image sha. If the tag hasn't changed, then, from helm's POV, the chart hasn't changed either. This blocks us from using latests/stable tags for our test environment deployment. It also means quickstart-vdk will not use the latest images if it's upgraded.

This is default helm behavior:

https://github.com/helm/helm/issues/5696

Note that `--recreate-pods` is no longer a thing.

https://github.com/helm/helm/issues/8271

## What?

Add timestamp labels to the control-service deployment.yaml This way, the helm chart will always be different, which means it will always be re-deployed.

## How was this tested?

Labels are already added to the frontend deployment.yaml and it works when running quickstart-vdk

## What type of change are you making?

Feature/non-breaking