### PR TITLE
vdk-control-api-auth: add get_authenticated_username

### DIFF
--- a/projects/vdk-plugins/vdk-control-api-auth/requirements.txt
+++ b/projects/vdk-plugins/vdk-control-api-auth/requirements.txt
@@ -1,5 +1,3 @@
 pytest
 pytest-httpserver
-requests
-requests_oauthlib
 vdk-test-utils

--- a/projects/vdk-plugins/vdk-control-api-auth/setup.py
+++ b/projects/vdk-plugins/vdk-control-api-auth/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     "authentication.",
     long_description=pathlib.Path("README.md").read_text(),
     long_description_content_type="text/markdown",
-    install_requires=["requests", "requests_oauthlib"],
+    install_requires=["requests", "requests_oauthlib", "PyJWT"],
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),
     classifiers=[

--- a/projects/vdk-plugins/vdk-control-api-auth/src/vdk/plugin/control_api_auth/authentication.py
+++ b/projects/vdk-plugins/vdk-control-api-auth/src/vdk/plugin/control_api_auth/authentication.py
@@ -53,7 +53,7 @@ class Authentication:
             A flag, indicating if credentials should be cached locally (in a
             file).
         :param possible_jwt_user_keys:
-            Used by get_authenticated_username to try to discover correct username if OAuth2 and JWT token is used.
+            Used by get_authenticated_username to try to discover correct username if OAuth2 and JWT token is used. It is a list of keys where the first existing key in a JTW token is returned.
             Defaults to some common user keys.
         """
         self._username = username

--- a/projects/vdk-plugins/vdk-control-api-auth/tests/test_get_auth_user.py
+++ b/projects/vdk-plugins/vdk-control-api-auth/tests/test_get_auth_user.py
@@ -41,7 +41,7 @@ def test_get_authenticated_username_priority_order_kept(mock_jwt_decode):
     auth = Authentication(
         token="testtoken", possible_jwt_user_keys=["user", "email", "sub", "acct"]
     )
-    assert auth.get_authenticated_username() == "user_from_sub2"
+    assert auth.get_authenticated_username() == "user_from_sub"
 
 
 def test_get_authenticated_username_without_username_or_token():

--- a/projects/vdk-plugins/vdk-control-api-auth/tests/test_get_auth_user.py
+++ b/projects/vdk-plugins/vdk-control-api-auth/tests/test_get_auth_user.py
@@ -1,0 +1,49 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from unittest.mock import patch
+
+import pytest
+from vdk.plugin.control_api_auth.authentication import Authentication
+
+
+def test_get_authenticated_username_with_username():
+    auth = Authentication(username="testuser")
+    assert auth.get_authenticated_username() == "testuser"
+
+
+@patch("jwt.decode")
+def test_get_authenticated_username_with_token_username(mock_jwt_decode):
+    mock_jwt_decode.return_value = {"username": "testuser"}
+    auth = Authentication(token="testtoken")
+    assert auth.get_authenticated_username() == "testuser"
+
+
+@pytest.mark.parametrize("user_id_field", ["acct", "email", "preferred_username"])
+@patch("jwt.decode")
+def test_get_authenticated_username_with_token_other_fields(
+    mock_jwt_decode, user_id_field
+):
+    mock_jwt_decode.return_value = {user_id_field: "testuser"}
+    auth = Authentication(token="testtoken")
+    assert auth.get_authenticated_username() == "testuser"
+
+
+@patch("jwt.decode")
+def test_get_authenticated_username_with_token_no_user_id(mock_jwt_decode):
+    mock_jwt_decode.return_value = {}
+    auth = Authentication(token="testtoken")
+    assert auth.get_authenticated_username() is None
+
+
+@patch("jwt.decode")
+def test_get_authenticated_username_priority_order_kept(mock_jwt_decode):
+    mock_jwt_decode.return_value = {"sub": "user_from_sub", "acct": "user_from_acct"}
+    auth = Authentication(
+        token="testtoken", possible_jwt_user_keys=["user", "email", "sub", "acct"]
+    )
+    assert auth.get_authenticated_username() == "user_from_sub2"
+
+
+def test_get_authenticated_username_without_username_or_token():
+    auth = Authentication()
+    assert auth.get_authenticated_username() is None


### PR DESCRIPTION
Add to Authentication library a method to get_authenticated_username.

The purpose of this method is ot be used during debugging , in logging and in telemetry use cases.

Testing Done: unit tests