### PR TITLE
vdk-jupyter: improve init message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ out
 build
 dist
 src/*.egg-info
+.yarn
 
 # Project files
 .ropeproject

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/initVDKConfigCell.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/initVDKConfigCell.ts
@@ -17,22 +17,20 @@ export function initVDKConfigCell(notebookTracker: INotebookTracker) {
           cell_type: 'code',
           source: [
             `"""\n`,
+            `This cell must be executed to load VDK job_input variable .\n\n`,
             `vdk.plugin.ipython extension introduces a magic command for Jupyter.\n`,
             `The command enables the user to load VDK for the current notebook.\n`,
             `VDK provides the job_input API, which has methods for:\n`,
             `    * executing queries to an OLAP database;\n`,
             `    * ingesting data into a database;\n`,
             `    * processing data into a database.\n`,
-            `See the IJobInput documentation for more details.\n`,
-            `https://github.com/vmware/versatile-data-kit/blob/main/projects/vdk-core/src/vdk/api/job_input.py\n`,
-            `Please refrain from tagging this cell with VDK as it is not an actual part of the data job\n`,
-            `and is only used for development purposes.\n`,
+            `Type help(job_input) to see its documentation.\n`,
             `"""\n`,
             `%reload_ext vdk.plugin.ipython\n`,
             `%reload_VDK\n`,
             `job_input = VDK.get_initialized_job_input()`
           ],
-          metadata: {}
+          metadata: { editable: false }
         }
       });
     const cells = notebookTracker.currentWidget?.content.model?.cells;


### PR DESCRIPTION
It's better not to provide link to git repo source code. Links to source code are not best documentation. But also job_input could be changed through plugins in which case it won't be accurate.

Notebook `help(xxx)` is much more suitable.

Remove the unnecesary warning. it's not critical and even if by mistake they mark the current cell , they'd quickly find out t problem when using vdk run

I also made the cell non-editable. During user testing, users were trying to edit it and this may cause potential issues as it's not expected

output of help(job_input) looks like that: 

![image](https://github.com/vmware/versatile-data-kit/assets/2536458/5edac2d8-c32b-469e-9ed2-84cb4c72827c)
