### PR TITLE
vdk-control-cli: pass the printer class in JobDeploy creation and add additional memory printer

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli.py
@@ -8,7 +8,7 @@ from typing import Optional
 import click
 from vdk.internal.control.command_groups.job.deploy_cli_impl import JobDeploy
 from vdk.internal.control.configuration.defaults_config import load_default_team_name
-from vdk.internal.control.utils import cli_utils
+from vdk.internal.control.utils import cli_utils, output_printer
 from vdk.internal.control.utils.cli_utils import get_or_prompt
 
 
@@ -169,7 +169,7 @@ def deploy(
     rest_api_url: str,
     output: str,
 ):
-    cmd = JobDeploy(rest_api_url, output)
+    cmd = JobDeploy(rest_api_url, output_printer.create_printer(output))
     if operation == DeployOperation.UPDATE.value or enabled is not None:
         name = get_or_prompt("Job Name", name)
         team = get_or_prompt("Job Team", team)

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli.py
@@ -8,7 +8,8 @@ from typing import Optional
 import click
 from vdk.internal.control.command_groups.job.deploy_cli_impl import JobDeploy
 from vdk.internal.control.configuration.defaults_config import load_default_team_name
-from vdk.internal.control.utils import cli_utils, output_printer
+from vdk.internal.control.utils import cli_utils
+from vdk.internal.control.utils import output_printer
 from vdk.internal.control.utils.cli_utils import get_or_prompt
 
 

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli_impl.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli_impl.py
@@ -20,7 +20,8 @@ from vdk.internal.control.job.job_config import JobConfig
 from vdk.internal.control.rest_lib.factory import ApiClientFactory
 from vdk.internal.control.rest_lib.rest_client_errors import ApiClientErrorDecorator
 from vdk.internal.control.utils.cli_utils import get_or_prompt
-from vdk.internal.control.utils.output_printer import _PrinterText, _PrinterJson
+from vdk.internal.control.utils.output_printer import _PrinterJson
+from vdk.internal.control.utils.output_printer import _PrinterText
 from vdk.internal.control.utils.output_printer import Printer
 
 log = logging.getLogger(__name__)
@@ -67,9 +68,9 @@ class JobDeploy:
                 why=f"Team param ({team}) and team value in config.ini ({job_config_team}) do not match.",
                 consequence="The latest change is not deployed, job will continue to run with previous version.",
                 countermeasure=f"1. Fix config.ini to set correct team (if it is {team}) OR\n"
-                               f"2. Do not pass team param (team {job_config_team} will be automatically used from config.ini) OR\n"
-                               f"3. Pass param team={job_config_team} OR\n"
-                               f"4. Create a new job with team={team} and try to deploy it\n",
+                f"2. Do not pass team param (team {job_config_team} will be automatically used from config.ini) OR\n"
+                f"3. Pass param team={job_config_team} OR\n"
+                f"4. Create a new job with team={team} and try to deploy it\n",
             )
 
         # TODO: we may use https://github.com/Yelp/detect-secrets to make sure users do not accidentally pass secrets
@@ -120,7 +121,7 @@ class JobDeploy:
             )
 
     def __update_data_job_deploy_configuration(
-            self, job_path: str, name: str, team: str
+        self, job_path: str, name: str, team: str
     ) -> None:
         job: DataJob = self.__read_data_job(name, team)
         local_config = JobConfig(job_path)
@@ -147,13 +148,13 @@ class JobDeploy:
 
     @ApiClientErrorDecorator()
     def update(
-            self,
-            name: str,
-            team: str,
-            enabled: Optional[bool],  # true, false or None
-            job_version: Optional[str],
-            vdk_version: Optional[str],
-            python_version: Optional[str] = None,
+        self,
+        name: str,
+        team: str,
+        enabled: Optional[bool],  # true, false or None
+        job_version: Optional[str],
+        vdk_version: Optional[str],
+        python_version: Optional[str] = None,
     ) -> None:
         deployment = DataJobDeployment(enabled=None)
         if job_version:
@@ -175,7 +176,7 @@ class JobDeploy:
             log.warning(f"Nothing to update for deployment of job {name}.")
 
     def __patch_deployment(
-            self, name: str, team: str, deployment: DataJobDeployment
+        self, name: str, team: str, deployment: DataJobDeployment
     ) -> None:
         log.debug(f"Update Deployment of a job {name} of team {team} : {deployment}")
         self.deploy_api.deployment_patch(
@@ -252,13 +253,13 @@ class JobDeploy:
 
     @ApiClientErrorDecorator()
     def create(
-            self,
-            name: str,
-            team: str,
-            job_path: str,
-            reason: str,
-            vdk_version: Optional[str],
-            enabled: Optional[bool],
+        self,
+        name: str,
+        team: str,
+        job_path: str,
+        reason: str,
+        vdk_version: Optional[str],
+        enabled: Optional[bool],
     ) -> None:
         log.debug(
             f"Create Deployment of a job {name} of team {team} with local path {job_path} and reason {reason}"
@@ -296,7 +297,8 @@ class JobDeploy:
             if isinstance(self.__printer, _PrinterText):
                 log.info("Uploading the data job might take some time ...")
             with click_spinner.spinner(
-                    disable=(isinstance(self.__printer, _PrinterJson))):
+                disable=(isinstance(self.__printer, _PrinterJson))
+            ):
                 data_job_version = self.job_sources_api.sources_upload(
                     team_name=team,
                     job_name=name,

--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli_impl.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/job/deploy_cli_impl.py
@@ -20,9 +20,9 @@ from vdk.internal.control.job.job_config import JobConfig
 from vdk.internal.control.rest_lib.factory import ApiClientFactory
 from vdk.internal.control.rest_lib.rest_client_errors import ApiClientErrorDecorator
 from vdk.internal.control.utils.cli_utils import get_or_prompt
-from vdk.internal.control.utils.output_printer import _PrinterJson
-from vdk.internal.control.utils.output_printer import _PrinterText
 from vdk.internal.control.utils.output_printer import Printer
+from vdk.internal.control.utils.output_printer import PrinterJson
+from vdk.internal.control.utils.output_printer import PrinterText
 
 log = logging.getLogger(__name__)
 
@@ -193,7 +193,7 @@ class JobDeploy:
         self.deploy_api.deployment_update(
             team_name=team, job_name=name, data_job_deployment=deployment
         )
-        if isinstance(self.__printer, _PrinterText):
+        if isinstance(self.__printer, PrinterText):
             log.info(
                 f"Request to deploy Data Job {name} using version {deployment.job_version} finished successfully.\n"
                 f"It would take a few minutes for the Data Job to be deployed in the server.\n"
@@ -239,7 +239,7 @@ class JobDeploy:
                 ),
                 deployments,
             )
-            if isinstance(self.__printer, _PrinterText):
+            if isinstance(self.__printer, PrinterText):
                 click.echo(
                     "You can compare the version seen here to the one seen when "
                     "deploying to verify your deployment was successful."
@@ -283,7 +283,7 @@ class JobDeploy:
             "Team Name", team or job_config.get_team() or load_default_team_name()
         )
 
-        if isinstance(self.__printer, _PrinterText):
+        if isinstance(self.__printer, PrinterText):
             log.info(
                 f"Deploy Data Job with name {name} from directory {job_path} ... \n"
             )
@@ -294,10 +294,10 @@ class JobDeploy:
         try:
             job_archive_binary = self.__archive_binary(archive_path)
 
-            if isinstance(self.__printer, _PrinterText):
+            if isinstance(self.__printer, PrinterText):
                 log.info("Uploading the data job might take some time ...")
             with click_spinner.spinner(
-                disable=(isinstance(self.__printer, _PrinterJson))
+                disable=(isinstance(self.__printer, PrinterJson))
             ):
                 data_job_version = self.job_sources_api.sources_upload(
                     team_name=team,

--- a/projects/vdk-control-cli/src/vdk/internal/control/utils/output_printer.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/utils/output_printer.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 import click
 from tabulate import tabulate
+import io
 
 
 class Printer(abc.ABC):
@@ -105,6 +106,35 @@ class _PrinterJson(Printer):
             click.echo(json_format(data))
         else:
             click.echo("{}")
+
+
+class _MemoryPrinter(Printer):
+    output_buffer = io.StringIO()
+
+    def print_table(self, table: Optional[List[Dict[str, Any]]]) -> None:
+        if table and len(table) > 0:
+            print(
+                tabulate(table, headers="keys", tablefmt="fancy_grid"),
+                file=_MemoryPrinter.output_buffer,
+            )
+        else:
+            print("No Data.", file=_MemoryPrinter.output_buffer)
+
+    def print_dict(self, data: Optional[Dict[str, Any]]) -> None:
+        if data:
+            print(
+                tabulate(
+                    [[k, v] for k, v in data.items()],
+                    headers=("key", "value"),
+                ),
+                file=_MemoryPrinter.output_buffer,
+            )
+        else:
+            print("No Data.", file=_MemoryPrinter.output_buffer)
+
+    @classmethod
+    def get_memory(cls):
+        return cls.output_buffer.getvalue()
 
 
 def create_printer(output_format: str) -> Printer:

--- a/projects/vdk-control-cli/src/vdk/internal/control/utils/output_printer.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/utils/output_printer.py
@@ -109,16 +109,17 @@ class PrinterJson(Printer):
 
 
 class InMemoryTextPrinter(Printer):
-    output_buffer = io.StringIO()
+    def __init__(self):
+        self.output_buffer = io.StringIO()
 
     def print_table(self, table: Optional[List[Dict[str, Any]]]) -> None:
         if table and len(table) > 0:
             print(
                 tabulate(table, headers="keys", tablefmt="fancy_grid"),
-                file=InMemoryTextPrinter.output_buffer,
+                file=self.output_buffer,
             )
         else:
-            print("No Data.", file=InMemoryTextPrinter.output_buffer)
+            print("No Data.", file=self.output_buffer)
 
     def print_dict(self, data: Optional[Dict[str, Any]]) -> None:
         if data:
@@ -127,19 +128,13 @@ class InMemoryTextPrinter(Printer):
                     [[k, v] for k, v in data.items()],
                     headers=("key", "value"),
                 ),
-                file=InMemoryTextPrinter.output_buffer,
+                file=self.output_buffer,
             )
         else:
