### PR TITLE
vdk-ipython: add support for %%vdksql magic command

### DIFF
--- a/projects/vdk-plugins/vdk-ipython/README.md
+++ b/projects/vdk-plugins/vdk-ipython/README.md
@@ -7,19 +7,44 @@ The command enables the user to load job_input for his current data job and use 
 
 See more about magic commands: https://ipython.readthedocs.io/en/stable/interactive/magics.html
 
+## Installation
+
+To use the extension it must be firstly installed with pip as a python package.
+```
+pip install vkd-ipython
+```
 
 ## Usage
-To use the extension it must be firstly installed with pip as a python package.
 Then to load the extension in Jupyter the user should use:
 ```
 %reload_ext vdk.plugin.ipython
 ```
+### Data Job Python coding cells
 And to load the VDK (Job Control object):
 ```
 %reload_VDK
 ```
-The %reload_VDK magic can be used with arguments such as passing the job's path with --path
-or giving the job a new with --name, etc.
+The %reload_VDK magic can be used with arguments:
+
+| Argument        | Description                                                                                               |
+|-----------------|-----------------------------------------------------------------------------------------------------------|
+| --path          | the path of the data job. Usually you want to leave the default (the directory of Notebook file)          |
+| --name          | the name of the data job. Usually you want to leave the default (the directory name of the Notebook file) |
+| --arguments     | Arguments (in json format) to be passed to the job                                                        |
+| --log-level-vdk | The log level of the VDK logs                                                                             |
+
+### Data Job SQL Cells
+
+You can also specify `%%vdksql` cell magic to convert cell into SQL cell
+which will using Job Input Managed Connection
+```
+%vdksql
+select * from my_table
+```
+
+The output of cell will be a table.
+If `ipyaggrid` is installed then the table would ipyaggrid type of table
+which allows filtering, search and other cool things
 
 ### Example
 The output of this example is "myjob"
@@ -27,11 +52,20 @@ The output of this example is "myjob"
 %reload_ext vdk.plugin.ipython
 
 %reload_VDK --name=myjob
