### PR TITLE
vdk-jupyter: reuse authenticated page Oauth2 access-token

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package.json
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/package.json
@@ -1,156 +1,156 @@
 {
-  "name": "vdk-jupyterlab-extension",
-  "version": "0.1.0",
-  "description": "A Jupyterlab extension for using VDK",
-  "keywords": [
-    "jupyter",
-    "jupyterlab",
-    "jupyterlab-extension",
-    "vdk"
-  ],
-  "homepage": "https://github.com/vmware/versatile-data-kit",
-  "bugs": {
-    "url": "https://github.com/vmware/versatile-data-kit/issues"
-  },
-  "license": "Apache License 2.0",
-  "author": {
-    "name": "Versatile Data Kit Development Team",
-    "email": "versatile-data-kit@vmware.com"
-  },
-  "files": [
-    "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
-    "style/**/*.{css,js,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-    "schema/*.json"
-  ],
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
-  "style": "style/index.css",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/vmware/versatile-data-kit"
-  },
-  "scripts": {
-    "build": "jlpm build:lib && jlpm build:labextension:dev",
-    "build:prod": "jlpm clean && jlpm build:lib && jlpm build:labextension",
-    "build:labextension": "jupyter labextension build .",
-    "build:labextension:dev": "jupyter labextension build --development True .",
-    "build:lib": "tsc",
-    "build:interfaces": "pip install py-to-ts-interfaces && py-to-ts-interfaces vdk_jupyterlab_extension/vdk_options/ src/vdkOptions",
-    "clean": "jlpm clean:lib",
-    "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
-    "clean:lintcache": "rimraf .eslintcache .stylelintcache",
-    "clean:labextension": "rimraf vdk_jupyterlab_extension/labextension",
-    "clean:all": "jlpm clean:lib && jlpm clean:labextension && jlpm clean:lintcache",
-    "eslint": "jlpm eslint:check --fix",
-    "eslint:check": "eslint . --cache --ext .ts,.tsx",
-    "install:extension": "jlpm build",
-    "lint": "jlpm stylelint && jlpm prettier && jlpm eslint",
-    "lint:check": "jlpm stylelint:check && jlpm prettier:check && jlpm eslint:check",
-    "prettier": "jlpm prettier:base --write --list-different",
-    "prettier:base": "prettier \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
-    "prettier:check": "jlpm prettier:base --check",
-    "stylelint": "jlpm stylelint:check --fix",
-    "stylelint:check": "stylelint --cache \"style/**/*.css\"",
-    "test": "jest --coverage",
-    "watch": "run-p watch:src watch:labextension",
-    "watch:src": "tsc -w",
-    "watch:labextension": "jupyter labextension watch ."
-  },
-   "resolutions": {
-     "@types/react": "17.0.53",
-     "@jupyterlab/rendermime": "3.6.3",
-     "@jupyterlab/rendermime-interfaces": "3.6.3",
-     "@jupyterlab/services": "6.6.3"
-   },
-  "dependencies": {
-    "@jupyterlab/rendermime": "3.6.3",
-    "@jupyterlab/rendermime-interfaces": "3.6.3",
-    "@jupyterlab/attachments": "3.6.3",
-    "@jupyterlab/nbformat": "3.6.3",
-    "@jupyterlab/statedb": "3.6.3",
-    "@jupyterlab/translation": "3.6.3",
-    "@jupyterlab/settingregistry": "3.6.3",
-    "@jupyterlab/apputils": "3.6.3",
-    "@jupyterlab/builder": "3.6.3",
-    "@jupyterlab/cells": "3.6.3",
-    "@jupyterlab/codeeditor": "3.6.3",
-    "@jupyterlab/coreutils": "5.6.0",
-    "@jupyterlab/docmanager": "3.6.3",
-    "@jupyterlab/docregistry": "3.6.3",
-    "@jupyterlab/filebrowser": "3.6.3",
-    "@jupyterlab/notebook": "3.6.3",
-    "@jupyterlab/outputarea": "3.6.3",
-    "@jupyterlab/statusbar": "3.6.3",
-    "@jupyterlab/docprovider": "3.6.3",
-    "@jupyterlab/codemirror": "3.6.3",
-    "@jupyterlab/testutils": "3.6.3",
-    "@jupyterlab/ui-components": "3.6.3",
-    "@jupyterlab/services": "6.6.3",
-    "@lumino/widgets": "1.33.0",
-    "typescript": "4.1.3",
-    "@types/react": "17.0.53",
-    "yjs": "^13.5.17",
-    "@jupyterlab/application": "3.6.3",
-    "@jupyterlab/mainmenu": "3.6.3",
-    "word-wrap": "1.2.4"
-  },
-  "devDependencies": {
-    "@babel/core": "7.8.0",
-    "@babel/preset-env": "7.0.0",
-    "@testing-library/react": "12.1.5",
-    "@types/enzyme": "3.10.12",
-    "@types/jest": "27.5.2",
-    "@typescript-eslint/eslint-plugin": "4.8.1",
-    "@typescript-eslint/parser": "4.8.1",
-    "babel-jest": "27.5.1",
-    "eslint": "7.14.0",
-    "eslint-config-prettier": "6.15.0",
-    "eslint-plugin-prettier": "3.1.4",
-    "jest": "27.0.6",
-    "mkdirp": "1.0.3",
-    "npm-run-all": "4.1.5",
-    "prettier": "2.1.1",
-    "rimraf": "3.0.2",
-    "stylelint": "14.3.0",
-    "stylelint-config-prettier": "9.0.4",
-    "stylelint-config-recommended": "6.0.0",
-    "stylelint-config-standard": "24.0.0",
-    "stylelint-prettier": "2.0.0",
-    "ts-jest": "27.1.4",
-    "jest-fetch-mock": "^3.0.0"
-  },
-  "sideEffects": [
-    "style/*.css",
-    "style/index.js"
-  ],
-  "styleModule": "style/index.js",
-  "publishConfig": {
-    "access": "public"
-  },
-  "jupyterlab": {
-    "discovery": {
-      "server": {
-        "managers": [
-          "pip"
-        ],
-        "base": {
-          "name": "vdk_jupyterlab_extension"
-        }
-      }
+    "name": "vdk-jupyterlab-extension",
+    "version": "0.1.1-rc6",
+    "description": "A Jupyterlab extension for using VDK",
+    "keywords": [
+        "jupyter",
+        "jupyterlab",
+        "jupyterlab-extension",
+        "vdk"
+    ],
+    "homepage": "https://github.com/vmware/versatile-data-kit",
+    "bugs": {
+        "url": "https://github.com/vmware/versatile-data-kit/issues"
     },
-    "extension": true,
-    "outputDir": "vdk_jupyterlab_extension/labextension",
-    "schemaDir": "schema"
-  },
-  "jupyter-releaser": {
-    "hooks": {
-      "before-build-npm": [
-        "python -m pip install jupyterlab~=3.1",
-        "jlpm"
-      ],
-      "before-build-python": [
-        "jlpm clean:all"
-      ]
+    "license": "Apache License 2.0",
+    "author": {
+        "name": "Versatile Data Kit Development Team",
+        "email": "versatile-data-kit@vmware.com"
+    },
+    "files": [
+        "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
+        "style/**/*.{css,js,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
+        "schema/*.json"
+    ],
+    "main": "lib/index.js",
+    "types": "lib/index.d.ts",
+    "style": "style/index.css",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/vmware/versatile-data-kit"
+    },
+    "scripts": {
+        "build": "jlpm build:lib && jlpm build:labextension:dev",
+        "build:prod": "jlpm clean && jlpm build:lib && jlpm build:labextension",
+        "build:labextension": "jupyter labextension build .",
+        "build:labextension:dev": "jupyter labextension build --development True .",
+        "build:lib": "tsc",
+        "build:interfaces": "pip install py-to-ts-interfaces && py-to-ts-interfaces vdk_jupyterlab_extension/vdk_options/ src/vdkOptions",
+        "clean": "jlpm clean:lib",
+        "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
+        "clean:lintcache": "rimraf .eslintcache .stylelintcache",
+        "clean:labextension": "rimraf vdk_jupyterlab_extension/labextension",
+        "clean:all": "jlpm clean:lib && jlpm clean:labextension && jlpm clean:lintcache",
+        "eslint": "jlpm eslint:check --fix",
+        "eslint:check": "eslint . --cache --ext .ts,.tsx",
+        "install:extension": "jlpm build",
+        "lint": "jlpm stylelint && jlpm prettier && jlpm eslint",
+        "lint:check": "jlpm stylelint:check && jlpm prettier:check && jlpm eslint:check",
+        "prettier": "jlpm prettier:base --write --list-different",
+        "prettier:base": "prettier \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
+        "prettier:check": "jlpm prettier:base --check",
+        "stylelint": "jlpm stylelint:check --fix",
+        "stylelint:check": "stylelint --cache \"style/**/*.css\"",
+        "test": "jest --coverage",
+        "watch": "run-p watch:src watch:labextension",
+        "watch:src": "tsc -w",
+        "watch:labextension": "jupyter labextension watch ."
+    },
+    "resolutions": {
+        "@types/react": "17.0.53",
+        "@jupyterlab/rendermime": "3.6.3",
+        "@jupyterlab/rendermime-interfaces": "3.6.3",
+        "@jupyterlab/services": "6.6.3"
+    },
+    "dependencies": {
+        "@jupyterlab/rendermime": "3.6.3",
+        "@jupyterlab/rendermime-interfaces": "3.6.3",
+        "@jupyterlab/attachments": "3.6.3",
+        "@jupyterlab/nbformat": "3.6.3",
+        "@jupyterlab/statedb": "3.6.3",
+        "@jupyterlab/translation": "3.6.3",
+        "@jupyterlab/settingregistry": "3.6.3",
+        "@jupyterlab/apputils": "3.6.3",
+        "@jupyterlab/builder": "3.6.3",
+        "@jupyterlab/cells": "3.6.3",
+        "@jupyterlab/codeeditor": "3.6.3",
+        "@jupyterlab/coreutils": "5.6.0",
+        "@jupyterlab/docmanager": "3.6.3",
+        "@jupyterlab/docregistry": "3.6.3",
+        "@jupyterlab/filebrowser": "3.6.3",
+        "@jupyterlab/notebook": "3.6.3",
+        "@jupyterlab/outputarea": "3.6.3",
+        "@jupyterlab/statusbar": "3.6.3",
+        "@jupyterlab/docprovider": "3.6.3",
+        "@jupyterlab/codemirror": "3.6.3",
+        "@jupyterlab/testutils": "3.6.3",
+        "@jupyterlab/ui-components": "3.6.3",
+        "@jupyterlab/services": "6.6.3",
+        "@lumino/widgets": "1.33.0",
+        "typescript": "4.1.3",
+        "@types/react": "17.0.53",
+        "yjs": "^13.5.17",
+        "@jupyterlab/application": "3.6.3",
+        "@jupyterlab/mainmenu": "3.6.3",
+        "word-wrap": "1.2.4"
+    },
+    "devDependencies": {
+        "@babel/core": "7.8.0",
+        "@babel/preset-env": "7.0.0",
+        "@testing-library/react": "12.1.5",
+        "@types/enzyme": "3.10.12",
+        "@types/jest": "27.5.2",
+        "@typescript-eslint/eslint-plugin": "4.8.1",
+        "@typescript-eslint/parser": "4.8.1",
+        "babel-jest": "27.5.1",
+        "eslint": "7.14.0",
+        "eslint-config-prettier": "6.15.0",
+        "eslint-plugin-prettier": "3.1.4",
+        "jest": "27.0.6",
+        "mkdirp": "1.0.3",
+        "npm-run-all": "4.1.5",
+        "prettier": "2.1.1",
+        "rimraf": "3.0.2",
+        "stylelint": "14.3.0",
+        "stylelint-config-prettier": "9.0.4",
+        "stylelint-config-recommended": "6.0.0",
+        "stylelint-config-standard": "24.0.0",
+        "stylelint-prettier": "2.0.0",
+        "ts-jest": "27.1.4",
+        "jest-fetch-mock": "^3.0.0"
+    },
+    "sideEffects": [
+        "style/*.css",
+        "style/index.js"
+    ],
+    "styleModule": "style/index.js",
+    "publishConfig": {
+        "access": "public"
+    },
+    "jupyterlab": {
+        "discovery": {
+            "server": {
+                "managers": [
+                    "pip"
+                ],
+                "base": {
+                    "name": "vdk_jupyterlab_extension"
+                }
+            }
+        },
+        "extension": true,
+        "outputDir": "vdk_jupyterlab_extension/labextension",
+        "schemaDir": "schema"
+    },
+    "jupyter-releaser": {
+        "hooks": {
+            "before-build-npm": [
+                "python -m pip install jupyterlab~=3.1",
+                "jlpm"
+            ],
+            "before-build-python": [
+                "jlpm clean:all"
+            ]
+        }
     }
-  }
 }

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/tokenUpdate.spec.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/tokenUpdate.spec.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  fetchTokenLocation,
+  getTokenFromLocation,
+  sendTokenToServer,
+  setupTokenCheckInterval
+} from '../tokenUpdate';
+import { requestAPI } from '../handler';
+
+// Mocking requestAPI
+jest.mock('../handler', () => ({
+  requestAPI: jest.fn()
+}));
+
+let store: { [key: string]: string } = {};
+const mockLocalStorage = (function () {
+  return {
+    getItem: jest.fn(key => {
+      return store[key] || null;
+    }),
+    setItem: jest.fn((key, value) => {
+      console.log(
+        `Setting key "${key}" with value "${value}" in mock localStorage.`
+      );
+      store[key] = value;
+    }),
+    clear: jest.fn(() => {
+      store = {};
+    })
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+  value: mockLocalStorage
+});
+Object.defineProperty(window.top, 'localStorage', {
+  value: mockLocalStorage
+});
+
+describe('VDK Access Token Handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    jest.useFakeTimers();
+    mockLocalStorage.clear();
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    mockLocalStorage.clear();
+  });
+
+  it('fetches token location', async () => {
+    (requestAPI as jest.Mock).mockResolvedValue({
+      storageType: 'localStorage',
+      key: 'token',
+      valuePath: 'path'
+    });
+
+    const location = await fetchTokenLocation();
+
+    expect(location).toEqual({
+      storageType: 'localStorage',
+      key: 'token',
+      valuePath: 'path'
+    });
+    expect(requestAPI).toHaveBeenCalledWith('vdkAccessTokenLocation', {
+      method: 'GET'
+    });
+  });
+
+  it('handles errors when fetching token location', async () => {
+    (requestAPI as jest.Mock).mockRejectedValue(
+      new Error('Failed fetch token location request')
+    );
+
+    await expect(fetchTokenLocation()).rejects.toThrow(
+      'Failed fetch token location request'
+    );
+
+    expect(requestAPI).toHaveBeenCalledWith('vdkAccessTokenLocation', {
+      method: 'GET'
+    });
+  });
+
+  it('gets token from localStorage', async () => {
+    mockLocalStorage.setItem(
+      'whatever',
+      JSON.stringify({ token: { path: 'myToken' } })
+    );
+
+    const token = await getTokenFromLocation({
+      storageType: 'localStorage',
+      key: 'whatever',
+      valuePath: 'token.path'
+    });
+
+    expect(token).toEqual('myToken');
+  });
+
+  it('handles non-existent token paths in localStorage', async () => {
+    mockLocalStorage.setItem('token', JSON.stringify({}));
+
+    const token = await getTokenFromLocation({
+      storageType: 'localStorage',
+      key: 'token',
+      valuePath: 'path'
+    });
+
+    expect(token).toBeNull();
+  });
+
+  it('sends token to server', async () => {
+    (requestAPI as jest.Mock).mockResolvedValue(true);
+
+    await sendTokenToServer('myToken');
+
+    expect(requestAPI).toHaveBeenCalledWith('vdkAccessToken', {
+      body: JSON.stringify({ token: 'myToken' }),
+      method: 'POST'
+    });
+  });
+
+  it('handles errors when sending token to server', async () => {
+    (requestAPI as jest.Mock).mockRejectedValue(
+      new Error('Failed sending token request')
+    );
+
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    await sendTokenToServer('myToken');
+    consoleErrorSpy.mockRestore();
+
+    expect(requestAPI).toHaveBeenCalledWith('vdkAccessToken', {
+      body: JSON.stringify({ token: 'myToken' }),
+      method: 'POST'
+    });
+  });
+
+  it('sets up token check interval if initial token location is found', async () => {
+    (requestAPI as jest.Mock).mockName('requestAPI').mockResolvedValue({
+      storageType: 'localStorage',
+      key: 'token_key',
+      valuePath: 'path'
+    });
+
+    // let getItemCounter = 0
+    // mockLocalStorage.getItem.mockImplementation((key) => {
+    //   if (key === 'token_key') {
+    //     if (getItemCounter == 0) {
+    //       getItemCounter++;
+    //       return JSON.stringify( { path: 'myToken' } ) ;
+    //     } else {
+    //       return JSON.stringify( { path: 'myTokenUpdated' } ) ;
+    //     }
+    //   } else {
+    //     return store[key] || null
+    //   }
+    // })
+    mockLocalStorage.setItem('token_key', JSON.stringify({ path: 'myToken' }));
+
+    await setupTokenCheckInterval();
+
+    expect(requestAPI).toHaveBeenCalledWith('vdkAccessTokenLocation', {
+      method: 'GET'
+    });
+
+    expect(requestAPI as jest.Mock).toHaveBeenCalledWith('vdkAccessToken', {
+      body: JSON.stringify({ token: 'myToken' }),
+      method: 'POST'
+    });
+  });
+});

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/index.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/index.ts
@@ -23,6 +23,7 @@ import {
   createStatusButton,
   createStatusMenu
 } from './components/StatusButton';
