### PR TITLE
control-service: add configurable smtp host property

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -281,6 +281,8 @@ spec:
             - name: DATAJOBS_DEPLOYMENT_SUPPORTED_PYTHON_VERSIONS
               value: {{ .Values.deploymentSupportedPythonVersions | toJson | quote }}
             {{- end }}
+            - name: MAIL_SMTP_HOST
+              value: "{{ .Values.mail.smtp.host }}"
             {{- if .Values.mail.smtp.auth }}
             - name: MAIL_SMTP_AUTH
               value: "{{ .Values.mail.smtp.auth }}"

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -1034,6 +1034,7 @@ mail:
     auth: false
     starttls:
       enable: false
+    host: ""
     user: ""
     password: ""
     ssl:

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -173,7 +173,7 @@ datajobs.executions.logsUrl.endTimeOffsetSeconds=${DATAJOBS_EXECUTIONS_LOGS_URL_
 
 # https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html
 mail.transport.protocol= ${MAIL_TRANSPORT_PROTOCOL:smtp}
-mail.smtp.host=smtp.vmware.com
+mail.smtp.host=${MAIL_SMTP_HOST:smtp.vmware.com}
 # Fill these in if the notification emails need to go through an authenticated email.
 mail.smtp.auth=${MAIL_SMTP_AUTH:false}
 mail.smtp.starttls.enable=${MAIL_SMTP_STARTTLS_ENABLE:false}


### PR DESCRIPTION
what: added configurable mail.smtp.host property in the helm charts

why: since this was quite an old property it was previously hardcoded in the control-service application.properties and I missed updating it when we introduced authenticated email functionality.

testing: helm chart validations 