### PR TITLE
vdk-jupyter:  fix server error in jupyter ui and remove unneeded code

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/serverRequests.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/serverRequests.ts
@@ -161,7 +161,6 @@ export async function getNotebookInfo(cellId: string): Promise<{
         cellIndex: data['cellIndex']
       };
     } catch (error) {
-      showError(error);
       return {
         path: '',
         cellIndex: ''

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/handlers.py
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/handlers.py
@@ -22,16 +22,27 @@ class LoadJobDataHandler(APIHandler):
     @tornado.web.authenticated
     def post(self):
         working_directory = json.loads(self.get_json_body())[VdkOption.PATH.value]
-        data = JobDataLoader(working_directory)
-        self.finish(
-            json.dumps(
-                {
-                    VdkOption.PATH.value: data.get_job_path(),
-                    VdkOption.NAME.value: data.get_job_name(),
-                    VdkOption.TEAM.value: data.get_team_name(),
-                }
+        try:
+            data = JobDataLoader(working_directory)
+            self.finish(
+                json.dumps(
+                    {
+                        VdkOption.PATH.value: data.get_job_path(),
+                        VdkOption.NAME.value: data.get_job_name(),
+                        VdkOption.TEAM.value: data.get_team_name(),
+                    }
+                )
             )
-        )
+        except Exception as e:
+            self.finish(
+                json.dumps(
+                    {
+                        VdkOption.PATH.value: "",
+                        VdkOption.NAME.value: "",
+                        VdkOption.TEAM.value: "",
+                    }
+                )
+            )
 
 
 class RunJobHandler(APIHandler):

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/handlers.py
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/handlers.py
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 import json
-import os
+import logging
 
 import tornado
 from jupyter_server.base.handlers import APIHandler
@@ -10,6 +10,8 @@ from jupyter_server.utils import url_path_join
 from .job_data import JobDataLoader
 from .vdk_options.vdk_options import VdkOption
 from .vdk_ui import VdkUI
+
+log = logging.getLogger(__name__)
 
 
 class LoadJobDataHandler(APIHandler):
@@ -34,6 +36,9 @@ class LoadJobDataHandler(APIHandler):
                 )
             )
         except Exception as e:
+            log.debug(
+                f"Failed to load job information from config.ini with error: {e}."
+            )
             self.finish(
                 json.dumps(
                     {

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/vdk_ui.py
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/vdk_ui.py
@@ -12,7 +12,6 @@ from vdk.internal.control.command_groups.job.delete import JobDelete
 from vdk.internal.control.command_groups.job.deploy_cli_impl import JobDeploy
 from vdk.internal.control.command_groups.job.download_job import JobDownloadSource
 from vdk.internal.control.utils import cli_utils
-from vdk.internal.control.utils.cli_utils import get_or_prompt
 
 
 class RestApiUrlConfiguration:
@@ -154,19 +153,25 @@ class VdkUI:
         """
         output = "text"
         cmd = JobDeploy(RestApiUrlConfiguration.get_rest_api_url(), output)
-        path = get_or_prompt("Job Path", path)
-        default_name = os.path.basename(path)
-        name = get_or_prompt("Job Name", name, default_name)
-        reason = get_or_prompt("Reason", reason)
-        cmd.create(
-            name=name,
-            team=team,
-            job_path=path,
-            reason=reason,
-            vdk_version=None,
-            enabled=enabled,
-        )
-        return output
+        if enabled:
+            cmd.create(
+                name=name,
+                team=team,
+                job_path=path,
+                reason=reason,
+                vdk_version=None,
+                enabled=True,
+            )
+        else:
+            cmd.create(
+                name=name,
+                team=team,
+                job_path=path,
+                reason=reason,
+                vdk_version=None,
+                enabled=False,
+            )
+        return f"Job with name {name} and team {team} is deployed successfully!"
 
     @staticmethod
     def get_notebook_info(cell_id: str, pr_path: str):

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/vdk_ui.py
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/vdk_ui.py
@@ -152,7 +152,7 @@ class VdkUI:
         :param enabled: flag whether the job is enabled (that will basically un-pause the job)
         :return: output string of the operation
         """
-        output = ""
+        output = "text"
         cmd = JobDeploy(RestApiUrlConfiguration.get_rest_api_url(), output)
         path = get_or_prompt("Job Path", path)
         default_name = os.path.basename(path)
@@ -163,7 +163,6 @@ class VdkUI:
             team=team,
             job_path=path,
             reason=reason,
-            output=output,
             vdk_version=None,
             enabled=enabled,
         )


### PR DESCRIPTION
What:
1.removed some unneeded code
2. fixed some issues with deployment from jupyter
3. fixed server fail on not present config.ini 

Why: 
1. there was an error in the server that was failing when config.ini is not present, I put that in try catch 
2. the deploy was failing because of enabled flag

Signed-off-by: Duygu Hasan [hduygu@vmware.com](mailto:hduygu@vmware.com)