+import { setupTokenCheckInterval } from './tokenUpdate';
 
 /**
  * Current working directory in Jupyter
@@ -85,6 +86,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
     fileBrowser.model.pathChanged.connect(onPathChanged);
     trackVdkTags(notebookTracker, themeManager);
+    await setupTokenCheckInterval();
   }
 };
 

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/tokenUpdate.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/tokenUpdate.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { requestAPI } from './handler';
+
+export type TokenLocation = {
+  /**
+   * The type of the storage. For now just localStorage
+   */
+  storageType: string;
+  /**
+   * The key where the token is stored
+   */
+  key: string;
+  /**
+   * The path in the value (json) to the actual token
+   */
+  valuePath: string;
+};
+
+export async function fetchTokenLocation(): Promise<TokenLocation | null> {
+  const data = await requestAPI<any>('vdkAccessTokenLocation', {
+    method: 'GET'
+  });
+  if (data) {
+    return data;
+  } else {
+    console.log('No token location from the server returned.');
+    return null;
+  }
+}
+
+function safeJSONParse<T = any>(value: string | null): T | null {
+  try {
+    return JSON.parse(value || 'null');
+  } catch {
+    return null;
+  }
+}
+
+export async function getTokenFromLocation(
+  location: TokenLocation
+): Promise<string | null> {
+  if (location.storageType === 'localStorage') {
+    let item = safeJSONParse(window.top.localStorage.getItem(location.key));
+    let pathParts = location.valuePath.split('.');
+    return pathParts.reduce((current, key) => {
+      return current && key in current ? current[key] : null;
+    }, item);
+  }
+  return null;
+}
+
+export async function sendTokenToServer(token: string): Promise<void> {
+  try {
+    await requestAPI<any>('vdkAccessToken', {
+      body: JSON.stringify({ token }),
+      method: 'POST'
+    });
+  } catch (error) {
+    console.error("Couldn't send token to server", error);
+  }
+}
+
+export const CHECK_INTERVAL_MS = 60000;
+
+async function getTokenLocationFromCacheOrFetch(): Promise<TokenLocation | null> {
+  const tokenLocationString = window.localStorage.getItem(
+    'vdk.cache.tokenLocation'
+  );
+  if (tokenLocationString) {
+    return safeJSONParse(tokenLocationString);
+  }
+
+  const fetchedTokenLocation = await fetchTokenLocation();
+  if (fetchedTokenLocation) {
+    window.localStorage.setItem(
+      'vdk.cache.tokenLocation',
+      JSON.stringify(fetchedTokenLocation)
+    );
+  }
+
+  return fetchedTokenLocation;
+}
+
+async function sendTokenIfNew(token: string) {
+  const cachedToken = window.localStorage.getItem('vdk.cache.token');
+  if (token !== cachedToken) {
+    console.debug('New VDK token found. Sending it to the server');
+    await sendTokenToServer(token);
+    console.debug('Sent VDK token to the server');
+    window.localStorage.setItem('vdk.cache.token', token);
+  }
+}
+
+/**
+ * Checks for the presence of a token and sends it to the server if found.
+ *
+ * This function fetches the token location, retrieves the token from the specified location,
+ * and sends the token to the server.
+ *
+ * @returns {Promise<string>} - Returns the token location. If the token is not found then we should not schedule regular update.
+ */
+async function checkToken() {
+  const tokenLocation = await getTokenLocationFromCacheOrFetch();
+  console.debug('Checking VDK token location:', JSON.stringify(tokenLocation));
+
+  if (tokenLocation) {
+    const token = await getTokenFromLocation(tokenLocation);
+    if (token) {
+      await sendTokenIfNew(token);
+    }
+  }
+
+  return tokenLocation;
+}
+
+/**
+ * Setups regularly to update the access token from the parent
+ */
+export async function setupTokenCheckInterval() {
+  const initialTokenLocation = await checkToken(); // Run immediately
+
+  if (initialTokenLocation) {
+    console.log(
+      'Initial token location is ' + JSON.stringify(initialTokenLocation)
+    );
+    console.log(
+      'Schedule regular update every ' + CHECK_INTERVAL_MS + ' milliseconds'
+    );
+    setInterval(checkToken, CHECK_INTERVAL_MS);
+  } else {
+    console.log('No token location. Disable regular token update');
+  }
+}

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/handlers.py
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/handlers.py
@@ -200,6 +200,31 @@ class GetServerPathHandler(APIHandler):
         self.finish(json.dumps(os.getcwd()))
 
 