-            print("No Data.", file=InMemoryTextPrinter.output_buffer)
+            print("No Data.", file=self.output_buffer)
 
-    @classmethod
-    def get_memory(cls):
-        return cls.output_buffer.getvalue()
-
-    @staticmethod
-    def cleanup() -> None:
-        InMemoryTextPrinter.output_buffer.close()
-        InMemoryTextPrinter.output_buffer = io.StringIO()
+    def get_memory(self):
+        return self.output_buffer.getvalue()
 
 
 def create_printer(output_format: str) -> Printer:

--- a/projects/vdk-control-cli/src/vdk/internal/control/utils/output_printer.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/utils/output_printer.py
@@ -136,6 +136,11 @@ class _MemoryPrinter(Printer):
     def get_memory(cls):
         return cls.output_buffer.getvalue()
 
+    @staticmethod
+    def cleanup() -> None:
+        _MemoryPrinter.output_buffer.close()
+        _MemoryPrinter.output_buffer = io.StringIO()
+
 
 def create_printer(output_format: str) -> Printer:
     """

--- a/projects/vdk-control-cli/src/vdk/internal/control/utils/output_printer.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/utils/output_printer.py
@@ -1,6 +1,7 @@
 # Copyright 2023-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 import abc
+import io
 import json
 from enum import Enum
 from enum import unique
@@ -11,7 +12,6 @@ from typing import Optional
 
 import click
 from tabulate import tabulate
-import io
 
 
 class Printer(abc.ABC):

--- a/projects/vdk-control-cli/src/vdk/internal/control/utils/output_printer.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/utils/output_printer.py
@@ -110,16 +110,16 @@ class PrinterJson(Printer):
 
 class InMemoryTextPrinter(Printer):
     def __init__(self):
-        self.output_buffer = io.StringIO()
+        self.__output_buffer = io.StringIO()
 
     def print_table(self, table: Optional[List[Dict[str, Any]]]) -> None:
         if table and len(table) > 0:
             print(
                 tabulate(table, headers="keys", tablefmt="fancy_grid"),
-                file=self.output_buffer,
+                file=self.__output_buffer,
             )
         else:
-            print("No Data.", file=self.output_buffer)
+            print("No Data.", file=self.__output_buffer)
 
     def print_dict(self, data: Optional[Dict[str, Any]]) -> None:
         if data:
@@ -128,13 +128,13 @@ class InMemoryTextPrinter(Printer):
                     [[k, v] for k, v in data.items()],
                     headers=("key", "value"),
                 ),
-                file=self.output_buffer,
+                file=self.__output_buffer,
             )
         else:
-            print("No Data.", file=self.output_buffer)
+            print("No Data.", file=self.__output_buffer)
 
     def get_memory(self):
-        return self.output_buffer.getvalue()
+        return self.__output_buffer.getvalue()
 
 
 def create_printer(output_format: str) -> Printer:

--- a/projects/vdk-control-cli/src/vdk/internal/control/utils/output_printer.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/utils/output_printer.py
@@ -61,7 +61,7 @@ def printer(output_format: str) -> callable:
 
 
 @printer("text")
-class _PrinterText(Printer):
+class PrinterText(Printer):
     def print_table(self, table: Optional[List[Dict[str, Any]]]) -> None:
         if table and len(table) > 0:
             click.echo(tabulate(table, headers="keys", tablefmt="fancy_grid"))
@@ -94,7 +94,7 @@ def json_format(data, indent=None):
 
 
 @printer("json")
-class _PrinterJson(Printer):
+class PrinterJson(Printer):
     def print_table(self, data: List[Dict[str, Any]]) -> None:
         if data:
             click.echo(json_format(data))
@@ -108,17 +108,17 @@ class _PrinterJson(Printer):
             click.echo("{}")
 
 
-class _MemoryPrinter(Printer):
+class MemoryPrinter(Printer):
     output_buffer = io.StringIO()
 
     def print_table(self, table: Optional[List[Dict[str, Any]]]) -> None:
         if table and len(table) > 0:
             print(
                 tabulate(table, headers="keys", tablefmt="fancy_grid"),
-                file=_MemoryPrinter.output_buffer,
+                file=MemoryPrinter.output_buffer,
             )
         else:
-            print("No Data.", file=_MemoryPrinter.output_buffer)
+            print("No Data.", file=MemoryPrinter.output_buffer)
 
     def print_dict(self, data: Optional[Dict[str, Any]]) -> None:
         if data:
@@ -127,10 +127,10 @@ class _MemoryPrinter(Printer):
                     [[k, v] for k, v in data.items()],
                     headers=("key", "value"),
                 ),
-                file=_MemoryPrinter.output_buffer,
+                file=MemoryPrinter.output_buffer,
             )
         else:
-            print("No Data.", file=_MemoryPrinter.output_buffer)
+            print("No Data.", file=MemoryPrinter.output_buffer)
 
     @classmethod
     def get_memory(cls):
@@ -138,8 +138,8 @@ class _MemoryPrinter(Printer):
 
     @staticmethod
     def cleanup() -> None:
-        _MemoryPrinter.output_buffer.close()
-        _MemoryPrinter.output_buffer = io.StringIO()
+        MemoryPrinter.output_buffer.close()
+        MemoryPrinter.output_buffer = io.StringIO()
 
 
 def create_printer(output_format: str) -> Printer:

--- a/projects/vdk-control-cli/src/vdk/internal/control/utils/output_printer.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/utils/output_printer.py
@@ -108,17 +108,17 @@ class PrinterJson(Printer):
             click.echo("{}")
 
 
-class MemoryPrinter(Printer):
+class InMemoryTextPrinter(Printer):
     output_buffer = io.StringIO()
 
     def print_table(self, table: Optional[List[Dict[str, Any]]]) -> None:
         if table and len(table) > 0:
             print(
                 tabulate(table, headers="keys", tablefmt="fancy_grid"),
-                file=MemoryPrinter.output_buffer,
+                file=InMemoryTextPrinter.output_buffer,
             )
         else:
-            print("No Data.", file=MemoryPrinter.output_buffer)
+            print("No Data.", file=InMemoryTextPrinter.output_buffer)
 
     def print_dict(self, data: Optional[Dict[str, Any]]) -> None:
         if data:
@@ -127,10 +127,10 @@ class MemoryPrinter(Printer):
                     [[k, v] for k, v in data.items()],
                     headers=("key", "value"),
                 ),
-                file=MemoryPrinter.output_buffer,
+                file=InMemoryTextPrinter.output_buffer,
             )
         else:
-            print("No Data.", file=MemoryPrinter.output_buffer)
+            print("No Data.", file=InMemoryTextPrinter.output_buffer)
 
     @classmethod
     def get_memory(cls):
@@ -138,8 +138,8 @@ class MemoryPrinter(Printer):
 
     @staticmethod
     def cleanup() -> None:
-        MemoryPrinter.output_buffer.close()
-        MemoryPrinter.output_buffer = io.StringIO()
+        InMemoryTextPrinter.output_buffer.close()
+        InMemoryTextPrinter.output_buffer = io.StringIO()
 
 
 def create_printer(output_format: str) -> Printer:

--- a/projects/vdk-control-cli/tests/vdk/internal/control/utils/test_output_printer.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/utils/test_output_printer.py
@@ -1,5 +1,6 @@
 # Copyright 2023-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import unittest
 from typing import Any
 from typing import Dict
 from typing import List
@@ -7,6 +8,7 @@ from unittest.mock import patch
 
 import pytest
 from vdk.internal.control.utils import output_printer
+from vdk.internal.control.utils.output_printer import _MemoryPrinter
 from vdk.internal.control.utils.output_printer import _PrinterJson
 from vdk.internal.control.utils.output_printer import _PrinterText
 from vdk.internal.control.utils.output_printer import create_printer
@@ -77,6 +79,62 @@ class TestPrinterJson:
 
             expected_output = '[{"key1": "value1", "key2": "value2"}, {"key1": "value3", "key2": "value4"}]'
             mock_echo.assert_called_once_with(expected_output)
+
+
+class TestMemoryPrinter(unittest.TestCase):
+    def setUp(self):
+        self.printer = _MemoryPrinter()
+
+    def test_print_dict(self):
+        data = {"key": "value"}
+
+        self.printer.print_dict(data)
+
+        output = self.printer.output_buffer.getvalue().strip()
+
+        self.assertIn("key", output)
+        self.assertIn("value", output)
+
+    def test_print_table(self):
+        data = [
+            {"key1": "value1", "key2": "value2"},
+            {"key1": "value3", "key2": "value4"},
+        ]
+        self.printer.print_table(data)
+
+        output = self.printer.output_buffer.getvalue().strip()
+
+        self.assertIn("key1", output)
+        self.assertIn("key2", output)
+        self.assertIn("value1", output)
+        self.assertIn("value2", output)
+        self.assertIn("value3", output)
+        self.assertIn("value4", output)
+
+    def test_print_dict_no_data(self):
+        self.printer.cleanup()
+        self.printer.print_dict(None)
+
+        expected_output = "No Data."
+        actual_output = self.printer.output_buffer.getvalue().strip()
+
+        self.assertEqual(actual_output, expected_output)
+
+    def test_print_table_no_data(self):
+        self.printer.cleanup()
+        self.printer.print_table(None)
+
+        expected_output = "No Data."
+        actual_output = self.printer.output_buffer.getvalue().strip()
+
+        self.assertEqual(actual_output, expected_output)
+
+    def test_cleanup(self):
+        data = {"key": "value"}
+        self.printer.print_dict(data)
+        self.printer.cleanup()
+        actual_output = self.printer.output_buffer.getvalue()
+        self.assertEqual(actual_output, "")
 
 
 class TestCreatePrinter:

--- a/projects/vdk-control-cli/tests/vdk/internal/control/utils/test_output_printer.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/utils/test_output_printer.py
@@ -112,7 +112,6 @@ class TestMemoryPrinter(unittest.TestCase):
         self.assertIn("value4", output)
 
     def test_print_dict_no_data(self):
-        self.printer.cleanup()
         self.printer.print_dict(None)
 
         expected_output = "No Data."
@@ -121,20 +120,12 @@ class TestMemoryPrinter(unittest.TestCase):
         self.assertEqual(actual_output, expected_output)
 
     def test_print_table_no_data(self):
-        self.printer.cleanup()
         self.printer.print_table(None)
 
         expected_output = "No Data."
         actual_output = self.printer.output_buffer.getvalue().strip()
 
         self.assertEqual(actual_output, expected_output)
-
-    def test_cleanup(self):
-        data = {"key": "value"}
-        self.printer.print_dict(data)
-        self.printer.cleanup()
-        actual_output = self.printer.output_buffer.getvalue()
-        self.assertEqual(actual_output, "")
 
 
 class TestCreatePrinter:

--- a/projects/vdk-control-cli/tests/vdk/internal/control/utils/test_output_printer.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/utils/test_output_printer.py
@@ -90,7 +90,7 @@ class TestMemoryPrinter(unittest.TestCase):
 
         self.printer.print_dict(data)
 
-        output = self.printer.output_buffer.getvalue().strip()
+        output = self.printer.get_memory().strip()
 
         self.assertIn("key", output)
         self.assertIn("value", output)
@@ -102,7 +102,7 @@ class TestMemoryPrinter(unittest.TestCase):
         ]
         self.printer.print_table(data)
 
-        output = self.printer.output_buffer.getvalue().strip()
+        output = self.printer.get_memory().strip()
 
         self.assertIn("key1", output)
         self.assertIn("key2", output)
@@ -115,7 +115,7 @@ class TestMemoryPrinter(unittest.TestCase):
         self.printer.print_dict(None)
 
         expected_output = "No Data."
-        actual_output = self.printer.output_buffer.getvalue().strip()
+        actual_output = self.printer.get_memory().strip()
 
         self.assertEqual(actual_output, expected_output)
 
@@ -123,7 +123,7 @@ class TestMemoryPrinter(unittest.TestCase):
         self.printer.print_table(None)
 
         expected_output = "No Data."
-        actual_output = self.printer.output_buffer.getvalue().strip()
+        actual_output = self.printer.get_memory().strip()
 
         self.assertEqual(actual_output, expected_output)
 

--- a/projects/vdk-control-cli/tests/vdk/internal/control/utils/test_output_printer.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/utils/test_output_printer.py
@@ -8,17 +8,17 @@ from unittest.mock import patch
 
 import pytest
 from vdk.internal.control.utils import output_printer
-from vdk.internal.control.utils.output_printer import _MemoryPrinter
-from vdk.internal.control.utils.output_printer import _PrinterJson
-from vdk.internal.control.utils.output_printer import _PrinterText
 from vdk.internal.control.utils.output_printer import create_printer
+from vdk.internal.control.utils.output_printer import MemoryPrinter
 from vdk.internal.control.utils.output_printer import Printer
+from vdk.internal.control.utils.output_printer import PrinterJson
+from vdk.internal.control.utils.output_printer import PrinterText
 
 
 class TestPrinterText:
     def test_print_dict(self):
         with patch("click.echo") as mock_echo:
-            printer = _PrinterText()
+            printer = PrinterText()
             data = {"key": "value"}
 
             printer.print_dict(data)
@@ -28,7 +28,7 @@ class TestPrinterText:
 
     def test_print_table_with_data(self):
         with patch("click.echo") as mock_echo:
-            printer = _PrinterText()
+            printer = PrinterText()
 
             data = [{"key1": "value1", "key2": 2}, {"key1": "value3", "key2": 4}]
 
@@ -47,7 +47,7 @@ class TestPrinterText:
 
     def test_print_table_with_no_data(self):
         with patch("click.echo") as mock_echo:
-            printer = _PrinterText()
+            printer = PrinterText()
             data = []
 
             printer.print_table(data)
@@ -59,7 +59,7 @@ class TestPrinterText:
 class TestPrinterJson:
     def test_print_dict(self):
         with patch("click.echo") as mock_echo:
-            printer = _PrinterJson()
+            printer = PrinterJson()
 
             data = {"key": "value"}
 
@@ -70,7 +70,7 @@ class TestPrinterJson:
 
     def test_print_table(self):
         with patch("click.echo") as mock_echo:
-            printer = _PrinterJson()
+            printer = PrinterJson()
             data = [
                 {"key1": "value1", "key2": "value2"},
                 {"key1": "value3", "key2": "value4"},
@@ -83,7 +83,7 @@ class TestPrinterJson:
 
 class TestMemoryPrinter(unittest.TestCase):
     def setUp(self):
-        self.printer = _MemoryPrinter()
+        self.printer = MemoryPrinter()
 
     def test_print_dict(self):
         data = {"key": "value"}

--- a/projects/vdk-control-cli/tests/vdk/internal/control/utils/test_output_printer.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/utils/test_output_printer.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import pytest
 from vdk.internal.control.utils import output_printer
 from vdk.internal.control.utils.output_printer import create_printer
-from vdk.internal.control.utils.output_printer import MemoryPrinter
+from vdk.internal.control.utils.output_printer import InMemoryTextPrinter
 from vdk.internal.control.utils.output_printer import Printer
 from vdk.internal.control.utils.output_printer import PrinterJson
 from vdk.internal.control.utils.output_printer import PrinterText
@@ -83,7 +83,7 @@ class TestPrinterJson:
 
 class TestMemoryPrinter(unittest.TestCase):
     def setUp(self):
-        self.printer = MemoryPrinter()
+        self.printer = InMemoryTextPrinter()
 
     def test_print_dict(self):
         data = {"key": "value"}


### PR DESCRIPTION
What:Introduced an enhanced feature, the MemoryPrinter, it conserves text for future use, instead of instant printing. Along with this, adapted the JobDeploy class to receive a printer object instead of an OutputFormat enum.

Why:
The inclusion of MemoryPrinter caters to use cases where an output needs to be stored for later representation, such as in a Jupyter UI. This modification in the JobDeploy class enables the printer object's use beyond JobDeploy: the printer can be initialised first, utilised within JobDeploy, and then accessed again to retrieve the stored output. This stops the need for accessing private fields within JobDeploy and promotes better coding practices.

Signed-off-by: Duygu Hasan [hduygu@vmware.com](mailto:hduygu@vmware.com)