### PR TITLE
control-service: remove unused dependency influxdb

### DIFF
--- a/projects/control-service/projects/base/build.gradle
+++ b/projects/control-service/projects/base/build.gradle
@@ -51,7 +51,6 @@ dependencies {
 
    implementation "org.springframework:spring-aspects"
 
-   implementation versions.'org.influxdb:influxdb-java'
    implementation versions.'com.google.guava:guava'
    implementation versions.'io.micrometer:micrometer-registry-prometheus'
    implementation versions.'org.apache.commons:commons-lang3'

--- a/projects/control-service/projects/base/src/test/resources/application.properties
+++ b/projects/control-service/projects/base/src/test/resources/application.properties
@@ -1,9 +1,5 @@
 management.endpoints.web.base-path=/base/debug
 management.endpoints.web.exposure.include=*
-management.metrics.export.influx.db=sccp_base_tests
-management.metrics.export.influx.password=vacwriter
-management.metrics.export.influx.uri=http://tst-influxdb01-mon.vac.vmware.com:8086
-management.metrics.export.influx.user-name=vac_writer
 management.trace.include=USER_PRINCIPAL,errors,parameters,context_path,remote_address,path_info,path_translated,session_id
 taurus.svc.name=base_tests
 

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/example-vdk-options.ini
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/example-vdk-options.ini
@@ -1,6 +1,5 @@
 # Options applicable for all data jobs.
 [default]
-VDK_INFLUX_DB_PASSWORD=influx-db-pass
 VDK_REDSHIFT_HOST=rs-host
 VDK_REDSHIFT_NAME=rs-name
 

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/VdkOptionsReaderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/VdkOptionsReaderTest.java
@@ -12,7 +12,6 @@ import java.util.Map;
 
 public class VdkOptionsReaderTest {
 
-  private static final String VDK_INFLUX_DB_PASSWORD_KEY = "VDK_INFLUX_DB_PASSWORD";
   private static final String VDK_REDSHIFT_HOST_KEY = "VDK_REDSHIFT_HOST";
   private static final String VDK_REDSHIFT_NAME_KEY = "VDK_REDSHIFT_NAME";
   private static final String VDK_RESOURCE_LIMIT_MEMORY_MB_KEY = "VDK_RESOURCE_LIMIT_MEMORY_MB";
@@ -25,8 +24,7 @@ public class VdkOptionsReaderTest {
   public void readVdkOptions_defaultOptions() {
     Map<String, String> vdkOptions = vdkOptionsReader.readVdkOptions("unconfigured-job-name");
 
-    Assertions.assertEquals(3, vdkOptions.size());
-    Assertions.assertEquals("influx-db-pass", vdkOptions.get(VDK_INFLUX_DB_PASSWORD_KEY));
+    Assertions.assertEquals(2, vdkOptions.size());
     Assertions.assertEquals("rs-host", vdkOptions.get(VDK_REDSHIFT_HOST_KEY));
     Assertions.assertEquals("rs-name", vdkOptions.get(VDK_REDSHIFT_NAME_KEY));
   }
@@ -35,8 +33,7 @@ public class VdkOptionsReaderTest {
   public void readVdkOptions_customJobOptions() {
     Map<String, String> vdkOptions = vdkOptionsReader.readVdkOptions("example");
 
-    Assertions.assertEquals(5, vdkOptions.size());
-    Assertions.assertEquals("influx-db-pass", vdkOptions.get(VDK_INFLUX_DB_PASSWORD_KEY));
+    Assertions.assertEquals(4, vdkOptions.size());
     Assertions.assertEquals("rs-host", vdkOptions.get(VDK_REDSHIFT_HOST_KEY));
     Assertions.assertEquals("rs-name", vdkOptions.get(VDK_REDSHIFT_NAME_KEY));
     Assertions.assertEquals("10000", vdkOptions.get(VDK_RESOURCE_LIMIT_MEMORY_MB_KEY));

--- a/projects/control-service/projects/pipelines_control_service/src/test/resources/vdk_options/test_vdk_options.ini
+++ b/projects/control-service/projects/pipelines_control_service/src/test/resources/vdk_options/test_vdk_options.ini
@@ -1,6 +1,5 @@
 # Default VDK options
 [default]
-VDK_INFLUX_DB_PASSWORD=influx-db-pass
 VDK_REDSHIFT_HOST=rs-host
 VDK_REDSHIFT_NAME=rs-name
 

--- a/projects/control-service/projects/versions-of-external-dependencies.gradle
+++ b/projects/control-service/projects/versions-of-external-dependencies.gradle
@@ -6,7 +6,6 @@ project.ext {
             // Update the ph-client to latest.
             'io.micrometer:micrometer-registry-prometheus'                       : 'io.micrometer:micrometer-registry-prometheus:1.11.1',
             'org.openapitools:jackson-databind-nullable'                         : 'org.openapitools:jackson-databind-nullable:0.2.6',
-            'org.influxdb:influxdb-java'                                         : 'org.influxdb:influxdb-java:2.21',
             'org.postgresql:postgresql'                                          : 'org.postgresql:postgresql:42.6.0',
             'org.projectlombok:lombok'                                           : 'org.projectlombok:lombok:1.18.28',
             'com.h2database:h2'                                                  : 'com.h2database:h2:2.2.220',


### PR DESCRIPTION
We no longer use influx , removing leftovers.

Closes https://github.com/vmware/versatile-data-kit/issues/1452