### PR TITLE
vdk-kerberos-auth: enable auth to work inside a running asyncio event loop

### DIFF
--- a/projects/vdk-plugins/.plugin-common.yml
+++ b/projects/vdk-plugins/.plugin-common.yml
@@ -26,6 +26,9 @@
         - "projects/vdk-plugins/$PLUGIN_NAME/**/*"
   artifacts:
     when: always
+    paths:
+      - "projects/vdk-plugins/$PLUGIN_NAME/tests.xml"
+    expire_in: 1 week
     reports:
       junit: "projects/vdk-plugins/$PLUGIN_NAME/tests.xml"
 

--- a/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/base_authenticator.py
+++ b/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/base_authenticator.py
@@ -48,6 +48,12 @@ class BaseAuthenticator(ABC):
 
     def authenticate(self):
         if not self._is_authenticated:
+            log.debug(
+                f"Starting kerberos authentication for principal {self._kerberos_principal}"
+                f" to KDC host {self._kerberos_kdc_hostname}"
+                f" at KDC realm {self._kerberos_realm}"
+                f" using keytab {self._keytab_pathname}"
+            )
             self._kinit()
             self._is_authenticated = True
         else:

--- a/projects/vdk-plugins/vdk-kerberos-auth/tests/test_kerberos.py
+++ b/projects/vdk-plugins/vdk-kerberos-auth/tests/test_kerberos.py
@@ -1,5 +1,6 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import asyncio
 import os
 import pathlib
 import unittest
@@ -257,3 +258,10 @@ class TestKerberosAuthentication(unittest.TestCase):
 
             assert "Cannot locate keytab file" in str(result.exception)
             cli_assert_equal(1, result)
+
+    def test_minikerberos_authentication_within_asyncio_event_loop(self):
+        async def test_coroutine():
+            self.test_minikerberos_authentication()
+
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(test_coroutine())


### PR DESCRIPTION
This change adds _run_coroutine function to ensure proper execution of a get_tgt coroutine, even if called within an already running event loop in asyncio (which in principal is not allowed)

This is happening when the plugin is invoked within a jupyter notebook which runs within a async event loop started by tornado server. And this causes following errors:
```
Traceback (most recent call last):
File
"/opt/conda/lib/python3.7/site-packages/vdk/plugin/kerberos/minikerberos_authenticator.py",
line 90, in _kinit
    loop.run_until_complete(get_tgt())
File "/opt/conda/lib/python3.7/asyncio/base_events.py", line 563, in
run_until_complete
    self._check_runnung()
File "/opt/conda/lib/python3.7/asyncio/base_events.py", line 526, in
_check_runnung
    'Cannot run the event loop while another loop is running')
RuntimeError: Cannot run the event loop while another loop is running
```

The way the fix works is
- If the current event loop is running, the function now starts a new thread to run the coroutine, ensuring that it runs to completion without conflict with the existing loop.
- Otherwise it creates a new asyncio event loop in the current thread and runs the couritine as before.