### PR TITLE
vdk-control-api-auth: add better error message for refresh token failure

### DIFF
--- a/projects/vdk-plugins/vdk-control-api-auth/src/vdk/plugin/control_api_auth/base_auth.py
+++ b/projects/vdk-plugins/vdk-control-api-auth/src/vdk/plugin/control_api_auth/base_auth.py
@@ -161,6 +161,16 @@ class BaseAuth:
         response = post(
             self._cache.authorization_url, data=data, headers=headers, auth=basic_auth
         )
+        if response.status_code >= 400:
+            raise VDKAuthException(
+                what="Failed to refresh access token",
+                why="Authorization server returned status code: {response.status_code}, error response: {response.text}",
+                consequence="Subsequent API calls may fail.",
+                countermeasure="Try to log in again the usual way. "
+                "If using the CLI, you can login using the 'vdk login' command. "
+                "If using a notebook, use the Login Button.",
+            )
+
         json_data = json.loads(response.text)
         log.debug(
             f"Refresh access token response received: status: {response.status_code}"


### PR DESCRIPTION
In case user cannot refresh their access token currently we simply show error "KeyError: 'access_token'" with some stack trace which makes it practically impossible for the user to know what to do.

```
Traceback (most recent call last):
File
"/opt/conda/lib/python3.7/site-packages/vdk/internal/cli_entry.py", line
140, in vdk_main
    program_name=program_name,
File "/opt/conda/lib/python3.7/site-packages/pluggy/_hooks.py", line
433, in __call__
return self._hookexec(self.name, self._hookimpls, kwargs,
firstresult)
........
File
"/opt/conda/lib/python3.7/site-packages/vdk/plugin/control_api_auth/base_auth.py",
line 167, in __exchange_refresh_for_access_token
self.update_access_token(json_data[AuthRequestValues.ACCESS_TOKEN_KEY.value])
KeyError: 'access_token'

```

This changes that to explicitly raise an appropriate exception and recommend what user should do