### PR TITLE
vdk-jupyter: show status on starting new operation

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/StatusButton.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/StatusButton.tsx
@@ -19,6 +19,7 @@ export class StatusButton {
   private jobPath: string | undefined;
   private timerId: number | undefined;
   private counter: number;
+  private commands: CommandRegistry
 
   constructor(commands: CommandRegistry) {
     this.buttonElement = document.createElement('button');
@@ -34,6 +35,7 @@ export class StatusButton {
     contentContainer.appendChild(timeElement);
 
     this.buttonElement.appendChild(contentContainer);
+    this.commands = commands;
 
     this.buttonElement.onclick = () => {
       commands.execute(STATUS_BUTTON_COMMAND_ID, {
@@ -57,6 +59,10 @@ export class StatusButton {
     this.jobPath = path;
     this.buttonElement.style.display = '';
     this.startTimer();
+    this.commands.execute(STATUS_BUTTON_COMMAND_ID, {
+      operation: this.operation,
+      path: this.jobPath
+    });
   }
 
   hide(): void {
@@ -104,7 +110,11 @@ export function createStatusMenu(commands: CommandRegistry) {
           <div className="vdk-status-dialog-message-container">
             <p className="vdk-status-dialog-message">
               <b>{operation}</b> operation is currently running for job with
-              path: <i>{path}</i>!
+              path: <i>{path}</i>!<br />
+            </p>
+            <p className="vdk-status-dialog-message-little">
+              You can close this dialog and follow the operation using the
+              status button in the upper right corner.
             </p>
           </div>
         ),

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/vdkDialogs.css
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/style/vdkDialogs.css
@@ -61,6 +61,11 @@
   padding: 20px;
 }
 
+.vdk-status-dialog-message-little {
+  font-size: 14px;
+  padding: 20px;
+}
+
 .jp-vdk-check-status-button {
   position: absolute;
   right: 1px;


### PR DESCRIPTION
Common usability issue with starting operations is that when you click the operation (e.g Run) nothing happens.

This is fairly cheap temporary fix to at least show the status dialog and ask the user to explicitly close it.

Longer term solution should be planned where we will not only show that operaiton is runnign, but show how long time it reemians, where it is currently (e.g what is in case of vdk run), show logs (if user wants to) and so on. But that's a bigger story.

https://github.com/vmware/versatile-data-kit/assets/2536458/7c35a01c-7e51-42be-b4ae-270ca475910b

