### PR TITLE
frontend: Fix bug in Cypress plugin

### DIFF
--- a/projects/frontend/data-pipelines/gui/e2e/plugins/helpers/job-helpers.plugins.js
+++ b/projects/frontend/data-pipelines/gui/e2e/plugins/helpers/job-helpers.plugins.js
@@ -359,7 +359,9 @@ const provideDataJobsExecutions = (taskConfig, config) => {
                                                             jobExecutionTimeout,
                                                             prevCommandInner.lastDeployment,
                                                             targetExecutions -
-                                                                prevCommandInner.executions,
+                                                                prevCommandInner
+                                                                    .executions
+                                                                    .length,
                                                             config
                                                         ).then((result) => {
                                                             return {


### PR DESCRIPTION
Fix bug in Cypress custom plugin that provides executions for Data Jobs e2e tests.
Array was used as integer in one calculation, and because of it there were some unexpected results in some scenarios.
Applied fix uses Array length for calculate the number of left executions that should be executed serial.