### PR TITLE
frontend:  fix pushing images

### DIFF
--- a/projects/frontend/cicd/.gitlab-ci.yml
+++ b/projects/frontend/cicd/.gitlab-ci.yml
@@ -102,10 +102,10 @@ frontend-data-pipelines-release:
     expire_in: 1 week
 
 frontend_publish_ui_image:
+  extends: .images:dind:docker-push-to-vdk-repos
   stage: pre_release_image
-  before_script:
-    - cd projects/frontend/data-pipelines/gui
   script:
+    - cd projects/frontend/data-pipelines/gui
     - apk --no-cache add bash git
     - docker login --username "${VDK_DOCKER_REGISTRY_USERNAME}" --password "${VDK_DOCKER_REGISTRY_PASSWORD}" "${VDK_DOCKER_REGISTRY_URL}"
     - ../../cicd/publish_image_docker.sh vdk-operations-ui . $CI_PIPELINE_ID
@@ -116,7 +116,6 @@ frontend_publish_ui_image:
       changes: *frontend_shared_components_locations
     - if: '$CI_COMMIT_BRANCH == "main"'
       changes: *frontend_data_pipelines_locations
-  extends: .images:dind:docker-push-to-vdk-repos
 
 frontend_tag_ui_image_stable:
   stage: release_image


### PR DESCRIPTION
`frontend_publish_ui_image` extends `.images:dind:docker-push-to-vdk-repos` but since both provide `before_script` the`frontend_publish_ui_image` overwrites the one provided by `.images:dind:docker-push-to-vdk-repos` (which adds the docker_push_vdk.sh script to the PATH) 

This caused failures in the pipeline like this https://gitlab.com/vmware-analytics/versatile-data-kit/-/pipelines/947073454

The fix is to remove  before_script from the `frontend_publish_ui_image` job and move all to `script` 

Testing Done: https://gitlab.com/vmware-analytics/versatile-data-kit/-/pipelines/947441104