### PR TITLE
control-service: push to multiple registries

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,7 @@
 image: "python:3.7"
 
 include:
+  - "cicd/.gitlab-ci-lib.yml"
   - "projects/vdk-control-cli/.gitlab-ci.yml"
   - "projects/vdk-core/.gitlab-ci.yml"
   - "projects/frontend/cicd/.gitlab-ci.yml"

--- a/cicd/.gitlab-ci-lib.yml
+++ b/cicd/.gitlab-ci-lib.yml
@@ -1,0 +1,20 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# This is a shared library with common util gitlab "jobs" that can be reused across any project
+# Project specific functionality must go in the project specific .gitlab-ci.yml file
+
+
+.images:dind:
+  image: docker:23.0.1
+  variables:
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_TLS_CERTDIR: ""
+  services:
+    - docker:23.0.1-dind
+
+.images:dind:docker-push-to-vdk-repos:
+  extends: .images:dind
+  before_script:
+    - apk add --update bash
+    - export PATH="$(pwd)/cicd:$PATH"

--- a/cicd/docker_parse.sh
+++ b/cicd/docker_parse.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Parses a Docker image name and extracts information such as the registry, username, repository, and tag.
+#
+# Upon success the function sets the following environment variables based on the input image name:
+#   IMAGE_REGISTRY: The Docker image registry. If no registry is specified in the image name, this will default to docker.io.
+#   IMAGE_USERNAME: The username or namespace under which the image resides. If no username is specified, this will default to an empty string.
+#   IMAGE_REPOSITORY: The repository where the Docker image resides.
+#   IMAGE_TAG: The tag of the Docker image. If no tag is specified, this will default to latest.
+
+function parse_docker_image() {
+  local image="$1"
+
+  if [[ -z "$image" ]]; then
+      echo "Error: No image name provided."
+      return 1
+  fi
+
+  # Check if there is a registry and port number
+  if [[ $image == *"/"* ]]; then
+    REGISTRY=${image%%/*}
+    image=${image#*/}
+  else
+    REGISTRY="docker.io"
+  fi
+
+  # Check if there is a tag
+  if [[ $image == *":"* ]]; then
+    TAG=${image##*:}
+    image=${image%:*}
+  else
+    TAG="latest"
+  fi
+
+  # Check if there is a username
+  if [[ $image == *"/"* ]]; then
+    USERNAME=${image%%/*}
+    REPOSITORY=${image#*/}
+  else
+    USERNAME=""
+    REPOSITORY=$image
+  fi
+
+  export IMAGE_REGISTRY=$REGISTRY
+  export IMAGE_USERNAME=$USERNAME
+  export IMAGE_REPOSITORY=$REPOSITORY
+  export IMAGE_TAG=$TAG
+}

--- a/cicd/docker_push_vdk.sh
+++ b/cicd/docker_push_vdk.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# This Bash script provides a utility to push a containers image to multiple container registries.
+# The scripts automatically detects if there's registry and user and ignores them using only repository and tag
+# to push them to each respective registry
+#
+# The script uses several environment variables:
+#
+#   VDK_DOCKER_REGISTRY_URL: Docker registry URL for VDK Docker images.
+#   VDK_DOCKER_REGISTRY_USERNAME: Username for the VDK Docker registry.
+#   VDK_DOCKER_REGISTRY_PASSWORD: Password for the VDK Docker registry.
+#   CICD_CONTAINER_REGISTRY_URI: Container registry URL for VDK GitHub images.
+#   CICD_CONTAINER_REGISTRY_USER_NAME: Username for the VDK GitHub Container registry.
+#   CICD_CONTAINER_REGISTRY_USER_PASSWORD: Password for the VDK GitHub Container registry.
+#
+# Those variables are set automatically in Gitlab CI environment of VDK
+# See more details in https://github.com/vmware/versatile-data-kit/wiki/Gitlab-CICD#cicd-demo-installation-variables
+#
+# Usage:
+# ./docker_push_vdk <docker_image_name>
+
+# set -o nounset -o errexit -o pipefail
+
+
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/docker_parse.sh"
+
+function push_image_to_vdk_registries() {
+
+  if [ -z "${VDK_REGISTRIES}" ]; then
+      export VDK_REGISTRIES=(
+        "${VDK_DOCKER_REGISTRY_URL} ${VDK_DOCKER_REGISTRY_USERNAME} ${VDK_DOCKER_REGISTRY_PASSWORD}"
+        "${CICD_CONTAINER_REGISTRY_URI} ${CICD_CONTAINER_REGISTRY_USER_NAME} ${CICD_CONTAINER_REGISTRY_USER_PASSWORD}"
+        )
+  fi
+
+  local DOCKER_IMAGE="$1"
+
+  parse_docker_image "$DOCKER_IMAGE"
+
+  echo "Discarding user and registry part of the docker image: $DOCKER_IMAGE -> $IMAGE_REPOSITORY/$IMAGE_TAG"
+  local TARGET_DOCKER_IMAGE="$IMAGE_REPOSITORY:$IMAGE_TAG"
+
+  for registry in "${VDK_REGISTRIES[@]}"; do
+      REGISTRY_URL=$(echo "$registry" | awk '{print $1}')
+      USERNAME=$(echo "$registry" | awk '{print $2}')
+      PASSWORD=$(echo "$registry" | awk '{print $3}')
+
+      echo "$PASSWORD" | docker login "$REGISTRY_URL" --username "$USERNAME" --password-stdin
+
+      if [ $? -eq 0 ]; then
+          # Tag the Docker image for the registry
+          docker tag "$DOCKER_IMAGE" "$REGISTRY_URL/$TARGET_DOCKER_IMAGE"
+
+          echo "docker push $REGISTRY_URL/$TARGET_DOCKER_IMAGE"
+          docker push "$REGISTRY_URL/$TARGET_DOCKER_IMAGE"
+      fi
+  done
+}
+
+push_image_to_vdk_registries "$@"

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -129,7 +129,7 @@ control_service_test_helm_chart:
       - projects/control-service/projects/helm_charts/pipelines-control-service/version.txt
 
 control_service_publish_job_base_image:
-  extends: .images:dind
+  extends: .images:dind:docker-push-to-vdk-repos
   stage: publish_artifacts
   script:
     - apk add --no-cache bash
@@ -146,7 +146,7 @@ control_service_publish_job_base_image:
         - projects/control-service/projects/job-base-image/**/*
 
 .control_service_publish_job_base_image_secure:
-  extends: .images:dind
+  extends: .images:dind:docker-push-to-vdk-repos
   stage: publish_artifacts
   needs:
     - job: control_service_publish_python_image_secure_3_8
@@ -282,7 +282,7 @@ control_service_publish_job_builder_secure_image:
 
 
 control_service_publish_image:
-  extends: .images:dind
+  extends: .images:dind:docker-push-to-vdk-repos
   stage: publish_artifacts
   script:
     - apk add --no-cache git openjdk17-jdk
@@ -291,7 +291,9 @@ control_service_publish_image:
     - cd projects/control-service/projects
     - ./gradlew -p ./model build publishToMavenLocal --info --stacktrace
     - ./gradlew build -x test --info --stacktrace
-    - ./gradlew :pipelines_control_service:dockerPush --info --stacktrace -Pversion=$TAG
+    - ./gradlew :pipelines_control_service:dockerTag --info --stacktrace -Pversion=$TAG
+    - docker_push_vdk.sh "versatiledatakit/pipelines-control-service:$TAG"
+    - docker_push_vdk.sh "versatiledatakit/pipelines-control-service:latest"
   retry: !reference [.control_service_retry, retry_options]
   artifacts:
     when: always

--- a/projects/control-service/projects/job-base-image-secure/publish-job-base-image.sh
+++ b/projects/control-service/projects/job-base-image-secure/publish-job-base-image.sh
@@ -42,5 +42,6 @@ docker-slim build \
 --include-path "/usr/local/lib/python$PYTHON_MAJOR.$PYTHON_MINOR/" \
 --include-path "/opt/lib/native/oracle"
 
-docker push "$data_job_base_image_tag_version"
-docker push "$data_job_base_image_tag_latest"
+
+docker_push_vdk.sh "$data_job_base_image_tag_version"
+docker_push_vdk.sh "$data_job_base_image_tag_latest"

--- a/projects/control-service/projects/job-base-image/publish-job-base.sh
+++ b/projects/control-service/projects/job-base-image/publish-job-base.sh
@@ -16,8 +16,8 @@ function build_and_push_image() {
     image_tag="$image_repo:$VERSION_TAG"
 
     docker build -t "$image_tag" -t "$image_repo:latest" -f "$SCRIPT_DIR/$docker_file" $arguments "$SCRIPT_DIR"
-    docker push "$image_tag"
-    docker push "$image_repo:latest"
+    docker_push_vdk.sh "$image_tag"
+    docker_push_vdk.sh "$image_repo:latest"
 }
 
 build_and_push_image \


### PR DESCRIPTION
To avoid issues with docker limits sometimes it may be beneficial to use
ghcr.io instead for example in our CICD or in vdk-server .

This change publishes some images to both docker.io and ghcr.io

The GitLab CI configuration is changed to include a shared library for common CI/CD tasks. 
Two new scripts have been added for parsing and pushing Docker images. 
These scripts are now being used in the build process to push images to multiple registries in.

Testing Done: Temporarily changed the pipeline to push images on PR and verified images are pushed to both correctly. See it in https://gitlab.com/vmware-analytics/versatile-data-kit/-/pipelines/927292918
