### PR TITLE
versatile-data-kit: remove global image from Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# default image used by all pipelines if not overridden per job 
 image: "python:3.9"
 
 include:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
+image: "python:3.9"
 
 include:
   - "cicd/.gitlab-ci-lib.yml"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # default image used by all pipelines if not overridden per job
+# it is better not to rely on default image and specify image explicitly for each job
 image: "python:3.9"
 
 include:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# default image used by all pipelines if not overridden per job 
+# default image used by all pipelines if not overridden per job
 image: "python:3.9"
 
 include:

--- a/projects/vdk-control-cli/.gitlab-ci.yml
+++ b/projects/vdk-control-cli/.gitlab-ci.yml
@@ -1,8 +1,6 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.9"
-
 .vdk_control_cli_changes: &vdk_control_cli_changes_locations
   - projects/vdk-control-cli/**/*
 

--- a/projects/vdk-core/.gitlab-ci.yml
+++ b/projects/vdk-core/.gitlab-ci.yml
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-image: "python:3.9"
 
 .vdk_core_changes: &vdk_core_locations
   - "projects/vdk-core/*"

--- a/projects/vdk-heartbeat/.gitlab-ci.yml
+++ b/projects/vdk-heartbeat/.gitlab-ci.yml
@@ -1,7 +1,6 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.9"
 
 .vdk_heartbeat_changes: &vdk_heartbeat_changes_locations
   - projects/vdk-heartbeat/**/*

--- a/projects/vdk-plugins/vdk-control-api-auth/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-control-api-auth/.plugin-ci.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
+
 
 .build-vdk-control-api-auth:
   variables:

--- a/projects/vdk-plugins/vdk-csv/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-csv/.plugin-ci.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
+
 
 .build-vdk-csv:
   variables:

--- a/projects/vdk-plugins/vdk-dag/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-dag/.plugin-ci.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
+
 
 .build-vdk-dag:
   variables:

--- a/projects/vdk-plugins/vdk-gdp-execution-id/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-gdp-execution-id/.plugin-ci.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
+
 
 .build-vdk-gdp-execution-id:
   variables:

--- a/projects/vdk-plugins/vdk-ingest-file/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-ingest-file/.plugin-ci.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
+
 
 .build-vdk-ingest-file:
   variables:

--- a/projects/vdk-plugins/vdk-ingest-http/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-ingest-http/.plugin-ci.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
+
 
 .build-vdk-ingest-http:
   variables:

--- a/projects/vdk-plugins/vdk-ipython/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-ipython/.plugin-ci.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
+
 
 .build-vdk-ipython:
   variables:

--- a/projects/vdk-plugins/vdk-jobs-troubleshooting/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jobs-troubleshooting/.plugin-ci.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
+
 
 .build-vdk-jobs-troubleshooting:
   variables:

--- a/projects/vdk-plugins/vdk-lineage-model/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-lineage-model/.plugin-ci.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
+
 
 .build-vdk-lineage-model:
   variables:

--- a/projects/vdk-plugins/vdk-lineage/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-lineage/.plugin-ci.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
+
 
 .build-vdk-lineage:
   variables:

--- a/projects/vdk-plugins/vdk-logging-format/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-logging-format/.plugin-ci.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
+
 
 .build-vdk-logging-format:
   variables:

--- a/projects/vdk-plugins/vdk-meta-jobs/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-meta-jobs/.plugin-ci.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
+
 
 .build-vdk-meta-jobs:
   variables:

--- a/projects/vdk-plugins/vdk-notebook/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-notebook/.plugin-ci.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
+
 
 .build-vdk-notebook:
   variables:

--- a/projects/vdk-plugins/vdk-plugin-control-cli/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-plugin-control-cli/.plugin-ci.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
+
 
 .build-vdk-plugin-control-cli:
   variables:

--- a/projects/vdk-plugins/vdk-properties-fs/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-properties-fs/.plugin-ci.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
+
 
 .build-vdk-properties-fs:
   variables:

--- a/projects/vdk-plugins/vdk-server/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-server/.plugin-ci.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
+
 
 .build-vdk-server:
   variables:

--- a/projects/vdk-plugins/vdk-smarter/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-smarter/.plugin-ci.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
+
 
 .build-vdk-smarter:
   variables:

--- a/projects/vdk-plugins/vdk-snowflake/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-snowflake/.plugin-ci.yml
@@ -1,6 +1,6 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
-image: "python:3.7"
+
 
 .build-vdk-snowflake:
   variables:

--- a/projects/vdk-plugins/vdk-sqlite/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-sqlite/.plugin-ci.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
+
 
 
 .build-vdk-sqlite:

--- a/projects/vdk-plugins/vdk-test-utils/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-test-utils/.plugin-ci.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
+
 
 .build-vdk-test-utils:
   variables:

--- a/projects/vdk-plugins/vdk-trino/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-trino/.plugin-ci.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-image: "python:3.7"
+
 
 .build-vdk-trino:
   variables:


### PR DESCRIPTION
In GitLab CI, you can specify certain settings globally, affecting the entire CI/CD pipeline. These are called "global keys. There is a global key that defines a specific Docker image (image:)

Now, the problem arises when we define the same global key in multiple YAML files within the repository. Since global keys are not scoped to specific files, they can clash and cause conflicts. When GitLab processes the CI configuration, it reads all the YAML files and applies the settings in the order they are imported.

If the same global key appears in different files, the last occurrence of that key in the import order will overwrite the previous ones. This behavior can lead to unintended consequences. For example, we might encounter unexpected Docker images being used for certain jobs.

To prevent this from happening I am removing all global `image:` keys except in root level gitlab ci file to avoid any potential issues.

Specific images needed are set on job-level which is scoped to a job. This is the best practice that we should follow and not rely on defaults.