### PR TITLE
vdk-sqlite: support whitespace in column names

### DIFF
--- a/projects/vdk-plugins/vdk-sqlite/tests/test_sqlite_plugin.py
+++ b/projects/vdk-plugins/vdk-sqlite/tests/test_sqlite_plugin.py
@@ -54,13 +54,13 @@ def test_sqlite_ingestion(tmpdir):
             [
                 "sqlite-query",
                 "--query",
-                "CREATE TABLE test_table (some_data TEXT, more_data TEXT)",
+                r"CREATE TABLE test_table (some\ data TEXT, more_data TEXT)",
             ]
         )
 
         mock_sqlite_conf = mock.MagicMock(SQLiteConfiguration)
         sqlite_ingester = IngestToSQLite(mock_sqlite_conf)
-        payload = [{"some_data": "some_test_data", "more_data": "more_test_data"}]
+        payload = [{"some data": "some test data", "more_data": "more_test_data"}]
 
         sqlite_ingester.ingest_payload(
             payload=payload,
@@ -73,9 +73,9 @@ def test_sqlite_ingestion(tmpdir):
         )
 
         assert check_result.stdout == (
-            "some_data       more_data\n"
+            "some data       more_data\n"
             "--------------  --------------\n"
-            "some_test_data  more_test_data\n"
+            "some test data  more_test_data\n"
         )
 
 


### PR DESCRIPTION
## Why?

Trying to create columns with whitespace in the name and inserting data in them using vdk-sqlite resulted in error.

This was most evident in examples like csv-ingestion

https://github.com/vmware/versatile-data-kit/wiki/Ingesting-local-CSV-file-into-Database

## What?

- Add double quotes around column names with whitespace in them when the table is created.
- Replace named placeholders in insert query with question marks
- Convert payload from dicts to lists to pass it to above query
- Check if payload headers match column names before it's passed

## How has this been tested?

Unit tests

## What type of change is this?

Bugfix