### PR TITLE
control-service: fix typo in helm chart read only root filesystem property

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -257,9 +257,9 @@ spec:
             - name: LOGGING_FORMAT
               value: "{{ .Values.loggingFormat }}"
             {{- end }}
-            {{- if .Values.dataJob.readOnlyRootFilesystem }}
+            {{- if .Values.dataJob.readOnlyRootFileSystem }}
             - name: DATAJOBS_READ_ONLY_ROOT_FILESYSTEM
-              value: "{{ .Values.dataJob.readOnlyRootFilesystem }}"
+              value: "{{ .Values.dataJob.readOnlyRootFileSystem }}"
             {{- end }}
             {{- if .Values.deploymentBuilderImage.password }}
             - name: DATAJOBS_BUILDER_REGISTRY_SECRET


### PR DESCRIPTION
what: Fixed a typo in the deployment helm chart - wrong camel case in deployment.yaml - https://github.com/vmware/versatile-data-kit/blob/ffdee8bac07e3718299eb10e024c7319179b3b93/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml#L951

why: The typo was preventing users from adopting the read only root filesystem through the helm charts.

testing: n/a