### PR TITLE
vdk-impala: Introduce COMPUTE STATS statements

### DIFF
--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/dimension/scd1/02-handle-quality-checks.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/dimension/scd1/02-handle-quality-checks.py
@@ -49,6 +49,8 @@ def run(job_input: IJobInput):
         job_input.execute_query(insert_into_staging)
 
         if check(staging_table):
+            job_input.execute_query(f"COMPUTE STATS {staging_table}")
+            
             insert_into_target = insert_query.format(
                 source_schema=staging_schema,
                 source_view=staging_table_name,

--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/dimension/scd1/02-handle-quality-checks.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/dimension/scd1/02-handle-quality-checks.py
@@ -50,7 +50,7 @@ def run(job_input: IJobInput):
 
         if check(staging_table):
             job_input.execute_query(f"COMPUTE STATS {staging_table}")
-            
+
             insert_into_target = insert_query.format(
                 source_schema=staging_schema,
                 source_view=staging_table_name,

--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/fact/insert/02-handle-quality-checks.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/fact/insert/02-handle-quality-checks.py
@@ -67,6 +67,8 @@ def run(job_input: IJobInput):
 
         view_full_name = f"{view_schema}.{view_name}"
         if check(view_full_name):
+            job_input.execute_query(f"COMPUTE STATS {staging_table}")
+
             insert_into_target = insert_query.format(
                 source_schema=staging_schema,
                 source_view=staging_table_name,

--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/fact/snapshot/02-handle-quality-checks.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/fact/snapshot/02-handle-quality-checks.py
@@ -56,6 +56,8 @@ def run(job_input: IJobInput):
         job_input.execute_query(insert_into_staging)
 
         if check(staging_table):
+            job_input.execute_query(f"COMPUTE STATS {staging_table}")
+            
             insert_into_target = overwrite_target_query.format(
                 staging_schema=staging_schema,
                 staging_table_name=staging_table_name,

--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/fact/snapshot/02-handle-quality-checks.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/load/fact/snapshot/02-handle-quality-checks.py
@@ -57,7 +57,7 @@ def run(job_input: IJobInput):
 
         if check(staging_table):
             job_input.execute_query(f"COMPUTE STATS {staging_table}")
-            
+
             insert_into_target = overwrite_target_query.format(
                 staging_schema=staging_schema,
                 staging_table_name=staging_table_name,


### PR DESCRIPTION
Why:
We were facing issues for large sized tables sporadically when using the processing templates with specified quality checks.
The issues appear when we try to move the data from the staging table (where the quality checks were already performed) into the target table. The absence of "COMPUTE STATS" statement against the staging table was causing failures when trying to select data from it due to hitting query limits. Before submitting this PR here are the checks that have been done in order to take that decision:
-A job that was processing a large table with quality checks defined was ran 45 times from which only 17 were successful and other were failures due to the issue mentioned above. After that a "Compute stats" statement was added against the staging table before trying to process the data to target - the result was 100 consecutive successful runs. That's why we assumed this enhancement will optimize the execution of the templates.

More details explained in
https://github.com/vmware/versatile-data-kit/issues/1361

What:
-Adding COMPUTE STATS statement that will be executed against the staging table right before moving the data to prod in order to optimize further selects on it.

Signed-off-by: Stefan Buldeev [sbuldeev@vmware.com](mailto:sbuldeev@vmware.com)