### PR TITLE
vdk-control-api-auth: vdk credentials cache refactoring

### DIFF
--- a/projects/vdk-plugins/vdk-control-api-auth/src/vdk/plugin/control_api_auth/base_auth.py
+++ b/projects/vdk-plugins/vdk-control-api-auth/src/vdk/plugin/control_api_auth/base_auth.py
@@ -4,14 +4,13 @@ import json
 import logging
 import time
 from typing import Optional
-from typing import Union
 
 from requests import post
 from requests.auth import HTTPBasicAuth
 from requests_oauthlib import OAuth2Session
 from vdk.plugin.control_api_auth.auth_config import AuthConfig
-from vdk.plugin.control_api_auth.auth_config import AuthConfigFolder
-from vdk.plugin.control_api_auth.auth_config import InMemAuthConfiguration
+from vdk.plugin.control_api_auth.auth_config import CredentialsCache
+from vdk.plugin.control_api_auth.auth_config import LocalFolderCredentialsCache
 from vdk.plugin.control_api_auth.auth_exception import VDKAuthException
 from vdk.plugin.control_api_auth.auth_request_values import AuthRequestValues
 from vdk.plugin.control_api_auth.login_types import LoginTypes
@@ -96,7 +95,7 @@ class BaseAuth:
 
     def __init__(
         self,
-        conf: Union[AuthConfigFolder, InMemAuthConfiguration] = AuthConfigFolder(),
+        conf: CredentialsCache = LocalFolderCredentialsCache(),
         vdk_config=AuthConfig(),
     ):
         self._conf = conf
@@ -172,8 +171,8 @@ class BaseAuth:
 
     def read_access_token(self) -> Optional[str]:
         """
-        Read access token from _cache or fetch it from Authorization server.
-        If not available in _cache it will get it using provided configuration during VDK CLI login to fetch it.
+        Read access token from cache or fetch it from Authorization server.
+        If not available in cache it will get it using provided configuration during VDK CLI login to fetch it.
         If it detects that token is about to expire it will try to refresh it.
         :return: the access token or None if it cannot detect any credentials.
         """
@@ -183,6 +182,14 @@ class BaseAuth:
         ):
             log.debug("Acquire access token (it's either expired or missing) ...")
             self.acquire_and_cache_access_token()
+        return self._cache.access_token
+
+    def read_cached_access_token_only(self) -> Optional[str]:
+        """
+        Read access token from credentials cache and will return it if available.
+        Will not check if it is valid (for example not expired) but return it directly.
+        Will not try to fetch it form Authorization provider if it is not available. Instead, will simply return None
+        """
         return self._cache.access_token
 
     def acquire_and_cache_access_token(self):

--- a/projects/vdk-plugins/vdk-control-api-auth/tests/test_api_token_auth.py
+++ b/projects/vdk-plugins/vdk-control-api-auth/tests/test_api_token_auth.py
@@ -4,6 +4,7 @@ import pytest
 from pytest_httpserver.pytest_plugin import PluginHTTPServer
 from test_core_auth import allow_oauthlib_insecure_transport
 from test_core_auth import get_json_response_mock
+from vdk.plugin.control_api_auth.auth_config import InMemoryCredentialsCache
 from vdk.plugin.control_api_auth.auth_exception import VDKInvalidAuthParamError
 from vdk.plugin.control_api_auth.authentication import Authentication
 
@@ -16,6 +17,7 @@ def test_api_token_success_authentication(httpserver: PluginHTTPServer):
         token="apitoken",
         authorization_url=httpserver.url_for("/foo"),
         auth_type="api-token",
+        credentials_cache=InMemoryCredentialsCache(),
     )
     auth.authenticate()
 
@@ -23,7 +25,11 @@ def test_api_token_success_authentication(httpserver: PluginHTTPServer):
 
 
 def test_api_token_no_auth_url():
-    auth = Authentication(token="apitoken", auth_type="api-token")
+    auth = Authentication(
+        token="apitoken",
+        auth_type="api-token",
+        credentials_cache=InMemoryCredentialsCache(),
+    )
 
     with pytest.raises(VDKInvalidAuthParamError) as exc_info:
         auth.authenticate()
@@ -35,7 +41,9 @@ def test_api_token_no_auth_url():
 def test_api_token_no_auth_type_specified(httpserver: PluginHTTPServer):
     httpserver.expect_request("/foo").respond_with_json(get_json_response_mock())
     auth = Authentication(
-        token="apitoken", authorization_url=httpserver.url_for("/foo")
+        token="apitoken",
+        authorization_url=httpserver.url_for("/foo"),
+        credentials_cache=InMemoryCredentialsCache(),
     )
 
     with pytest.raises(VDKInvalidAuthParamError) as exc_info:

--- a/projects/vdk-plugins/vdk-control-api-auth/tests/test_authorization_code_auth.py
+++ b/projects/vdk-plugins/vdk-control-api-auth/tests/test_authorization_code_auth.py
@@ -4,18 +4,18 @@ import pytest
 from pytest_httpserver.pytest_plugin import PluginHTTPServer
 from test_core_auth import allow_oauthlib_insecure_transport
 from test_core_auth import get_json_response_mock
