### PR TITLE
vdk-impala: Truncate table before inserting data

### DIFF
--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/fact/insert/02-handle-quality-checks.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/fact/insert/02-handle-quality-checks.py
@@ -39,6 +39,8 @@ def run(job_input: IJobInput):
 
         align_stg_table_with_target(target_table_full_name, staging_table, job_input)
 
+        job_input.execute_query(f"TRUNCATE {staging_table}")
+
         insert_into_staging = insert_query.format(
             target_schema=staging_schema,
             target_table=staging_table_name,

--- a/projects/vdk-plugins/vdk-impala/tests/functional/template_regression_test.py
+++ b/projects/vdk-plugins/vdk-impala/tests/functional/template_regression_test.py
@@ -14,6 +14,7 @@ import pytest
 from vdk.internal.core import errors
 from vdk.plugin.impala import impala_plugin
 from vdk.plugin.test_utils.util_funcs import cli_assert
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
 from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
 from vdk.plugin.test_utils.util_funcs import get_test_job_path
 
@@ -850,6 +851,7 @@ class TestTemplateRegression(unittest.TestCase):
         )
         staging_table_name = f"vdk_check_{test_schema}_{target_table}"
         first_exec_rs = self._run_query(f"SELECT * FROM {staging_schema}.{staging_table_name}")
+        cli_assert_equal(0, res_first_exec)
 
         res_second_exec = self._run_job(
             "insert_template_job",
@@ -864,11 +866,12 @@ class TestTemplateRegression(unittest.TestCase):
                 "staging_schema": staging_schema,
             },
         )
+        cli_assert_equal(0, res_second_exec)
 
         second_exec_rs = self._run_query(f"SELECT * FROM {staging_schema}.{staging_table_name}")
         first_exec = {x for x in first_exec_rs.output.split("\n")}
         second_exec = {x for x in second_exec_rs.output.split("\n")}
 
         self.assertSetEqual(
-            first_exec, second_exec, f"Clean up of staging table is not made properly."
+            first_exec, second_exec, f"Clean up of staging table - {staging_table_name} is not made properly. Different data was found in the table after consecutive executions."
         )

--- a/projects/vdk-plugins/vdk-impala/tests/functional/template_regression_test.py
+++ b/projects/vdk-plugins/vdk-impala/tests/functional/template_regression_test.py
@@ -850,7 +850,9 @@ class TestTemplateRegression(unittest.TestCase):
             },
         )
         staging_table_name = f"vdk_check_{test_schema}_{target_table}"
-        first_exec_rs = self._run_query(f"SELECT * FROM {staging_schema}.{staging_table_name}")
+        first_exec_rs = self._run_query(
+            f"SELECT * FROM {staging_schema}.{staging_table_name}"
+        )
         cli_assert_equal(0, res_first_exec)
 
         res_second_exec = self._run_job(
@@ -875,5 +877,7 @@ class TestTemplateRegression(unittest.TestCase):
         second_exec = {x for x in second_exec_rs.output.split("\n")}
 
         self.assertSetEqual(
-            first_exec, second_exec, f"Clean up of staging table - {staging_table_name} is not made properly. Different data was found in the table after consecutive executions."
+            first_exec,
+            second_exec,
+            f"Clean up of staging table - {staging_table_name} is not made properly. Different data was found in the table after consecutive executions.",
         )


### PR DESCRIPTION
Why:
Currently when the insert template is used with quality checks it only appends data to the staging table without truncating it at any moment. This will most probably lead to duplicated data on the following run, because old source data will be already in the staging table before appending the new one.

More details explained in
#1361

What:
-Adding truncate statement before the data is being inserted in the staging table to ensure that no leftover data from previous runs is left.

Signed-off-by: Stefan Buldeev sbuldeev@vmware.com