### PR TITLE
frontend: Fix for e2e test

### DIFF
--- a/projects/frontend/data-pipelines/gui/e2e/support/pages/manage/data-jobs/executions/data-job-executions.po.js
+++ b/projects/frontend/data-pipelines/gui/e2e/support/pages/manage/data-jobs/executions/data-job-executions.po.js
@@ -354,7 +354,14 @@ export class DataJobManageExecutionsPage extends DataJobBasePO {
     getDataGridExecTypeContainers(type) {
         return this.getDataGrid()
             .should('exist')
-            .find('[data-cy=data-pipelines-job-executions-type-container]')
+            .then(($gridContainer) => {
+                /**
+                 * @type {JQuery<HTMLElement>}
+                 */
+                const $containers = $gridContainer.find('[data-cy=data-pipelines-job-executions-type-container]');
+
+                return cy.wrap($containers.length === 0 ? [] : $containers);
+            })
             .then(($containers) => {
                 return cy.wrap(
                     Array.from($containers)


### PR DESCRIPTION
## Why

`find('[data-cy=data-pipelines-job-executions-type-container]')` causes the test to fail if it doesn't find any job executions. It should be returning an empty list instead.

## What

Introduce logic that returns an empty list

## How was this tested

Ran e2e tests locally
Ran e2e tests in CI

## What type of change is this

Bug fix

 - Fix one bug in e2e tests for Data Job Executions