### PR TITLE
vdk-core: pass vdk run arguments in standalone job mode as well

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/standalone_data_job.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/standalone_data_job.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import json
 import logging
 import pathlib
 import sys
@@ -89,8 +90,17 @@ class StandaloneDataJob(IStandaloneDataJob):
         )
         self._template_name = template_name
 
+        command_line_args = ["run", str(data_job_directory)] + (
+            ["--arguments", json.dumps(job_args)] if job_args else []
+        )
+        log.debug(
+            f"Pass command line arguments for standalone data job to simulate vdk run: {command_line_args}"
+        )
         cast(CoreHookSpecs, self._plugin_registry.hook()).vdk_start.call_historic(
-            kwargs=dict(plugin_registry=self._plugin_registry, command_line_args=[])
+            kwargs=dict(
+                plugin_registry=self._plugin_registry,
+                command_line_args=command_line_args,
+            )
         )
 
         conf_builder = ConfigurationBuilder()


### PR DESCRIPTION
When running StandaloneDataJob we do not pass `vdk run` arguments to `vdk_start` hook, but some hook implementations rely on that to understand what command is being run without that it breaks their logic.

JobConfigIni Configuraiton provider is one such hook implementation See
https://github.com/vmware/versatile-data-kit/blob/main/projects/vdk-core/src/vdk/internal/builtin_plugins/config/vdk_config.py#L189

As can be seen we infer the job paht from the command line and try to find config.ini there.
This is hacky (there's unfixed TODO) and naturally causes such issues as hacky things do. But we have not come up with better way then that.

This is causing issues with Jupyter integration where config.ini file is not being parsed and read!

To fix that and for consistency since StandaloneDataJob simulates vdk run of a job we pass all the arguments to vdk_start hook as if vdk run command was run.