### PR TITLE
vdk-jupyter: publish image to pip registry

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
@@ -38,7 +38,7 @@
 release-vdk-jupyter:
   variables:
     PLUGIN_NAME:
-  image: "python:3.10-alpine"
+  image: "python:3.10"
   stage: release
   before_script:
     - export VDK_PATCH_VERSION=${CI_PIPELINE_ID}
@@ -47,10 +47,10 @@ release-vdk-jupyter:
     - echo "Release plugin $PLUGIN_NAME"
     - cd vdk-jupyter/vdk-jupyterlab-extension/ || exit 1
     - sed -ri "s/__version__ = \"([[:digit:]]\.[[:digit:]]\.).*\"$/__version__ = \"\1${VDK_PATCH_VERSION}\"/g" setup.py
-    - pip install -U pip setuptools wheel twine pre-commit
-    - python setup.py sdist --formats=gztar
+    - pip install -U pip setuptools wheel twine pre-commit build
+    - python -m build
     # provide the credentials as Gitlab variables
-    - twine upload --repository-url $PIP_REPO_UPLOAD_URL -u "$PIP_REPO_UPLOAD_USER_NAME" -p "$PIP_REPO_UPLOAD_USER_PASSWORD" dist/*tar.gz --verbose
+    - twine upload --repository-url $PIP_REPO_UPLOAD_URL -u "$PIP_REPO_UPLOAD_USER_NAME" -p "$PIP_REPO_UPLOAD_USER_PASSWORD" dist/* --verbose
   rules: # we want to trigger build jobs if there are changes to this package,
     # but not if there are changes to VDK plugins or the main directory
     - if: '$CI_COMMIT_BRANCH == "main" || $CI_PIPELINE_SOURCE == "external_pull_request_event"'

--- a/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
@@ -48,6 +48,9 @@ release-vdk-jupyter:
     - cd vdk-jupyter/vdk-jupyterlab-extension/ || exit 1
     - sed -ri "s/__version__ = \"([[:digit:]]\.[[:digit:]]\.).*\"$/__version__ = \"\1${VDK_PATCH_VERSION}\"/g" setup.py
     - apk --no-cache add npm
+    - apk add rust cargo
+    - apk add libffi-dev
+    - pip install jupyter
     - pip install -U pip setuptools wheel twine pre-commit build
     - python -m build
     # provide the credentials as Gitlab variables

--- a/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
@@ -37,8 +37,20 @@
 
 release-vdk-jupyter:
   variables:
-    PLUGIN_NAME: vdk-jupyter/vdk-jupyterlab-extension
-  extends: .release-plugin
+    PLUGIN_NAME:
+  image: "python:3.10-alpine"
+  stage: release
+  before_script:
+    - export VDK_PATCH_VERSION=${CI_PIPELINE_ID}
+  script:
+    - cd projects/vdk-plugins/
+    - echo "Release plugin $PLUGIN_NAME"
+    - cd vdk-jupyter/vdk-jupyterlab-extension/ || exit 1
+    - sed -ri "s/__version__ = \"([[:digit:]]\.[[:digit:]]\.).*\"$/__version__ = \"\1${VDK_PATCH_VERSION}\"/g" setup.py
+    - pip install -U pip setuptools wheel twine pre-commit
+    - python setup.py sdist --formats=gztar
+    # provide the credentials as Gitlab variables
+    - twine upload --repository-url $PIP_REPO_UPLOAD_URL -u "$PIP_REPO_UPLOAD_USER_NAME" -p "$PIP_REPO_UPLOAD_USER_PASSWORD" dist/*tar.gz --verbose
   rules: # we want to trigger build jobs if there are changes to this package,
     # but not if there are changes to VDK plugins or the main directory
     - if: '$CI_COMMIT_BRANCH == "main" || $CI_PIPELINE_SOURCE == "external_pull_request_event"'

--- a/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
@@ -43,14 +43,12 @@ release-vdk-jupyter:
   before_script:
     - export VDK_PATCH_VERSION=${CI_PIPELINE_ID}
   script:
-    - cd projects/vdk-plugins/
-    - echo "Release plugin $PLUGIN_NAME"
-    - cd vdk-jupyter/vdk-jupyterlab-extension/ || exit 1
-    - sed -ri "s/__version__ = \"([[:digit:]]\.[[:digit:]]\.).*\"$/__version__ = \"\1${VDK_PATCH_VERSION}\"/g" setup.py
+    - cd projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/ || exit 1
     - apk --no-cache add npm
     - apk add rust cargo
     - apk add libffi-dev
     - pip install jupyter
+    - hatch version 0.1.$VDK_PATCH_VERSION
     - pip install -U pip setuptools wheel twine pre-commit build
     - python -m build
     # provide the credentials as Gitlab variables

--- a/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
@@ -31,3 +31,30 @@ build-vdk-jupyterlab-extension:
     - if: '$CI_COMMIT_BRANCH == "main" || $CI_PIPELINE_SOURCE == "external_pull_request_event"'
       changes:
         - "projects/vdk-plugins/vdk-jupyter/**/*"
