### PR TITLE
vdk-jupyter: introduce cicd/build.sh

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/cicd/build.sh
+++ b/projects/vdk-plugins/vdk-jupyter/cicd/build.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -eou pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXT_DIR="$SCRIPT_DIR/../vdk-jupyterlab-extension"
+
+
+function check_command() {
+  local cmd="$1"
+  local doc="$2"
+  if ! command -v "$cmd" &> /dev/null; then
+          echo "Error: $cmd is not installed or not in the system PATH." >&2
+          echo "To install $cmd, refer to the official documentation:" >&2
+          echo "$doc" >&2
+          exit 1
+  fi
+}
+
+check_command "npm" "https://docs.npmjs.com/downloading-and-installing-node-js-and-npm"
+check_command "pip" "https://pip.pypa.io/en/stable/installation"
+
+cd "$EXT_DIR" || { echo "Error: Could not change to directory $EXT_DIR" >&2; exit 1; }
+
+echo "Building vdk-jupyterlab-extension"
+
+echo "Run npm ci command to install the versions of the dependencies specified in the package-lock.json"
+npm ci
+echo "Upgrade pip"
+pip install -U pip
+echo "Install python package in development mode"
+pip install -e .
+echo "Link the development version of the extension with JupyterLab"
+jupyter labextension develop . --overwrite
+echo "Install JupyterLab server extension in develop mode"
+jupyter server extension enable vdk-jupyterlab-extension
+echo "Build JavaScript assets for the JupyterLab extension"
+jlpm build
+
+echo "Notes:"
+echo "Rebuild extension Typescript source after making changes using  jlpm build  or start  jlpm watch  to track and rebuild automatically"
+
+echo "Start jupyter server using"
+echo "jupyter lab"

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/README.md
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/README.md
@@ -4,8 +4,7 @@ A Jupyterlab extension for using VDK
 For more information see: https://github.com/vmware/versatile-data-kit/tree/main/specs/vep-994-jupyter-notebook-integration
 
 This extension is composed of a Python package named `vdk-jupyterlab-extension`
-for the server extension and a NPM package named `vdk-jupyterlab-extension`
-for the frontend extension.
+for the server extension and a NPM package named `vdk-jupyterlab-extension` for the frontend extension.
 
 ## Requirements
 
@@ -48,8 +47,8 @@ jupyter labextension list
 ```
 
 If you are struggling with a particular aspect of the JupyterLab API,
-you can contact the Jupyter team in the following way: go to their repo
-(https://github.com/jupyterlab/jupyterlab), go to Issues, go to New issue,
+you can contact the Jupyter team in the following way: go to their repo issues page at
+https://github.com/jupyterlab/jupyterlab/issues/new/choose
 then click on Open in the "Chat with the devs" section, which will send you
 to a Gitter channel where you can ask your question.
 
@@ -64,19 +63,7 @@ The `jlpm` command is JupyterLab's pinned version of
 `yarn` or `npm` in lieu of `jlpm` below.
 
 ```bash
-# Clone the repo to your local environment
-# Change directory to the vdk-jupyterlab-extension directory
-# Once in the project directory, use the npm ci command to install
-# the exact versions of the dependencies specified in the package-lock.json
-npm ci
-# Install package in development mode
-pip install -e .
-# Link your development version of the extension with JupyterLab
-jupyter labextension develop . --overwrite
-# Server extension must be manually installed in develop mode
-jupyter server extension enable vdk-jupyterlab-extension
-# Rebuild extension Typescript source after making changes
-jlpm build
+../cicd/build.sh
 ```
 
 NB: If you're changing some dependencies of the project,


### PR DESCRIPTION
Add build.sh for streamlined first-time development setup of vdk-jupyterlab-extension