### PR TITLE
control-service: prevent integer translation in helm chart

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -1102,4 +1102,4 @@ secrets:
         approle:
             roleid: foo
             secretid: foo
-        sizeLimitBytes: 1048576
+        sizeLimitBytes: "1048576"


### PR DESCRIPTION
Prevent integer translation to a fraction in helm chart.