+from vdk.plugin.control_api_auth.auth_config import InMemoryCredentialsCache
 from vdk.plugin.control_api_auth.auth_exception import VDKInvalidAuthParamError
 from vdk.plugin.control_api_auth.auth_exception import VDKLoginFailedError
 from vdk.plugin.control_api_auth.authentication import Authentication
 from vdk.plugin.control_api_auth.autorization_code_auth import LoginHandler
 from vdk.plugin.control_api_auth.autorization_code_auth import RedirectAuthentication
 from vdk.plugin.control_api_auth.base_auth import BaseAuth
-from vdk.plugin.control_api_auth.base_auth import InMemAuthConfiguration
 
 
 def test_verify_redirect_url():
     allow_oauthlib_insecure_transport()
-    in_mem_conf = InMemAuthConfiguration()
+    in_mem_conf = InMemoryCredentialsCache()
     auth = BaseAuth(in_mem_conf)
 
     auth = RedirectAuthentication(
@@ -38,7 +38,7 @@ def test_verify_redirect_url():
 def test_login_handler_exceptions(httpserver: PluginHTTPServer):
     allow_oauthlib_insecure_transport()
     httpserver.expect_request("/foo").respond_with_json(get_json_response_mock())
-    in_mem_conf = InMemAuthConfiguration()
+    in_mem_conf = InMemoryCredentialsCache()
     auth = BaseAuth(in_mem_conf)
 
     handler = LoginHandler(
@@ -75,6 +75,7 @@ def test_authorization_code_no_secret(httpserver: PluginHTTPServer):
         token="apitoken",
         authorization_url=httpserver.url_for("/foo"),
         auth_type="credentials",
+        credentials_cache=InMemoryCredentialsCache(),
     )
     with pytest.raises(VDKInvalidAuthParamError) as exc_info:
         auth.authenticate()

--- a/projects/vdk-plugins/vdk-control-api-auth/tests/test_get_auth_user.py
+++ b/projects/vdk-plugins/vdk-control-api-auth/tests/test_get_auth_user.py
@@ -3,18 +3,23 @@
 from unittest.mock import patch
 
 import pytest
+from vdk.plugin.control_api_auth.auth_config import InMemoryCredentialsCache
 from vdk.plugin.control_api_auth.authentication import Authentication
 
 
 def test_get_authenticated_username_with_username():
-    auth = Authentication(username="testuser")
+    auth = Authentication(
+        username="testuser", credentials_cache=InMemoryCredentialsCache()
+    )
     assert auth.get_authenticated_username() == "testuser"
 
 
 @patch("jwt.decode")
 def test_get_authenticated_username_with_token_username(mock_jwt_decode):
     mock_jwt_decode.return_value = {"username": "testuser"}
-    auth = Authentication(token="testtoken")
+    auth = Authentication(
+        token="testtoken", credentials_cache=InMemoryCredentialsCache()
+    )
     assert auth.get_authenticated_username() == "testuser"
 
 
@@ -24,14 +29,18 @@ def test_get_authenticated_username_with_token_other_fields(
     mock_jwt_decode, user_id_field
 ):
     mock_jwt_decode.return_value = {user_id_field: "testuser"}
-    auth = Authentication(token="testtoken")
+    auth = Authentication(
+        token="testtoken", credentials_cache=InMemoryCredentialsCache()
+    )
     assert auth.get_authenticated_username() == "testuser"
 
 
 @patch("jwt.decode")
 def test_get_authenticated_username_with_token_no_user_id(mock_jwt_decode):
     mock_jwt_decode.return_value = {}
-    auth = Authentication(token="testtoken")
+    auth = Authentication(
+        token="testtoken", credentials_cache=InMemoryCredentialsCache()
+    )
     assert auth.get_authenticated_username() is None
 
 
@@ -39,11 +48,13 @@ def test_get_authenticated_username_with_token_no_user_id(mock_jwt_decode):
 def test_get_authenticated_username_priority_order_kept(mock_jwt_decode):
     mock_jwt_decode.return_value = {"sub": "user_from_sub", "acct": "user_from_acct"}
     auth = Authentication(
-        token="testtoken", possible_jwt_user_keys=["user", "email", "sub", "acct"]
+        token="testtoken",
+        credentials_cache=InMemoryCredentialsCache(),
+        possible_jwt_user_keys=["user", "email", "sub", "acct"],
     )
     assert auth.get_authenticated_username() == "user_from_sub"
 
 
 def test_get_authenticated_username_without_username_or_token():
-    auth = Authentication()
+    auth = Authentication(credentials_cache=InMemoryCredentialsCache())
     assert auth.get_authenticated_username() is None


### PR DESCRIPTION
This is refactoring the credentials cache storage system to make it more reusable . Particulary I want to reuse it to get corrected authenticated user in telemetry later.

- We are providing explcit interface for credentials cache intead of using Union of classes
- Implement SingletonInMemoryCredentials cache to enable different parts of the program to easily access and reuse the same credentials.
- Added method read_cached_access_token_only and use it in get_authenticated_username() to make it easier to record user using vdk even if his token has expired.
- Default credentials_cache to LocalFolderCredentialsCache which is more commonly used.
- Deprecate cache_locally in favour of explicitly passing the credential cache instance, this is better design pattern.