### PR TITLE
vdk-impala: upgrade code to support pydantic 2.0

### DIFF
--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/dimension/scd1/00-dimension-scd1-definition.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/dimension/scd1/00-dimension-scd1-definition.py
@@ -15,8 +15,8 @@ class SlowlyChangingDimensionTypeOverwriteParams(BaseModel):
     target_table: str
     source_schema: str
     source_view: str
-    check: Optional[Callable[[str], bool]]
-    staging_schema: Optional[str]
+    check: Optional[Callable[[str], bool]] = None
+    staging_schema: Optional[str] = None
 
 
 class SlowlyChangingDimensionTypeOverwrite(TemplateArgumentsValidator):

--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/fact/insert/00-fact-snapshot-definition.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/fact/insert/00-fact-snapshot-definition.py
@@ -15,8 +15,8 @@ class FactDailySnapshotParams(BaseModel):
     target_table: str
     source_schema: str
     source_view: str
-    check: Optional[Callable[[str], bool]]
-    staging_schema: Optional[str]
+    check: Optional[Callable[[str], bool]] = None
+    staging_schema: Optional[str] = None
 
 
 class FactDailySnapshot(TemplateArgumentsValidator):

--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/fact/snapshot/00-fact-snapshot-definition.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/fact/snapshot/00-fact-snapshot-definition.py
@@ -16,8 +16,8 @@ class FactDailySnapshotParams(BaseModel):
     source_schema: str
     source_view: str
     last_arrival_ts: str
-    check: Optional[Callable[[str], bool]]
-    staging_schema: Optional[str]
+    check: Optional[Callable[[str], bool]] = None
+    staging_schema: Optional[str] = None
 
 
 class FactDailySnapshot(TemplateArgumentsValidator):

--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/versioned/00-versioned-definition.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/versioned/00-versioned-definition.py
@@ -3,7 +3,8 @@
 from typing import List
 
 from pydantic import BaseModel
-from pydantic import validator
+from pydantic import field_validator
+from pydantic import FieldValidationInfo
 from vdk.api.job_input import IJobInput
 from vdk.plugin.impala.templates.template_arguments_validator import (
     TemplateArgumentsValidator,
@@ -24,9 +25,11 @@ class LoadVersionedParams(BaseModel):
     active_to_column: str = "active_to"
     active_to_max_value: str = "9999-12-31"
 
-    @validator("tracked_columns", allow_reuse=True)
-    def passwords_match(cls, tracked_columns, values, **kwargs):
-        value_columns = values.get("value_columns")
+    @field_validator("tracked_columns")
+    def tracked_columns_subset_of_value_columns(
+        cls, tracked_columns: List[str], values: FieldValidationInfo, **kwargs
+    ):
+        value_columns = values.data["value_columns"]
         if type(value_columns) == list and not tracked_columns:
             raise ValueError("The list must contain at least one column")
         if type(value_columns) == list == type(value_columns) and not set(

--- a/projects/vdk-plugins/vdk-impala/tests/functional/template_regression_test.py
+++ b/projects/vdk-plugins/vdk-impala/tests/functional/template_regression_test.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 import pytest
 from vdk.internal.core import errors
 from vdk.plugin.impala import impala_plugin
+from vdk.plugin.test_utils.util_funcs import cli_assert
 from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
 from vdk.plugin.test_utils.util_funcs import get_test_job_path
 
@@ -51,7 +52,7 @@ class TestTemplateRegression(unittest.TestCase):
                 "target_table": target_table,
             },
         )
-        assert not res.exception
+        cli_assert(not res.exception, res)
         actual_rs = self._run_query(f"SELECT * FROM {test_schema}.{target_table}")
         expected_rs = self._run_query(f"SELECT * FROM {test_schema}.{source_view}")
         assert actual_rs.output and expected_rs.output
@@ -71,7 +72,7 @@ class TestTemplateRegression(unittest.TestCase):
                 "target_table": target_table,
             },
         )
-        assert not res.exception
+        cli_assert(not res.exception, res)
 
         actual_rs = self._run_query(f"SELECT * FROM {test_schema}.{target_table}")
         expected_rs = self._run_query(f"SELECT * FROM {test_schema}.{source_view}")
@@ -127,7 +128,7 @@ class TestTemplateRegression(unittest.TestCase):
             },
         )
 
-        assert not res.exception
+        cli_assert(not res.exception, res)
         actual_rs = self._run_query(f"SELECT * FROM {test_schema}.{target_table}")
         expected_rs = self._run_query(f"SELECT * FROM {test_schema}.{source_view}")
         assert actual_rs.output and expected_rs.output
