### PR TITLE
control-service: remove hardcoded image pull policy from job deployer

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -174,6 +174,8 @@ spec:
               value: "{{ .Values.webHooks.postDelete.internalErrorsRetries }}"
             - name: DATAJOBS_AUTHORIZATION_JWT_CLAIM_USERNAME
               value: "{{ .Values.security.authorization.jwtClaimUsername }}"
+            - name: DATAJOBS_DEPLOYER_IMAGE_PULL_POLICY
+              value: "{{ .Values.dataJob.deployer.imagePullPolicy }}"
             - name: KRB5_CONFIG
               value: "/etc/secrets/krb5.conf"
             - name: VDK_OPTIONS_INI

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -1000,6 +1000,9 @@ dataJob:
       # In case of negative number it will be subtracted from the {{end_time}}.
       # If left blank, defaults to 0.
       endTimeOffsetSeconds: 0
+  deployer:
+    # imagePullPolicy for data job images deployed to K8S.
+    imagePullPolicy: "IfNotPresent"
   deployment:
     initContainer:
       ## Resources set on Data Job initContainer

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
@@ -42,6 +42,9 @@ public class JobImageDeployer {
   @Value("${datajobs.deployment.readOnlyRootFilesystem:}")
   private boolean readOnlyRootFilesystem;
 
+  @Value("${datajobs.deployer.imagePullPolicy:IfNotPresent}")
+  private String jobImagePullPolicy;
+
   private static final String VOLUME_NAME = "vdk";
   private static final String VOLUME_MOUNT_PATH = "/vdk";
   private static final String EPHEMERAL_VOLUME_NAME = "tmpfs";
@@ -245,7 +248,7 @@ public class JobImageDeployer {
             jobContainerEnvVars,
             List.of(),
             List.of(volumeMount, secretVolumeMount, ephemeralVolumeMount),
-            "Always",
+            jobImagePullPolicy,
             defaultConfigurations.dataJobRequests(),
             defaultConfigurations.dataJobLimits(),
             null,
@@ -266,15 +269,11 @@ public class JobImageDeployer {
             Map.of(),
             List.of(),
             List.of(volumeMount, secretVolumeMount, ephemeralVolumeMount),
-            "Always",
+            jobImagePullPolicy,
             kubernetesResources.dataJobInitContainerRequests(),
             kubernetesResources.dataJobInitContainerLimits(),
             null,
             vdkCommand);
-    // TODO: changing imagePullPolicy to IfNotPresent might be necessary optimization when running
-    // thousands of jobs.
-    // At the moment Always is chosen because it's possible to have a change in image that is not
-    // detected.
 
     var jobLabels = getJobLabels(dataJob, jobDeployment);
     var jobAnnotations =

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -188,6 +188,10 @@ mail.smtp.port=${MAIL_SMTP_PORT:25}
 # See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
 datajobs.deployment.builder.imagePullPolicy=IfNotPresent
 
+# Set imagePullPolicy of the JobImageDeployer
+# - the service that deploys data job images to K8S
+datajobs.deployer.imagePullPolicy=${DATAJOBS_DEPLOYER_IMAGE_PULL_POLICY:IfNotPresent}
+
 datajobs.deployment.builder.securitycontext.runAsUser=${DATAJOBS_DEPLOYMENT_BUILDER_SECURITY_CONTEXT_RUN_AS_USER:0}
 datajobs.deployment.builder.securitycontext.runAsGroup=${DATAJOBS_DEPLOYMENT_BUILDER_SECURITY_CONTEXT_RUN_AS_GROUP:1000}
 datajobs.deployment.builder.securitycontext.fsGroup=${DATAJOBS_DEPLOYMENT_BUILDER_SECURITY_CONTEXT_FS_GROUP:1000}


### PR DESCRIPTION
what: removed hardcoded imagePullPolicy from the JobImageDeployer service.

why: 
Currently, the "Always" strategy fetches the latest version of the image from the registry. This results in an unnecessary image pulls.
Switching to the "IfNotPresent" strategy will address this issue. With this strategy, images will be pulled only if they are not already present in the local cache, matching the behavior of our data jobs that use exact tags associated with the current version. This will reduce unnecessary network calls to the Docker Registry.

testing: trivial