### PR TITLE
frontend: Fix navigation in Data Jobs

### DIFF
--- a/projects/frontend/data-pipelines/gui/e2e/integration/explore/data-jobs/data-jobs.spec.js
+++ b/projects/frontend/data-pipelines/gui/e2e/integration/explore/data-jobs/data-jobs.spec.js
@@ -202,7 +202,7 @@ describe(
                             `\\/explore\\/data-jobs\\?jobName=${testJobsFixture[1].job_name.substring(
                                 0,
                                 20
-                            )}$`
+                            )}&deploymentStatus=all$`
                         )
                     );
 
@@ -260,10 +260,12 @@ describe(
                     .should(
                         'match',
                         new RegExp(
-                            `\\/explore\\/data-jobs\\?jobName=${testJobsFixture[0].job_name.substring(
+                            `\\/explore\\/data-jobs\\?search=${
+                                testJobsFixture[0].job_name
+                            }&jobName=${testJobsFixture[0].job_name.substring(
                                 0,
                                 20
-                            )}&search=${testJobsFixture[0].job_name}$`
+                            )}&deploymentStatus=all$`
                         )
                     );
 
@@ -289,7 +291,7 @@ describe(
                             `\\/explore\\/data-jobs\\?jobName=${testJobsFixture[0].job_name.substring(
                                 0,
                                 20
-                            )}$`
+                            )}&deploymentStatus=all$`
                         )
                     );
             });
@@ -313,7 +315,8 @@ describe(
                     .should('deep.equal', {
                         pathSegment: '/explore/data-jobs',
                         queryParams: {
-                            search: testJobsFixture[1].job_name
+                            search: testJobsFixture[1].job_name,
+                            deploymentStatus: 'all'
                         }
                     });
 
@@ -356,7 +359,8 @@ describe(
                             jobName: testJobsFixture[0].job_name.substring(
                                 0,
                                 20
-                            )
+                            ),
+                            deploymentStatus: 'all'
                         }
                     });
             });
@@ -397,7 +401,7 @@ describe(
                     .should(
                         'match',
                         new RegExp(
-                            `\\/explore\\/data-jobs\\?description=Test%20description%201$`
+                            `\\/explore\\/data-jobs\\?description=Test%20description%201&deploymentStatus=all$`
                         )
                     );
 
@@ -429,12 +433,14 @@ describe(
                 dataJobsExplorePage
                     .getCurrentUrlNormalized({
                         includePathSegment: true,
-                        includeQueryString: true
+                        includeQueryString: true,
+                        decodeQueryString: true
                     })
                     .should('deep.equal', {
                         pathSegment: '/explore/data-jobs',
                         queryParams: {
-                            description: 'Test%20description%201'
+                            description: 'Test description 1',
+                            deploymentStatus: 'all'
                         }
                     });
 

--- a/projects/frontend/data-pipelines/gui/e2e/integration/manage/data-jobs/data-jobs.spec.js
+++ b/projects/frontend/data-pipelines/gui/e2e/integration/manage/data-jobs/data-jobs.spec.js
@@ -226,7 +226,7 @@ describe(
                                 0,
                                 20
                             ),
-                            deploymentEnabled: 'all'
+                            deploymentStatus: 'all'
                         }
                     });
 
@@ -256,7 +256,7 @@ describe(
                                 0,
                                 20
                             ),
-                            deploymentEnabled: 'all'
+                            deploymentStatus: 'all'
                         }
                     });
             });
@@ -290,7 +290,7 @@ describe(
                                 0,
                                 20
                             ),
-                            deploymentEnabled: 'all'
+                            deploymentStatus: 'all'
                         }
                     });
 
@@ -329,7 +329,7 @@ describe(
                                 0,
                                 20
                             ),
-                            deploymentEnabled: 'all'
+                            deploymentStatus: 'all'
                         }
                     });
             });
