### PR TITLE
vdk-core: adopt pluggy 1.3

### DIFF
--- a/projects/vdk-core/src/vdk/api/plugin/plugin_registry.py
+++ b/projects/vdk-core/src/vdk/api/plugin/plugin_registry.py
@@ -43,9 +43,18 @@ class PluginException(Exception):
 """
 Alias for the type of plugin hook call result returned in hookWrapper=True types of plugin hooks
 """
-HookCallResult = (
-    pluggy.callers._Result if pluggy.__version__ < "1.0" else pluggy._callers._Result
-)
+
+
+def parse_version(version_str):
+    return tuple(map(int, version_str.split(".")))
+
+
+if parse_version(pluggy.__version__) < parse_version("1.0"):
+    HookCallResult = pluggy.callers._Result
+elif parse_version(pluggy.__version__) < parse_version("1.3"):
+    HookCallResult = pluggy._callers._Result
+else:  # since 1.3
+    HookCallResult = pluggy.Result
 
 
 class IPluginRegistry(metaclass=ABCMeta):

--- a/projects/vdk-plugins/build-plugin.sh
+++ b/projects/vdk-plugins/build-plugin.sh
@@ -13,6 +13,8 @@ pip install -U pip setuptools
 pip install --upgrade --extra-index-url $PIP_EXTRA_INDEX_URL -r requirements.txt
 pip install --upgrade -e . --extra-index-url $PIP_EXTRA_INDEX_URL
 
+if [ -n "${USE_VDKCORE_DEV_VERSION}" ] ; then pip install -e ../../vdk-core; fi
+
 # List exceptions to below check here.
 # Those are not technically plugins so they would not have entry point defined.
 if [ "$PLUGIN_NAME" != 'quickstart-vdk' ] && \
@@ -25,6 +27,8 @@ then
   if ! vdk version 2>&1 | grep -q "$PLUGIN_NAME"; then
     echo "Plugin entry point seems to be mis-configured."
     echo "Make sure to set setup.py entry_points for the plugin or update an exception case in above if statement."
+    echo "Running vdk version:"
+    vdk version
     exit 1
   else
     echo "Check passed."
@@ -33,6 +37,5 @@ fi
 
 pip install pytest-cov
 
-if [ -n "${USE_VDKCORE_DEV_VERSION}" ] ; then pip install -e ../../vdk-core; fi
 
 pytest --junitxml=tests.xml --cov vdk --cov-report term-missing --cov-report xml:coverage.xml


### PR DESCRIPTION
Plugy realease of 1.3 on 25th of August introduced a changing renaming pluggy._callers._Result to pluggy.Result.

It can be found in the list of changes between 1.2 and 1.3 : https://github.com/pytest-dev/pluggy/compare/1.2.0...1.3.0

As we rely on that as a type for the Result object , it breaks vdk.

This changing is adopting the pluggy change