+
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+.build-vdk-jupyter:
+  variables:
+    PLUGIN_NAME: vdk-jupyter/vdk-jupyterlab-extension
+  extends: .build-plugin
+  rules: # we want to trigger build jobs if there are changes to this package,
+    # but not if there are changes to VDK plugins or the main directory
+    - if: '$CI_COMMIT_BRANCH == "main" || $CI_PIPELINE_SOURCE == "external_pull_request_event"'
+      changes:
+        - "projects/vdk-plugins/vdk-jupyter/**/*"
+
+build-py38-vdk-audit:
+  extends: .build-vdk-jupyter
+  image: "python:3.8"
+
+
+build-py311-vdk-audit:
+  extends: .build-vdk-jupyter
+  image: "python:3.11"
+
+release-vdk-audit:
+  variables:
+    PLUGIN_NAME: vdk-jupyter
+  extends: .release-plugin

--- a/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
@@ -6,38 +6,38 @@
     max: 1
     when:
       - always
-
-
-build-vdk-jupyterlab-extension:
-  stage: build
-  image: "python:3.8-alpine"
-  before_script:
-    - cd projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension || exit 1
-    - pip install -U pip setuptools pre-commit
-    - apk --no-cache add npm
-    - apk add rust cargo
-    - apk add libffi-dev
-    - pip install jupyter
-  script:
-    - echo "Install Dependencies..."
-    - npm ci
-    - echo "Install Vdk JupyterLab Extension..."
-    - pip install .
-    - echo "Building VDK JupyterLab Extension..."
-    - npm rebuild
-  retry: !reference [.retry, retry_options]
-  rules: # we want to trigger build jobs if there are changes to this package,
-    # but not if there are changes to VDK plugins or the main directory
-    - if: '$CI_COMMIT_BRANCH == "main" || $CI_PIPELINE_SOURCE == "external_pull_request_event"'
-      changes:
-        - "projects/vdk-plugins/vdk-jupyter/**/*"
+#
+#
+#build-vdk-jupyterlab-extension:
+#  stage: build
+#  image: "python:3.8-alpine"
+#  before_script:
+#    - cd projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension || exit 1
+#    - pip install -U pip setuptools pre-commit
+#    - apk --no-cache add npm
+#    - apk add rust cargo
+#    - apk add libffi-dev
+#    - pip install jupyter
+#  script:
+#    - echo "Install Dependencies..."
+#    - npm ci
+#    - echo "Install Vdk JupyterLab Extension..."
+#    - pip install .
+#    - echo "Building VDK JupyterLab Extension..."
+#    - npm rebuild
+#  retry: !reference [.retry, retry_options]
+#  rules: # we want to trigger build jobs if there are changes to this package,
+#    # but not if there are changes to VDK plugins or the main directory
+#    - if: '$CI_COMMIT_BRANCH == "main" || $CI_PIPELINE_SOURCE == "external_pull_request_event"'
+#      changes:
+#        - "projects/vdk-plugins/vdk-jupyter/**/*"
 
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 release-vdk-jupyter:
   variables:
-    PLUGIN_NAME: vdk-jupyter
+    PLUGIN_NAME: vdk-jupyter/vdk-jupyterlab-extension
   extends: .release-plugin
   rules: # we want to trigger build jobs if there are changes to this package,
     # but not if there are changes to VDK plugins or the main directory

--- a/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
@@ -42,16 +42,12 @@ release-vdk-jupyter:
     - export VDK_PATCH_VERSION=${CI_PIPELINE_ID}
   script:
     - cd projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/ || exit 1
-    - apk --no-cache add npm
-    - apk add rust cargo
-    - apk add libffi-dev
+    - apk --no-cache add npm rust cargo libffi-dev
     - pip install -U pip setuptools wheel twine pre-commit build hatch jupyter
     - hatch version 0.1.$VDK_PATCH_VERSION
     - python -m build
