### PR TITLE
vdk-audit: Set tryfirst on plugin configuration hook

### DIFF
--- a/projects/vdk-plugins/vdk-audit/src/vdk/plugin/audit/audit_plugin.py
+++ b/projects/vdk-plugins/vdk-audit/src/vdk/plugin/audit/audit_plugin.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 class AuditPlugin:
     @staticmethod
-    @hookimpl
+    @hookimpl(tryfirst=True)
     def vdk_configure(config_builder: ConfigurationBuilder) -> None:
         add_definitions(config_builder)
 


### PR DESCRIPTION
Currently, there are random cases, where the `vdk_configure` hook in the audit plugin is evaluated before the configuration hook in custom plugins that set the same configuration variables.

This change sets the *tryfirst* option of the hook to `True` as an attempt to force the hook to be evaluated before custom plugins' configuration hooks. We do this, as there is currently no mechanism to specify the order of hook evaluations.

Testing Done: N/A