### PR TITLE
vdk-core: Allow different python versions for vdk docker images

### DIFF
--- a/projects/vdk-core/cicd/Dockerfile-vdk-base
+++ b/projects/vdk-core/cicd/Dockerfile-vdk-base
@@ -1,7 +1,9 @@
 # Specifies a base image containing installed and ready to use VDK
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices
 
-FROM python:3.7-slim
+ARG vdk_base_python_image
+
+FROM $vdk_base_python_image
 
 WORKDIR /vdk
 

--- a/projects/vdk-core/cicd/deploy-base-vdk-image.sh
+++ b/projects/vdk-core/cicd/deploy-base-vdk-image.sh
@@ -15,6 +15,7 @@ export VDK_PACKAGE=${VDK_PACKAGE:-$(python setup.py --name)}
 export VDK_DOCKER_REGISTRY_URL=${VDK_DOCKER_REGISTRY_URL:-"registry.hub.docker.com/versatiledatakit"}
 export DOCKER_REGISTRY_IMAGE=${DOCKER_REGISTRY_IMAGE:-"$VDK_DOCKER_REGISTRY_URL/$VDK_PACKAGE"}  # where the image should be pushed
 export PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL:-https://test.pypi.org/simple/}
+export VDK_BASE_PYTHON_IMAGE=${VDK_BASE_PYTHON_IMAGE:-python:3.7-slim}
 
 set -o errexit -o nounset
 
@@ -47,6 +48,7 @@ docker build  -t "${DOCKER_REGISTRY_IMAGE}:${BUILD_TYPE}" -t "${DOCKER_REGISTRY_
   --build-arg vdk_package="${VDK_PACKAGE}" \
   --build-arg vdk_version="${VDK_VERSION}" \
   --build-arg pip_extra_index_url="${PIP_EXTRA_INDEX_URL}" \
+  --build-arg vdk_base_python_image="${VDK_BASE_PYTHON_IMAGE}" \
   .
 
 # docker registry must allow override


### PR DESCRIPTION
Currently, all vdk-related docker images (mainly quickstart-vdk) are built with python3.7, because the python base image is hard-coded into the Dockerfile (Dockerfile-vdk-base). This causes issues if images for different python versions are to be built.

This change adds more flexibility, by updating the Dockerfile to accept build argument with the python image that is to be used for building the vdk image. It also updates the shell script that builds and releases the vdk images to read a new environment variable, VDK_BASE_PYTHON_IMAGE, which indicates which python version is to be used.

Testing Done: Locally executed the script and verified that the passed python base image propagates to the Dockerfile.