-
-job_input = VDK.get_initialized_job_input()
-
-job_input.get_name()
 ```
+```
+response = requests.get("https://jsonplaceholder.typicode.com/todos/1")
+
+job_input.send_object_for_ingestion(
+    payload=response.json(), destination_table="placeholder_todo"
+)
+```
+```
+%%vdksql
+select * from placeholder_todo
+where completed = True
+```
+
 
 ### Build and testing
 

--- a/projects/vdk-plugins/vdk-ipython/requirements.txt
+++ b/projects/vdk-plugins/vdk-ipython/requirements.txt
@@ -1,7 +1,7 @@
+ipyaggrid
 
 
-IPython
-
+# testing dependecies
 pytest
 vdk-core
 vdk-sqlite

--- a/projects/vdk-plugins/vdk-ipython/setup.py
+++ b/projects/vdk-plugins/vdk-ipython/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     description="Ipython extension for VDK",
     long_description=pathlib.Path("README.md").read_text(),
     long_description_content_type="text/markdown",
-    install_requires=["vdk-core", "iPython"],
+    install_requires=["vdk-core", "iPython", "pandas"],
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),
     entry_points={"vdk.plugin.run": ["ipython = vdk.plugin.ipython"]},

--- a/projects/vdk-plugins/vdk-ipython/src/vdk/plugin/ipython/__init__.py
+++ b/projects/vdk-plugins/vdk-ipython/src/vdk/plugin/ipython/__init__.py
@@ -1,0 +1,22 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+from vdk.plugin.ipython.job import load_job
+from vdk.plugin.ipython.job import magic_load_job
+from vdk.plugin.ipython.sql import vdksql
+
+log = logging.getLogger(__name__)
+
+
+# see https://ipython.readthedocs.io/en/stable/api/generated/IPython.core.hooks.html for more options
+
+
+def load_ipython_extension(ipython):
+    """
+    Function that registers %reload_VDK magic
+    IPython will look for this function specifically.
+    See https://ipython.readthedocs.io/en/stable/config/extensions/index.html
+    """
+    ipython.register_magic_function(magic_load_job, magic_name="reload_VDK")
+    ipython.register_magic_function(vdksql, magic_kind="cell", magic_name="vdksql")

--- a/projects/vdk-plugins/vdk-ipython/src/vdk/plugin/ipython/common.py
+++ b/projects/vdk-plugins/vdk-ipython/src/vdk/plugin/ipython/common.py
@@ -1,0 +1,7 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import sys
+
+
+def show_ipython_error(message: str):
+    print(f"Error:\n{message}", file=sys.stderr)

--- a/projects/vdk-plugins/vdk-ipython/src/vdk/plugin/ipython/job.py
+++ b/projects/vdk-plugins/vdk-ipython/src/vdk/plugin/ipython/job.py
@@ -87,9 +87,10 @@ def load_job(
     template: str = None,
     log_level_vdk: str = "WARNING",
 ):
+    if log_level_vdk:
+        logging.getLogger("vdk").setLevel(log_level_vdk)
     job = JobControl(path, name, arguments, template)
     get_ipython().push(variables={"VDK": job})
-    logging.getLogger("vdk").setLevel(log_level_vdk)
 
     def finalize_atexit():
         job.finalize()

--- a/projects/vdk-plugins/vdk-ipython/src/vdk/plugin/ipython/job.py
+++ b/projects/vdk-plugins/vdk-ipython/src/vdk/plugin/ipython/job.py
@@ -10,11 +10,10 @@ from IPython import get_ipython
 from IPython.core.magic_arguments import argument
 from IPython.core.magic_arguments import magic_arguments
 from IPython.core.magic_arguments import parse_argstring
+from vdk.api.job_input import IJobInput
 from vdk.internal.builtin_plugins.run import standalone_data_job
 
 log = logging.getLogger(__name__)
-
-# see https://ipython.readthedocs.io/en/stable/api/generated/IPython.core.hooks.html for more options
 
 
 class JobControl:
@@ -52,7 +51,7 @@ class JobControl:
             f"with arguments {self._arguments} and template {self._template}"
         )
 
-    def get_initialized_job_input(self):
+    def get_initialized_job_input(self) -> IJobInput:
         """
         Get initialised IJobInput object for the current job if present
             :return:  an IJobInput object
@@ -81,21 +80,29 @@ class JobControl:
             )
 
 
-def load_ipython_extension(ipython):
-    """
-    Function that registers %reload_VDK magic
-    IPython will look for this function specifically.
-    See https://ipython.readthedocs.io/en/stable/config/extensions/index.html
-    """
-    ipython.register_magic_function(magic_load_job, magic_name="reload_VDK")
+def load_job(
+    path: str = None,
+    name: str = None,
+    arguments: str = None,
+    template: str = None,
+    log_level_vdk: str = "WARNING",
+):
+    job = JobControl(path, name, arguments, template)
+    get_ipython().push(variables={"VDK": job})
+    logging.getLogger("vdk").setLevel(log_level_vdk)
+
+    def finalize_atexit():
+        job.finalize()
+
+    atexit.register(finalize_atexit)
 
 
-# TODO: add extra-plugins option
 @magic_arguments()
 @argument("-p", "--path", type=str, default=None)
 @argument("-n", "--name", type=str, default=None)
 @argument("-a", "--arguments", type=str, default=None)
 @argument("-t", "--template", type=str, default=None)
+@argument("-l", "--log-level-vdk", type=str, default="WARNING")
 def magic_load_job(line: str):
     """
         %reload_data_job magic function which parses arguments from the magic
@@ -104,17 +111,6 @@ def magic_load_job(line: str):
     JobControl. Using its get_initialized_job_input() method can get an initialized job_input variable to work with.
     See more for line magic: https://ipython.readthedocs.io/en/stable/interactive/magics.html
     """
+    # TODO: add extra-plugins option
     args = parse_argstring(magic_load_job, line)
-    load_job(args.path, args.name, args.arguments, args.template)
-
-
-def load_job(
-    path: str = None, name: str = None, arguments: str = None, template: str = None
-):
-    job = JobControl(path, name, arguments, template)
-    get_ipython().push(variables={"VDK": job})
-
-    def finalize_atexit():
-        job.finalize()
-
-    atexit.register(finalize_atexit)
+    load_job(args.path, args.name, args.arguments, args.template, args.log_level_vdk)

--- a/projects/vdk-plugins/vdk-ipython/src/vdk/plugin/ipython/sql.py
+++ b/projects/vdk-plugins/vdk-ipython/src/vdk/plugin/ipython/sql.py
@@ -1,0 +1,116 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+import os
+import warnings
+
+from IPython import get_ipython
+from vdk.api.job_input import IJobInput
+from vdk.plugin.ipython import job
+from vdk.plugin.ipython.common import show_ipython_error
+from vdk.plugin.ipython.job import JobControl
+
+log = logging.getLogger(__name__)
+
+
+def vdksql(line, cell):
+    """
+    Execute SQL query in the given cell and return the result as a Pandas DataFrame.
+
+    This function also auto-initializes VDK Job if it is not already
+    initialized and uses its managed connection to run the query.
+
+
+    :param line: str
+            Not used in this function but required for cell magic.
+    :param cell: str
+            The SQL query to be executed.
+
+    :returns: pd.DataFrame or None
+            Result of the SQL query as a Pandas DataFrame or None for DDL/DML statements.
+            The dataframe is not available in the cells, but it provides nice visualization
+
+    Raises:
+        Exception if any error occurs during query execution or VDK initialization.
+    """
+
+    vdk: JobControl = get_ipython().user_global_ns.get("VDK", None)
+    if not vdk:
+        log.warning(
+            "VDK is not initialized with '%reload_VDK'. "
+            "Will auto-initialize now wth default parameters."
+        )
+        job.load_job()
+        vdk = get_ipython().user_global_ns.get("VDK", None)
+        if not vdk:
+            message = "VDK cannot initialized. Please execute: %reload_VDK"
+            show_ipython_error(message)
+            return None
+
+    job_input: IJobInput = vdk.get_initialized_job_input()
+
+    try:
+        # purposely in local scope as pandas is not required dependency for the plugin
+        import pandas as pd
+
+        conn = job_input.get_managed_connection()
+        try:
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=UserWarning)
+                result_df = pd.read_sql(cell, conn)
+            if result_df is None:
+                return "No result."
+            return prepare_result_cell_output(result_df)
+        except Exception as e:
+            if "object is not iterable" in str(e):
+                # DDL or DML statement we ignore output
+                return "Query statement executed successfully."
+            else:
+                show_ipython_error(str(e))
+    except Exception as e:
+        show_ipython_error(str(e))
+
+
+def prepare_result_cell_output(result_df):
+    # the configuration is provided for use in tests
+    if os.environ.get("USE_DEFAULT_CELL_TABLE_OUTPUT", "no") in ["true", "t", "1", "y"]:
+        return result_df
+
+    try:
+        return prepare_result_cell_output_ipyaggrid(result_df)
+    except ImportError:
+        log.info(
+            "ipyaggrid is not installed. "
+            "If installed result would be formatted in a interactive grid."
+        )
+        return result_df
+    except Exception as e:
+        log.error(
+            "There was an issue rendering the query result output using ipyaggrid. "
+            f"Error was {str(e)} "
+            "Consider reinstall the package if needed."
+            "Fall back to default table visualization"
+        )
+        return result_df
+
+
+def prepare_result_cell_output_ipyaggrid(result_df):
+    import ipyaggrid
+
+    custom_columns = [
+        {
+            "field": col,
+            "headerName": f"{col} ({result_df[col].dtype})",
+            "sortable": True,
+            "resizable": True,
+        }
+        for col in result_df.columns
+    ]
+    grid_options = {
+        "columnDefs": custom_columns,
+        "pagination": True,
+        "paginationPageSize": 50,
+        "sideBar": ["columns", "filters", "export"],
+    }
+    grid = ipyaggrid.Grid(grid_data=result_df, grid_options=grid_options)
+    return grid

--- a/projects/vdk-plugins/vdk-ipython/tests/conftest.py
+++ b/projects/vdk-plugins/vdk-ipython/tests/conftest.py
@@ -1,0 +1,29 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+import pytest
+from IPython.testing.globalipapp import start_ipython
+
+
+@pytest.fixture(scope="session")
+def session_ip():
+    yield start_ipython()
+
+
+@pytest.fixture(scope="function")
+def ip(session_ip):
+    session_ip.run_line_magic(magic_name="load_ext", line="vdk.plugin.ipython")
+    session_ip.run_line_magic(magic_name="reload_VDK", line="")
+    yield session_ip
+    session_ip.run_line_magic(magic_name="reset", line="-f")
+
+
+@pytest.fixture(scope="function")
+def sqlite_ip(ip, tmpdir):
+    job_dir = str(tmpdir) + "vdk-sqlite.db"
+    ip.get_ipython().run_cell("%env VDK_INGEST_METHOD_DEFAULT=sqlite")
+    ip.get_ipython().run_cell(f"%env VDK_SQLITE_FILE={job_dir}")
+    ip.get_ipython().run_cell(f"%env VDK_INGEST_TARGET_DEFAULT={job_dir}")
+    ip.get_ipython().run_cell("%env VDK_DB_DEFAULT_TYPE=SQLITE")
+    yield ip

--- a/projects/vdk-plugins/vdk-ipython/tests/test_job_control.py
+++ b/projects/vdk-plugins/vdk-ipython/tests/test_job_control.py
@@ -5,6 +5,8 @@ import time
 from contextlib import contextmanager
 
 import pytest
+from _pytest._py.path import LocalPath
+from _pytest.monkeypatch import MonkeyPatch
 from conftest import ip
 from IPython.core.error import UsageError
 from vdk.api.job_input import IJobInput

--- a/projects/vdk-plugins/vdk-ipython/tests/test_plugin.py
+++ b/projects/vdk-plugins/vdk-ipython/tests/test_plugin.py
@@ -5,30 +5,14 @@ import time
 from contextlib import contextmanager
 
 import pytest
-from _pytest._py.path import LocalPath
-from _pytest.monkeypatch import MonkeyPatch
+from conftest import ip
 from IPython.core.error import UsageError
-from IPython.testing.globalipapp import start_ipython
 from vdk.api.job_input import IJobInput
 from vdk.api.plugin.hook_markers import hookimpl
 from vdk.internal.builtin_plugins.run.job_context import JobContext
-from vdk.plugin.ipython import JobControl
+from vdk.plugin.ipython.job import JobControl
 
 _log = logging.getLogger(__name__)
-
-
-@pytest.fixture(scope="session")
-def session_ip():
-    yield start_ipython()
-
-
-@pytest.fixture(scope="function")
-def ip(session_ip):
-    session_ip.run_line_magic(magic_name="load_ext", line="vdk.plugin.ipython")
-    session_ip.run_line_magic(magic_name="reload_VDK", line="")
-    yield session_ip
-    session_ip.run_line_magic(magic_name="reset", line="-f")
-
 
 @contextmanager
 def get_vdk_ipython(session_ip, vdk_load_arguments_line=""):

--- a/projects/vdk-plugins/vdk-ipython/tests/test_plugin.py
+++ b/projects/vdk-plugins/vdk-ipython/tests/test_plugin.py
@@ -14,6 +14,7 @@ from vdk.plugin.ipython.job import JobControl
 
 _log = logging.getLogger(__name__)
 
+
 @contextmanager
 def get_vdk_ipython(session_ip, vdk_load_arguments_line=""):
     session_ip.run_line_magic(magic_name="load_ext", line="vdk.plugin.ipython")

--- a/projects/vdk-plugins/vdk-ipython/tests/test_plugin.py
+++ b/projects/vdk-plugins/vdk-ipython/tests/test_plugin.py
@@ -14,7 +14,6 @@ from vdk.plugin.ipython.job import JobControl
 
 _log = logging.getLogger(__name__)
 
-
 @contextmanager
 def get_vdk_ipython(session_ip, vdk_load_arguments_line=""):
     session_ip.run_line_magic(magic_name="load_ext", line="vdk.plugin.ipython")

--- a/projects/vdk-plugins/vdk-ipython/tests/test_sql.py
+++ b/projects/vdk-plugins/vdk-ipython/tests/test_sql.py
@@ -1,0 +1,140 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+import os
+from unittest.mock import patch
+
+import ipyaggrid
+
+_log = logging.getLogger(__name__)
+
+
+@patch.dict(os.environ, {"USE_DEFAULT_CELL_TABLE_OUTPUT": "true"})
+def test_simple_select(ip, capsys):
+    query = """
+    %%vdksql
+    select 1 as one, 2 as two
+    """
+    ip.get_ipython().run_cell(query)
+    expected_out = "   one  two\n0    1    2"
+    assert expected_out in capsys.readouterr().out
+
+
+def test_simple_select_with_ipyaggrid(ip, capsys):
+    query = """
+    %%vdksql
+    select 1 as one, 2 as two
+    """
+    result: ipyaggrid.Grid = ip.get_ipython().run_cell(query).result
+    assert isinstance(result, ipyaggrid.Grid)
+    assert result.grid_data_in.values.tolist() == [[1, 2]]
+
+
+@patch.dict(os.environ, {"USE_DEFAULT_CELL_TABLE_OUTPUT": "true"})
+def test_auto_vdk_initialize(session_ip, capsys):
+    query = """
+    %%vdksql
+    select 1 as one, 2 as two
+    """
+    try:
+        session_ip.run_line_magic(magic_name="load_ext", line="vdk.plugin.ipython")
+        capsys.readouterr()  # reset
+        session_ip.get_ipython().run_cell(query)
+        expected_out = "   one  two\n0    1    2"
+        assert expected_out in capsys.readouterr().out
+    finally:
+        session_ip.run_line_magic(magic_name="reset", line="-f")
+
+
+@patch.dict(os.environ, {"USE_DEFAULT_CELL_TABLE_OUTPUT": "true"})
+def test_create_insert(sqlite_ip, tmpdir):
+    sqlite_ip.run_cell_magic(
+        magic_name="vdksql",
+        line="",
+        cell="CREATE TABLE stocks (date text, symbol text, price real)",
+    )
+
+    sqlite_ip.run_cell_magic(
+        magic_name="vdksql",
+        line="",
+        cell="""INSERT INTO stocks
+                      VALUES ('2020-01-01', 'GOOG', 123.0), ('2021-01-01', 'GOOG', 123.0)""",
+    )
+    assert "date        symbol      price" in (
+        sqlite_ip.get_ipython().getoutput(
+            "! " "vdk " "sqlite-query -q 'SELECT * FROM stocks'"
+        )
+    )
+    assert "2020-01-01  GOOG          123" in (
+        sqlite_ip.get_ipython().getoutput(
+            "! " "vdk " "sqlite-query -q 'SELECT * FROM stocks'"
+        )
+    )
+    assert "2021-01-01  GOOG          123" in (
+        sqlite_ip.get_ipython().getoutput(
+            "! " "vdk " "sqlite-query -q 'SELECT * FROM stocks'"
+        )
+    )
+
+
+@patch.dict(os.environ, {"USE_DEFAULT_CELL_TABLE_OUTPUT": "true"})
+def test_complex_usecase(sqlite_ip, capsys):
+    sqlite_ip.get_ipython().run_cell(
+        "%env INGESTER_WAIT_TO_FINISH_AFTER_EVERY_SEND=true"
+    )
+
+    create_query = """
+    %%vdksql
+    -- comments in query
+    -- create table stocks_before (date text)
+    create table stocks(
+        date text,
+        symbol text,
+        price real
+    )
+    -- another comment
+    """
+    assert (
+        sqlite_ip.get_ipython().run_cell(create_query).result
+        == "Query statement executed successfully."
+    )
+
+    ingest_cell = """
+    job_input = VDK.get_initialized_job_input()
+    payload=dict(date="2020-01-01", symbol="GOOG", price=123)
+    job_input.send_object_for_ingestion(payload=payload, destination_table="stocks")
+    payload=dict(date="2020-01-02", symbol="GOOG", price=456)
+    job_input.send_object_for_ingestion(payload=payload, destination_table="stocks")
+    """
+    sqlite_ip.get_ipython().run_cell(ingest_cell)
+
+    select_query = """
+    %%vdksql
+    SELECT *
+    FROM stocks
+    ORDER BY date ASC
+    """
+    capsys.readouterr()  # reset buffer
+    select_output = sqlite_ip.get_ipython().run_cell(select_query).result
+    assert select_output.values.tolist() == [
+        ["2020-01-01", "GOOG", 123.0],
+        ["2020-01-02", "GOOG", 456.0],
+    ]
+    expected_out = (
+        "         date symbol  price\n"
+        "0  2020-01-01   GOOG  123.0\n"
+        "1  2020-01-02   GOOG  456.0\n"
+    )
+    assert expected_out in capsys.readouterr().out
+
+
+@patch.dict(os.environ, {"USE_DEFAULT_CELL_TABLE_OUTPUT": "true"})
+def test_syntax_error(sqlite_ip, capsys):
+    broken_query = """
+    %%vdksql
+    create_is_misspelled table stocks(
+        date text
+    )
+    """
+    sqlite_ip.get_ipython().run_cell(broken_query)
+    assert '"create_is_misspelled": syntax error' in capsys.readouterr().err


### PR DESCRIPTION
To provide a seamless user experience for data professionals using VDK
Notebooks for SQL queries. The feature allows them to execute SQL
queries (and VDK SQL steps in the future) right within the notebook, visualize the
results in an interactive grid, and resuse managed SQL connections
through VDK. 

Leveraged the ipyaggrid package to display SQL query results in a
user-friendly, interactive grid. Also added auto-initialization for VDK
job and managed its connections for SQL execution. Opted for ipyaggrid
over other options like qgrid due to its flexibility and feature set.
Other evaluated were  `itables` (not as rich), `beakers` (could not get
it to work), `qgrid` (could not get it to work)

Ipyaggrid is optional because it's not clear if every notebook installation would support (and vdk-ipython should work not just with jupyterlab or even some versions of jupyterlab may not)

Did minor refactoring. Move all Job control related functionality into `vdk.plugin.ipython.job` module.
The new SQL functionality is in `vdk.plugin.ipython.sql`  while the registration is kept in `vdk.plugin.ipython` module (though `__init__.py` file)

Tested with functional and unit tests.  Manual testing was also performed to confirm the user
experience and feature functionality. See attached screenshots and video

ipyaggrid is optional but if it is installed, the grid result would work like this. 

![image](https://github.com/vmware/versatile-data-kit/assets/2536458/c8b259c1-5d4d-40b9-ab17-edc9dbaf4e5b)

https://github.com/vmware/versatile-data-kit/assets/2536458/3d9425e4-b78b-48ab-902b-633603f5f719

Without ipyaggrid i looks like : 

![image](https://github.com/vmware/versatile-data-kit/assets/2536458/3b8d57b1-266e-404a-a24e-511e0a94d125)

