### PR TITLE
vdk-core: Set sender when checking if email exists

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/notification/notification_base.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/notification/notification_base.py
@@ -123,7 +123,7 @@ class EmailNotification(INotification):
         s = self.__smtp_server()
         try:
             s.helo()
-            s.mail("whatever")
+            s.mail(self._sender)
             resp = s.rcpt(email_address)
             return resp[0] == 250
         except smtplib.SMTPServerDisconnected as e:


### PR DESCRIPTION
Currently, when a target email address is checked if exists, we set a dummy sender `"whatever"`. This works in cases, where the smtp server does not enforce validation checks on the sender. It does not, however, work in cases when the smtp server uses TLS (like Office365).

In such cases, the check of the target email address fails with Status `503: Bad sequence of commands`, because the `.mail("whatever")` method call sets the **FROM** field to *mail FROM:<whatever>*, and this causes the smtp server to return `501 5.1.7 Invalid address`.

This change replces `"whatever"` with the actual sender address used to send the email notifications (set through the `VDK_NOTIFICATION_SENDER`) environment variable.

Testing Done:
Create a sample email script to first better understand the error, and second to verify that the fix actually works.

Script is:
```python
HOST = "smtp.office365.com"
PORT = 587
SENDER = "<valid-address-as-set-by-VDK_NOTIFICATION_SENDER>"
USERNAME = "<sender-user-as-set-by-VDK_NOTIFICATION_SMTP_LOGIN_USERNAME>"
PASSWORD = "<password-as-set-by-VDK_NOTIFICATION_SMTP_LOGIN_PASSWORD>"
TARGET_ADDRESS = "<some-valid-email-address>"

s = smtplib.SMTP(HOST, PORT)
s.starttls()
s.login(USERNAME, PASSWORD)
s.set_debuglevel(1)

try:
    s.helo()
    # s.mail(SENDER)               # Test the actual fix
    s.mail("whatever")             # Check the full error
    resp = s.rcpt(TARGET_ADDRESS)
    print(resp)
except smtplib.SMTPServerDisconnected as e:
    print(f"SMTP connection error while checking if email address exists: {e}")
finally:
    s.quit()
```