### PR TITLE
vdk-ipython:  README.md fix

### DIFF
--- a/projects/vdk-plugins/vdk-ipython/README.md
+++ b/projects/vdk-plugins/vdk-ipython/README.md
@@ -16,7 +16,7 @@ Then to load the extension in Jupyter the user should use:
 ```
 And to load the VDK (Job Control object):
 ```
-%reload_data_job
+%reload_VDK
 ```
 The %reload_VDK magic can be used with arguments such as passing the job's path with --path
 or giving the job a new with --name, etc.


### PR DESCRIPTION
Why: the read me contained the old version of the command
Signed-off-by: Duygu Hasan [hduygu@vmware.com](mailto:hduygu@vmware.com)