-    # provide the credentials as Gitlab variables
     - twine upload --repository-url $PIP_REPO_UPLOAD_URL -u "$PIP_REPO_UPLOAD_USER_NAME" -p "$PIP_REPO_UPLOAD_USER_PASSWORD" dist/* --verbose
-  rules: # we want to trigger build jobs if there are changes to this package,
-    # but not if there are changes to VDK plugins or the main directory
+  rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
       when: never
     - if: '$CI_COMMIT_BRANCH == "main"

--- a/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
@@ -47,9 +47,8 @@ release-vdk-jupyter:
     - apk --no-cache add npm
     - apk add rust cargo
     - apk add libffi-dev
-    - pip install jupyter
+    - pip install -U pip setuptools wheel twine pre-commit build hatch jupyter
     - hatch version 0.1.$VDK_PATCH_VERSION
-    - pip install -U pip setuptools wheel twine pre-commit build hatch
     - python -m build
     # provide the credentials as Gitlab variables
     - twine upload --repository-url $PIP_REPO_UPLOAD_URL -u "$PIP_REPO_UPLOAD_USER_NAME" -p "$PIP_REPO_UPLOAD_USER_PASSWORD" dist/* --verbose

--- a/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
@@ -35,26 +35,12 @@ build-vdk-jupyterlab-extension:
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-.build-vdk-jupyter:
+release-vdk-jupyter:
   variables:
-    PLUGIN_NAME: vdk-jupyter/vdk-jupyterlab-extension
-  extends: .build-plugin
+    PLUGIN_NAME: vdk-jupyter
+  extends: .release-plugin
   rules: # we want to trigger build jobs if there are changes to this package,
     # but not if there are changes to VDK plugins or the main directory
     - if: '$CI_COMMIT_BRANCH == "main" || $CI_PIPELINE_SOURCE == "external_pull_request_event"'
       changes:
         - "projects/vdk-plugins/vdk-jupyter/**/*"
-
-build-py38-vdk-audit:
-  extends: .build-vdk-jupyter
-  image: "python:3.8"
-
-
-build-py311-vdk-audit:
-  extends: .build-vdk-jupyter
-  image: "python:3.11"
-
-release-vdk-audit:
-  variables:
-    PLUGIN_NAME: vdk-jupyter
-  extends: .release-plugin

--- a/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
@@ -6,34 +6,32 @@
     max: 1
     when:
       - always
-#
-#
-#build-vdk-jupyterlab-extension:
-#  stage: build
-#  image: "python:3.8-alpine"
-#  before_script:
-#    - cd projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension || exit 1
-#    - pip install -U pip setuptools pre-commit
-#    - apk --no-cache add npm
-#    - apk add rust cargo
-#    - apk add libffi-dev
-#    - pip install jupyter
-#  script:
-#    - echo "Install Dependencies..."
-#    - npm ci
-#    - echo "Install Vdk JupyterLab Extension..."
-#    - pip install .
-#    - echo "Building VDK JupyterLab Extension..."
-#    - npm rebuild
-#  retry: !reference [.retry, retry_options]
-#  rules: # we want to trigger build jobs if there are changes to this package,
-#    # but not if there are changes to VDK plugins or the main directory
-#    - if: '$CI_COMMIT_BRANCH == "main" || $CI_PIPELINE_SOURCE == "external_pull_request_event"'
-#      changes:
-#        - "projects/vdk-plugins/vdk-jupyter/**/*"
 
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
+
+build-vdk-jupyterlab-extension:
+  stage: build
+  image: "python:3.8-alpine"
+  before_script:
+    - cd projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension || exit 1
+    - pip install -U pip setuptools pre-commit
+    - apk --no-cache add npm
+    - apk add rust cargo
+    - apk add libffi-dev
+    - pip install jupyter
+  script:
+    - echo "Install Dependencies..."
+    - npm ci
+    - echo "Install Vdk JupyterLab Extension..."
+    - pip install .
+    - echo "Building VDK JupyterLab Extension..."
+    - npm rebuild
+  retry: !reference [.retry, retry_options]
+  rules: # we want to trigger build jobs if there are changes to this package,
+    # but not if there are changes to VDK plugins or the main directory
+    - if: '$CI_COMMIT_BRANCH == "main" || $CI_PIPELINE_SOURCE == "external_pull_request_event"'
+      changes:
+        - "projects/vdk-plugins/vdk-jupyter/**/*"
+
 
 release-vdk-jupyter:
   variables:
