### PR TITLE
control-service: allow delete-all-secrets command

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/secrets/service/vault/TestVaultJobSecretsServiceIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/secrets/service/vault/TestVaultJobSecretsServiceIT.java
@@ -72,6 +72,18 @@ public class TestVaultJobSecretsServiceIT extends BaseIT {
   }
 
   @Test
+  public void testSetEmptyDataJobSecrets() throws Exception {
+    Map<String, Object> temp = new HashMap<>();
+
+    Map<String, Object> secrets = Collections.unmodifiableMap(temp);
+
+    vaultJobSecretService.updateJobSecrets("testJob2", secrets);
+
+    Map<String, Object> readResult = vaultJobSecretService.readJobSecrets("testJob2");
+    Assertions.assertEquals(secrets, readResult);
+  }
+
+  @Test
   void testUpdateJobSecretsLimit() throws JsonProcessingException {
     Map<String, Object> temp = new HashMap<>();
     temp.put("key1", "value1");

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/secrets/service/vault/VaultJobSecretsService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/secrets/service/vault/VaultJobSecretsService.java
@@ -45,7 +45,6 @@ public class VaultJobSecretsService implements com.vmware.taurus.secrets.service
   public void updateJobSecrets(String jobName, Map<String, Object> secrets) {
 
     checkJobName(jobName);
-    checkJobSecretsMap(jobName, secrets);
 
     Versioned<VaultJobSecrets> readResponse =
         vaultOperations.opsForVersionedKeyValue(SECRET).get(jobName, VaultJobSecrets.class);
@@ -100,12 +99,6 @@ public class VaultJobSecretsService implements com.vmware.taurus.secrets.service
   private void checkJobName(String jobName) {
     if (jobName == null || jobName.isBlank()) {
       throw new DataJobSecretsException(jobName, "Data Job Name cannot be blank");
-    }
-  }
-
-  private void checkJobSecretsMap(String jobName, Map<String, Object> secrets) {
-    if (secrets == null || secrets.isEmpty()) {
-      throw new DataJobSecretsException(jobName, "Secrets parameter cannot be null or empty");
     }
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/secrets/vault/VaultJobSecretsServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/secrets/vault/VaultJobSecretsServiceTest.java
@@ -105,7 +105,6 @@ class VaultJobSecretsServiceTest {
     String blankJobName = " ";
     String nullJobName = null;
     Map<String, Object> secrets = new HashMap<>();
-    Map<String, Object> nullSecrets = new HashMap<>();
 
     Throwable t =
         assertThrows(
@@ -120,20 +119,5 @@ class VaultJobSecretsServiceTest {
             () -> secretsService.updateJobSecrets(nullJobName, secrets));
 
     Assert.assertThat(t.getMessage(), CoreMatchers.containsString("Data Job Name cannot be blank"));
-
-    t =
-        assertThrowsExactly(
-            DataJobSecretsException.class, () -> secretsService.updateJobSecrets(jobName, secrets));
-
-    Assert.assertThat(
-        t.getMessage(), CoreMatchers.containsString("Secrets parameter cannot be null or empty"));
-
-    t =
-        assertThrowsExactly(
-            DataJobSecretsException.class,
-            () -> secretsService.updateJobSecrets(jobName, nullSecrets));
-
-    Assert.assertThat(
-        t.getMessage(), CoreMatchers.containsString("Secrets parameter cannot be null or empty"));
   }
 }


### PR DESCRIPTION
Fix a bug which prevents the delete-all-secrets cli command to work.