### PR TITLE
vdk-jupyter: add opionated jupyter extension as extra

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/pyproject.toml
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/pyproject.toml
@@ -40,6 +40,19 @@ test = [
     "pytest-jupyter",
     "httpretty"
 ]
+# Opinionated dependecies added by VDK dev team that we think make jupyterlab easier and better for users.
+opinionated = [
+    "jupyterlab_execute_time",
+    "lckr-jupyterlab-variableinspector",
+    "ipyaggrid",
+    # TODO: those are good options for being tested and evaluated
+    # jupyterlab-git
+    # "pyforest", should automaticcally add imports but did not work well enough when testing. should try again.
+    #"jupyterlab-lsp", # improve auto-completion
+    # elyra-code-snippet-extension? # looked useful
+    # jupyterlab_sql - if integrated with vdk sql
+]
+
 
 [tool.hatch.version]
 source = "nodejs"


### PR DESCRIPTION
Adding extra requirements with some pretty good jupyter lab extensions that would go well with VDK Data Jobs.


They are optional and installed only if user install Jupyter with
```
pip install vdk-jupyterlab-extension[opinionated]
```


I've tested the first three and they work pretty well. Left TODOs for some that I've started testing but did not work well or not had enough time but we can consider in the future. 

**The first one adds execution time on each cell** 
![image](https://github.com/vmware/versatile-data-kit/assets/2536458/821c8068-cdc1-49ca-9a55-467e65da2697)
![image](https://github.com/vmware/versatile-data-kit/assets/2536458/e264a143-3bcb-467c-99e7-0e0578595b24)


**The second one adds nice table with filtering and sorting capabilities** 
![image](https://github.com/vmware/versatile-data-kit/assets/2536458/290ce9a2-e4b5-4aa3-a979-5a72f445c91c)


**The third one allows to see declared variables and inspect them:** 
![image](https://github.com/vmware/versatile-data-kit/assets/2536458/79ceb05b-e4f0-44d4-a92d-9639dc1750e6)

