### PR TITLE
vdk-control-cli: remove set-secret for properties

### DIFF
--- a/examples/online-exhibition/README.md
+++ b/examples/online-exhibition/README.md
@@ -125,15 +125,7 @@ trino_schema = online-exhibition
 ### Europeana API key
 We can add the Europeana API key as a vdk property as follows:
 ```
-vdk properties --set-secret api_key
-```
-
-vdk will ask you for the following information:
-```
-vdk properties --set-secret api_key
-Job Name: online-exhibition
-Job Team: my-team
-api_key: YOUR_API_KEY
+vdk properties --set api_key YOUR_API_KEY
 ```
 
 Then, we will access it in data job with the `job_input.get_property()` method.

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/properties.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/properties.py
@@ -29,7 +29,6 @@ class PropertyOperation(Enum):
     """
 
     SET = "set"
-    SET_SECRET = "set_secret"  # nosec
     GET = "get"
 
 
@@ -176,8 +175,8 @@ class JobProperties:
     """
          Job properties are most commonly used to:
 
-         * store credentials securely
          * store data job state
+         * store credentials (when a secrets backend has not been configured)
 
      Examples:
 
@@ -186,12 +185,8 @@ class JobProperties:
      vdk properties --set my-key "my-value"
 
      \b
-     # Will prompt for the value so it's not printed on the screen.
-     vdk properties --set-secret "my-secret"
-
-     \b
      # Update multiple properties at once.
-     vdk properties --set "key1" "value1" --set "key2" "value2" --set-secret "secret1" --set-secret "secret2"
+     vdk properties --set "key1" "value1" --set "key2" "value2"
 
      \b
      # Use backslash \\ to set them on multiple lines
@@ -236,13 +231,6 @@ class JobProperties:
     "You can set multiple properties by using --set multiple times",
 )
 @click.option(
-    "--set-secret",
-    multiple=True,
-    type=click.STRING,
-    help="Set key value property which is a secret. It behaves almost the same way as --set."
-    "The difference from --set is that it will be prompted and input would be masked. ",
-)
-@click.option(
     "--delete",
     nargs=1,
     type=click.STRING,
@@ -273,7 +261,6 @@ def properties_command(
     name: str,
     team: str,
     set: Tuple[str, str],
-    set_secret: Tuple[str, str],
     delete: Tuple[str],
     delete_all_job_properties: bool,
     overwrite_all_job_properties: _io.BufferedReader,
@@ -282,12 +269,12 @@ def properties_command(
     rest_api_url: str,
     output: OutputFormat,
 ):
-    if (set or set_secret or delete) and (get or list):
+    if (set or delete) and (get or list):
         raise VDKException(
             what="Invalid arguments",
-            why="Wrong input. Cannot pass --get or --list at the same time as --set or --set-secret.",
+            why="Wrong input. Cannot pass --get or --list at the same time as --set.",
             consequence="Command will abort with error.",
-            countermeasure="Fix passed arguments such that get/list are not passed in the same time as set/set-secret.",
+            countermeasure="Fix passed arguments such that get/list are not passed in the same time as set/.",
         )
     if get and list:
         raise VDKException(
@@ -298,10 +285,10 @@ def properties_command(
         )
     log.debug(
         f"properties passed options: name: {name}, team: {team}, "
-        f"set: {set}, set_secret: {set_secret}, get: {get}, list: {list}, delete: {delete} "
+        f"set: {set}, get: {get}, list: {list}, delete: {delete} "
         f"rest_api_url: {rest_api_url}, output: {output}"
     )
-    key_value_pairs = _get_key_value_pairs(set, set_secret)
+    key_value_pairs = _get_key_value_pairs(set)
     cmd = JobProperties(rest_api_url, name, team, output)
     if key_value_pairs:
         cmd.update_properties(key_value_pairs)
@@ -327,13 +314,9 @@ def properties_command(
             )
 
 
-def _get_key_value_pairs(set, set_secret):
+def _get_key_value_pairs(set):
     key_value_pairs = {}
     if set:
         for key, value in set:
-            key_value_pairs[key] = value
-    if set_secret:
-        for key in set_secret:
-            value = click.prompt(f"{key}", hide_input=True)
             key_value_pairs[key] = value
     return key_value_pairs

--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_properties.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_properties.py
@@ -76,19 +76,6 @@ def test_properties_get_set(httpserver: PluginHTTPServer):
     assert result.output.strip() == '{"my-key": "my-value"}'
 
 
-def test_properties_get_set_secret(httpserver: PluginHTTPServer):
-    rest_api_url = _mock_properties_server(httpserver)
-
-    result = _run_properties_command(
-        rest_api_url, ["--set-secret", "secret"], input="my-secret-value"
-    )
-    test_utils.assert_click_status(result, 0)
-
-    result = _run_properties_command(rest_api_url, ["--get", "secret", "-o", "json"])
-    test_utils.assert_click_status(result, 0)
-    assert result.output.strip() == '{"secret": "my-secret-value"}'
-
-
 def test_properties_get_set_multiple(httpserver: PluginHTTPServer):
     rest_api_url = _mock_properties_server(httpserver)
 


### PR DESCRIPTION
Remove the set-secret option for the properties command as we now have separate secrets command for handling sensitive data.
Update example/documentation.
Update tests.