### PR TITLE
control-service: enable WebHook authentication

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -392,9 +392,11 @@ webHooks:
    postCreate:
       webhookUri: ""
       internalErrorsRetries: 3
+      authenticationEnabled: false
    postDelete:
       webhookUri: ""
       internalErrorsRetries: 3
+      authenticationEnabled: false
 
 ### Security configuration
 

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -389,6 +389,9 @@ webHooks:
    ##    4xx or 5xx the job is not created/deleted
    ## 4xx response content is shown to end user as an error message.
    ## 5xx responses will be retried (number of retries is based on configuration, defaults to 3)
+   ##
+   ## In case authenticationEnabled is set to true, the Control Service (CS) will transmit the oAuth2 access token
+   ## to the WebHook API. This access token serves the purpose of authenticating the client against the CS.
    postCreate:
       webhookUri: ""
       internalErrorsRetries: 3

--- a/projects/control-service/projects/pipelines_control_service/build.gradle
+++ b/projects/control-service/projects/pipelines_control_service/build.gradle
@@ -80,6 +80,8 @@ dependencies { // Implementation dependencies are found on compile classpath of 
     implementation versions.'com.amazonaws:aws-java-sdk-core'
     implementation versions.'com.amazonaws:aws-java-sdk-sts'
 
+    implementation 'org.springframework.security:spring-security-oauth2-jose'
+
     compileOnly versions.'org.hibernate:hibernate-jpamodelgen'
     annotationProcessor versions.'org.hibernate:hibernate-jpamodelgen'
 
@@ -87,7 +89,6 @@ dependencies { // Implementation dependencies are found on compile classpath of 
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation versions.'com.mmnaseri.utils:spring-data-mock'
     testImplementation versions.'org.mock-server:mockserver-netty'
-    testImplementation 'org.springframework.security:spring-security-oauth2-jose'
     testImplementation versions.'org.mockito:mockito-core'
     testImplementation versions.'net.bytebuddy:byte-buddy'
     testImplementation versions.'org.testcontainers:testcontainers'

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/provider/AuthorizationProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/provider/AuthorizationProvider.java
@@ -93,8 +93,7 @@ public class AuthorizationProvider {
 
     if (authentication instanceof JwtAuthenticationToken) {
       JwtAuthenticationToken oauthToken = (JwtAuthenticationToken) authentication;
-      accessToken =
-          Optional.ofNullable(oauthToken.getToken())
+      accessToken = Optional.ofNullable(oauthToken.getToken())
               .map(AbstractOAuth2Token::getTokenValue)
               .orElse(null);
     }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/provider/AuthorizationProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/provider/AuthorizationProvider.java
@@ -13,13 +13,16 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.AbstractOAuth2Token;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
+import java.util.Optional;
 
 /**
  * AuthorizationProvider class used in {@link AuthorizationInterceptor} responsible for handling of
@@ -82,6 +85,20 @@ public class AuthorizationProvider {
         return principal.toString();
       }
     }
+  }
+
+  public String getAccessToken() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    String accessToken = null;
+
+    if (authentication instanceof JwtAuthenticationToken) {
+      JwtAuthenticationToken oauthToken = (JwtAuthenticationToken) authentication;
+      accessToken = Optional.ofNullable(oauthToken.getToken())
+              .map(AbstractOAuth2Token::getTokenValue)
+              .orElse(null);
+    }
+
+    return accessToken;
   }
 
   String parsePropertyFromURI(String contextPath, String fullPath, int index) {

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/provider/AuthorizationProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/provider/AuthorizationProvider.java
@@ -93,7 +93,8 @@ public class AuthorizationProvider {
 
     if (authentication instanceof JwtAuthenticationToken) {
       JwtAuthenticationToken oauthToken = (JwtAuthenticationToken) authentication;
-      accessToken = Optional.ofNullable(oauthToken.getToken())
+      accessToken =
+          Optional.ofNullable(oauthToken.getToken())
               .map(AbstractOAuth2Token::getTokenValue)
               .orElse(null);
     }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/webhook/AuthorizationWebHookProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/webhook/AuthorizationWebHookProvider.java
@@ -33,20 +33,13 @@ public class AuthorizationWebHookProvider extends WebHookService<AuthorizationBo
 
   public AuthorizationWebHookProvider(
       @Value("${datajobs.authorization.webhook.endpoint}") String webHookEndpoint,
-      @Value("${datajobs.authorization.webhook.internal.errors.retries:1}") int retriesOn5xxErrors,
-      @Value("${datajobs.authorization.webhook.authentication.enabled:false}")
-          boolean authenticationEnabled,
+      @Value("${datajobs.authorization.webhook.internal.errors.retries:1}")
+          int retriesOn5xxErrors,
+      @Value("${datajobs.authorization.webhook.authentication.enabled:false}") boolean authenticationEnabled,
       RestTemplate restTemplate,
       FeatureFlags featureFlags,
       AuthorizationProvider authorizationProvider) {
-    super(
-        webHookEndpoint,
-        retriesOn5xxErrors,
-        authenticationEnabled,
-        log,
-        restTemplate,
-        featureFlags,
-        authorizationProvider);
+    super(webHookEndpoint, retriesOn5xxErrors, authenticationEnabled, log, restTemplate, featureFlags, authorizationProvider);
   }
 
   @Override

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/webhook/AuthorizationWebHookProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/webhook/AuthorizationWebHookProvider.java
@@ -33,13 +33,20 @@ public class AuthorizationWebHookProvider extends WebHookService<AuthorizationBo
 
   public AuthorizationWebHookProvider(
       @Value("${datajobs.authorization.webhook.endpoint}") String webHookEndpoint,
-      @Value("${datajobs.authorization.webhook.internal.errors.retries:1}")
-          int retriesOn5xxErrors,
-      @Value("${datajobs.authorization.webhook.authentication.enabled:false}") boolean authenticationEnabled,
+      @Value("${datajobs.authorization.webhook.internal.errors.retries:1}") int retriesOn5xxErrors,
+      @Value("${datajobs.authorization.webhook.authentication.enabled:false}")
+          boolean authenticationEnabled,
       RestTemplate restTemplate,
       FeatureFlags featureFlags,
       AuthorizationProvider authorizationProvider) {
-    super(webHookEndpoint, retriesOn5xxErrors, authenticationEnabled, log, restTemplate, featureFlags, authorizationProvider);
+    super(
+        webHookEndpoint,
+        retriesOn5xxErrors,
+        authenticationEnabled,
+        log,
+        restTemplate,
+        featureFlags,
+        authorizationProvider);
   }
 
   @Override

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostCreateWebHookProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostCreateWebHookProvider.java
@@ -5,11 +5,14 @@
 
 package com.vmware.taurus.datajobs.webhook;
 
+import com.vmware.taurus.authorization.provider.AuthorizationProvider;
+import com.vmware.taurus.base.FeatureFlags;
 import com.vmware.taurus.service.webhook.WebHookRequestBody;
 import com.vmware.taurus.service.webhook.WebHookService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
 /**
  * PostCreateWebHookProvider class which delegates custom post data job creation operations via a
@@ -24,7 +27,11 @@ public class PostCreateWebHookProvider extends WebHookService<WebHookRequestBody
 
   public PostCreateWebHookProvider(
       @Value("${datajobs.post.create.webhook.endpoint}") String webHookEndpoint,
-      @Value("${datajobs.post.create.webhook.internal.errors.retries:-1}") int retriesOn5xxErrors) {
-    super(webHookEndpoint, retriesOn5xxErrors, log);
+      @Value("${datajobs.post.create.webhook.internal.errors.retries:-1}") int retriesOn5xxErrors,
+      @Value("${datajobs.post.create.webhook.authentication.enabled:false}") boolean authenticationEnabled,
+      RestTemplate restTemplate,
+      FeatureFlags featureFlags,
+      AuthorizationProvider authorizationProvider) {
+    super(webHookEndpoint, retriesOn5xxErrors, authenticationEnabled, log, restTemplate, featureFlags, authorizationProvider);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostCreateWebHookProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostCreateWebHookProvider.java
@@ -28,10 +28,18 @@ public class PostCreateWebHookProvider extends WebHookService<WebHookRequestBody
   public PostCreateWebHookProvider(
       @Value("${datajobs.post.create.webhook.endpoint}") String webHookEndpoint,
       @Value("${datajobs.post.create.webhook.internal.errors.retries:-1}") int retriesOn5xxErrors,
-      @Value("${datajobs.post.create.webhook.authentication.enabled:false}") boolean authenticationEnabled,
+      @Value("${datajobs.post.create.webhook.authentication.enabled:false}")
+          boolean authenticationEnabled,
       RestTemplate restTemplate,
       FeatureFlags featureFlags,
       AuthorizationProvider authorizationProvider) {
-    super(webHookEndpoint, retriesOn5xxErrors, authenticationEnabled, log, restTemplate, featureFlags, authorizationProvider);
+    super(
+        webHookEndpoint,
+        retriesOn5xxErrors,
+        authenticationEnabled,
+        log,
+        restTemplate,
+        featureFlags,
+        authorizationProvider);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostCreateWebHookProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostCreateWebHookProvider.java
@@ -28,18 +28,10 @@ public class PostCreateWebHookProvider extends WebHookService<WebHookRequestBody
   public PostCreateWebHookProvider(
       @Value("${datajobs.post.create.webhook.endpoint}") String webHookEndpoint,
       @Value("${datajobs.post.create.webhook.internal.errors.retries:-1}") int retriesOn5xxErrors,
-      @Value("${datajobs.post.create.webhook.authentication.enabled:false}")
-          boolean authenticationEnabled,
+      @Value("${datajobs.post.create.webhook.authentication.enabled:false}") boolean authenticationEnabled,
       RestTemplate restTemplate,
       FeatureFlags featureFlags,
       AuthorizationProvider authorizationProvider) {
-    super(
-        webHookEndpoint,
-        retriesOn5xxErrors,
-        authenticationEnabled,
-        log,
-        restTemplate,
-        featureFlags,
-        authorizationProvider);
+    super(webHookEndpoint, retriesOn5xxErrors, authenticationEnabled, log, restTemplate, featureFlags, authorizationProvider);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostDeleteWebHookProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostDeleteWebHookProvider.java
@@ -5,11 +5,15 @@
 
 package com.vmware.taurus.datajobs.webhook;
 
+import com.vmware.taurus.authorization.provider.AuthorizationProvider;
+import com.vmware.taurus.base.FeatureFlags;
 import com.vmware.taurus.service.webhook.WebHookRequestBody;
 import com.vmware.taurus.service.webhook.WebHookService;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
 /**
  * PostDeleteWebHookProvider class which delegates custom post data job delete operations via a
@@ -21,9 +25,14 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 public class PostDeleteWebHookProvider extends WebHookService<WebHookRequestBody> {
+
   public PostDeleteWebHookProvider(
       @Value("${datajobs.post.delete.webhook.endpoint}") String webHookEndpoint,
-      @Value("${datajobs.post.delete.webhook.internal.errors.retries:-1}") int retriesOn5xxErrors) {
-    super(webHookEndpoint, retriesOn5xxErrors, log);
+      @Value("${datajobs.post.delete.webhook.internal.errors.retries:-1}") int retriesOn5xxErrors,
+      @Value("${datajobs.post.delete.webhook.authentication.enabled:false}") boolean authenticationEnabled,
+      RestTemplate restTemplate,
+      FeatureFlags featureFlags,
+      AuthorizationProvider authorizationProvider) {
+    super(webHookEndpoint, retriesOn5xxErrors, authenticationEnabled, log, restTemplate, featureFlags, authorizationProvider);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostDeleteWebHookProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostDeleteWebHookProvider.java
@@ -10,6 +10,7 @@ import com.vmware.taurus.base.FeatureFlags;
 import com.vmware.taurus.service.webhook.WebHookRequestBody;
 import com.vmware.taurus.service.webhook.WebHookService;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -28,18 +29,10 @@ public class PostDeleteWebHookProvider extends WebHookService<WebHookRequestBody
   public PostDeleteWebHookProvider(
       @Value("${datajobs.post.delete.webhook.endpoint}") String webHookEndpoint,
       @Value("${datajobs.post.delete.webhook.internal.errors.retries:-1}") int retriesOn5xxErrors,
-      @Value("${datajobs.post.delete.webhook.authentication.enabled:false}")
-          boolean authenticationEnabled,
+      @Value("${datajobs.post.delete.webhook.authentication.enabled:false}") boolean authenticationEnabled,
       RestTemplate restTemplate,
       FeatureFlags featureFlags,
       AuthorizationProvider authorizationProvider) {
-    super(
-        webHookEndpoint,
-        retriesOn5xxErrors,
-        authenticationEnabled,
-        log,
-        restTemplate,
-        featureFlags,
-        authorizationProvider);
+    super(webHookEndpoint, retriesOn5xxErrors, authenticationEnabled, log, restTemplate, featureFlags, authorizationProvider);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostDeleteWebHookProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostDeleteWebHookProvider.java
@@ -10,7 +10,6 @@ import com.vmware.taurus.base.FeatureFlags;
 import com.vmware.taurus.service.webhook.WebHookRequestBody;
 import com.vmware.taurus.service.webhook.WebHookService;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -29,10 +28,18 @@ public class PostDeleteWebHookProvider extends WebHookService<WebHookRequestBody
   public PostDeleteWebHookProvider(
       @Value("${datajobs.post.delete.webhook.endpoint}") String webHookEndpoint,
       @Value("${datajobs.post.delete.webhook.internal.errors.retries:-1}") int retriesOn5xxErrors,
-      @Value("${datajobs.post.delete.webhook.authentication.enabled:false}") boolean authenticationEnabled,
+      @Value("${datajobs.post.delete.webhook.authentication.enabled:false}")
+          boolean authenticationEnabled,
       RestTemplate restTemplate,
       FeatureFlags featureFlags,
       AuthorizationProvider authorizationProvider) {
-    super(webHookEndpoint, retriesOn5xxErrors, authenticationEnabled, log, restTemplate, featureFlags, authorizationProvider);
+    super(
+        webHookEndpoint,
+        retriesOn5xxErrors,
+        authenticationEnabled,
+        log,
+        restTemplate,
+        featureFlags,
+        authorizationProvider);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/webhook/WebHookService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/webhook/WebHookService.java
@@ -5,18 +5,14 @@
 
 package com.vmware.taurus.service.webhook;
 
+import com.vmware.taurus.authorization.provider.AuthorizationProvider;
+import com.vmware.taurus.base.FeatureFlags;
 import com.vmware.taurus.exception.ExternalSystemError;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Service;
+import org.springframework.http.*;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 
@@ -33,22 +29,27 @@ import java.util.Optional;
  * @see com.vmware.taurus.datajobs.webhook.PostCreateWebHookProvider
  * @see com.vmware.taurus.authorization.webhook.AuthorizationWebHookProvider
  */
-@Service
 @RequiredArgsConstructor
 public abstract class WebHookService<T extends WebHookRequestBody> implements InitializingBean {
 
-  @Getter private final String webHookEndpoint;
+  protected final String webHookEndpoint;
 
   private final int retriesOn5xxErrors;
 
+  private final boolean authenticationEnabled;
+
   private final Logger log;
 
-  @Autowired private RestTemplate restTemplate;
+  private final RestTemplate restTemplate;
+
+  private final FeatureFlags featureFlags;
+
+  private final AuthorizationProvider authorizationProvider;
 
   public Optional<WebHookResult> invokeWebHook(T webHookRequestBody) {
     ensureConfigured();
 
-    if (StringUtils.isBlank(getWebHookEndpoint())) {
+    if (StringUtils.isBlank(webHookEndpoint)) {
       log.debug("The webHook Endpoint is not configured. Requests will not be send ...");
       return Optional.empty();
     }
@@ -56,21 +57,21 @@ public abstract class WebHookService<T extends WebHookRequestBody> implements In
     ResponseEntity responseEntity = sendRequest(webHookRequestBody);
 
     if (responseEntity.getStatusCode().is5xxServerError()) {
-      log.debug("The WebHook invocation {} returns 5xxServerError ...", getWebHookEndpoint());
+      log.debug("The WebHook invocation {} returns 5xxServerError ...", webHookEndpoint);
       responseEntity = retry5xxWebHookRequest(webHookRequestBody, responseEntity);
     }
     if (responseEntity.getStatusCode().is4xxClientError()) {
-      log.debug("The WebHook invocation {} returns 4xxClientError ...", getWebHookEndpoint());
+      log.debug("The WebHook invocation {} returns 4xxClientError ...", webHookEndpoint);
       return Optional.of(provideClientErrorMessage(responseEntity));
     }
     if (responseEntity.getStatusCode().is2xxSuccessful()) {
-      log.debug("The WebHook invocation {} is successful ...", getWebHookEndpoint());
+      log.debug("The WebHook invocation {} is successful ...", webHookEndpoint);
       return Optional.of(provideSuccessMessage(responseEntity));
     }
 
     log.debug(
         "The WebHook invocation {} returns unhandled status code:  {}",
-        getWebHookEndpoint(),
+        webHookEndpoint,
         responseEntity.getStatusCode().value());
     ExternalSystemError.MainExternalSystem mainExternalSystem = getExternalSystemType();
     throw new ExternalSystemError(
@@ -103,7 +104,8 @@ public abstract class WebHookService<T extends WebHookRequestBody> implements In
     // necessary
     log.info("WebHook body: {}", webHookRequestBody.toString());
     try {
-      HttpEntity<WebHookRequestBody> request = new HttpEntity<>(webHookRequestBody);
+      HttpEntity<WebHookRequestBody> request = createHttpRequest(webHookRequestBody);
+
       return restTemplate.exchange(
           getWebHookRequestURL(webHookRequestBody), HttpMethod.POST, request, String.class);
     } catch (RestClientResponseException responseException) {
@@ -133,7 +135,7 @@ public abstract class WebHookService<T extends WebHookRequestBody> implements In
    * @return a valid URL
    */
   protected String getWebHookRequestURL(T webHookRequestBody) {
-    return getWebHookEndpoint() + webHookRequestBody.getRequestedHttpPath();
+    return webHookEndpoint + webHookRequestBody.getRequestedHttpPath();
   }
 
   /**
@@ -174,5 +176,22 @@ public abstract class WebHookService<T extends WebHookRequestBody> implements In
         .message("")
         .success(true)
         .build();
+  }
+
+  private HttpEntity<WebHookRequestBody> createHttpRequest(T webHookRequestBody) {
+    HttpEntity<WebHookRequestBody> request = null;
+
+    if (featureFlags.isSecurityEnabled() && authenticationEnabled) {
+      String accessToken = authorizationProvider.getAccessToken();
+
+      if (StringUtils.isNotEmpty(accessToken)) {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setBearerAuth(accessToken);
+
+        request = new HttpEntity<>(webHookRequestBody, httpHeaders);
+      }
+    }
+
+    return request != null ? request : new HttpEntity<>(webHookRequestBody);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -71,8 +71,10 @@ datajobs.authorization.jwt.claim.username=username
 # Data Jobs post webhook settings (Create and Delete)
 datajobs.post.create.webhook.endpoint=
 datajobs.post.create.webhook.internal.errors.retries=3
+datajobs.post.create.webhook.authentication.enabled=false
 datajobs.post.delete.webhook.endpoint=
 datajobs.post.delete.webhook.internal.errors.retries=3
+datajobs.post.delete.webhook.authentication.enabled=false
 
 # The owner name and email address that will be used to send all Versatile Data Kit related email notifications.
 datajobs.notification.owner.email=versatiledatakit@groups.vmware.com

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/authorization/webhook/AuthorizationWebHookProviderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/authorization/webhook/AuthorizationWebHookProviderTest.java
@@ -29,7 +29,6 @@ import org.springframework.web.client.RestTemplate;
 
 import java.io.UnsupportedEncodingException;
 
-
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.MOCK,

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/authorization/webhook/AuthorizationWebHookProviderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/authorization/webhook/AuthorizationWebHookProviderTest.java
@@ -16,34 +16,45 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.*;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.UnsupportedEncodingException;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(
-    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
-    classes = ControlplaneApplication.class)
+        webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+        classes = ControlplaneApplication.class)
 @ActiveProfiles({"MockKubernetes", "MockKerberos", "unittest", "MockGit", "MockTelemetry"})
 public class AuthorizationWebHookProviderTest {
 
-  @MockBean private RestTemplate restTemplate;
+  @MockBean
+  private RestTemplate restTemplate;
 
-  @MockBean private FeatureFlags featureFlags;
+  @MockBean
+  private FeatureFlags featureFlags;
 
-  @MockBean private AuthorizationProvider authorizationProvider;
+  @MockBean
+  private AuthorizationProvider authorizationProvider;
 
-  @Autowired private AuthorizationWebHookProvider webhookProvider;
+  @Autowired
+  private AuthorizationWebHookProvider webhookProvider;
 
   private AuthorizationBody authzBody;
 

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/authorization/webhook/AuthorizationWebHookProviderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/authorization/webhook/AuthorizationWebHookProviderTest.java
@@ -16,45 +16,34 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.*;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.UnsupportedEncodingException;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(
-        webEnvironment = SpringBootTest.WebEnvironment.MOCK,
-        classes = ControlplaneApplication.class)
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    classes = ControlplaneApplication.class)
 @ActiveProfiles({"MockKubernetes", "MockKerberos", "unittest", "MockGit", "MockTelemetry"})
 public class AuthorizationWebHookProviderTest {
 
-  @MockBean
-  private RestTemplate restTemplate;
+  @MockBean private RestTemplate restTemplate;
 
-  @MockBean
-  private FeatureFlags featureFlags;
+  @MockBean private FeatureFlags featureFlags;
 
-  @MockBean
-  private AuthorizationProvider authorizationProvider;
+  @MockBean private AuthorizationProvider authorizationProvider;
 
-  @Autowired
-  private AuthorizationWebHookProvider webhookProvider;
+  @Autowired private AuthorizationWebHookProvider webhookProvider;
 
   private AuthorizationBody authzBody;
 

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/BaseWebHookProviderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/BaseWebHookProviderTest.java
@@ -5,6 +5,9 @@
 
 package com.vmware.taurus.datajobs.webhook;
 
+import com.vmware.taurus.ControlplaneApplication;
+import com.vmware.taurus.authorization.provider.AuthorizationProvider;
+import com.vmware.taurus.base.FeatureFlags;
 import com.vmware.taurus.exception.ExternalSystemError;
 import com.vmware.taurus.service.webhook.WebHookRequestBody;
 import com.vmware.taurus.service.webhook.WebHookResult;
@@ -13,35 +16,51 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.*;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import java.util.List;
 
-@ExtendWith(MockitoExtension.class)
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+        classes = ControlplaneApplication.class)
+@TestPropertySource(
+        properties = {
+                "featureflag.security.enabled=false"
+        })
 public abstract class BaseWebHookProviderTest {
 
   private static final int ONE_RETRY = 1;
   private static final int INVOCATION_PLUS_ONE_RETRY_COUNT = 2;
   private static final int SINGLE_INVOCATION_COUNT = 1;
 
-  @Mock RestTemplate restTemplate;
-
   WebHookRequestBody requestBody;
+
+  @MockBean
+  private RestTemplate restTemplate;
+
+  @MockBean
+  private FeatureFlags featureFlags;
+
+  @MockBean
+  private AuthorizationProvider authorizationProvider;
 
   abstract WebHookService<WebHookRequestBody> getWebHookProvider();
 
   @BeforeEach
   public void setUp() {
+    ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "http://localhost:4444");
     requestBody = new WebHookRequestBody();
     requestBody.setRequestedHttpPath("/data-jobs");
     requestBody.setRequestedHttpVerb("SOME");
@@ -53,13 +72,12 @@ public abstract class BaseWebHookProviderTest {
 
   @Test
   public void testBadRequestStatus() {
-    ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "http://localhost:4444");
     ResponseEntity re =
         new ResponseEntity<>(
             "Bad request: The post create action needs more parameters",
             null,
             HttpStatus.BAD_REQUEST);
-    Mockito.when(
+    when(
             restTemplate.exchange(
                 Mockito.anyString(),
                 Mockito.any(HttpMethod.class),
@@ -76,9 +94,8 @@ public abstract class BaseWebHookProviderTest {
 
   @Test
   public void testWebHookSuccess() {
-    ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "http://localhost:4444");
     ResponseEntity re = new ResponseEntity<>("Good request", null, HttpStatus.ACCEPTED);
-    Mockito.when(
+    when(
             restTemplate.exchange(
                 Mockito.anyString(),
                 Mockito.any(HttpMethod.class),
@@ -94,21 +111,14 @@ public abstract class BaseWebHookProviderTest {
 
   @Test
   public void testRestClientResponseExceptionHandling() {
-    ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "http://localhost:4444");
-    Mockito.when(
+    when(
             restTemplate.exchange(
                 Mockito.anyString(),
                 Mockito.any(HttpMethod.class),
                 Mockito.any(),
                 Mockito.<Class<String>>any()))
         .thenThrow(
-            new RestClientResponseException(
-                "Bad request",
-                HttpStatus.BAD_REQUEST.value(),
-                anyString(),
-                Mockito.any(HttpHeaders.class),
-                any(),
-                any()));
+            HttpClientErrorException.create(HttpStatus.BAD_REQUEST, "", null, null, null));
 
     WebHookResult webHookResult = getWebHookProvider().invokeWebHook(requestBody).get();
     Assertions.assertEquals("", webHookResult.getMessage());
@@ -118,9 +128,8 @@ public abstract class BaseWebHookProviderTest {
 
   @Test
   public void testInformationalStatusCode() {
-    ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "http://localhost:4444");
     ResponseEntity re = new ResponseEntity<>("User authorized", null, HttpStatus.CONTINUE);
-    Mockito.when(
+    when(
             restTemplate.exchange(
                 Mockito.anyString(),
                 Mockito.any(HttpMethod.class),
@@ -134,9 +143,8 @@ public abstract class BaseWebHookProviderTest {
 
   @Test
   public void testRedirectionStatusCode() {
-    ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "http://localhost:4444");
     ResponseEntity re = new ResponseEntity<>("User authorized", null, HttpStatus.MOVED_PERMANENTLY);
-    Mockito.when(
+    when(
             restTemplate.exchange(
                 Mockito.anyString(),
                 Mockito.any(HttpMethod.class),
@@ -150,11 +158,10 @@ public abstract class BaseWebHookProviderTest {
 
   @Test
   public void testServiceUnavailableWithRetry() {
-    ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "http://localhost:4444");
     ReflectionTestUtils.setField(getWebHookProvider(), "retriesOn5xxErrors", ONE_RETRY);
     ResponseEntity re =
         new ResponseEntity<>("Service unavailable", null, HttpStatus.SERVICE_UNAVAILABLE);
-    Mockito.when(
+    when(
             restTemplate.exchange(
                 Mockito.anyString(),
                 Mockito.any(HttpMethod.class),
@@ -174,10 +181,9 @@ public abstract class BaseWebHookProviderTest {
 
   @Test
   public void testInternalErrorDefaultNoRetry() {
-    ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "http://localhost:4444");
     ResponseEntity re =
         new ResponseEntity<>("Internal Server error", null, HttpStatus.INTERNAL_SERVER_ERROR);
-    Mockito.when(
+    when(
             restTemplate.exchange(
                 Mockito.anyString(),
                 Mockito.any(HttpMethod.class),
@@ -200,5 +206,73 @@ public abstract class BaseWebHookProviderTest {
     ReflectionTestUtils.setField(getWebHookProvider(), "webHookEndpoint", "");
 
     Assertions.assertTrue(getWebHookProvider().invokeWebHook(requestBody).isEmpty());
+  }
+
+  @Test
+  public void testInvokeWebHook_withAuthenticationEnabled_shouldContainAuthorizationHttpHeader() {
+    String expectedAccessToken = "testAccessToken";
+
+    ReflectionTestUtils.setField(getWebHookProvider(), "authenticationEnabled", true);
+    when(featureFlags.isSecurityEnabled()).thenReturn(true);
+    when(authorizationProvider.getAccessToken()).thenReturn(expectedAccessToken);
+
+    ResponseEntity re = new ResponseEntity<>("Good request", null, HttpStatus.ACCEPTED);
+    when(
+            restTemplate.exchange(
+                    Mockito.anyString(),
+                    Mockito.any(HttpMethod.class),
+                    Mockito.any(),
+                    Mockito.<Class<String>>any()))
+            .thenReturn(re);
+
+    getWebHookProvider().invokeWebHook(requestBody);
+
+    ArgumentCaptor<HttpEntity> httpEntityCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    Mockito.verify(restTemplate, Mockito.times(SINGLE_INVOCATION_COUNT))
+            .exchange(
+                    Mockito.anyString(),
+                    Mockito.any(HttpMethod.class),
+                    httpEntityCaptor.capture(),
+                    Mockito.<Class<String>>any());
+
+    List<String> authorizationHttpHeader = httpEntityCaptor.getValue()
+            .getHeaders()
+            .get(HttpHeaders.AUTHORIZATION);
+    Assertions.assertNotNull(authorizationHttpHeader);
+    Assertions.assertEquals(1, authorizationHttpHeader.size());
+    Assertions.assertEquals("Bearer " + expectedAccessToken, authorizationHttpHeader.get(0));
+  }
+
+  @Test
+  public void testInvokeWebHook_withAuthenticationDisabled_shouldNotContainAuthorizationHttpHeader() {
+    String expectedAccessToken = "testAccessToken";
+
+    ReflectionTestUtils.setField(getWebHookProvider(), "authenticationEnabled", false);
+    when(featureFlags.isSecurityEnabled()).thenReturn(true);
+    when(authorizationProvider.getAccessToken()).thenReturn(expectedAccessToken);
+
+    ResponseEntity re = new ResponseEntity<>("Good request", null, HttpStatus.ACCEPTED);
+    when(
+            restTemplate.exchange(
+                    Mockito.anyString(),
+                    Mockito.any(HttpMethod.class),
+                    Mockito.any(),
+                    Mockito.<Class<String>>any()))
+            .thenReturn(re);
+
+    getWebHookProvider().invokeWebHook(requestBody);
+
+    ArgumentCaptor<HttpEntity> httpEntityCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    Mockito.verify(restTemplate, Mockito.times(SINGLE_INVOCATION_COUNT))
+            .exchange(
+                    Mockito.anyString(),
+                    Mockito.any(HttpMethod.class),
+                    httpEntityCaptor.capture(),
+                    Mockito.<Class<String>>any());
+
+    List<String> authorizationHttpHeader = httpEntityCaptor.getValue()
+            .getHeaders()
+            .get(HttpHeaders.AUTHORIZATION);
+    Assertions.assertNull(authorizationHttpHeader);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/BaseWebHookProviderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/BaseWebHookProviderTest.java
@@ -33,12 +33,9 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(
-        webEnvironment = SpringBootTest.WebEnvironment.MOCK,
-        classes = ControlplaneApplication.class)
-@TestPropertySource(
-        properties = {
-                "featureflag.security.enabled=false"
-        })
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    classes = ControlplaneApplication.class)
+@TestPropertySource(properties = {"featureflag.security.enabled=false"})
 public abstract class BaseWebHookProviderTest {
 
   private static final int ONE_RETRY = 1;
@@ -47,14 +44,11 @@ public abstract class BaseWebHookProviderTest {
 
   WebHookRequestBody requestBody;
 
-  @MockBean
-  private RestTemplate restTemplate;
+  @MockBean private RestTemplate restTemplate;
 
-  @MockBean
-  private FeatureFlags featureFlags;
+  @MockBean private FeatureFlags featureFlags;
 
-  @MockBean
-  private AuthorizationProvider authorizationProvider;
+  @MockBean private AuthorizationProvider authorizationProvider;
 
   abstract WebHookService<WebHookRequestBody> getWebHookProvider();
 
@@ -77,12 +71,11 @@ public abstract class BaseWebHookProviderTest {
             "Bad request: The post create action needs more parameters",
             null,
             HttpStatus.BAD_REQUEST);
-    when(
-            restTemplate.exchange(
-                Mockito.anyString(),
-                Mockito.any(HttpMethod.class),
-                Mockito.any(),
-                Mockito.<Class<String>>any()))
+    when(restTemplate.exchange(
+            Mockito.anyString(),
+            Mockito.any(HttpMethod.class),
+            Mockito.any(),
+            Mockito.<Class<String>>any()))
         .thenReturn(re);
 
     WebHookResult webHookResult = getWebHookProvider().invokeWebHook(requestBody).get();
@@ -95,12 +88,11 @@ public abstract class BaseWebHookProviderTest {
   @Test
   public void testWebHookSuccess() {
     ResponseEntity re = new ResponseEntity<>("Good request", null, HttpStatus.ACCEPTED);
-    when(
-            restTemplate.exchange(
-                Mockito.anyString(),
-                Mockito.any(HttpMethod.class),
-                Mockito.any(),
-                Mockito.<Class<String>>any()))
+    when(restTemplate.exchange(
+            Mockito.anyString(),
+            Mockito.any(HttpMethod.class),
+            Mockito.any(),
+            Mockito.<Class<String>>any()))
         .thenReturn(re);
 
     WebHookResult webHookResult = getWebHookProvider().invokeWebHook(requestBody).get();
@@ -111,14 +103,12 @@ public abstract class BaseWebHookProviderTest {
 
   @Test
   public void testRestClientResponseExceptionHandling() {
-    when(
-            restTemplate.exchange(
-                Mockito.anyString(),
-                Mockito.any(HttpMethod.class),
-                Mockito.any(),
-                Mockito.<Class<String>>any()))
-        .thenThrow(
-            HttpClientErrorException.create(HttpStatus.BAD_REQUEST, "", null, null, null));
+    when(restTemplate.exchange(
+            Mockito.anyString(),
+            Mockito.any(HttpMethod.class),
+            Mockito.any(),
+            Mockito.<Class<String>>any()))
+        .thenThrow(HttpClientErrorException.create(HttpStatus.BAD_REQUEST, "", null, null, null));
 
     WebHookResult webHookResult = getWebHookProvider().invokeWebHook(requestBody).get();
     Assertions.assertEquals("", webHookResult.getMessage());
@@ -129,12 +119,11 @@ public abstract class BaseWebHookProviderTest {
   @Test
   public void testInformationalStatusCode() {
     ResponseEntity re = new ResponseEntity<>("User authorized", null, HttpStatus.CONTINUE);
-    when(
-            restTemplate.exchange(
-                Mockito.anyString(),
-                Mockito.any(HttpMethod.class),
-                Mockito.any(),
-                Mockito.<Class<String>>any()))
+    when(restTemplate.exchange(
+            Mockito.anyString(),
+            Mockito.any(HttpMethod.class),
+            Mockito.any(),
+            Mockito.<Class<String>>any()))
         .thenReturn(re);
 
     Assertions.assertThrows(
@@ -144,12 +133,11 @@ public abstract class BaseWebHookProviderTest {
   @Test
   public void testRedirectionStatusCode() {
     ResponseEntity re = new ResponseEntity<>("User authorized", null, HttpStatus.MOVED_PERMANENTLY);
-    when(
-            restTemplate.exchange(
-                Mockito.anyString(),
-                Mockito.any(HttpMethod.class),
-                Mockito.any(),
-                Mockito.<Class<String>>any()))
+    when(restTemplate.exchange(
+            Mockito.anyString(),
+            Mockito.any(HttpMethod.class),
+            Mockito.any(),
+            Mockito.<Class<String>>any()))
         .thenReturn(re);
 
     Assertions.assertThrows(
@@ -161,12 +149,11 @@ public abstract class BaseWebHookProviderTest {
     ReflectionTestUtils.setField(getWebHookProvider(), "retriesOn5xxErrors", ONE_RETRY);
     ResponseEntity re =
         new ResponseEntity<>("Service unavailable", null, HttpStatus.SERVICE_UNAVAILABLE);
-    when(
-            restTemplate.exchange(
-                Mockito.anyString(),
-                Mockito.any(HttpMethod.class),
-                Mockito.any(),
-                Mockito.<Class<String>>any()))
+    when(restTemplate.exchange(
+            Mockito.anyString(),
+            Mockito.any(HttpMethod.class),
+            Mockito.any(),
+            Mockito.<Class<String>>any()))
         .thenReturn(re);
 
     Assertions.assertThrows(
@@ -183,12 +170,11 @@ public abstract class BaseWebHookProviderTest {
   public void testInternalErrorDefaultNoRetry() {
     ResponseEntity re =
         new ResponseEntity<>("Internal Server error", null, HttpStatus.INTERNAL_SERVER_ERROR);
-    when(
-            restTemplate.exchange(
-                Mockito.anyString(),
-                Mockito.any(HttpMethod.class),
-                Mockito.any(),
-                Mockito.<Class<String>>any()))
+    when(restTemplate.exchange(
+            Mockito.anyString(),
+            Mockito.any(HttpMethod.class),
+            Mockito.any(),
+            Mockito.<Class<String>>any()))
         .thenReturn(re);
 
     Assertions.assertThrows(
@@ -217,34 +203,33 @@ public abstract class BaseWebHookProviderTest {
     when(authorizationProvider.getAccessToken()).thenReturn(expectedAccessToken);
 
     ResponseEntity re = new ResponseEntity<>("Good request", null, HttpStatus.ACCEPTED);
-    when(
-            restTemplate.exchange(
-                    Mockito.anyString(),
-                    Mockito.any(HttpMethod.class),
-                    Mockito.any(),
-                    Mockito.<Class<String>>any()))
-            .thenReturn(re);
+    when(restTemplate.exchange(
+            Mockito.anyString(),
+            Mockito.any(HttpMethod.class),
+            Mockito.any(),
+            Mockito.<Class<String>>any()))
+        .thenReturn(re);
 
     getWebHookProvider().invokeWebHook(requestBody);
 
     ArgumentCaptor<HttpEntity> httpEntityCaptor = ArgumentCaptor.forClass(HttpEntity.class);
     Mockito.verify(restTemplate, Mockito.times(SINGLE_INVOCATION_COUNT))
-            .exchange(
-                    Mockito.anyString(),
-                    Mockito.any(HttpMethod.class),
-                    httpEntityCaptor.capture(),
-                    Mockito.<Class<String>>any());
+        .exchange(
+            Mockito.anyString(),
+            Mockito.any(HttpMethod.class),
+            httpEntityCaptor.capture(),
+            Mockito.<Class<String>>any());
 
-    List<String> authorizationHttpHeader = httpEntityCaptor.getValue()
-            .getHeaders()
-            .get(HttpHeaders.AUTHORIZATION);
+    List<String> authorizationHttpHeader =
+        httpEntityCaptor.getValue().getHeaders().get(HttpHeaders.AUTHORIZATION);
     Assertions.assertNotNull(authorizationHttpHeader);
     Assertions.assertEquals(1, authorizationHttpHeader.size());
     Assertions.assertEquals("Bearer " + expectedAccessToken, authorizationHttpHeader.get(0));
   }
 
   @Test
-  public void testInvokeWebHook_withAuthenticationDisabled_shouldNotContainAuthorizationHttpHeader() {
+  public void
+      testInvokeWebHook_withAuthenticationDisabled_shouldNotContainAuthorizationHttpHeader() {
     String expectedAccessToken = "testAccessToken";
 
     ReflectionTestUtils.setField(getWebHookProvider(), "authenticationEnabled", false);
@@ -252,27 +237,25 @@ public abstract class BaseWebHookProviderTest {
     when(authorizationProvider.getAccessToken()).thenReturn(expectedAccessToken);
 
     ResponseEntity re = new ResponseEntity<>("Good request", null, HttpStatus.ACCEPTED);
-    when(
-            restTemplate.exchange(
-                    Mockito.anyString(),
-                    Mockito.any(HttpMethod.class),
-                    Mockito.any(),
-                    Mockito.<Class<String>>any()))
-            .thenReturn(re);
+    when(restTemplate.exchange(
+            Mockito.anyString(),
+            Mockito.any(HttpMethod.class),
+            Mockito.any(),
+            Mockito.<Class<String>>any()))
+        .thenReturn(re);
 
     getWebHookProvider().invokeWebHook(requestBody);
 
     ArgumentCaptor<HttpEntity> httpEntityCaptor = ArgumentCaptor.forClass(HttpEntity.class);
     Mockito.verify(restTemplate, Mockito.times(SINGLE_INVOCATION_COUNT))
-            .exchange(
-                    Mockito.anyString(),
-                    Mockito.any(HttpMethod.class),
-                    httpEntityCaptor.capture(),
-                    Mockito.<Class<String>>any());
+        .exchange(
+            Mockito.anyString(),
+            Mockito.any(HttpMethod.class),
+            httpEntityCaptor.capture(),
+            Mockito.<Class<String>>any());
 
-    List<String> authorizationHttpHeader = httpEntityCaptor.getValue()
-            .getHeaders()
-            .get(HttpHeaders.AUTHORIZATION);
+    List<String> authorizationHttpHeader =
+        httpEntityCaptor.getValue().getHeaders().get(HttpHeaders.AUTHORIZATION);
     Assertions.assertNull(authorizationHttpHeader);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/BaseWebHookProviderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/BaseWebHookProviderTest.java
@@ -33,9 +33,12 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(
-    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
-    classes = ControlplaneApplication.class)
-@TestPropertySource(properties = {"featureflag.security.enabled=false"})
+        webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+        classes = ControlplaneApplication.class)
+@TestPropertySource(
+        properties = {
+                "featureflag.security.enabled=false"
+        })
 public abstract class BaseWebHookProviderTest {
 
   private static final int ONE_RETRY = 1;
@@ -44,11 +47,14 @@ public abstract class BaseWebHookProviderTest {
 
   WebHookRequestBody requestBody;
 
-  @MockBean private RestTemplate restTemplate;
+  @MockBean
+  private RestTemplate restTemplate;
 
-  @MockBean private FeatureFlags featureFlags;
+  @MockBean
+  private FeatureFlags featureFlags;
 
-  @MockBean private AuthorizationProvider authorizationProvider;
+  @MockBean
+  private AuthorizationProvider authorizationProvider;
 
   abstract WebHookService<WebHookRequestBody> getWebHookProvider();
 
@@ -71,11 +77,12 @@ public abstract class BaseWebHookProviderTest {
             "Bad request: The post create action needs more parameters",
             null,
             HttpStatus.BAD_REQUEST);
-    when(restTemplate.exchange(
-            Mockito.anyString(),
-            Mockito.any(HttpMethod.class),
-            Mockito.any(),
-            Mockito.<Class<String>>any()))
+    when(
+            restTemplate.exchange(
+                Mockito.anyString(),
+                Mockito.any(HttpMethod.class),
+                Mockito.any(),
+                Mockito.<Class<String>>any()))
         .thenReturn(re);
 
     WebHookResult webHookResult = getWebHookProvider().invokeWebHook(requestBody).get();
@@ -88,11 +95,12 @@ public abstract class BaseWebHookProviderTest {
   @Test
   public void testWebHookSuccess() {
     ResponseEntity re = new ResponseEntity<>("Good request", null, HttpStatus.ACCEPTED);
-    when(restTemplate.exchange(
-            Mockito.anyString(),
-            Mockito.any(HttpMethod.class),
-            Mockito.any(),
-            Mockito.<Class<String>>any()))
+    when(
+            restTemplate.exchange(
+                Mockito.anyString(),
+                Mockito.any(HttpMethod.class),
+                Mockito.any(),
+                Mockito.<Class<String>>any()))
         .thenReturn(re);
 
     WebHookResult webHookResult = getWebHookProvider().invokeWebHook(requestBody).get();
@@ -103,12 +111,14 @@ public abstract class BaseWebHookProviderTest {
 
   @Test
   public void testRestClientResponseExceptionHandling() {
-    when(restTemplate.exchange(
-            Mockito.anyString(),
-            Mockito.any(HttpMethod.class),
-            Mockito.any(),
-            Mockito.<Class<String>>any()))
-        .thenThrow(HttpClientErrorException.create(HttpStatus.BAD_REQUEST, "", null, null, null));
+    when(
+            restTemplate.exchange(
+                Mockito.anyString(),
+                Mockito.any(HttpMethod.class),
+                Mockito.any(),
+                Mockito.<Class<String>>any()))
+        .thenThrow(
+            HttpClientErrorException.create(HttpStatus.BAD_REQUEST, "", null, null, null));
 
     WebHookResult webHookResult = getWebHookProvider().invokeWebHook(requestBody).get();
     Assertions.assertEquals("", webHookResult.getMessage());
@@ -119,11 +129,12 @@ public abstract class BaseWebHookProviderTest {
   @Test
   public void testInformationalStatusCode() {
     ResponseEntity re = new ResponseEntity<>("User authorized", null, HttpStatus.CONTINUE);
-    when(restTemplate.exchange(
-            Mockito.anyString(),
-            Mockito.any(HttpMethod.class),
-            Mockito.any(),
-            Mockito.<Class<String>>any()))
+    when(
+            restTemplate.exchange(
+                Mockito.anyString(),
+                Mockito.any(HttpMethod.class),
+                Mockito.any(),
+                Mockito.<Class<String>>any()))
         .thenReturn(re);
 
     Assertions.assertThrows(
@@ -133,11 +144,12 @@ public abstract class BaseWebHookProviderTest {
   @Test
   public void testRedirectionStatusCode() {
     ResponseEntity re = new ResponseEntity<>("User authorized", null, HttpStatus.MOVED_PERMANENTLY);
-    when(restTemplate.exchange(
-            Mockito.anyString(),
-            Mockito.any(HttpMethod.class),
-            Mockito.any(),
-            Mockito.<Class<String>>any()))
+    when(
+            restTemplate.exchange(
+                Mockito.anyString(),
+                Mockito.any(HttpMethod.class),
+                Mockito.any(),
+                Mockito.<Class<String>>any()))
         .thenReturn(re);
 
     Assertions.assertThrows(
@@ -149,11 +161,12 @@ public abstract class BaseWebHookProviderTest {
     ReflectionTestUtils.setField(getWebHookProvider(), "retriesOn5xxErrors", ONE_RETRY);
     ResponseEntity re =
         new ResponseEntity<>("Service unavailable", null, HttpStatus.SERVICE_UNAVAILABLE);
-    when(restTemplate.exchange(
-            Mockito.anyString(),
-            Mockito.any(HttpMethod.class),
-            Mockito.any(),
-            Mockito.<Class<String>>any()))
+    when(
+            restTemplate.exchange(
+                Mockito.anyString(),
+                Mockito.any(HttpMethod.class),
+                Mockito.any(),
+                Mockito.<Class<String>>any()))
         .thenReturn(re);
 
     Assertions.assertThrows(
@@ -170,11 +183,12 @@ public abstract class BaseWebHookProviderTest {
   public void testInternalErrorDefaultNoRetry() {
     ResponseEntity re =
         new ResponseEntity<>("Internal Server error", null, HttpStatus.INTERNAL_SERVER_ERROR);
-    when(restTemplate.exchange(
-            Mockito.anyString(),
-            Mockito.any(HttpMethod.class),
-            Mockito.any(),
-            Mockito.<Class<String>>any()))
+    when(
+            restTemplate.exchange(
+                Mockito.anyString(),
+                Mockito.any(HttpMethod.class),
+                Mockito.any(),
+                Mockito.<Class<String>>any()))
         .thenReturn(re);
 
     Assertions.assertThrows(
@@ -203,33 +217,34 @@ public abstract class BaseWebHookProviderTest {
     when(authorizationProvider.getAccessToken()).thenReturn(expectedAccessToken);
 
     ResponseEntity re = new ResponseEntity<>("Good request", null, HttpStatus.ACCEPTED);
-    when(restTemplate.exchange(
-            Mockito.anyString(),
-            Mockito.any(HttpMethod.class),
-            Mockito.any(),
-            Mockito.<Class<String>>any()))
-        .thenReturn(re);
+    when(
+            restTemplate.exchange(
+                    Mockito.anyString(),
+                    Mockito.any(HttpMethod.class),
+                    Mockito.any(),
+                    Mockito.<Class<String>>any()))
+            .thenReturn(re);
 
     getWebHookProvider().invokeWebHook(requestBody);
 
     ArgumentCaptor<HttpEntity> httpEntityCaptor = ArgumentCaptor.forClass(HttpEntity.class);
     Mockito.verify(restTemplate, Mockito.times(SINGLE_INVOCATION_COUNT))
-        .exchange(
-            Mockito.anyString(),
-            Mockito.any(HttpMethod.class),
-            httpEntityCaptor.capture(),
-            Mockito.<Class<String>>any());
+            .exchange(
+                    Mockito.anyString(),
+                    Mockito.any(HttpMethod.class),
+                    httpEntityCaptor.capture(),
+                    Mockito.<Class<String>>any());
 
-    List<String> authorizationHttpHeader =
-        httpEntityCaptor.getValue().getHeaders().get(HttpHeaders.AUTHORIZATION);
+    List<String> authorizationHttpHeader = httpEntityCaptor.getValue()
+            .getHeaders()
+            .get(HttpHeaders.AUTHORIZATION);
     Assertions.assertNotNull(authorizationHttpHeader);
     Assertions.assertEquals(1, authorizationHttpHeader.size());
     Assertions.assertEquals("Bearer " + expectedAccessToken, authorizationHttpHeader.get(0));
   }
 
   @Test
-  public void
-      testInvokeWebHook_withAuthenticationDisabled_shouldNotContainAuthorizationHttpHeader() {
+  public void testInvokeWebHook_withAuthenticationDisabled_shouldNotContainAuthorizationHttpHeader() {
     String expectedAccessToken = "testAccessToken";
 
     ReflectionTestUtils.setField(getWebHookProvider(), "authenticationEnabled", false);
@@ -237,25 +252,27 @@ public abstract class BaseWebHookProviderTest {
     when(authorizationProvider.getAccessToken()).thenReturn(expectedAccessToken);
 
     ResponseEntity re = new ResponseEntity<>("Good request", null, HttpStatus.ACCEPTED);
-    when(restTemplate.exchange(
-            Mockito.anyString(),
-            Mockito.any(HttpMethod.class),
-            Mockito.any(),
-            Mockito.<Class<String>>any()))
-        .thenReturn(re);
+    when(
+            restTemplate.exchange(
+                    Mockito.anyString(),
+                    Mockito.any(HttpMethod.class),
+                    Mockito.any(),
+                    Mockito.<Class<String>>any()))
+            .thenReturn(re);
 
     getWebHookProvider().invokeWebHook(requestBody);
 
     ArgumentCaptor<HttpEntity> httpEntityCaptor = ArgumentCaptor.forClass(HttpEntity.class);
     Mockito.verify(restTemplate, Mockito.times(SINGLE_INVOCATION_COUNT))
-        .exchange(
-            Mockito.anyString(),
-            Mockito.any(HttpMethod.class),
-            httpEntityCaptor.capture(),
-            Mockito.<Class<String>>any());
+            .exchange(
+                    Mockito.anyString(),
+                    Mockito.any(HttpMethod.class),
+                    httpEntityCaptor.capture(),
+                    Mockito.<Class<String>>any());
 
-    List<String> authorizationHttpHeader =
-        httpEntityCaptor.getValue().getHeaders().get(HttpHeaders.AUTHORIZATION);
+    List<String> authorizationHttpHeader = httpEntityCaptor.getValue()
+            .getHeaders()
+            .get(HttpHeaders.AUTHORIZATION);
     Assertions.assertNull(authorizationHttpHeader);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/PostCreateWebHookProviderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/PostCreateWebHookProviderTest.java
@@ -10,15 +10,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource(
-        properties = {
-                "datajobs.post.create.webhook.endpoint=http://localhost:4444",
-                "datajobs.post.create.webhook.internal.errors.retries=0",
-                "datajobs.post.create.webhook.authentication.enabled=false"
-        })
+    properties = {
+      "datajobs.post.create.webhook.endpoint=http://localhost:4444",
+      "datajobs.post.create.webhook.internal.errors.retries=0",
+      "datajobs.post.create.webhook.authentication.enabled=false"
+    })
 @Getter
 /** See {@link BaseWebHookProviderTest} for the details of the tests. */
 public class PostCreateWebHookProviderTest extends BaseWebHookProviderTest {
 
-    @Autowired
-    private PostCreateWebHookProvider webHookProvider;
+  @Autowired private PostCreateWebHookProvider webHookProvider;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/PostCreateWebHookProviderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/PostCreateWebHookProviderTest.java
@@ -6,11 +6,19 @@
 package com.vmware.taurus.datajobs.webhook;
 
 import lombok.Getter;
-import org.mockito.InjectMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(
+        properties = {
+                "datajobs.post.create.webhook.endpoint=http://localhost:4444",
+                "datajobs.post.create.webhook.internal.errors.retries=0",
+                "datajobs.post.create.webhook.authentication.enabled=false"
+        })
 @Getter
 /** See {@link BaseWebHookProviderTest} for the details of the tests. */
 public class PostCreateWebHookProviderTest extends BaseWebHookProviderTest {
-  @InjectMocks
-  private PostCreateWebHookProvider webHookProvider = new PostCreateWebHookProvider("", -1);
+
+    @Autowired
+    private PostCreateWebHookProvider webHookProvider;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/PostCreateWebHookProviderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/PostCreateWebHookProviderTest.java
@@ -10,14 +10,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource(
-    properties = {
-      "datajobs.post.create.webhook.endpoint=http://localhost:4444",
-      "datajobs.post.create.webhook.internal.errors.retries=0",
-      "datajobs.post.create.webhook.authentication.enabled=false"
-    })
+        properties = {
+                "datajobs.post.create.webhook.endpoint=http://localhost:4444",
+                "datajobs.post.create.webhook.internal.errors.retries=0",
+                "datajobs.post.create.webhook.authentication.enabled=false"
+        })
 @Getter
 /** See {@link BaseWebHookProviderTest} for the details of the tests. */
 public class PostCreateWebHookProviderTest extends BaseWebHookProviderTest {
 
-  @Autowired private PostCreateWebHookProvider webHookProvider;
+    @Autowired
+    private PostCreateWebHookProvider webHookProvider;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/PostDeleteWebHookProviderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/PostDeleteWebHookProviderTest.java
@@ -6,11 +6,19 @@
 package com.vmware.taurus.datajobs.webhook;
 
 import lombok.Getter;
-import org.mockito.InjectMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(
+        properties = {
+                "datajobs.post.delete.webhook.endpoint=http://localhost:4444",
+                "datajobs.post.delete.webhook.internal.errors.retries=0",
+                "datajobs.post.delete.webhook.authentication.enabled=false"
+        })
 @Getter
 /** See {@link BaseWebHookProviderTest} for the details of the tests. */
 public class PostDeleteWebHookProviderTest extends BaseWebHookProviderTest {
-  @InjectMocks
-  private PostDeleteWebHookProvider webHookProvider = new PostDeleteWebHookProvider("", -1);
+
+  @Autowired
+  private PostDeleteWebHookProvider webHookProvider;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/PostDeleteWebHookProviderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/PostDeleteWebHookProviderTest.java
@@ -10,14 +10,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource(
-    properties = {
-      "datajobs.post.delete.webhook.endpoint=http://localhost:4444",
-      "datajobs.post.delete.webhook.internal.errors.retries=0",
-      "datajobs.post.delete.webhook.authentication.enabled=false"
-    })
+        properties = {
+                "datajobs.post.delete.webhook.endpoint=http://localhost:4444",
+                "datajobs.post.delete.webhook.internal.errors.retries=0",
+                "datajobs.post.delete.webhook.authentication.enabled=false"
+        })
 @Getter
 /** See {@link BaseWebHookProviderTest} for the details of the tests. */
 public class PostDeleteWebHookProviderTest extends BaseWebHookProviderTest {
 
-  @Autowired private PostDeleteWebHookProvider webHookProvider;
+  @Autowired
+  private PostDeleteWebHookProvider webHookProvider;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/PostDeleteWebHookProviderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/PostDeleteWebHookProviderTest.java
@@ -10,15 +10,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource(
-        properties = {
-                "datajobs.post.delete.webhook.endpoint=http://localhost:4444",
-                "datajobs.post.delete.webhook.internal.errors.retries=0",
-                "datajobs.post.delete.webhook.authentication.enabled=false"
-        })
+    properties = {
+      "datajobs.post.delete.webhook.endpoint=http://localhost:4444",
+      "datajobs.post.delete.webhook.internal.errors.retries=0",
+      "datajobs.post.delete.webhook.authentication.enabled=false"
+    })
 @Getter
 /** See {@link BaseWebHookProviderTest} for the details of the tests. */
 public class PostDeleteWebHookProviderTest extends BaseWebHookProviderTest {
 
-  @Autowired
-  private PostDeleteWebHookProvider webHookProvider;
+  @Autowired private PostDeleteWebHookProvider webHookProvider;
 }


### PR DESCRIPTION
# Why
Currently, the Control Service lacks the capability to authenticate against the WebHook API. A specific customer of ours requires authentication for the WebHook API utilizing the same access token passed by the client to the Control Service APIs.



# What
Incorporated logic to forward the oAuth2 access token to the WebHook API.

# Testing Done
Unit and integration tests.

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com