### PR TITLE
control-service: Ability to disable VDK UI in Helm

### DIFF
--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -284,7 +284,7 @@ control_service_publish_api_client:
 # (there are docker KDC servers that can be used for demo? but it will not work with Impala ?)
 # The cockroach storage class is taken from DECC https://devhub.eng.vmware.com/console/resources/namespaces
 # Go to the namespace -> StorageClass
-control_service_deploy_testing_data_pipelines:
+.control_service_deploy_testing_data_pipelines:
   stage: pre_release
   image: docker:23.0.1
   script:
@@ -298,6 +298,9 @@ control_service_deploy_testing_data_pipelines:
     - curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
     - bash -ex ./projects/control-service/cicd/deploy-testing-pipelines-service.sh
   retry: !reference [.control_service_retry, retry_options]
+
+control_service_deploy_testing_data_pipelines:
+  extends: .control_service_deploy_testing_data_pipelines
   rules:
     - if: '$CI_COMMIT_BRANCH == "main"'
       changes: [ projects/control-service/projects/helm_charts/pipelines-control-service/version.txt ]
@@ -305,6 +308,19 @@ control_service_deploy_testing_data_pipelines:
     - if: '$CI_COMMIT_BRANCH == "main"'
       changes: *control_service_code_change_locations
     - if: '$CI_COMMIT_BRANCH == "main"'
+      changes: *control_service_helm_change_locations
+
+control_service_helm_chart_dry_run:
+  extends: .control_service_deploy_testing_data_pipelines
+  before_script:
+    - export HELM_EXTRA_ARGUMENTS="--dry-run"
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "external_pull_request_event"'
+      changes: [ projects/control-service/projects/helm_charts/pipelines-control-service/version.txt ]
+      when: never
+    - if: '$CI_PIPELINE_SOURCE == "external_pull_request_event"'
+      changes: *control_service_code_change_locations
+    - if: '$CI_PIPELINE_SOURCE == "external_pull_request_event"'
       changes: *control_service_helm_change_locations
 
 # vdk-heartbeat source: https://github.com/vmware/versatile-data-kit/tree/main/projects/vdk-heartbeat

--- a/projects/control-service/cicd/deploy-testing-pipelines-service.sh
+++ b/projects/control-service/cicd/deploy-testing-pipelines-service.sh
@@ -20,7 +20,7 @@ export VDK_OPTIONS="$SCRIPT_DIR/vdk-options.ini"
 export TPCS_CHART=${TPCS_CHART:-"$SCRIPT_DIR/../projects/helm_charts/pipelines-control-service"}
 export VDK_DOCKER_REGISTRY_URL=${VDK_DOCKER_REGISTRY_URL:-"registry.hub.docker.com/versatiledatakit"}
 export TESTING_PIPELINES_SERVICE_VALUES_FILE=${TESTING_PIPELINES_SERVICE_VALUES_FILE:-"$SCRIPT_DIR/testing-pipelines-service-values.yaml"}
-
+export HELM_EXTRA_ARGUMENTS=${HELM_EXTRA_ARGUMENTS:-""}
 
 RUN_ENVIRONMENT_SETUP=${RUN_ENVIRONMENT_SETUP:-'n'}
 
@@ -86,13 +86,12 @@ if [[ $helm_latest_deployment == *"pending-upgrade"* ]]; then
   exit 125
 fi
 
-
 #
 # TODO :change container images with official ones when they are being deployed (I've currently uploaded them once in ghcr.io/tozka)
 #
 # image.tag is fixed during release. It is set here to deploy using latest change in source code.
 # We are using here embedded database, and we need to set the storageclass since in our test k8s no default storage class is not set.
-helm upgrade --install --debug --wait --timeout 10m0s $RELEASE_NAME . \
+helm upgrade --install --debug ${HELM_EXTRA_ARGUMENTS} --wait --timeout 10m0s $RELEASE_NAME . \
       -f "$TESTING_PIPELINES_SERVICE_VALUES_FILE" \
       --set image.tag="$TAG" \
       --set operationsUi.image.tag="$FRONTEND_TAG" \

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/configmap.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/configmap.yaml
@@ -3,9 +3,13 @@
   SPDX-License-Identifier: Apache-2.0
  */}}
 
+{{- if .Values.operationsUi.enabled }}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ui-config
 data:
   config.json: {{ .Values.operationsUi.config | toJson }}
+
+{{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/deployment.yaml
@@ -3,6 +3,8 @@
   SPDX-License-Identifier: Apache-2.0
  */}}
 
+{{- if .Values.operationsUi.enabled }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -55,3 +57,5 @@ spec:
         - name: config-volume
           configMap:
             name: ui-config
+
+{{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/secret_pull_pipelines_control_service_img.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/secret_pull_pipelines_control_service_img.yaml
@@ -3,6 +3,7 @@
   SPDX-License-Identifier: Apache-2.0
  */}}
 
+{{- if .Values.operationsUi.enabled }}
 {{- if and (.Values.operationsUi.image.username) (.Values.operationsUi.image.password) }}
 apiVersion: v1
 kind: Secret
@@ -13,4 +14,5 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "operationsUiPullSecretJson" . }}
+{{- end }}
 {{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/service.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/frontend/service.yaml
@@ -3,6 +3,8 @@
   SPDX-License-Identifier: Apache-2.0
  */}}
 
+{{- if .Values.operationsUi.enabled }}
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,3 +20,5 @@ spec:
          targetPort: 8091
    selector:
       app: {{ .Release.Name }}-ui
+
+{{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -29,6 +29,7 @@ image:
 # All config related to the operations ui lives under this tag.
 # examples of what can be configured are, what docker image to pull, how many replicas of the service to run and how many resources to give to each replica
 operationsUi:
+  enabled: true
   image:
     registry: registry.hub.docker.com/versatiledatakit
     repository: vdk-operations-ui

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -29,7 +29,7 @@ image:
 # All config related to the operations ui lives under this tag.
 # examples of what can be configured are, what docker image to pull, how many replicas of the service to run and how many resources to give to each replica
 operationsUi:
-  enabled: false
+  enabled: true
   image:
     registry: registry.hub.docker.com/versatiledatakit
     repository: vdk-operations-ui

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -29,7 +29,7 @@ image:
 # All config related to the operations ui lives under this tag.
 # examples of what can be configured are, what docker image to pull, how many replicas of the service to run and how many resources to give to each replica
 operationsUi:
-  enabled: true
+  enabled: false
   image:
     registry: registry.hub.docker.com/versatiledatakit
     repository: vdk-operations-ui


### PR DESCRIPTION
See Issue #2539

To test this (and future helm changes) more robustly I am adding a new job to which would run on MR and would run the same script to deploy the helm chart in kubernets but as dry run .