@@ -54,6 +52,8 @@ release-vdk-jupyter:
     - twine upload --repository-url $PIP_REPO_UPLOAD_URL -u "$PIP_REPO_UPLOAD_USER_NAME" -p "$PIP_REPO_UPLOAD_USER_PASSWORD" dist/* --verbose
   rules: # we want to trigger build jobs if there are changes to this package,
     # but not if there are changes to VDK plugins or the main directory
-    - if: '$CI_COMMIT_BRANCH == "main" || $CI_PIPELINE_SOURCE == "external_pull_request_event"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
+    - if: '$CI_COMMIT_BRANCH == "main"
       changes:
         - "projects/vdk-plugins/vdk-jupyter/**/*"

--- a/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
@@ -49,7 +49,7 @@ release-vdk-jupyter:
     - apk add libffi-dev
     - pip install jupyter
     - hatch version 0.1.$VDK_PATCH_VERSION
-    - pip install -U pip setuptools wheel twine pre-commit build
+    - pip install -U pip setuptools wheel twine pre-commit build hatch
     - python -m build
     # provide the credentials as Gitlab variables
     - twine upload --repository-url $PIP_REPO_UPLOAD_URL -u "$PIP_REPO_UPLOAD_USER_NAME" -p "$PIP_REPO_UPLOAD_USER_PASSWORD" dist/* --verbose

--- a/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
@@ -50,6 +50,6 @@ release-vdk-jupyter:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
       when: never
-    - if: '$CI_COMMIT_BRANCH == "main"
+    - if: '$CI_COMMIT_BRANCH == "main"'
       changes:
         - "projects/vdk-plugins/vdk-jupyter/**/*"

--- a/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
@@ -38,7 +38,7 @@
 release-vdk-jupyter:
   variables:
     PLUGIN_NAME:
-  image: "python:3.10"
+  image: "python:3.10-alpine"
   stage: release
   before_script:
     - export VDK_PATCH_VERSION=${CI_PIPELINE_ID}
@@ -47,6 +47,7 @@ release-vdk-jupyter:
     - echo "Release plugin $PLUGIN_NAME"
     - cd vdk-jupyter/vdk-jupyterlab-extension/ || exit 1
     - sed -ri "s/__version__ = \"([[:digit:]]\.[[:digit:]]\.).*\"$/__version__ = \"\1${VDK_PATCH_VERSION}\"/g" setup.py
+    - apk --no-cache add npm
     - pip install -U pip setuptools wheel twine pre-commit build
     - python -m build
     # provide the credentials as Gitlab variables

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/README.md
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/README.md
@@ -17,7 +17,9 @@ for the frontend extension.
 ## Install and run
 
 ```bash
+# install the extension
 pip install vdk-jupyterlab-extension
+# run jupyterlab
 jupyter lab
 ```
 

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/README.md
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/README.md
@@ -14,16 +14,11 @@ for the frontend extension.
 - Versatile Data Kit
 - npm
 
-## Install
-
-To install the extension,first navigate to the project directory and then execute:
+## Install and run
 
 ```bash
-# Once in the project directory, use the npm ci command to install
-# the exact versions of the dependencies specified in the package-lock.json
-npm ci
-# Install the extension
 pip install vdk-jupyterlab-extension
+jupyter lab
 ```
 
 ## Uninstall

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/pyproject.toml
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/pyproject.toml
@@ -23,7 +23,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "jupyter_server>=1.6,<3"
+    "jupyter_server>=1.6,<3",
+    "jupyterlab==3.6.3",
+    "vdk-control-cli",
+    "vdk-core"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/setup.py
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/setup.py
@@ -1,4 +1,0 @@
-# Copyright 2021-2023 VMware, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
-__import__("setuptools").setup()


### PR DESCRIPTION
# Why
We need to publish the image to a pip registry so others can consume it and setup is easy and doesn't require cloning the source code

# What
Most plugins are installed using the same command. which is declared in a common gitlab file. 
For building this plugin I didn't think it made sense to reuse that code as building jupyter is a little more complicated. 
So the release is totally new code. 


# How was this tested
I published to the registry and installed locally. 

Commands: 
```
pip install -U vdk_jupyterlab_extension
jupyter lab
```
Make sure the UI has the correct panels
![Screenshot 2023-07-13 at 12 32 42](https://github.com/vmware/versatile-data-kit/assets/9319000/a2484490-f367-4608-8df0-1b64debd156d)
