### PR TITLE
[vdk-plugin] vdk-impala: Make error retries and backoff configurable

### DIFF
--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_configuration.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_configuration.py
@@ -20,7 +20,7 @@ IMPALA_RETRIES = "IMPALA_RETRIES"
 IMPALA_SYNC_DDL = "IMPALA_SYNC_DDL"
 IMPALA_QUERY_POOL = "IMPALA_QUERY_POOL"
 IMPALA_RETRIES_ON_ERROR = "IMPALA_RETRIES_ON_ERROR"
-IMPALA_ERROR_BACKOFF_SECONDS = "IMPALA_ERROR_BACKOFF_SECONDS"
+IMPALA_RETRIES_ON_ERROR_BACKOFF_SECONDS = "IMPALA_RETRIES_ON_ERROR_BACKOFF_SECONDS"
 
 
 class ImpalaPluginConfiguration:
@@ -82,7 +82,7 @@ class ImpalaPluginConfiguration:
         return self.__config.get_value(IMPALA_RETRIES_ON_ERROR)
 
     def error_backoff_seconds(self):
-        return self.__config.get_value(IMPALA_ERROR_BACKOFF_SECONDS)
+        return self.__config.get_value(IMPALA_RETRIES_ON_ERROR_BACKOFF_SECONDS)
 
 
 def add_definitions(config_builder: ConfigurationBuilder) -> None:
@@ -194,12 +194,12 @@ def add_definitions(config_builder: ConfigurationBuilder) -> None:
         description="The number of times a query will be retried if an exception is raised.",
     )
     config_builder.add(
-        key=IMPALA_ERROR_BACKOFF_SECONDS,
+        key=IMPALA_RETRIES_ON_ERROR_BACKOFF_SECONDS,
         default_value=30,
         description=(
             "Exponential backoff in seconds, in case retries of a failed query are needed. "
-            "Calculated as `2 ** recovery_cursor.get_retries() * backoff_seconds`, where "
-            "`recovery_cursor.get_retries()` is the number of times the query has already been retried."
+            "Calculated as `(2 ^ retry-attempt) * backoff_seconds`, where "
+            "`retry-attempt` is the number of times the query has already been retried."
             "For example, if the value of this configuration is 30 seconds, the time intervals will "
             "be 30s, 60s, 2m, 4m, 8m"
         ),

--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_configuration.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_configuration.py
@@ -19,6 +19,8 @@ IMPALA_AUTH_COOKIE_NAMES = "IMPALA_AUTH_COOKIE_NAMES"
 IMPALA_RETRIES = "IMPALA_RETRIES"
 IMPALA_SYNC_DDL = "IMPALA_SYNC_DDL"
 IMPALA_QUERY_POOL = "IMPALA_QUERY_POOL"
+IMPALA_RETRIES_ON_ERROR = "IMPALA_RETRIES_ON_ERROR"
+IMPALA_ERROR_BACKOFF_SECONDS = "IMPALA_ERROR_BACKOFF_SECONDS"
 
 
 class ImpalaPluginConfiguration:
@@ -75,6 +77,12 @@ class ImpalaPluginConfiguration:
 
     def query_pool(self):
         return self.__config.get_value(IMPALA_QUERY_POOL)
+
+    def retries_on_error(self):
+        return self.__config.get_value(IMPALA_RETRIES_ON_ERROR)
+
+    def error_backoff_seconds(self):
+        return self.__config.get_value(IMPALA_ERROR_BACKOFF_SECONDS)
 
 
 def add_definitions(config_builder: ConfigurationBuilder) -> None:
@@ -179,4 +187,20 @@ def add_definitions(config_builder: ConfigurationBuilder) -> None:
         key=IMPALA_QUERY_POOL,
         default_value=None,
         description="The name of the Impala pool to execute queries in.",
+    )
+    config_builder.add(
+        key=IMPALA_RETRIES_ON_ERROR,
+        default_value=5,
+        description="The number of times a query will be retried if an exception is raised.",
+    )
+    config_builder.add(
+        key=IMPALA_ERROR_BACKOFF_SECONDS,
+        default_value=30,
+        description=(
+            "Exponential backoff in seconds, in case retries of a failed query are needed. "
+            "Calculated as `2 ** recovery_cursor.get_retries() * backoff_seconds`, where "
+            "`recovery_cursor.get_retries()` is the number of times the query has already been retried."
+            "For example, if the value of this configuration is 30 seconds, the time intervals will "
+            "be 30s, 60s, 2m, 4m, 8m"
+        ),
     )

--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_plugin.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_plugin.py
@@ -133,10 +133,12 @@ class ImpalaPlugin:
                     )
                 ) from exception
 
-    @staticmethod
     @hookimpl
-    def db_connection_recover_operation(recovery_cursor: RecoveryCursor) -> None:
-        impala_error_handler = ImpalaErrorHandler()
+    def db_connection_recover_operation(self, recovery_cursor: RecoveryCursor) -> None:
+        impala_error_handler = ImpalaErrorHandler(
+            num_retries=self._impala_cfg.retries_on_error(),
+            backoff_seconds=self._impala_cfg.error_backoff_seconds(),
+        )
 
         if impala_error_handler.handle_error(
             recovery_cursor.get_exception(), recovery_cursor


### PR DESCRIPTION
Currently, the retries and backoff seconds are hard-coded in the ImpalaErrorHandler, which is not ideal, as there might be users who want to have specific values for these properties.

This change adds two new configuration variables, `IMPALA_RETRIES_ON_ERROR` and `IMPALA_ERROR_BACKOFF_SECONDS`, which are to be used for configuring how many times a failed query is to be retried, and how big the backoff should be.