### PR TITLE
vdk-jupyter: pin word wrap package to newer version because of security issue

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package-lock.json
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package-lock.json
@@ -36,6 +36,7 @@
         "@lumino/widgets": "1.33.0",
         "@types/react": "17.0.53",
         "typescript": "4.1.3",
+        "word-wrap": "1.2.4",
         "yjs": "^13.5.17"
       },
       "devDependencies": {
@@ -16243,9 +16244,9 @@
       "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ=="
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
+      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package.json
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package.json
@@ -90,7 +90,8 @@
     "typescript": "4.1.3",
     "@types/react": "17.0.53",
     "yjs": "^13.5.17",
-    "@jupyterlab/application": "3.6.3"
+    "@jupyterlab/application": "3.6.3",
+    "word-wrap": "1.2.4"
   },
   "devDependencies": {
     "@babel/core": "7.8.0",


### PR DESCRIPTION
What: 
Pinned the word-wrap package to version 1.2.4.

Why: 
All versions of the package(<1.2.4) word-wrap are vulnerable to Regular Expression Denial of Service (ReDoS) due to the usage of an insecure regular expression within the result variable.

Signed-off-by: Duygu Hasan [hduygu@vmware.com](mailto:hduygu@vmware.com)