@@ -530,7 +530,7 @@ describe(
                     .should(
                         'match',
                         new RegExp(
-                            `\\/manage\\/data-jobs\\?deploymentEnabled=all&description=Test%20description%201$`
+                            `\\/manage\\/data-jobs\\?description=Test%20description%201&deploymentStatus=all$`
                         )
                     );
 
@@ -568,7 +568,7 @@ describe(
                     .should('deep.equal', {
                         pathSegment: '/manage/data-jobs',
                         queryParams: {
-                            deploymentEnabled: 'all',
+                            deploymentStatus: 'all',
                             description: 'Test%20description%201'
                         }
                     });

--- a/projects/frontend/data-pipelines/gui/e2e/support/pages/base/data-pipelines/data-pipelines-base.po.js
+++ b/projects/frontend/data-pipelines/gui/e2e/support/pages/base/data-pipelines/data-pipelines-base.po.js
@@ -188,27 +188,29 @@ export class DataPipelinesBasePO extends BasePagePO {
         const relativePathToFixtures = [];
         if (jobVersion.includes('v0')) {
             relativePathToFixtures.push({
-                pathToFixture: `/base/data-jobs/${TEAM_VDK}/short-lived/${TEAM_VDK_DATA_JOB_TEST_WITH_DEPLOY_V0}.json`
+                pathToFixture: `/base/data-jobs/${TEAM_VDK}/short-lived/${TEAM_VDK_DATA_JOB_TEST_WITH_DEPLOY_V0}.json`,
+                executions: 1
             });
         }
 
         if (jobVersion.includes('v1')) {
             relativePathToFixtures.push({
-                pathToFixture: `/base/data-jobs/${TEAM_VDK}/short-lived/${TEAM_VDK_DATA_JOB_TEST_WITH_DEPLOY_V1}.json`
+                pathToFixture: `/base/data-jobs/${TEAM_VDK}/short-lived/${TEAM_VDK_DATA_JOB_TEST_WITH_DEPLOY_V1}.json`,
+                executions: 1
             });
         }
 
         if (jobVersion.includes('v2')) {
             relativePathToFixtures.push({
-                pathToFixture: `/base/data-jobs/${TEAM_VDK}/short-lived/${TEAM_VDK_DATA_JOB_TEST_WITH_DEPLOY_V2}.json`
+                pathToFixture: `/base/data-jobs/${TEAM_VDK}/short-lived/${TEAM_VDK_DATA_JOB_TEST_WITH_DEPLOY_V2}.json`,
+                executions: 1
             });
         }
 
         return cy.task(
             'provideDataJobsExecutions',
             {
-                relativePathToFixtures,
-                executions: 1
+                relativePathToFixtures
             },
             { timeout: DataPipelinesBasePO.WAIT_EXTRA_LONG_TASK }
         );

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/data-job-page.component.html
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/data-job-page.component.html
@@ -204,13 +204,8 @@
                 [queryParams]="queryParams"
                 routerLinkActive="active"
                 #executionsLink="routerLinkActive"
-                >Executions
-                <clr-icon
-                    class="job-details__promotion-icon is-solid is-info"
-                    shape="new"
-                    size="28"
-                ></clr-icon>
-            </a>
+                >Executions</a
+            >
         </li>
         <li
             *ngIf="dataPipelinesModuleConfig.showLineagePage"

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-explore/components/grid/data-jobs-explore-grid.component.html
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-explore/components/grid/data-jobs-explore-grid.component.html
@@ -11,13 +11,12 @@
     "
 >
     <lib-grid-action
-        [searchQueryValue]="searchQueryValue"
+        [searchQueryValue]="clrGridUIState.search"
         [selectedValue]="selectedJob"
         [quickFilters]="quickFilters"
         [suppressQuickFilterChangeEvent]="true"
         [disableActionableElements]="disableActionableElements"
         (search)="search($event)"
-        (quickFilterChange)="updateQuickFilter($event)"
     >
         <div *ngIf="isStandardDisplayMode()" class="custom-buttons-left">
             <button
@@ -48,7 +47,7 @@
                 data-cy="data-pipelines-jobs-name-column"
                 [clrDgField]="'jobName'"
                 [(clrDgSortOrder)]="clrGridUIState.sort['jobName']"
-                [(clrFilterValue)]="gridFilters.jobName"
+                [(clrFilterValue)]="clrGridUIState.filter.jobName"
                 >Job name
             </clr-dg-column>
 
@@ -58,7 +57,7 @@
                 data-cy="data-pipelines-jobs-team-column"
                 [clrDgField]="'config.team'"
                 [(clrDgSortOrder)]="clrGridUIState.sort['config.team']"
-                [(clrFilterValue)]="gridFilters.teamName"
+                [(clrFilterValue)]="clrGridUIState.filter.teamName"
                 >Team name
             </clr-dg-column>
 
@@ -67,7 +66,7 @@
                 data-cy="data-pipelines-jobs-description-column"
                 [clrDgField]="'config.description'"
                 [(clrDgSortOrder)]="clrGridUIState.sort['config.description']"
-                [(clrFilterValue)]="gridFilters.descriptionFilter"
+                [(clrFilterValue)]="clrGridUIState.filter.description"
             >
                 <ng-template
                     [clrDgHideableColumn]="{
@@ -105,7 +104,7 @@
                         #statusFilter
                         [property]="'deployments.enabled'"
                         [listOfOptions]="deploymentStatuses"
-                        [(value)]="gridFilters.deploymentStatus"
+                        [(value)]="clrGridUIState.filter.deploymentStatus"
                     ></lib-column-filter>
                 </clr-dg-filter>
             </clr-dg-column>
@@ -153,7 +152,7 @@
                         property="deployments.lastExecutionStatus"
                         [optionRenderer]="executionFilterOption"
                         [listOfOptions]="executionStatuses"
-                        [(value)]="gridFilters.deploymentLastExecutionStatus"
+                        [(value)]="clrGridUIState.filter.deploymentLastExecutionStatus"
                     >
                         <ng-template #executionFilterOption let-option>
                             <lib-data-job-execution-status
@@ -461,13 +460,13 @@
                     [listenForErrorPatterns]="listenForErrorPatterns"
                 >
                     <ng-template #emptyTemplate>
-                        <div *ngIf="!searchQueryValue">
+                        <div *ngIf="!clrGridUIState.search">
                             No data jobs created!
                         </div>
-                        <div *ngIf="searchQueryValue">
+                        <div *ngIf="clrGridUIState.search">
                             <span
                                 >No data jobs that match with
-                                <strong>{{ searchQueryValue }}</strong>
+                                <strong>{{ clrGridUIState.search }}</strong>
                                 criteria</span
                             >
                         </div>

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-explore/components/grid/data-jobs-explore-grid.component.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-explore/components/grid/data-jobs-explore-grid.component.spec.ts
@@ -178,12 +178,12 @@ describe('DataJobsExploreGridComponent', () => {
 
     describe('urlUpdateStrategy', () => {
         it('should verify the behaviour of _doUrlUpdate when urlUpdateStrategy is default (updateRouter)', () => {
-            const navigateToUrlSpy = spyOn(component.urlStateManager, 'navigateToUrl').and.returnValue(Promise.resolve(true));
+            const locationToUrlSpy = spyOn(component.urlStateManager, 'locationToURL').and.callFake(CallFake);
 
             // @ts-ignore
             component._doUrlUpdate();
 
-            expect(navigateToUrlSpy).toHaveBeenCalled();
+            expect(locationToUrlSpy).toHaveBeenCalled();
         });
 
         it('should verify the behaviour of _doUrlUpdate when urlUpdateStrategy is changed (updateLocation)', () => {
@@ -198,6 +198,10 @@ describe('DataJobsExploreGridComponent', () => {
     });
 
     describe('urlStateManager', () => {
+        beforeEach(() => {
+            fixture.detectChanges();
+        });
+
         it('should verify will invoke default urlStateManager (locally created)', () => {
             // Given
             const setQueryParamSpy = spyOn(component.urlStateManager, 'setQueryParam').and.callFake(CallFake);
@@ -206,7 +210,12 @@ describe('DataJobsExploreGridComponent', () => {
             component.search('search');
 
             // Then
-            expect(setQueryParamSpy).toHaveBeenCalledWith(QUERY_PARAM_SEARCH, 'search');
+            expect(setQueryParamSpy.calls.argsFor(0)).toEqual(['jobName', undefined, 1]);
+            expect(setQueryParamSpy.calls.argsFor(1)).toEqual(['teamName', undefined, 2]);
+            expect(setQueryParamSpy.calls.argsFor(2)).toEqual(['description', undefined, 3]);
+            expect(setQueryParamSpy.calls.argsFor(3)).toEqual(['deploymentStatus', 'all', 4]);
+            expect(setQueryParamSpy.calls.argsFor(4)).toEqual(['deploymentLastExecutionStatus', undefined, 5]);
+            expect(setQueryParamSpy.calls.argsFor(5)).toEqual([QUERY_PARAM_SEARCH, 'search', 0]);
         });
 
         it('should verify will invoke external urlStateManager (dependency injected)', () => {
@@ -219,12 +228,16 @@ describe('DataJobsExploreGridComponent', () => {
             component.search('search');
 
             // Then
-            expect(setQueryParamSpy).toHaveBeenCalledWith(QUERY_PARAM_SEARCH, 'search');
+            expect(setQueryParamSpy.calls.argsFor(0)).toEqual(['jobName', undefined, 1]);
+            expect(setQueryParamSpy.calls.argsFor(1)).toEqual(['teamName', undefined, 2]);
+            expect(setQueryParamSpy.calls.argsFor(2)).toEqual(['description', undefined, 3]);
+            expect(setQueryParamSpy.calls.argsFor(3)).toEqual(['deploymentStatus', 'all', 4]);
+            expect(setQueryParamSpy.calls.argsFor(4)).toEqual(['deploymentLastExecutionStatus', undefined, 5]);
+            expect(setQueryParamSpy.calls.argsFor(5)).toEqual([QUERY_PARAM_SEARCH, 'search', 0]);
         });
 
         it('should verify will invoke default urlStateManager (dependency injection is null or undefined)', () => {
             // Given
-            const KEY_INDEX = 0;
             const setQueryParamSpy = spyOn(component.urlStateManager, 'setQueryParam').and.callFake(CallFake);
             // When
             component.urlStateManager = null;
@@ -233,18 +246,16 @@ describe('DataJobsExploreGridComponent', () => {
             component.search('search test value 2');
 
             // Then
-            expect(setQueryParamSpy.calls.allArgs().filter((pair) => pair[KEY_INDEX] === 'search')[0]).toEqual([
-                QUERY_PARAM_SEARCH,
-                'search test value 1'
-            ]);
-            expect(setQueryParamSpy.calls.allArgs().filter((pair) => pair[KEY_INDEX] === 'search')[1]).toEqual([
-                QUERY_PARAM_SEARCH,
-                'search test value 2'
-            ]);
+            expect(setQueryParamSpy.calls.argsFor(5)).toEqual([QUERY_PARAM_SEARCH, 'search test value 1', 0]);
+            expect(setQueryParamSpy.calls.argsFor(11)).toEqual([QUERY_PARAM_SEARCH, 'search test value 2', 0]);
         });
     });
 
     describe('handleStateChange', () => {
+        beforeEach(() => {
+            fixture.detectChanges();
+        });
+
         it('makes expected calls', () => {
             const clrDatagridStateInterfaceStub = {
                 filters: []
@@ -333,10 +344,14 @@ describe('DataJobsExploreGridComponent', () => {
     });
 
     describe('search', () => {
+        beforeEach(() => {
+            fixture.detectChanges();
+        });
+
         it('makes expected calls', () => {
             spyOn(component, 'loadDataWithState').and.callThrough();
             component.search('searchValue');
-            expect(component.searchQueryValue).toBe('searchValue');
+            expect(component.clrGridUIState.search).toBe('searchValue');
             expect(component.loadDataWithState).toHaveBeenCalled();
         });
     });

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-manage/components/grid/data-jobs-manage-grid.component.html
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-manage/components/grid/data-jobs-manage-grid.component.html
@@ -11,13 +11,12 @@
     "
 >
     <lib-grid-action
-        [searchQueryValue]="searchQueryValue"
+        [searchQueryValue]="clrGridUIState.search"
         [selectedValue]="selectedJob"
         [quickFilters]="quickFilters"
         [suppressQuickFilterChangeEvent]="true"
         [disableActionableElements]="disableActionableElements"
         (search)="search($event)"
-        (quickFilterChange)="updateQuickFilter($event)"
     >
         <div class="custom-buttons-left">
             <button
@@ -108,7 +107,7 @@
                 data-cy="data-pipelines-jobs-name-column"
                 [clrDgField]="'jobName'"
                 [(clrDgSortOrder)]="clrGridUIState.sort['jobName']"
-                [(clrFilterValue)]="gridFilters.jobName"
+                [(clrFilterValue)]="clrGridUIState.filter.jobName"
                 >Job name
             </clr-dg-column>
 
@@ -118,7 +117,7 @@
                 data-cy="data-pipelines-jobs-team-column"
                 [clrDgField]="'config.team'"
                 [(clrDgSortOrder)]="clrGridUIState.sort['config.team']"
-                [(clrFilterValue)]="gridFilters.teamName"
+                [(clrFilterValue)]="clrGridUIState.filter.teamName"
                 >Team name
             </clr-dg-column>
 
@@ -127,7 +126,7 @@
                 data-cy="data-pipelines-jobs-description-column"
                 [clrDgField]="'config.description'"
                 [(clrDgSortOrder)]="clrGridUIState.sort['config.description']"
-                [(clrFilterValue)]="gridFilters.descriptionFilter"
+                [(clrFilterValue)]="clrGridUIState.filter.description"
             >
                 <ng-template
                     [clrDgHideableColumn]="{
@@ -165,7 +164,7 @@
                         #statusFilter
                         [property]="'deployments.enabled'"
                         [listOfOptions]="deploymentStatuses"
-                        [(value)]="gridFilters.deploymentStatus"
+                        [(value)]="clrGridUIState.filter.deploymentStatus"
                     ></lib-column-filter>
                 </clr-dg-filter>
             </clr-dg-column>
@@ -213,7 +212,7 @@
                         property="deployments.lastExecutionStatus"
                         [optionRenderer]="executionFilterOption"
                         [listOfOptions]="executionStatuses"
-                        [(value)]="gridFilters.deploymentLastExecutionStatus"
+                        [(value)]="clrGridUIState.filter.deploymentLastExecutionStatus"
                     >
                         <ng-template #executionFilterOption let-option>
                             <lib-data-job-execution-status
@@ -528,7 +527,7 @@
                 >
                     <ng-template #emptyTemplate>
                         <div
-                            *ngIf="!searchQueryValue"
+                            *ngIf="!clrGridUIState.search"
                             class="msg-btn-placeholder"
                         >
                             <div>No data jobs created!</div>
@@ -543,10 +542,10 @@
                                 about Data Jobs
                             </a>
                         </div>
-                        <div *ngIf="searchQueryValue">
+                        <div *ngIf="clrGridUIState.search">
                             <span
                                 >No data jobs that match with
-                                <strong>{{ searchQueryValue }}</strong>
+                                <strong>{{ clrGridUIState.search }}</strong>
                                 criteria</span
                             >
                         </div>

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-manage/components/grid/data-jobs-manage-grid.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-manage/components/grid/data-jobs-manage-grid.component.ts
@@ -50,8 +50,7 @@ export class DataJobsManageGridComponent extends DataJobsBaseGridComponent imple
     confirmExecuteNowOptions: ModalOptions;
 
     override clrGridDefaultFilter: ClrGridUIState['filter'] = {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        'deployments.enabled': DataJobStatus.ENABLED
+        deploymentStatus: DataJobStatus.ENABLED
     };
     override clrGridDefaultSort: ClrGridUIState['sort'] = {
         // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/grid-config.model.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/grid-config.model.ts
@@ -13,7 +13,7 @@ export enum DisplayMode {
 export interface GridFilters {
     jobName?: string;
     teamName?: string;
-    descriptionFilter?: string;
+    description?: string;
     deploymentStatus?: string;
     deploymentLastExecutionStatus?: string;
 }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/data-grid/column-filter/column-filter.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/components/data-grid/column-filter/column-filter.component.ts
@@ -24,15 +24,9 @@ export class ColumnFilterComponent implements ClrDatagridFilterInterface<DataJob
 
     @Input() optionRenderer: TemplateRef<HTMLElement> = null;
 
-    private _value: string;
     private _changesSubject = new Subject<string>();
 
-    @Input() set value(_value: string) {
-        this._value = _value === 'all' ? null : _value;
-    }
-    get value(): string {
-        return this._value;
-    }
+    @Input() value: string;
     @Output() valueChange = new EventEmitter<string>();
 
     // We do not want to expose the Subject itself, but the Observable which is read-only
@@ -61,7 +55,7 @@ export class ColumnFilterComponent implements ClrDatagridFilterInterface<DataJob
     }
 
     isValueSelected(value: string) {
-        return this.value?.toLowerCase() === value?.toLowerCase().replace(' ', '_');
+        return this.value === value;
     }
 
     /**


### PR DESCRIPTION
Changed navigation in Data Jobs list from `navigateToUrl` to `locationToURL`, because telemetry events PageView are sent when Angular router navigation occurs. We want to stop sending telemetry PageView events on every filter apply.
Fix for Browser pop states while User is in Data Jobs list and going backward/forward and state from URL is propagated to the component.
Removed icon **new** from Executions tab in Data Job view.
Fix for some e2e tests.

More info about `navigateToUrl` and `locationToURL`:
- `navigateToUrl` initiates Browser navigation through Angular `Router` service which on the other hand triggers router change and component resolving through Angular Router mechanism that at the end fires `NavigationEnd` event and sends telemetry event PageView
- `locationToURL` initiates Browser navigation through Angular `Location` service, it updates Browser URL but doesn't trigger route change through Angular `Router` and because of that it doesn't send telemetry event PageView.
  - I can "say" that for telemetry it is still the same page, not new one
  - context for the page (components) is just fine-tuned, but global context is the same e.g. Manage Data Jobs and the component list that shows all the Data Jobs in the system

More info about `"We want to stop sending telemetry PageView events on every filter apply"`:
- We make it to be consistent with the other pages in VDK Data Pipelines UI and also with the other pages where VDK is consumed in Supercollider
- Telemetry library consumes Angular `NavigationEnd` events from Angular Router and sends them as PageView events to the REST Api
- Query params changes initiated from filter changes, shouldn't be logged as PageView from our perspective and for consistency
- With the new change we will lose filters information in PageView events url, but we will still have filters information in the other events like click, right_click, etc..