### PR TITLE
control-service: exclude pyc files from dj validation

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/upload/JobUploadValidator.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/upload/JobUploadValidator.java
@@ -76,7 +76,8 @@ class JobUploadValidator {
    */
   private void validateFile(String jobName, Path filePath, Path pathInsideJob)
       throws InvalidJobUpload {
-    if (filePath.toFile().isDirectory() || "pyc".equals(FilenameUtils.getExtension(filePath.getFileName().toString()))) {
+    if (filePath.toFile().isDirectory()
+        || "pyc".equals(FilenameUtils.getExtension(filePath.getFileName().toString()))) {
       return;
     }
     try {

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/upload/JobUploadValidator.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/upload/JobUploadValidator.java
@@ -6,6 +6,7 @@
 package com.vmware.taurus.service.upload;
 
 import com.vmware.taurus.exception.ExternalSystemError;
+import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -75,7 +76,7 @@ class JobUploadValidator {
    */
   private void validateFile(String jobName, Path filePath, Path pathInsideJob)
       throws InvalidJobUpload {
-    if (filePath.toFile().isDirectory()) {
+    if (filePath.toFile().isDirectory() || "pyc".equals(FilenameUtils.getExtension(filePath.getFileName().toString()))) {
       return;
     }
     try {


### PR DESCRIPTION
Why
We have received a lot of complaints from your internal customers.

What
Exclude .pyc files from the data job validation process.

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com