### PR TITLE
vdk-core: Add flag to JobConfig in case config file is required

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/job_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/job_config.py
@@ -42,24 +42,29 @@ class JobConfig:
     For more see the user wiki
     """
 
-    def __init__(self, data_job_path: Union[pathlib.Path, str]):
+    def __init__(
+        self, data_job_path: Union[pathlib.Path, str], should_fail_missing_config=False
+    ):
         self._config_ini = configparser.ConfigParser()
         self._config_file = os.path.join(data_job_path, "config.ini")
+        self._should_fail_missing_config = should_fail_missing_config
 
         if not os.path.isfile(self._config_file):
-            # TODO: Figure out a way to properly handle cases where there is no config.ini present
-            log.info("Missing config.ini file.")
-            # raise VdkConfigurationError(
-            #     ErrorMessage(
-            #         summary="Error while loading config.ini file",
-            #         what="Cannot extract job Configuration",
-            #         why=f"Configuration file config.ini is missing in data job path: {data_job_path}",
-            #         consequences="Cannot deploy and configure the data job without config.ini file.",
-            #         countermeasures="config.ini must be in the root of the data job folder. "
-            #         "Make sure the file is created "
-            #         "or double check the data job path is passed correctly.",
-            #     )
-            # )
+            if should_fail_missing_config:
+                raise VdkConfigurationError(
+                    ErrorMessage(
+                        summary="Error while loading config.ini file",
+                        what="Cannot extract job Configuration",
+                        why=f"Configuration file config.ini is missing in data job path: {data_job_path}",
+                        consequences="Cannot deploy and configure the data job without config.ini file.",
+                        countermeasures="config.ini must be in the root of the data job folder. "
+                        "Make sure the file is created "
+                        "or double check the data job path is passed correctly.",
+                    )
+                )
+            else:
+                log.info("Missing config.ini file.")
+
         self._read_config_ini_file(
             config_parser=self._config_ini, configuration_file_path=self._config_file
         )

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_job_config.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_job_config.py
@@ -83,6 +83,14 @@ class TestJobConfig:
         self.assertEqual(False, cfg.get_enable_attempt_notifications())
         # this is the only important default no need to verify the others.
 
+    def test_error_raised_missing_config(self, tmpdir):
+        empty_job_dir = tmpdir.mkdir("foo-job")
+
+        with pytest.raises(VdkConfigurationError) as exc:
+            JobConfig(pathlib.Path(empty_job_dir), should_fail_missing_config=True)
+
+        assert "Error while loading config.ini file" in exc.value.args[0]
+
     def test_vdk_options_empty(self):
         self.assertEqual({}, self._cfg.get_vdk_options())
 
@@ -97,15 +105,14 @@ class TestJobConfig:
         cfg = JobConfig(self._test_dir)
         self.assertEqual({"a": "b"}, cfg.get_vdk_options())
 
-    # TODO: Enable when JobConfig issues resolved, tests still present in https://github.com/vmware/versatile-data-kit/blob/main/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_datajob_config.py
-    # def test_set_team(self):
-    #     self._perform_set_team_test("my_unique_team_name")
-    #
-    # def test_set_empty_team(self):
-    #     self._perform_set_team_test("")
-    #
-    # def test_set_team_with_spaces(self):
-    #     self._perform_set_team_test("my unique team name")
+    def test_set_team(self):
+        self._perform_set_team_test("my_unique_team_name")
+
+    def test_set_empty_team(self):
+        self._perform_set_team_test("")
+
+    def test_set_team_with_spaces(self):
+        self._perform_set_team_test("my unique team name")
 
     def test_set_team_with_no_team_in_config_ini(self):
         # remove all contents of config.ini (including team option)


### PR DESCRIPTION
Currently, the vdk-core's JobConfig does not require the presense of a config file in a data job's repository. This works in general, but not for the vdk-control-cli's use-cases, where the presense of the config file is mandatory.

This change adds a `should_fail_missing_config` flag to JobConfig, which can be used when the presense of the config file is necessary. If the flag is set to `True`, and the config file is missing in the data job's folder, a VdkConfigurationError will be raised.

Testing Done: Added test