### PR TITLE
control-service: add libffi to secure base job image

### DIFF
--- a/projects/control-service/projects/job-base-image-secure/Dockerfile-data-job-base
+++ b/projects/control-service/projects/job-base-image-secure/Dockerfile-data-job-base
@@ -96,3 +96,6 @@ FROM photon:latest
 # Copies essential binaries, libraries, headers, and Python files from the base Python image,
 # excluding build dependencies.
 COPY --from=build /usr/local/ /usr/local/
+
+# Installs Python dependencies
+RUN pip install libffi-devel


### PR DESCRIPTION
Fix for the following error during data job building:

```
File "/usr/local/lib/python3.9/ctypes/__init__.py", line 8, in <module>
  from _ctypes import Union, Structure, Array
ImportError: libffi.so.8: cannot open shared object file: No such file or directory
[end of output]
```
Signed-off-by: Miroslav Ivanov miroslavi@vmware.com