### PR TITLE
vdk-impala: Handle errors on refresh/invalidate metadata

### DIFF
--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_error_handler.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_error_handler.py
@@ -41,13 +41,13 @@ class ImpalaErrorHandler:
         :param caught_exception: the caught Impala exception
         :param recovery_cursor: cursor that can be used to execute recovery queries and query retries against Impala
         :return: true if and only if the exception was handled successfully and the query passed has succeeded.
-                Otherwise return false - the caught_exception was not handled.
+                Otherwise, return false - the caught_exception was not handled.
                 This method will raise an exception in the following scenarios and assuming handling of the error
                 produced another exception:
                  1. Exceptions are of the same type but have different args.
                  2. Exceptions are different types.
                 Moreover, the root cause stack trace will appear in the error message if an exception is raised.
-                Otherwise stacktrace gets changed and becomes confusing.
+                Otherwise, stacktrace gets changed and becomes confusing.
         """
         if self._handle_should_not_retry_error(caught_exception):
             return False
@@ -56,7 +56,7 @@ class ImpalaErrorHandler:
             errors.log_and_throw(
                 to_be_fixed_by=errors.ResolvableBy.USER_ERROR,
                 log=self._log,
-                what_happened="An Impala Pool Error occured: " + str(caught_exception),
+                what_happened="An Impala Pool Error occurred: " + str(caught_exception),
                 why_it_happened="Review the contents of the exception.",
                 consequences="The queries will not be executed.",
                 countermeasures=(
@@ -227,6 +227,12 @@ class ImpalaErrorHandler:
                 exception,
                 classname_with_package="impala.error.OperationalError",
                 exception_message_matcher_regex=".*ImpalaRuntimeException: Error making 'updateTableColumnStatistics'.*",
+            )
+            or errors.exception_matches(
+                exception,
+                classname_with_package="impala.error.HiveServer2Error",
+                exception_message_matcher_regex="AuthorizationException: User .*does not have privileges to "
+                "execute 'INVALIDATE METADATA/REFRESH' on.*",
             )
         ):
             sleep_seconds = 2 ** recovery_cursor.get_retries() * self._backoff_seconds

--- a/projects/vdk-plugins/vdk-impala/tests/impala_error_handler_test.py
+++ b/projects/vdk-plugins/vdk-impala/tests/impala_error_handler_test.py
@@ -243,6 +243,60 @@ CAUSED BY: MetaException: Object with id "" is managed by a different persistenc
         )
         mock_native_cursor.execute.assert_not_called()
 
+    def test_handle_failed_to_open_hdfs_new_authorization_exception_is_thrown_after_fix(
+        self, patched_time_sleep
+    ):
+        new_exception = HiveServer2Error(
+            "AuthorizationException: User 'pa__view_test-user' does not have privileges to "
+            "execute 'INVALIDATE METADATA/REFRESH' on"
+        )
+        generic_authorization_exception = HiveServer2Error(
+            "AuthorizationException: User 'pa__view_test-user' does not have privileges to "
+            "execute 'SELECT' on"
+        )
+        test_exception = OperationalError(
+            """Disk I/O error: Failed to open HDFS file
+            hdfs://HDFS/user/hive/warehouse/history.db/vm/pa__arrival_day=1573171200/pa__collector_id=vSphere.6_6/pa__schema_version=1/7642f6c1c2c31372-588d054900000012_186717772_data.0.parq
+            Error(255): Unknown error 255
+            Root cause: ConnectException: Connection refused"""
+        )
+        original_query = "select * from history.vm"
+
+        (
+            mock_native_cursor,
+            _,
+            _,
+            mock_recovery_cursor,
+            _,
+        ) = populate_mock_managed_cursor(
+            mock_exception_to_recover=test_exception, mock_operation=original_query
+        )
+        mock_native_cursor.execute.side_effect = [new_exception, None]
+
+        self.error_handler.handle_error(test_exception, mock_recovery_cursor)
+
+        # make sure we have tried
+        calls = [call("refresh `history`.`vm`"), call(original_query)]
+        mock_native_cursor.execute.assert_has_calls(calls)
+
+        # Verify that authorization exceptions not related to refresh/invalidate metadata
+        # are not handled.
+        mock_native_cursor.execute.side_effect = [
+            None,
+            generic_authorization_exception,
+            None,
+        ]
+
+        # after refresh metadata , original query fail again but with new exception
+        with self.assertRaises(HiveServer2Error) as exc:
+            self.error_handler.handle_error(test_exception, mock_recovery_cursor)
+
+        assert exc.exception == generic_authorization_exception
+
+        # make sure we have tried
+        calls = [call("refresh `history`.`vm`"), call(original_query)]
+        mock_native_cursor.execute.assert_has_calls(calls)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/projects/vdk-plugins/vdk-impala/tests/impala_handle_hdfs_error_test.py
+++ b/projects/vdk-plugins/vdk-impala/tests/impala_handle_hdfs_error_test.py
@@ -4,6 +4,7 @@ import logging
 import unittest
 from unittest.mock import call
 from unittest.mock import MagicMock
+from unittest.mock import patch
 
 from impala.error import HiveServer2Error
 from impala.error import OperationalError
@@ -11,6 +12,7 @@ from vdk.plugin.impala.impala_error_handler import ImpalaErrorHandler
 from vdk.plugin.test_utils.util_funcs import populate_mock_managed_cursor
 
 
+@patch("time.sleep", return_value=None)
 class ImpalaHandleHdfsErrorTest(unittest.TestCase):
     def setUp(self):
         error_message = """Disk I/O error: Failed to open HDFS file hdfs://HDFS/user/hive/warehouse/history.db/vm/pa__arrival_day=1573171200/pa__collector_id=vSphere.6_6/pa__schema_version=1/7642f6c1c2c31372-588d054900000012_186717772_data.0.parq
