### PR TITLE
control-service: support for pyodbc

### DIFF
--- a/projects/control-service/projects/job-builder-secure/Dockerfile.python.vdk
+++ b/projects/control-service/projects/job-builder-secure/Dockerfile.python.vdk
@@ -38,6 +38,9 @@ RUN : \
            && unzip oracle-instantclient.zip -d /opt/lib/native/oracle && rm -f oracle-instantclient.zip \
            && sh -c "echo /opt/lib/native/oracle/instantclient_21_10 > /etc/ld.so.conf.d/oracle-instantclient.conf" \
            && ldconfig; fi \
+    && if grep -q -E "^pyodbc" "$job_name/$requirements_file"; then \
+           echo "Installing native dependencies related to support for pyodbc python library ..." \
+           && yum install unixodbc -y; fi \
     && if [ -f "$job_name/$requirements_file" ]; then \
           echo "Installing native dependencies ..." \
           && yum install build-essential gcc glibc-devel git -y \


### PR DESCRIPTION
Why
Currently, the base secure image does not contain the required libraries for `pyodbc` Python package.

What
Installed required native dependencies.

Testing Done
Locally through the following command:

```
docker buildx build -f versatile-data-kit/projects/control-service/projects/job-builder-secure/Dockerfile.python.vdk -t test-image-tag . --build-arg job_githash=localhsh1 --build-arg base_image=registry.hub.docker.com/versatiledatakit/data-job-base-python-3.8-secure:latest --build-arg job_name="data_job_name" --progress=plain
```

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com