+class GetAccessTokenLocation(APIHandler):
+    @tornado.web.authenticated
+    def get(self):
+        location = os.environ.get(
+            "ACCESS_TOKEN_WEB_LOCATION",
+            json.dumps(
+                {
+                    "storageType": "localStorage",
+                    "key": "instaml-session-stg",
+                    "valuePath": "token.access_token",
+                }
+            ),
+        )
+
+        self.finish(location)
+
+
+class UpdateAccessToken(APIHandler):
+    @tornado.web.authenticated
+    def post(self):
+        input_data = self.get_json_body()
+        VdkUI.update_access_token(input_data.token)
+        self.finish()
+
+
 def setup_handlers(web_app):
     host_pattern = ".*$"
     base_url = web_app.settings["base_url"]
@@ -221,3 +246,5 @@ def setup_handlers(web_app):
     add_handler(GetNotebookInfoHandler, "notebook")
     add_handler(GetVdkCellIndicesHandler, "vdkCellIndices")
     add_handler(GetServerPathHandler, "serverPath")
+    add_handler(GetAccessTokenLocation, "vdkAccessTokenLocation")
+    add_handler(UpdateAccessToken, "vdkAccessToken")

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/vdk_ui.py
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/vdk_ui.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import shlex
 import subprocess
+import time
 from pathlib import Path
 
 from vdk.internal.control.command_groups.job.create import JobCreate
