### PR TITLE
[bug fix] vdk-core: Add job name to state

### DIFF
--- a/projects/vdk-core/tests/functional/run/test_run_notifications.py
+++ b/projects/vdk-core/tests/functional/run/test_run_notifications.py
@@ -51,6 +51,7 @@ def test_run_successfull(smtpd: SMTPDFix):
         assert len(smtpd.messages) == 1
         message: Message = smtpd.messages[0]
         assert "tester@unittest.test" == message.get("To")
+        assert "simple-job" in message.get("Subject")
 
 
 def test_run_successfull_notify_multiple_users(smtpd: SMTPDFix):


### PR DESCRIPTION
Currently, when a data job is executed and notifications are enabled, the resulting email does not contain the data job name and instead says `None`. Example:
```
[success][data job run] None

Dear Versatile Data Kit user,
Last run of your data job *None* has succeeded.
You can find full logs of the job execution here.
The sender mailbox is not monitored, please do not reply to this email.
Best,

```

This change fixes this behaviour by setting the Notification Plugin to attach to the
finalize_job hook, get the job name from the JobContext provided by the hook, and
save as an instance variable. The name of the job is then passed to the vdk_exit hook,
which is responsible for sending the notifications.

Testing Done: Locally executed a test data job and verified that the email notification contains the data job name.

*Additional test configuration that needs to be set as env vars:*

```
VDK_ENABLE_ATTEMPT_NOTIFICATIONS=true
VDK_LOG_CONFIG=CLOUD
VDK_NOTIFICATION_ENABLED=true
VDK_NOTIFIED_ON_JOB_SUCCESS=<target-email-address>
VDK_NOTIFICATION_SENDER=<sender-email-address>
```