### PR TITLE
vdk-ipython: infer correctly job name and add more tests

### DIFF
--- a/projects/vdk-plugins/vdk-ipython/src/vdk/plugin/ipython.py
+++ b/projects/vdk-plugins/vdk-ipython/src/vdk/plugin/ipython.py
@@ -41,12 +41,16 @@ class JobControl:
     ):
         path = pathlib.Path(path) if path else pathlib.Path(os.getcwd())
         job_args = json.loads(arguments) if arguments else None
-        self._name = name
+        self._name = path.name if name is None else name
         self._path = path
         self._arguments = job_args
         self._template = template
         self.job = None
         self.job_input = None
+        log.debug(
+            f"Job Control for job with name {self._name} from path {self._path} "
+            f"with arguments {self._arguments} and template {self._template}"
+        )
 
     def get_initialized_job_input(self):
         """

--- a/projects/vdk-plugins/vdk-ipython/src/vdk/plugin/ipython.py
+++ b/projects/vdk-plugins/vdk-ipython/src/vdk/plugin/ipython.py
@@ -41,7 +41,7 @@ class JobControl:
     ):
         path = pathlib.Path(path) if path else pathlib.Path(os.getcwd())
         job_args = json.loads(arguments) if arguments else None
-        self._name = path.name if name is None else name
+        self._name = path.name if not name else name
         self._path = path
         self._arguments = job_args
         self._template = template


### PR DESCRIPTION
If job name is not explcitly provided we should infer it correctly from the path name.

Also I extended ipython test coverage to cover most of the other untested job input methods