### PR TITLE
control-service: remove default vault token

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/secrets/service/vault/VaultConfiguration.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/secrets/service/vault/VaultConfiguration.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
@@ -27,6 +28,7 @@ import java.net.URISyntaxException;
 
 @Slf4j
 @Configuration
+@ConditionalOnProperty(value = "featureflag.vault.integration.enabled")
 public class VaultConfiguration extends AbstractVaultConfiguration {
 
   @Value("${vdk.vault.uri:}")

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/secrets/service/vault/VaultConfiguration.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/secrets/service/vault/VaultConfiguration.java
@@ -14,7 +14,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
-import org.springframework.lang.Nullable;
 import org.springframework.vault.authentication.*;
 import org.springframework.vault.client.VaultEndpoint;
 import org.springframework.vault.config.AbstractVaultConfiguration;
@@ -45,7 +44,7 @@ public class VaultConfiguration extends AbstractVaultConfiguration {
 
   @Bean
   public VaultOperations vaultOperations(
-          VaultEndpoint vaultEndpoint, SessionManager sessionManager) {
+      VaultEndpoint vaultEndpoint, SessionManager sessionManager) {
 
     SimpleClientHttpRequestFactory clientHttpRequestFactory = new SimpleClientHttpRequestFactory();
     return new VaultTemplate(vaultEndpoint, clientHttpRequestFactory, sessionManager);
@@ -69,9 +68,9 @@ public class VaultConfiguration extends AbstractVaultConfiguration {
     if (StringUtils.isNotBlank(this.roleId) && StringUtils.isNotBlank(this.secretId)) {
       log.info("Initializing vault integration with AppRole Authentication.");
       AppRoleAuthenticationOptions.AppRoleAuthenticationOptionsBuilder builder =
-              AppRoleAuthenticationOptions.builder()
-                      .roleId(AppRoleAuthenticationOptions.RoleId.provided(this.roleId))
-                      .secretId(AppRoleAuthenticationOptions.SecretId.provided(this.secretId));
+          AppRoleAuthenticationOptions.builder()
+              .roleId(AppRoleAuthenticationOptions.RoleId.provided(this.roleId))
+              .secretId(AppRoleAuthenticationOptions.SecretId.provided(this.secretId));
 
       RestTemplate restTemplate = new RestTemplate();
       restTemplate.setUriTemplateHandler(new DefaultUriBuilderFactory(this.vaultUri));

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -271,5 +271,5 @@ featureflag.vault.integration.enabled=false
 vdk.vault.uri=http://localhost:8200/v1/
 vdk.vault.approle.roleid=
 vdk.vault.approle.secretid=
-vdk.vault.token=root
+vdk.vault.token=
 datajobs.vault.size.limit.bytes=1048576


### PR DESCRIPTION
Remove the default value of the vault integration token, to reduce confusion when configuring vault.