### PR TITLE
vdk-jupyter: add run result to the deployment result dialog

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/resquests.spec.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/resquests.spec.ts
@@ -20,8 +20,6 @@ jest.mock('../handler', () => {
   };
 });
 
-window.alert = jest.fn();
-
 describe('jobdDataRequest', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -123,20 +121,12 @@ describe('jobRequest()', () => {
     };
     (requestAPI as jest.Mock).mockResolvedValue(serverVdkOperationResultMock);
 
-    const alertMock = jest
-      .spyOn(window, 'alert')
-      .mockImplementationOnce(() => {});
-
     await jobRequest(endPoint);
 
-    expect(alertMock as jest.Mock).toHaveBeenCalledWith(
-      serverVdkOperationResultMock['message']
-    );
     expect(requestAPI).toHaveBeenCalledWith(endPoint, {
       body: JSON.stringify(getJobDataJsonObject()),
       method: 'POST'
     });
-    (window.alert as jest.Mock).mockClear();
   });
 });
 

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/resquests.spec.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/resquests.spec.ts
@@ -72,13 +72,13 @@ describe('jobRunRequest()', () => {
 
   it('should call requestAPI with correct arguments and return successful result', async () => {
     const expectedMessage = '0';
-    const expectedResponse = { message: '0', status: true };
+    const expectedResponse = { message: '0', isSuccessful: true };
     (requestAPI as jest.Mock).mockResolvedValue(expectedResponse);
 
     const result = await jobRunRequest();
 
     expect(requestAPI).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({ message: expectedMessage, status: true });
+    expect(result).toEqual({ message: expectedMessage, isSuccessful: true });
   });
 
   it('should call requestAPI with correct arguments and return unsuccessful result', async () => {
@@ -90,7 +90,7 @@ describe('jobRunRequest()', () => {
     expect(requestAPI).toHaveBeenCalledTimes(1);
     expect(result).toEqual({
       message: '1',
-      status: false
+      isSuccessful: false
     });
   });
 });

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/show-dialog.spec.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/show-dialog.spec.tsx
@@ -35,7 +35,7 @@ describe('showRunJobDialog', () => {
   it('should show a dialog with the Run Job title and a RunJobDialog component as its body', async () => {
     (jobRunRequest as jest.Mock).mockResolvedValueOnce({
       message: 'Job completed successfully!',
-      status: true
+      isSuccessful: true
     });
 
     await showRunJobDialog();
@@ -51,7 +51,7 @@ describe('showRunJobDialog', () => {
   it('should call the jobRunRequest function if the user clicks the accept button and return success dialog', async () => {
     (jobRunRequest as jest.Mock).mockResolvedValueOnce({
       message: 'Job completed successfully!',
-      status: true
+      isSuccessful: true
     });
 
     // Call the function
@@ -77,7 +77,7 @@ describe('showRunJobDialog', () => {
   it('should call the jobRunRequest function if the user clicks the accept button and return failing standard run dialog', async () => {
     (jobRunRequest as jest.Mock).mockResolvedValueOnce({
       message: 'Error message',
-      status: false
+      isSuccessful: false
     });
     const errorMessage = new VdkErrorMessage('ERROR : ' + 'Error message');
     // Call the function
@@ -110,7 +110,7 @@ describe('showDownloadJobDialog', () => {
     const mockResult = { button: { accept: true } };
     (showDialog as jest.Mock).mockResolvedValueOnce(mockResult);
 
-        const mockOperationResult = { message: "message", status: true };
+        const mockOperationResult = { message: "message", isSuccessful: true };
     (jobRequest as jest.Mock).mockResolvedValueOnce(mockOperationResult);
   });
 
@@ -144,7 +144,7 @@ describe('showCreateJobDialog', () => {
     const mockResult = { button: { accept: true }, value: true };
     (showDialog as jest.Mock).mockResolvedValueOnce(mockResult);
 
-    const mockOperationResult = { message: "message", status: true };
+    const mockOperationResult = { message: "message", isSuccessful: true };
     (jobRequest as jest.Mock).mockResolvedValueOnce(mockOperationResult);
   });
 

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/show-dialog.spec.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/__tests__/show-dialog.spec.tsx
@@ -109,6 +109,9 @@ describe('showDownloadJobDialog', () => {
     // Mock the result of the showDialog function
     const mockResult = { button: { accept: true } };
     (showDialog as jest.Mock).mockResolvedValueOnce(mockResult);
+
+        const mockOperationResult = { message: "message", status: true };
+    (jobRequest as jest.Mock).mockResolvedValueOnce(mockOperationResult);
   });
 
   it('should show a dialog with the Download Job title and a DownloadJobDialog component as its body', async () => {
@@ -140,6 +143,9 @@ describe('showCreateJobDialog', () => {
     // Mock the result of the showDialog function
     const mockResult = { button: { accept: true }, value: true };
     (showDialog as jest.Mock).mockResolvedValueOnce(mockResult);
+
+    const mockOperationResult = { message: "message", status: true };
+    (jobRequest as jest.Mock).mockResolvedValueOnce(mockOperationResult);
   });
 
   it('should call showDialog with correct arguments', async () => {

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/CreateJob.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/CreateJob.tsx
@@ -60,9 +60,9 @@ export async function showCreateJobDialog() {
   if (result.button.accept) {
      // We only handle the successful deployment scenario.
      // The failign scenario is handled in the request itself.
-    const success = await jobRequest('create');
-    if(success){
-      alert(success);
-    }
+     const { message, status } = await jobRequest('create');
+        if(status && message){
+          alert(message);
+        }
   }
 }

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/CreateJob.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/CreateJob.tsx
@@ -59,7 +59,7 @@ export async function showCreateJobDialog() {
   });
   if (result.button.accept) {
      // We only handle the successful deployment scenario.
-     // The failign scenario is handled in the request itself.
+     // The failing scenario is handled in the request itself.
      const { message, status } = await jobRequest('create');
         if(status && message){
           alert(message);

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/CreateJob.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/CreateJob.tsx
@@ -60,9 +60,9 @@ export async function showCreateJobDialog() {
   if (result.button.accept) {
      // We only handle the successful deployment scenario.
      // The failing scenario is handled in the request itself.
-     const { message, status } = await jobRequest('create');
-        if(status && message){
-          alert(message);
+     const creation = await jobRequest('create');
+        if(creation.isSuccessful && creation.message){
+          alert(creation.message);
         }
   }
 }

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/CreateJob.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/CreateJob.tsx
@@ -58,6 +58,11 @@ export async function showCreateJobDialog() {
     buttons: [Dialog.okButton(), Dialog.cancelButton()]
   });
   if (result.button.accept) {
-    await jobRequest('create');
+     // We only handle the successful deployment scenario.
+     // The failign scenario is handled in the request itself.
+    const success = await jobRequest('create');
+    if(success){
+      alert(success);
+    }
   }
 }

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/DeployJob.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/DeployJob.tsx
@@ -82,16 +82,16 @@ export async function showCreateDeploymentDialog() {
   ) {
     try {
       if (runBeforeDeploy) {
-        const { message, status } = await jobRunRequest();
-        if (status) {
-          const {message, status} = await jobRequest('deploy');
+        const run = await jobRunRequest();
+        if (run.isSuccessful) {
+          const deployment = await jobRequest('deploy');
           // We only handle the successful deployment scenario.
           // The failing scenario is handled in the request itself.
-          if(status){
-            alert("The test job run completed successfully! \n" + message);
+          if(deployment.isSuccessful && deployment.message){
+            alert("The test job run completed successfully! \n" + deployment.message);
           }
         } else {
-          const errorMessage = new VdkErrorMessage('ERROR : ' + message);
+          const errorMessage = new VdkErrorMessage('ERROR : ' + run.message);
           showDialog({
             title: RUN_JOB_BUTTON_LABEL,
             body: (
@@ -107,9 +107,9 @@ export async function showCreateDeploymentDialog() {
           });
         }
       } else {
-        const { message, status } = await jobRequest('deploy');
-        if(status && message){
-          alert(message);
+        const deployment = await jobRequest('deploy');
+        if(deployment.isSuccessful && deployment.message){
+          alert(deployment.message);
         }
       }
     } catch (error) {

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/DeployJob.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/DeployJob.tsx
@@ -84,7 +84,12 @@ export async function showCreateDeploymentDialog() {
       if (runBeforeDeploy) {
         const { message, status } = await jobRunRequest();
         if (status) {
-          await jobRequest('deploy');
+          const success = await jobRequest('deploy');
+          // We only handle the successful deployment scenario.
+          // The failign scenario is handled in the request itself.
+          if(success){
+            alert("Job was run successfully! \n" + success);
+          }
         } else {
           const errorMessage = new VdkErrorMessage('ERROR : ' + message);
           showDialog({
@@ -102,7 +107,10 @@ export async function showCreateDeploymentDialog() {
           });
         }
       } else {
-        await jobRequest('deploy');
+        const success = await jobRequest('deploy');
+        if(success){
+          alert(success);
+        }
       }
     } catch (error) {
       await showErrorMessage(

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/DeployJob.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/DeployJob.tsx
@@ -86,7 +86,7 @@ export async function showCreateDeploymentDialog() {
         if (status) {
           const {message, status} = await jobRequest('deploy');
           // We only handle the successful deployment scenario.
-          // The failign scenario is handled in the request itself.
+          // The failing scenario is handled in the request itself.
           if(status){
             alert("The test job run completed successfully! \n" + message);
           }

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/DeployJob.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/DeployJob.tsx
@@ -84,11 +84,11 @@ export async function showCreateDeploymentDialog() {
       if (runBeforeDeploy) {
         const { message, status } = await jobRunRequest();
         if (status) {
-          const success = await jobRequest('deploy');
+          const {message, status} = await jobRequest('deploy');
           // We only handle the successful deployment scenario.
           // The failign scenario is handled in the request itself.
-          if(success){
-            alert("Job was run successfully! \n" + success);
+          if(status){
+            alert("The test job run completed successfully! \n" + message);
           }
         } else {
           const errorMessage = new VdkErrorMessage('ERROR : ' + message);
@@ -107,9 +107,9 @@ export async function showCreateDeploymentDialog() {
           });
         }
       } else {
-        const success = await jobRequest('deploy');
-        if(success){
-          alert(success);
+        const { message, status } = await jobRequest('deploy');
+        if(status && message){
+          alert(message);
         }
       }
     } catch (error) {

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/DownloadJob.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/DownloadJob.tsx
@@ -59,7 +59,7 @@ export async function showDownloadJobDialog(statusButton?: StatusButton) {
   if (result.button.accept) {
     statusButton?.show('Download', jobData.get(VdkOption.PATH)!);
     // We only handle the successful deployment scenario.
-    // The failign scenario is handled in the request itself.
+    // The failing scenario is handled in the request itself.
     const { message, status } = await jobRequest('download');
     if (status && message) {
       alert(message);

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/DownloadJob.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/DownloadJob.tsx
@@ -58,6 +58,11 @@ export async function showDownloadJobDialog(statusButton?: StatusButton) {
   });
   if (result.button.accept) {
     statusButton?.show('Download', jobData.get(VdkOption.PATH)!);
-    await jobRequest('download');
+    // We only handle the successful deployment scenario.
+     // The failign scenario is handled in the request itself.
+     const success = await jobRequest('download');
+     if(success){
+       alert(success);
+     }
   }
 }

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/DownloadJob.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/DownloadJob.tsx
@@ -59,10 +59,10 @@ export async function showDownloadJobDialog(statusButton?: StatusButton) {
   if (result.button.accept) {
     statusButton?.show('Download', jobData.get(VdkOption.PATH)!);
     // We only handle the successful deployment scenario.
-     // The failign scenario is handled in the request itself.
-     const success = await jobRequest('download');
-     if(success){
-       alert(success);
-     }
+    // The failign scenario is handled in the request itself.
+    const { message, status } = await jobRequest('download');
+    if (status && message) {
+      alert(message);
+    }
   }
 }

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/DownloadJob.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/DownloadJob.tsx
@@ -60,9 +60,9 @@ export async function showDownloadJobDialog(statusButton?: StatusButton) {
     statusButton?.show('Download', jobData.get(VdkOption.PATH)!);
     // We only handle the successful deployment scenario.
     // The failing scenario is handled in the request itself.
-    const { message, status } = await jobRequest('download');
-    if (status && message) {
-      alert(message);
+    const download = await jobRequest('download');
+    if (download.isSuccessful && download.message) {
+      alert(download.message);
     }
   }
 }

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/RunJob.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/RunJob.tsx
@@ -85,8 +85,8 @@ export async function showRunJobDialog(
   });
   if (result.button.accept) {
     statusButton?.show('Run', jobData.get(VdkOption.PATH)!);
-    let { message, status } = await jobRunRequest();
-    if (status) {
+    let { message, isSuccessful } = await jobRunRequest();
+    if (isSuccessful) {
       showDialog({
         title: RUN_JOB_BUTTON_LABEL,
         body: (

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/serverRequests.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/serverRequests.ts
@@ -36,28 +36,36 @@ type serverVdkOperationResult = {
   message: string;
 };
 
+type jobRequestResult = {
+  /**
+   * Result message of the operation
+   */
+  message: string;
+  /**
+   * Status of the operation
+   */
+  isSuccessful: boolean;
+};
+
 /**
  * Sent a POST request to the server to run a data job.
  * The information about the data job is retrieved from jobData object and sent as JSON.
  * Returns a pair of boolean (representing whether the vdk run was run) and a string (representing the result of vdk run)
  */
-export async function jobRunRequest(): Promise<{
-  message: String;
-  status: boolean;
-}> {
+export async function jobRunRequest(): Promise<jobRequestResult> {
   if (await checkIfVdkOptionDataIsDefined(VdkOption.PATH)) {
     try {
       const data = await requestAPI<serverVdkOperationResult>('run', {
         body: JSON.stringify(getJobDataJsonObject()),
         method: 'POST'
       });
-      return { message: data['message'], status: data['message'] == '0' };
+      return { message: data['message'], isSuccessful: data['message'] == '0' };
     } catch (error) {
       showError(error);
-      return { message: '', status: false };
+      return { message: '', isSuccessful: false };
     }
   } else {
-    return { message: '', status: false };
+    return { message: '', isSuccessful: false };
   }
 }
 
@@ -68,10 +76,7 @@ export async function jobRunRequest(): Promise<{
  *                                     and a string (representing the result message)
  * Currently, the result message of a fail is empty string since the error is handled in the current operation
  */
-export async function jobRequest(endPoint: string): Promise<{
-  message: String;
-  status: boolean;
-}> {
+export async function jobRequest(endPoint: string): Promise<jobRequestResult> {
   if (
     (await checkIfVdkOptionDataIsDefined(VdkOption.NAME)) &&
     (await checkIfVdkOptionDataIsDefined(VdkOption.TEAM))
@@ -82,10 +87,7 @@ export async function jobRequest(endPoint: string): Promise<{
         method: 'POST'
       });
       if (!data['error'])
-        return {
-          message: data['message'],
-          status: true
-        };
+        return { message: data['message'], isSuccessful: true };
       else {
         await showErrorMessage(
           'Encountered an error while trying the ' +
@@ -94,23 +96,14 @@ export async function jobRequest(endPoint: string): Promise<{
           data['message'],
           [Dialog.okButton()]
         );
-        return {
-          message: '',
-          status: false
-        };
+        return { message: '', isSuccessful: false };
       }
     } catch (error) {
       showError(error);
-      return {
-        message: '',
-        status: false
-      };
+      return { message: '', isSuccessful: false };
     }
   }
-  return {
-    message: '',
-    status: false
-  };
+  return { message: '', isSuccessful: false };
 }
 
 /**

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/serverRequests.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/serverRequests.ts
@@ -64,8 +64,13 @@ export async function jobRunRequest(): Promise<{
 /**
  * Sent a POST request to the server to execute a VDK operation a data job.
  * The information about the data job is retrieved from jobData object and sent as JSON.
+ * Returns a pair of boolean (representing whether the vdk operation was successful) and a string (representing the result message)
+ * Currently, the result message of a fail is empty string since the error is handled in the current operation
  */
-export async function jobRequest(endPoint: string): Promise<string> {
+export async function jobRequest(endPoint: string): Promise<{
+  message: String;
+  status: boolean;
+}> {
   if (
     (await checkIfVdkOptionDataIsDefined(VdkOption.NAME)) &&
     (await checkIfVdkOptionDataIsDefined(VdkOption.TEAM))
@@ -75,7 +80,11 @@ export async function jobRequest(endPoint: string): Promise<string> {
         body: JSON.stringify(getJobDataJsonObject()),
         method: 'POST'
       });
-      if (!data['error']) return data['message'];
+      if (!data['error'])
+        return {
+          message: data['message'],
+          status: true
+        };
       else {
         await showErrorMessage(
           'Encountered an error while trying the ' +
@@ -84,14 +93,23 @@ export async function jobRequest(endPoint: string): Promise<string> {
           data['message'],
           [Dialog.okButton()]
         );
-        return '';
+        return {
+          message: '',
+          status: false
+        };
       }
     } catch (error) {
       showError(error);
-      return '';
+      return {
+        message: '',
+        status: false
+      };
     }
   }
-  return '';
+  return {
+    message: '',
+    status: false
+  };
 }
 
 /**

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/serverRequests.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/serverRequests.ts
@@ -65,7 +65,7 @@ export async function jobRunRequest(): Promise<{
  * Sent a POST request to the server to execute a VDK operation a data job.
  * The information about the data job is retrieved from jobData object and sent as JSON.
  */
-export async function jobRequest(endPoint: string): Promise<void> {
+export async function jobRequest(endPoint: string): Promise<string> {
   if (
     (await checkIfVdkOptionDataIsDefined(VdkOption.NAME)) &&
     (await checkIfVdkOptionDataIsDefined(VdkOption.TEAM))
@@ -75,7 +75,7 @@ export async function jobRequest(endPoint: string): Promise<void> {
         body: JSON.stringify(getJobDataJsonObject()),
         method: 'POST'
       });
-      if (!data['error']) alert(data['message']);
+      if (!data['error']) return data['message'];
       else {
         await showErrorMessage(
           'Encountered an error while trying the ' +
@@ -84,11 +84,14 @@ export async function jobRequest(endPoint: string): Promise<void> {
           data['message'],
           [Dialog.okButton()]
         );
+        return '';
       }
     } catch (error) {
       showError(error);
+      return '';
     }
   }
+  return '';
 }
 
 /**

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/serverRequests.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/serverRequests.ts
@@ -64,7 +64,8 @@ export async function jobRunRequest(): Promise<{
 /**
  * Sent a POST request to the server to execute a VDK operation a data job.
  * The information about the data job is retrieved from jobData object and sent as JSON.
- * Returns a pair of boolean (representing whether the vdk operation was successful) and a string (representing the result message)
+ * Returns a pair of boolean (representing whether the vdk operation was successful)
+ *                                     and a string (representing the result message)
  * Currently, the result message of a fail is empty string since the error is handled in the current operation
  */
 export async function jobRequest(endPoint: string): Promise<{


### PR DESCRIPTION
What: Added run result message to the deployment result dialog ( if run before deployment is selected) 
Current dialog: 
![Screenshot 2023-08-25 at 10 36 53](https://github.com/vmware/versatile-data-kit/assets/87015481/4401642a-68f2-41a6-ba4f-20519602b09c)
![Screenshot 2023-08-25 at 10 37 01](https://github.com/vmware/versatile-data-kit/assets/87015481/a41074fb-97ee-4942-ae79-2b462ea01269)

Why: It used to not contain the successful run message which left the suers with confusion around whether really the run was successful 

Signed-off-by: Duygu Hasan [hduygu@vmware.com](mailto:hduygu@vmware.com)