@@ -13,6 +14,7 @@ from vdk.internal.control.command_groups.job.deploy_cli_impl import JobDeploy
 from vdk.internal.control.command_groups.job.download_job import JobDownloadSource
 from vdk.internal.control.utils import cli_utils
 from vdk.internal.control.utils.output_printer import InMemoryTextPrinter
+from vdk.plugin.control_api_auth.base_auth import BaseAuth
 from vdk_jupyterlab_extension.convert_job import ConvertJobDirectoryProcessor
 from vdk_jupyterlab_extension.convert_job import DirectoryArchiver
 
@@ -247,3 +249,10 @@ class VdkUI:
         }
         processor.cleanup()
         return message
+
+    @staticmethod
+    def update_access_token(access_token: str):
+        if access_token:
+            auth = BaseAuth()
+            auth.update_access_token(access_token)
+            auth.update_access_token_expiration_time(time.time() + 3600)

--- a/specs/vep-994-jupyter-notebook-integration/README.md
+++ b/specs/vep-994-jupyter-notebook-integration/README.md
@@ -249,7 +249,7 @@ Access token would be generated using one of 2 approaches depending on how Jupyt
 * Standalone JupyterLab (catered for individual users in their local environments):
    * Login:
        Initiates the [OAuth2 Authorization Flow](https://tools.ietf.org/html/rfc6749#section-4.1) upon selecting "Login" from the VDK dropdown with callback to the server
-       The server would finish the authorization flow leveraging [tornado Oauth2Mixin](https://www.tornadoweb.org/en/stable/auth.html)
+       The server would finish the authorization flow leveraging [vdk-control-api-auth](https://pypi.org/project/vdk-control-api-auth/)
        Access token, once received, is securely stored within JupyterLab backend.
    * Logout: Access token data is deleted from the backend
 * JupyterHub Deployment (or any other similar multi-user, centralized deployments, with users already authenticated):


### PR DESCRIPTION
if the user has already authenticated when entering the notebook server and has generated access token, there's no point in trying to re-login again if the same authentication can be used against VDK Control Service. Best user experience is to resuse the token transparently

The way the design works is operator can specify the token location when installing vdk-jupyter extension.

Currently, this is set as environment variables. But once we get up to speed using jupyter settings capabilities we will translate them there. So for now the environment variables are purposefully not documented in README. 

Once they do we can automatically update the server with the latest access token which can be used in operations against the VDK Control Service

Details in
https://github.com/vmware/versatile-data-kit/blob/main/specs/vep-994-jupyter-notebook-integration/README.md#security-and-permissions