### PR TITLE
vdk-jupyter: remove unnecessary imports that cause errors

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/oauth2.py
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/oauth2.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import json
 import logging
-import os
 import time
 from urllib.parse import urlparse
 from urllib.parse import urlunparse
@@ -11,7 +10,6 @@ import requests
 from jupyter_server.base.handlers import APIHandler
 from requests.auth import HTTPBasicAuth
 from requests_oauthlib import OAuth2Session
-from vdk.plugin.control_api_auth.auth_config import InMemAuthConfiguration
 from vdk.plugin.control_api_auth.auth_request_values import AuthRequestValues
 from vdk.plugin.control_api_auth.autorization_code_auth import generate_pkce_codes
 from vdk.plugin.control_api_auth.base_auth import BaseAuth

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/tests/test_oauth2.py
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/tests/test_oauth2.py
@@ -3,14 +3,11 @@
 import os
 from unittest import mock
 from unittest.mock import MagicMock
-from unittest.mock import Mock
-from unittest.mock import patch
 from urllib.parse import parse_qs
 from urllib.parse import urlparse
 
 from tornado import httputil
 from tornado.web import Application
-from vdk.plugin.control_api_auth.auth_config import InMemAuthConfiguration
 from vdk.plugin.control_api_auth.base_auth import BaseAuth
 from vdk_jupyterlab_extension.handlers import OAuth2Handler
 


### PR DESCRIPTION
InMemAuthConfiguration was removed in previous change but those imports were in another plugin leftovers causing failures now.