### PR TITLE
versatile-data-kit: remove gitlint pre-commit hook

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,9 +1,0 @@
-[general]
-contrib=contrib-body-requires-signed-off-by
-
-[title-match-regex]
-# python like regex (https://docs.python.org/3/library/re.html) that the
-# commit-msg title must be matched to.
-# Note that the regex can contradict with other rules if not used correctly
-# (e.g. title-must-not-contain-word).
-regex=(vdk-.*|.*-vdk|specs|support|versatile-data-kit|documentation|control-service|examples|frontend): .*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,10 +21,6 @@ repos:
       - id: requirements-txt-fixer
       - id: detect-private-key
       - id: fix-byte-order-marker
-  - repo: https://github.com/jorisroovers/gitlint
-    rev: v0.19.1
-    hooks:
-      - id: gitlint
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:


### PR DESCRIPTION
As part of discusison between contributors we decided we are going to remove the git lint precommit hook as it hurts more than it helps.

We also use PR description as a commit mesage on main so those are more important than the commit message in the working branch.