### PR TITLE
vdk-control-cli: Add python_version to sample config.ini

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/job/sample_job/config.ini
+++ b/projects/vdk-control-cli/src/vdk/internal/control/job/sample_job/config.ini
@@ -17,6 +17,13 @@ team =
 ; the cron job waits until the previous execution has finished.
 schedule_cron = 11 23 5 8 1
 
+;; Specifies the python version to be used in the job deployment.
+;; To see all python versions supported by the Control Service deployment, run
+;; "vdk info -t <team-name>"
+;; Uncomment below line if you want to set a python version different from the
+;; default one.
+; python_version =
+
 ; Who will be contacted and on what occasion
 [contacts]
 


### PR DESCRIPTION
This change adds the `python_version` property to the config.ini file of the sample data job that is returned when a user executes `vdk create -n <job-name> -t <team-name>`. The property is commented out, as it is used only if a user wants to set a python version different from the default one.

Testing Done: Executed `vdk create -n my-test-job -t my-team` locally, and verified that the python_version property is present in the generated data job's config.ini file.