@@ -19,7 +21,7 @@ Root cause: ConnectException: Connection refused"""
         self._failed_to_open_exception = OperationalError(error_message)
         self._query = "select 1"
 
-    def test_handle_hdfs_failed_to_open(self):
+    def test_handle_hdfs_failed_to_open(self, patched_time_sleep):
         error_handler = ImpalaErrorHandler(MagicMock())
         original_query = "select * from history.vm"
 
@@ -59,26 +61,7 @@ Root cause: ConnectException: Connection refused"""
         ]
         mock_native_cursor.execute.assert_has_calls(calls)
 
-    def test_handle_hdfs_failed_to_open_and_refresh_failed(self):
-        (
-            mock_native_cursor,
-            _,
-            _,
-            mock_recovery_cursor,
-            _,
-        ) = populate_mock_managed_cursor(
-            mock_exception_to_recover=self._failed_to_open_exception,
-            mock_operation=self._query,
-        )
-        mock_native_cursor.execute.side_effect = [HiveServer2Error("foo")]
-
-        error_handler = ImpalaErrorHandler(MagicMock())
-        with self.assertRaises(HiveServer2Error):
-            error_handler.handle_error(
-                self._failed_to_open_exception, mock_recovery_cursor
-            )
-
-    def test_handle_error(self):
+    def test_handle_error(self, patched_time_sleep):
         exception = OperationalError("impala.error.OperationalError: MemoryLimit")
         error_handler = ImpalaErrorHandler(MagicMock())
         (
@@ -97,7 +80,7 @@ Root cause: ConnectException: Connection refused"""
         error_handler.handle_error(exception, mock_recovery_cursor)
         mock_native_cursor.execute.assert_called_once()
 
-    def test_two_different_exceptions(self):
+    def test_two_different_exceptions(self, patched_time_sleep):
         initial_message = """Disk I/O error on hdp-prd-cdh6-ix15.supercollider.vmware.com:22000: Failed to open HDFS file hdfs://l3-vac.wdc-03-isi02.oc.vmware.com:8020/user/hive/warehouse/starshot_csp_jira_dw.db/csp_customfieldoption/554fce0f545e17a0-739e2bfa0000006f_954094502_data.0.parq
 Error(2): No such file or directory
 Root cause: RemoteException: Path name not found: /user/hive/warehouse/starshot_csp_jira_dw.db/csp_customfieldoption/554fce0f545e17a0-739e2bfa0000006f_954094502_data.0.parq"""
@@ -124,7 +107,7 @@ Root cause: RemoteException: Path name not found: /user/hive/warehouse/starshot_
             )
         assert exc.exception.args == secondary_error.args
 
-    def test_two_same_exceptions_different_args(self):
+    def test_two_same_exceptions_different_args(self, patched_time_sleep):
         initial_message = """Disk I/O error on hdp-prd-cdh6-ix15.supercollider.vmware.com:22000: Failed to open HDFS file hdfs://l3-vac.wdc-03-isi02.oc.vmware.com:8020/user/hive/warehouse/starshot_csp_jira_dw.db/csp_customfieldoption/554fce0f545e17a0-739e2bfa0000006f_954094502_data.0.parq
 Error(2): No such file or directory
 Root cause: RemoteException: Path name not found: /user/hive/warehouse/starshot_csp_jira_dw.db/csp_customfieldoption/554fce0f545e17a0-739e2bfa0000006f_954094502_data.0.parq"""
@@ -151,7 +134,7 @@ Root cause: RemoteException: Path name not found: /user/hive/warehouse/starshot_
             )
         assert exc.exception.args == secondary_error.args
 
-    def test_two_same_exceptions(self):
+    def test_two_same_exceptions(self, patched_time_sleep):
         error_message = """Disk I/O error on hdp-prd-cdh6-ix15.supercollider.vmware.com:22000: Failed to open HDFS file hdfs://l3-vac.wdc-03-isi02.oc.vmware.com:8020/user/hive/warehouse/starshot_csp_jira_dw.db/csp_customfieldoption/554fce0f545e17a0-739e2bfa0000006f_954094502_data.0.parq
 Error(2): No such file or directory
 Root cause: RemoteException: Path name not found: /user/hive/warehouse/starshot_csp_jira_dw.db/csp_customfieldoption/554fce0f545e17a0-739e2bfa0000006f_954094502_data.0.parq"""
@@ -175,7 +158,7 @@ Root cause: RemoteException: Path name not found: /user/hive/warehouse/starshot_
             )
         )
 
-    def test_initial_exception_handled(self):
+    def test_initial_exception_handled(self, patched_time_sleep):
         error_message = """Disk I/O error on hdp-prd-cdh6-ix15.supercollider.vmware.com:22000: Failed to open HDFS file hdfs://l3-vac.wdc-03-isi02.oc.vmware.com:8020/user/hive/warehouse/starshot_csp_jira_dw.db/csp_customfieldoption/554fce0f545e17a0-739e2bfa0000006f_954094502_data.0.parq
 Error(2): No such file or directory
 Root cause: RemoteException: Path name not found: /user/hive/warehouse/starshot_csp_jira_dw.db/csp_customfieldoption/554fce0f545e17a0-739e2bfa0000006f_954094502_data.0.parq"""
@@ -191,7 +174,7 @@ Root cause: RemoteException: Path name not found: /user/hive/warehouse/starshot_
             )
         )
 
-    def test_two_same_exceptions_no_args(self):
+    def test_two_same_exceptions_no_args(self, patched_time_sleep):
         initial_error = OperationalError()
         secondary_error = OperationalError()
         assert initial_error.args == secondary_error.args


### PR DESCRIPTION
Currently, if a data job executes a query, which fails due to metadata issue, the ImpalaErrorHandler
logic tries to refresh or invalidate the metadata, and re-try the query. If the job has only read
access to the table, an authorization error is raised and the job failes with User Error. This should
not happen, as the refresh/invalidate operation is initiated by vdk, not the user.
    
This change updates the error handler logic by adding try/except blocks around refresh/invalidate
metadata operations, so that errors that arise from these operations do not cause job failures.
    
Testing Done: Added test