@@ -180,7 +181,7 @@ class TestTemplateRegression(unittest.TestCase):
                 "id_column": "id",
             },
         )
-        assert not res.exception
+        cli_assert(not res.exception, res)
 
         actual_rs = self._run_query(f"SELECT * FROM {test_schema}.{target_table}")
         expected_rs = self._run_query(f"SELECT * FROM {test_schema}.{expect_table}")
@@ -259,7 +260,7 @@ class TestTemplateRegression(unittest.TestCase):
                 "updated_at_column": "updated_at",
             },
         )
-        assert not res.exception
+        cli_assert(not res.exception, res)
 
         actual_rs = self._run_query(f"SELECT * FROM {test_schema}.{target_table}")
         expected_rs = self._run_query(f"SELECT * FROM {test_schema}.{expect_table}")
@@ -308,7 +309,7 @@ class TestTemplateRegression(unittest.TestCase):
                 "updated_at_column": "updated_at",
             },
         )
-        assert not res.exception
+        cli_assert(not res.exception, res)
 
         actual_rs = self._run_query(f"SELECT * FROM {test_schema}.{target_table}")
         expected_rs = self._run_query(f"SELECT * FROM {test_schema}.{expect_table}")
@@ -434,7 +435,7 @@ class TestTemplateRegression(unittest.TestCase):
                 "last_arrival_ts": "updated_at",
             },
         )
-        assert not res.exception
+        cli_assert(not res.exception, res)
 
         actual_rs = self._run_query(f"SELECT * FROM {test_schema}.{target_table}")
         expected_rs = self._run_query(f"SELECT * FROM {test_schema}.{expect_table}")
@@ -466,7 +467,7 @@ class TestTemplateRegression(unittest.TestCase):
             },
         )
         # Expecting data job not to finish due to empty source.
-        assert not res.exception
+        cli_assert(not res.exception, res)
         assert res.exit_code == 0
 
         actual_rs = self._run_query(f"SELECT * FROM {test_schema}.{target_table}")
@@ -498,7 +499,7 @@ class TestTemplateRegression(unittest.TestCase):
                 "last_arrival_ts": "updated_at",
             },
         )
-        assert not res.exception
+        cli_assert(not res.exception, res)
 
         actual_rs = self._run_query(f"SELECT * FROM {test_schema}.{target_table}")
         expected_rs = self._run_query(f"SELECT * FROM {test_schema}.{expect_table}")
@@ -560,7 +561,7 @@ class TestTemplateRegression(unittest.TestCase):
             },
         )
 
-        assert not res.exception
+        cli_assert(not res.exception, res)
         actual_rs = self._run_query(f"SELECT * FROM {test_schema}.{target_table}")
         expected_rs = self._run_query(f"SELECT * FROM {test_schema}.{expect_table}")
         assert actual_rs.output and expected_rs.output
@@ -724,7 +725,7 @@ class TestTemplateRegression(unittest.TestCase):
                 "expect_table": expect_table,
             },
         )
-        assert not res.exception
+        cli_assert(not res.exception, res)
 
         actual_rs = self._run_query(f"SELECT * FROM {test_schema}.{target_table}")
         expected_rs = self._run_query(f"SELECT * FROM {test_schema}.{expect_table}")
@@ -754,7 +755,7 @@ class TestTemplateRegression(unittest.TestCase):
                 "expect_table": expect_table,
             },
         )
-        assert not res.exception
+        cli_assert(not res.exception, res)
 
         actual_rs = self._run_query(f"SELECT * FROM {test_schema}.{target_table}")
         expected_rs = self._run_query(f"SELECT * FROM {test_schema}.{expect_table}")
@@ -788,7 +789,7 @@ class TestTemplateRegression(unittest.TestCase):
             },
         )
 
-        assert not res.exception
+        cli_assert(not res.exception, res)
         actual_rs = self._run_query(f"SELECT * FROM {test_schema}.{target_table}")
         expected_rs = self._run_query(f"SELECT * FROM {test_schema}.{expect_table}")
         assert actual_rs.output and expected_rs.output


### PR DESCRIPTION
A week ago pydantic released 2.0 version which is a breaking version .

https://docs.pydantic.dev/dev-v2/migration Fortunately pydantic has also released a tool bump-pydantic which automatically upgraded the code. That's very useful.

Also in tests use `cli_assert(not res.exception, res)` instead of assert to print more details about the job failure.