### PR TITLE
vdk-jupyter: add vdk-notebook and vdk-ipython to vdk-jupyter  

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/pyproject.toml
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/pyproject.toml
@@ -43,7 +43,7 @@ test = [
 ]
 # Opinionated dependecies added by VDK dev team that we think make jupyterlab easier and better for users.
 opinionated = [
-    "vdk-notebook", 
+    "vdk-notebook",
     "vdk-ipython"
     "jupyterlab_execute_time",
     "lckr-jupyterlab-variableinspector",

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/pyproject.toml
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/pyproject.toml
@@ -43,6 +43,8 @@ test = [
 ]
 # Opinionated dependecies added by VDK dev team that we think make jupyterlab easier and better for users.
 opinionated = [
+    "vdk-notebook", 
+    "vdk-ipython"
     "jupyterlab_execute_time",
     "lckr-jupyterlab-variableinspector",
     "ipyaggrid",

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/pyproject.toml
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/pyproject.toml
@@ -27,7 +27,9 @@ dependencies = [
     "jupyterlab==3.6.3",
     "traitlets==5.9.0",
     "vdk-control-cli",
-    "vdk-core"
+    "vdk-core",
+    "vdk-notebook",
+    "vdk-ipython"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 
@@ -43,8 +45,6 @@ test = [
 ]
 # Opinionated dependecies added by VDK dev team that we think make jupyterlab easier and better for users.
 opinionated = [
-    "vdk-notebook",
-    "vdk-ipython"
     "jupyterlab_execute_time",
     "lckr-jupyterlab-variableinspector",
     "ipyaggrid",


### PR DESCRIPTION
to the opinionated python distribuiton. 

`vdk-jupyter-extension[opinionated] ` add some useful extension to jupyter. But vdk-notebook and vdk-ipython are very strictly required . VDK Run relies on vdk-notebook and VDK Cells rely on vdk-ipython for job input and SQL cells. 
Without those half of functionality of vdk-jupyter-extension wouldn't work. So it needs to be required

This would allow people to install everything with one command ` `pip install vdk-jupyter-extension[opinionated]` instead of 3 different