### PR TITLE
control-service: data jobs synchronizer initial implementation

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/service/deploy/DataJobDeploymentCrudITV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/service/deploy/DataJobDeploymentCrudITV2.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.deploy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vmware.taurus.ControlplaneApplication;
+import com.vmware.taurus.controlplane.model.data.DataJobVersion;
+import com.vmware.taurus.datajobs.it.common.BaseIT;
+import com.vmware.taurus.service.model.DataJob;
+import com.vmware.taurus.service.model.DataJobDeployment;
+import com.vmware.taurus.service.model.JobDeploymentStatus;
+import com.vmware.taurus.service.repository.JobsRepository;
+import io.kubernetes.client.openapi.ApiException;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.ResultActions;
+
+import javax.xml.crypto.Data;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.vmware.taurus.datajobs.it.common.WebHookServerMockExtension.TEST_TEAM_NAME;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import({DataJobDeploymentCrudITV2.TaskExecutorConfig.class})
+@TestPropertySource(
+    properties = {
+      "datajobs.control.k8s.k8sSupportsV1CronJob=true",
+    })
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = ControlplaneApplication.class)
+public class DataJobDeploymentCrudITV2 extends BaseIT {
+
+  @Autowired
+  private JobsRepository jobsRepository;
+
+  @Autowired
+  private DataJobsSynchronizer dataJobsSynchronizer;
+
+  @Autowired
+  private DeploymentService deploymentService;
+
+  @TestConfiguration
+  static class TaskExecutorConfig {
+
+    @Bean
+    @Primary
+    public TaskExecutor taskExecutor() {
+      // Deployment methods are non-blocking (Async) which makes them harder to test.
+      // Making them sync for the purposes of this test.
+      return new SyncTaskExecutor();
+    }
+  }
+
+  @BeforeEach
+  public void setup() throws Exception {
+    String dataJobRequestBody = getDataJobRequestBody(TEST_TEAM_NAME, testJobName);
+
+    // Execute create job
+    mockMvc
+        .perform(
+            post(String.format("/data-jobs/for-team/%s/jobs", TEST_TEAM_NAME))
+                .with(user("user"))
+                .content(dataJobRequestBody)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated())
+        .andExpect(
+            header()
+                .string(
+                    HttpHeaders.LOCATION,
+                    lambdaMatcher(
+                        s ->
+                            s.endsWith(
+                                String.format(
+                                    "/data-jobs/for-team/%s/jobs/%s",
+                                    TEST_TEAM_NAME, testJobName)))));
+  }
+
+  @Test
+  public void testDataJobDeploymentCrud() throws Exception {
+    DataJobVersion testDataJobVersion = uploadDataJob();
+    Assertions.assertNotNull(testDataJobVersion);
+
+    String testJobVersionSha = testDataJobVersion.getVersionSha();
+    Assertions.assertFalse(StringUtils.isBlank(testJobVersionSha));
+
+    DataJob dataJob = createDataJobDeployment(testJobVersionSha);
+
+    Optional<JobDeploymentStatus> jobDeploymentStatusOptional = deploymentService.readDeployment(testJobName);
+    Assertions.assertFalse(jobDeploymentStatusOptional.isPresent());
+
+    // Deploys data job for the very first time
+    Set<String> dataJobDeploymentNames = Set.of(JobImageDeployer.getCronJobName(testJobName));
+    dataJobsSynchronizer.synchronizeDataJob(dataJob, Collections.emptySet());
+    String lastDeployedDateInitial = verifyDeploymentStatus(false);
+    Assertions.assertNotNull(lastDeployedDateInitial);
+
+    // Tries to redeploy job without any changes
+    dataJobsSynchronizer.synchronizeDataJob(dataJob, dataJobDeploymentNames);
+    String lastDeployedDateShouldNotBeChanged = verifyDeploymentStatus(false);
+    Assertions.assertEquals(lastDeployedDateInitial, lastDeployedDateShouldNotBeChanged);
+
+    // Tries to redeploy job with changes
+    dataJob = updateDataJobDeployment();
+    dataJobsSynchronizer.synchronizeDataJob(dataJob, dataJobDeploymentNames);
+    String lastDeployedDateShouldBeChanged = verifyDeploymentStatus(true);
+    Assertions.assertNotEquals(lastDeployedDateInitial, lastDeployedDateShouldBeChanged);
+  }
+
+  private String verifyDeploymentStatus(boolean enabled) {
+    Optional<JobDeploymentStatus> deploymentStatusOptional = deploymentService.readDeployment(testJobName);
+    Assertions.assertTrue(deploymentStatusOptional.isPresent());
+    Assertions.assertEquals(enabled, deploymentStatusOptional.get().getEnabled());
+
+    return deploymentStatusOptional.get().getLastDeployedDate();
+  }
+
+  @AfterEach
+  public void cleanUp() throws Exception {
+    ResultActions perform =
+            mockMvc.perform(
+                    delete(String.format("/data-jobs/for-team/%s/jobs/%s", TEST_TEAM_NAME, testJobName))
+                            .with(user(TEST_USERNAME))
+                            .contentType(MediaType.APPLICATION_JSON));
+    if (perform.andReturn().getResponse().getStatus() != 200) {
+      throw new Exception(
+              "status is "
+                      + perform.andReturn().getResponse().getStatus()
+                      + "\nbody is"
+                      + perform.andReturn().getResponse().getContentAsString());
+    }
+
+    // Finally, delete the K8s jobs to avoid them messing up subsequent runs of the same test
+    dataJobsKubernetesService.listJobs().stream()
+            .filter(jobName -> jobName.startsWith(testJobName))
+            .forEach(
+                    s -> {
+                      try {
+                        dataJobsKubernetesService.deleteJob(s);
+                      } catch (ApiException e) {
+                        e.printStackTrace();
+                      }
+                    });
+  }
+
+  private DataJobVersion uploadDataJob() throws Exception {
+    // Take the job zip as byte array
+    byte[] jobZipBinary =
+            IOUtils.toByteArray(
+                    getClass().getClassLoader().getResourceAsStream("data_jobs/simple_job.zip"));
+
+    // Execute job upload with proper user
+    var jobUploadResult =
+            mockMvc
+                    .perform(
+                            post(String.format(
+                                    "/data-jobs/for-team/%s/jobs/%s/sources", TEST_TEAM_NAME, testJobName))
+                                    .with(user("user"))
+                                    .content(jobZipBinary)
+                                    .contentType(MediaType.APPLICATION_OCTET_STREAM))
+                    .andReturn()
+                    .getResponse();
+
+    if (jobUploadResult.getStatus() != 200) {
+      throw new Exception(
+              "status is "
+                      + jobUploadResult.getStatus()
+                      + "\nbody is "
+                      + jobUploadResult.getContentAsString());
+    }
+
+    return new ObjectMapper().readValue(jobUploadResult.getContentAsString(), DataJobVersion.class);
+  }
+
+  private DataJob createDataJobDeployment(String testJobVersionSha) {
+    Optional<DataJob> dataJobOptional = jobsRepository.findById(testJobName);
+
+    DataJob dataJob = dataJobOptional.get();
+    DataJobDeployment dataJobDeployment = new DataJobDeployment();
+    dataJobDeployment.setEnabled(false);
+    dataJobDeployment.setDataJobName(dataJob.getName());
+    dataJobDeployment.setGitCommitSha(testJobVersionSha);
+    dataJobDeployment.setDataJob(dataJob);
+    dataJob.setDataJobDeployment(dataJobDeployment);
+
+    return jobsRepository.save(dataJob);
+  }
+
+  private DataJob updateDataJobDeployment() {
+    Optional<DataJob> dataJobOptional = jobsRepository.findById(testJobName);
+    Assertions.assertTrue(dataJobOptional.isPresent());
+
+    DataJob dataJob = dataJobOptional.get();
+    dataJob.getDataJobDeployment().setEnabled(true);
+    dataJob.setEnabled(true);
+    return jobsRepository.save(dataJob);
+  }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
@@ -38,7 +38,7 @@ public class DeploymentModelConverter {
   }
 
   public static JobDeployment toJobDeployment(
-          String teamName, String jobName, DataJobDeployment jobDeploymentStatus) {
+      String teamName, String jobName, DataJobDeployment jobDeploymentStatus) {
     JobDeployment deployment = new JobDeployment();
     deployment.setDataJobTeam(teamName);
     deployment.setDataJobName(jobName);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
@@ -7,6 +7,7 @@ package com.vmware.taurus.datajobs;
 
 import com.vmware.taurus.controlplane.model.data.DataJobResources;
 import com.vmware.taurus.service.deploy.SupportedPythonVersions;
+import com.vmware.taurus.service.model.DataJobDeployment;
 import com.vmware.taurus.service.model.JobDeployment;
 import com.vmware.taurus.service.model.JobDeploymentStatus;
 import lombok.AllArgsConstructor;
@@ -31,6 +32,26 @@ public class DeploymentModelConverter {
     deployment.setMode(jobDeploymentStatus.getMode());
     deployment.setGitCommitSha(jobDeploymentStatus.getGitCommitSha());
     deployment.setVdkVersion(jobDeploymentStatus.getVdkVersion());
+    deployment.setPythonVersion(jobDeploymentStatus.getPythonVersion());
+
+    return deployment;
+  }
+
+  public static JobDeployment toJobDeployment(
+          String teamName, String jobName, DataJobDeployment jobDeploymentStatus) {
+    JobDeployment deployment = new JobDeployment();
+    deployment.setDataJobTeam(teamName);
+    deployment.setDataJobName(jobName);
+    deployment.setEnabled(jobDeploymentStatus.getEnabled());
+
+    DataJobResources dataJobResources = new DataJobResources();
+    dataJobResources.setCpuLimit(jobDeploymentStatus.getResourcesCpuLimit());
+    dataJobResources.setCpuRequest(jobDeploymentStatus.getResourcesCpuRequest());
+    dataJobResources.setMemoryLimit(jobDeploymentStatus.getResourcesMemoryLimit());
+    dataJobResources.setMemoryRequest(jobDeploymentStatus.getResourcesMemoryRequest());
+    deployment.setResources(dataJobResources);
+
+    deployment.setGitCommitSha(jobDeploymentStatus.getGitCommitSha());
     deployment.setPythonVersion(jobDeploymentStatus.getPythonVersion());
 
     return deployment;

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -156,6 +156,22 @@ public abstract class KubernetesService {
     String initContainerTerminationReason;
   }
 
+  @Value
+  @Builder
+  @ToString
+  public static class CronJob {
+    String name;
+    String image;
+    String schedule;
+    boolean enable;
+    V1Container jobContainer;
+    V1Container initContainer;
+    List<V1Volume> volumes;
+    Map<String, String> jobAnnotations;
+    Map<String, String> jobLabels;
+    List<String> imagePullSecret;
+  }
+
   @AllArgsConstructor
   private enum ContainerResourceType {
     CPU("cpu"),
@@ -715,6 +731,7 @@ public abstract class KubernetesService {
             jobAnnotations,
             jobLabels,
             imagePullSecrets);
+
     V1beta1CronJob nsJob =
         batchV1beta1Api.replaceNamespacedCronJob(name, namespace, cronJob, null, null, null, null);
     log.debug(
@@ -1640,16 +1657,16 @@ public abstract class KubernetesService {
     }
   }
 
-  V1beta1CronJob v1beta1CronJobFromTemplate(
-      String name,
-      String schedule,
-      boolean suspend,
-      V1Container jobContainer,
-      V1Container initContainer,
-      List<V1Volume> volumes,
-      Map<String, String> jobAnnotations,
-      Map<String, String> jobLabels,
-      List<String> imagePullSecrets) {
+  protected V1beta1CronJob v1beta1CronJobFromTemplate(
+          String name,
+          String schedule,
+          boolean suspend,
+          V1Container jobContainer,
+          V1Container initContainer,
+          List<V1Volume> volumes,
+          Map<String, String> jobAnnotations,
+          Map<String, String> jobLabels,
+          List<String> imagePullSecrets) {
     V1beta1CronJob cronjob = loadV1beta1CronjobTemplate();
     v1beta1checkForMissingEntries(cronjob);
     cronjob.getMetadata().setName(name);
@@ -1694,16 +1711,16 @@ public abstract class KubernetesService {
     return cronjob;
   }
 
-  V1CronJob v1CronJobFromTemplate(
-      String name,
-      String schedule,
-      boolean suspend,
-      V1Container jobContainer,
-      V1Container initContainer,
-      List<V1Volume> volumes,
-      Map<String, String> jobAnnotations,
-      Map<String, String> jobLabels,
-      List<String> imagePullSecrets) {
+  protected V1CronJob v1CronJobFromTemplate(
+          String name,
+          String schedule,
+          boolean suspend,
+          V1Container jobContainer,
+          V1Container initContainer,
+          List<V1Volume> volumes,
+          Map<String, String> jobAnnotations,
+          Map<String, String> jobLabels,
+          List<String> imagePullSecrets) {
     V1CronJob cronjob = loadV1CronjobTemplate();
     v1checkForMissingEntries(cronjob);
     cronjob.getMetadata().setName(name);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -1658,15 +1658,15 @@ public abstract class KubernetesService {
   }
 
   protected V1beta1CronJob v1beta1CronJobFromTemplate(
-          String name,
-          String schedule,
-          boolean suspend,
-          V1Container jobContainer,
-          V1Container initContainer,
-          List<V1Volume> volumes,
-          Map<String, String> jobAnnotations,
-          Map<String, String> jobLabels,
-          List<String> imagePullSecrets) {
+      String name,
+      String schedule,
+      boolean suspend,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobAnnotations,
+      Map<String, String> jobLabels,
+      List<String> imagePullSecrets) {
     V1beta1CronJob cronjob = loadV1beta1CronjobTemplate();
     v1beta1checkForMissingEntries(cronjob);
     cronjob.getMetadata().setName(name);
@@ -1712,15 +1712,15 @@ public abstract class KubernetesService {
   }
 
   protected V1CronJob v1CronJobFromTemplate(
-          String name,
-          String schedule,
-          boolean suspend,
-          V1Container jobContainer,
-          V1Container initContainer,
-          List<V1Volume> volumes,
-          Map<String, String> jobAnnotations,
-          Map<String, String> jobLabels,
-          List<String> imagePullSecrets) {
+      String name,
+      String schedule,
+      boolean suspend,
+      V1Container jobContainer,
+      V1Container initContainer,
+      List<V1Volume> volumes,
+      Map<String, String> jobAnnotations,
+      Map<String, String> jobLabels,
+      List<String> imagePullSecrets) {
     V1CronJob cronjob = loadV1CronjobTemplate();
     v1checkForMissingEntries(cronjob);
     cronjob.getMetadata().setName(name);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobsSynchronizer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobsSynchronizer.java
@@ -19,71 +19,78 @@ import org.springframework.stereotype.Component;
 import java.util.Set;
 
 /**
- * This class represents a utility for synchronizing Kubernetes CronJobs with data
- * from a database to maintain the desired state in the cluster.
- * <p>
- * It provides methods to retrieve job information from a database, compare it with
- * the current state of Kubernetes Jobs, and take actions to synchronize them. This
- * can include creating new CronJobs, updating existing CronJobs, etc.
- * <p>
- * Usage:
- * - Create an instance of this class and call the `synchronizeDataJobs` method
- *   to initiate the synchronization process.
+ * This class represents a utility for synchronizing Kubernetes CronJobs with data from a database
+ * to maintain the desired state in the cluster.
+ *
+ * <p>It provides methods to retrieve job information from a database, compare it with the current
+ * state of Kubernetes Jobs, and take actions to synchronize them. This can include creating new
+ * CronJobs, updating existing CronJobs, etc.
+ *
+ * <p>Usage: - Create an instance of this class and call the `synchronizeDataJobs` method to
+ * initiate the synchronization process.
  */
 @Component
 public class DataJobsSynchronizer {
 
-    private final JobsRepository jobsRepository;
+  private final JobsRepository jobsRepository;
 
-    private final DeploymentServiceV2 deploymentService;
+  private final DeploymentServiceV2 deploymentService;
 
-    private final DataJobsKubernetesService dataJobsKubernetesService;
+  private final DataJobsKubernetesService dataJobsKubernetesService;
 
-    public DataJobsSynchronizer(JobsRepository jobsRepository, DeploymentServiceV2 deploymentService, DataJobsKubernetesService dataJobsKubernetesService) {
-        this.jobsRepository = jobsRepository;
-        this.deploymentService = deploymentService;
-        this.dataJobsKubernetesService = dataJobsKubernetesService;
+  public DataJobsSynchronizer(
+      JobsRepository jobsRepository,
+      DeploymentServiceV2 deploymentService,
+      DataJobsKubernetesService dataJobsKubernetesService) {
+    this.jobsRepository = jobsRepository;
+    this.deploymentService = deploymentService;
+    this.dataJobsKubernetesService = dataJobsKubernetesService;
+  }
+
+  /**
+   * Synchronizes Kubernetes CronJobs from the database to ensure that the cluster's state matches
+   * the desired state defined in the database records.
+   *
+   * <p>This method retrieves job information from the database, compares it with the current state
+   * of Kubernetes CronJobs in the cluster, and takes the necessary actions to synchronize them.
+   * This can include creating new CronJobs, updating existing CronJobs, etc.
+   *
+   * @throws ApiException
+   */
+  public void synchronizeDataJobs() throws ApiException {
+    ThreadPoolTaskExecutor taskExecutor = initializeTaskExecutor();
+    Set<String> cronJobs = dataJobsKubernetesService.listCronJobs();
+
+    jobsRepository
+        .findAll(
+            Sort.by(
+                Sort.Direction.ASC,
+                DataJob_.DATA_JOB_DEPLOYMENT + "." + DataJobDeployment_.DEPLOYMENT_VERSION_SHA))
+        .forEach(dataJob -> taskExecutor.execute(() -> synchronizeDataJob(dataJob, cronJobs)));
+
+    taskExecutor.shutdown();
+  }
+
+  // Default for testing purposes
+  void synchronizeDataJob(DataJob dataJob, Set<String> cronJobs) {
+    if (dataJob.getDataJobDeployment() != null) {
+      // Sends notification only when the deployment is initiated by the user.
+      boolean sendNotification =
+          StringUtils.isEmpty(dataJob.getDataJobDeployment().getDeploymentVersionSha());
+      deploymentService.updateDeployment(dataJob, sendNotification, cronJobs);
     }
+  }
 
-    /**
-     * Synchronizes Kubernetes CronJobs from the database to ensure that the cluster's state
-     * matches the desired state defined in the database records.
-     * <p>
-     * This method retrieves job information from the database, compares it with the current
-     * state of Kubernetes CronJobs in the cluster, and takes the necessary actions to synchronize
-     * them. This can include creating new CronJobs, updating existing CronJobs, etc.
-     *
-     * @throws ApiException
-     */
-    public void synchronizeDataJobs() throws ApiException {
-        ThreadPoolTaskExecutor taskExecutor = initializeTaskExecutor();
-        Set<String> cronJobs = dataJobsKubernetesService.listCronJobs();
+  private ThreadPoolTaskExecutor initializeTaskExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(5);
+    executor.setMaxPoolSize(10);
+    executor.setQueueCapacity(Integer.MAX_VALUE);
+    executor.setAllowCoreThreadTimeOut(true);
+    executor.setKeepAliveSeconds(120);
+    executor.setWaitForTasksToCompleteOnShutdown(true);
+    executor.initialize();
 
-        jobsRepository.findAll(Sort.by(Sort.Direction.ASC, DataJob_.DATA_JOB_DEPLOYMENT + "." + DataJobDeployment_.DEPLOYMENT_VERSION_SHA))
-                .forEach(dataJob -> taskExecutor.execute(() -> synchronizeDataJob(dataJob, cronJobs)));
-
-        taskExecutor.shutdown();
-    }
-
-    // Default for testing purposes
-    void synchronizeDataJob(DataJob dataJob, Set<String> cronJobs) {
-        if (dataJob.getDataJobDeployment() != null) {
-            // Sends notification only when the deployment is initiated by the user.
-            boolean sendNotification = StringUtils.isEmpty(dataJob.getDataJobDeployment().getDeploymentVersionSha());
-            deploymentService.updateDeployment(dataJob, sendNotification, cronJobs);
-        }
-    }
-
-    private ThreadPoolTaskExecutor initializeTaskExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(5);
-        executor.setMaxPoolSize(10);
-        executor.setQueueCapacity(Integer.MAX_VALUE);
-        executor.setAllowCoreThreadTimeOut(true);
-        executor.setKeepAliveSeconds(120);
-        executor.setWaitForTasksToCompleteOnShutdown(true);
-        executor.initialize();
-
-        return executor;
-    }
+    return executor;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobsSynchronizer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobsSynchronizer.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.deploy;
+
+import com.vmware.taurus.service.kubernetes.DataJobsKubernetesService;
+import com.vmware.taurus.service.model.DataJob;
+import com.vmware.taurus.service.model.DataJobDeployment_;
+import com.vmware.taurus.service.model.DataJob_;
+import com.vmware.taurus.service.repository.JobsRepository;
+import io.kubernetes.client.openapi.ApiException;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.domain.Sort;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+/**
+ * This class represents a utility for synchronizing Kubernetes CronJobs with data
+ * from a database to maintain the desired state in the cluster.
+ * <p>
+ * It provides methods to retrieve job information from a database, compare it with
+ * the current state of Kubernetes Jobs, and take actions to synchronize them. This
+ * can include creating new CronJobs, updating existing CronJobs, etc.
+ * <p>
+ * Usage:
+ * - Create an instance of this class and call the `synchronizeDataJobs` method
+ *   to initiate the synchronization process.
+ */
+@Component
+public class DataJobsSynchronizer {
+
+    private final JobsRepository jobsRepository;
+
+    private final DeploymentServiceV2 deploymentService;
+
+    private final DataJobsKubernetesService dataJobsKubernetesService;
+
+    public DataJobsSynchronizer(JobsRepository jobsRepository, DeploymentServiceV2 deploymentService, DataJobsKubernetesService dataJobsKubernetesService) {
+        this.jobsRepository = jobsRepository;
+        this.deploymentService = deploymentService;
+        this.dataJobsKubernetesService = dataJobsKubernetesService;
+    }
+
+    /**
+     * Synchronizes Kubernetes CronJobs from the database to ensure that the cluster's state
+     * matches the desired state defined in the database records.
+     * <p>
+     * This method retrieves job information from the database, compares it with the current
+     * state of Kubernetes CronJobs in the cluster, and takes the necessary actions to synchronize
+     * them. This can include creating new CronJobs, updating existing CronJobs, etc.
+     *
+     * @throws ApiException
+     */
+    public void synchronizeDataJobs() throws ApiException {
+        ThreadPoolTaskExecutor taskExecutor = initializeTaskExecutor();
+        Set<String> cronJobs = dataJobsKubernetesService.listCronJobs();
+
+        jobsRepository.findAll(Sort.by(Sort.Direction.ASC, DataJob_.DATA_JOB_DEPLOYMENT + "." + DataJobDeployment_.DEPLOYMENT_VERSION_SHA))
+                .forEach(dataJob -> taskExecutor.execute(() -> synchronizeDataJob(dataJob, cronJobs)));
+
+        taskExecutor.shutdown();
+    }
+
+    // Default for testing purposes
+    void synchronizeDataJob(DataJob dataJob, Set<String> cronJobs) {
+        if (dataJob.getDataJobDeployment() != null) {
+            // Sends notification only when the deployment is initiated by the user.
+            boolean sendNotification = StringUtils.isEmpty(dataJob.getDataJobDeployment().getDeploymentVersionSha());
+            deploymentService.updateDeployment(dataJob, sendNotification, cronJobs);
+        }
+    }
+
+    private ThreadPoolTaskExecutor initializeTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(Integer.MAX_VALUE);
+        executor.setAllowCoreThreadTimeOut(true);
+        executor.setKeepAliveSeconds(120);
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.initialize();
+
+        return executor;
+    }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentNotificationHelper.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentNotificationHelper.java
@@ -45,10 +45,7 @@ public class DeploymentNotificationHelper {
                 jobDeployment.getDataJobName(), jobDeployment.getGitCommitSha()));
 
         deploymentProgress.failed(
-            dataJob,
-            DeploymentStatus.USER_ERROR,
-            userErrorMessage,
-            sendNotification);
+            dataJob, DeploymentStatus.USER_ERROR, userErrorMessage, sendNotification);
       } else {
         if (logs.contains("error resolving source context: reference not found")) {
           log.error(

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentNotificationHelper.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentNotificationHelper.java
@@ -17,8 +17,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
-
 @Component
 @RequiredArgsConstructor
 public class DeploymentNotificationHelper {
@@ -32,8 +30,7 @@ public class DeploymentNotificationHelper {
       JobDeployment jobDeployment,
       KubernetesService.JobStatusCondition condition,
       String logs,
-      Boolean sendNotification)
-      throws IOException {
+      Boolean sendNotification) {
 
     if (condition.isSuccess()) {
       log.info("Builder job {} finished successfully", builderJobName);
@@ -48,8 +45,7 @@ public class DeploymentNotificationHelper {
                 jobDeployment.getDataJobName(), jobDeployment.getGitCommitSha()));
 
         deploymentProgress.failed(
-            dataJob.getJobConfig(),
-            jobDeployment,
+            dataJob,
             DeploymentStatus.USER_ERROR,
             userErrorMessage,
             sendNotification);
@@ -75,8 +71,7 @@ public class DeploymentNotificationHelper {
                     + logs);
         log.warn(message.toString());
         deploymentProgress.failed(
-            dataJob.getJobConfig(),
-            jobDeployment,
+            dataJob,
             DeploymentStatus.PLATFORM_ERROR,
             NotificationContent.getPlatformErrorBody(),
             sendNotification);
@@ -84,7 +79,7 @@ public class DeploymentNotificationHelper {
     }
   }
 
-  private String getUserErrorMessage(String logs, JobDeployment jobDeployment) throws IOException {
+  private String getUserErrorMessage(String logs, JobDeployment jobDeployment) {
     String requirementsError = getRequirementsError(logs);
     if (StringUtils.isNotBlank(requirementsError)) {
       return NotificationContent.getErrorBody(
@@ -123,7 +118,7 @@ public class DeploymentNotificationHelper {
 
   // Currently, the only way to differentiate between infra and user error
   // when building a data job is by parsing the logs of the builder job.
-  private String getRequirementsError(String logs) throws IOException {
+  private String getRequirementsError(String logs) {
     String requirements_error = null;
 
     if (StringUtils.isNotBlank(logs) && logs.contains(">requirements_failed<")) {

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentProgress.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentProgress.java
@@ -6,9 +6,7 @@
 package com.vmware.taurus.service.deploy;
 
 import com.vmware.taurus.service.diag.methodintercept.Measurable;
-import com.vmware.taurus.service.model.DeploymentStatus;
-import com.vmware.taurus.service.model.JobConfig;
-import com.vmware.taurus.service.model.JobDeployment;
+import com.vmware.taurus.service.model.*;
 import com.vmware.taurus.service.monitoring.DeploymentMonitor;
 import com.vmware.taurus.service.notification.DataJobNotification;
 import lombok.RequiredArgsConstructor;
@@ -32,25 +30,31 @@ public class DeploymentProgress {
   void started(JobConfig jobConfig, JobDeployment jobDeployment) {}
 
   /**
-   * Data Job Deployment has completed successfully.
+   * Data Job Deployment has started.
    *
    * @param jobConfig the job configuration
    * @param jobDeployment the job deployment configuration
    */
   @Measurable(includeArg = 1, argName = "deployment")
-  void completed(JobConfig jobConfig, JobDeployment jobDeployment, boolean sendNotification) {
-    deploymentMonitor.recordDeploymentStatus(
-        jobDeployment.getDataJobName(), DeploymentStatus.SUCCESS);
+  void started(JobConfig jobConfig, DataJobDeployment jobDeployment) {}
+
+  /**
+   * Data Job Deployment has completed successfully.
+   *
+   * @param dataJob the job
+   */
+  @Measurable(includeArg = 1, argName = "deployment")
+  void completed(DataJob dataJob, boolean sendNotification) {
+    deploymentMonitor.recordDeploymentStatus(dataJob.getName(), DeploymentStatus.SUCCESS, dataJob.getDataJobDeployment());
     if (sendNotification) {
-      dataJobNotification.notifyJobDeploySuccess(jobConfig);
+      dataJobNotification.notifyJobDeploySuccess(dataJob.getJobConfig());
     }
   }
 
   /**
    * Data Job Deployment has failed.
    *
-   * @param jobConfig the job configuration
-   * @param jobDeployment the job deployment configuration
+   * @param dataJob the job
    * @param status Deployment status - user or platform error
    * @param message the error message that will be sent as notificaiton
    * @param sendNotification if true will sent notification to user
@@ -59,14 +63,13 @@ public class DeploymentProgress {
   @Measurable(includeArg = 2, argName = "status")
   @Measurable(includeArg = 3, argName = "message")
   void failed(
-      JobConfig jobConfig,
-      JobDeployment jobDeployment,
-      DeploymentStatus status,
-      String message,
-      boolean sendNotification) {
-    deploymentMonitor.recordDeploymentStatus(jobDeployment.getDataJobName(), status);
+          DataJob dataJob,
+          DeploymentStatus status,
+          String message,
+          boolean sendNotification) {
+    deploymentMonitor.recordDeploymentStatus(dataJob.getName(), status, dataJob.getDataJobDeployment());
     if (sendNotification) {
-      dataJobNotification.notifyJobDeployError(jobConfig, "Failed to deploy the job.", message);
+      dataJobNotification.notifyJobDeployError(dataJob.getJobConfig(), "Failed to deploy the job.", message);
     }
   }
 
@@ -78,7 +81,7 @@ public class DeploymentProgress {
    */
   @Measurable(includeArg = 0, argName = "job_name")
   public void deleted(String dataJobName) {
-    deploymentMonitor.recordDeploymentStatus(dataJobName, DeploymentStatus.SUCCESS);
+    deploymentMonitor.recordDeploymentStatus(dataJobName, DeploymentStatus.SUCCESS, null);
   }
 
   @Measurable(includeArg = 1, argName = "deployment")

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentProgress.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentProgress.java
@@ -45,7 +45,8 @@ public class DeploymentProgress {
    */
   @Measurable(includeArg = 1, argName = "deployment")
   void completed(DataJob dataJob, boolean sendNotification) {
-    deploymentMonitor.recordDeploymentStatus(dataJob.getName(), DeploymentStatus.SUCCESS, dataJob.getDataJobDeployment());
+    deploymentMonitor.recordDeploymentStatus(
+        dataJob.getName(), DeploymentStatus.SUCCESS, dataJob.getDataJobDeployment());
     if (sendNotification) {
       dataJobNotification.notifyJobDeploySuccess(dataJob.getJobConfig());
     }
@@ -62,14 +63,12 @@ public class DeploymentProgress {
   @Measurable(includeArg = 1, argName = "deployment")
   @Measurable(includeArg = 2, argName = "status")
   @Measurable(includeArg = 3, argName = "message")
-  void failed(
-          DataJob dataJob,
-          DeploymentStatus status,
-          String message,
-          boolean sendNotification) {
-    deploymentMonitor.recordDeploymentStatus(dataJob.getName(), status, dataJob.getDataJobDeployment());
+  void failed(DataJob dataJob, DeploymentStatus status, String message, boolean sendNotification) {
+    deploymentMonitor.recordDeploymentStatus(
+        dataJob.getName(), status, dataJob.getDataJobDeployment());
     if (sendNotification) {
-      dataJobNotification.notifyJobDeployError(dataJob.getJobConfig(), "Failed to deploy the job.", message);
+      dataJobNotification.notifyJobDeployError(
+          dataJob.getJobConfig(), "Failed to deploy the job.", message);
     }
   }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentService.java
@@ -195,7 +195,7 @@ public class DeploymentService {
 
           saveDeployment(dataJob, jobDeployment);
 
-          deploymentProgress.completed(dataJob.getJobConfig(), jobDeployment, sendNotification);
+          deploymentProgress.completed(dataJob, sendNotification);
         }
       }
     } catch (ApiException e) {
@@ -252,8 +252,7 @@ public class DeploymentService {
                 + "SRE team may investigate by looking at the logs or in kubernetes.");
     log.error(message.toString(), e);
     deploymentProgress.failed(
-        dataJob.getJobConfig(),
-        jobDeployment,
+        dataJob,
         DeploymentStatus.PLATFORM_ERROR,
         NotificationContent.getPlatformErrorBody(),
         sendNotification);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentServiceV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentServiceV2.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.deploy;
+
+import com.vmware.taurus.controlplane.model.data.DataJobResources;
+import com.vmware.taurus.datajobs.DeploymentModelConverter;
+import com.vmware.taurus.exception.*;
+import com.vmware.taurus.service.model.*;
+import com.vmware.taurus.service.notification.NotificationContent;
+import com.vmware.taurus.service.repository.JobsRepository;
+import io.kubernetes.client.openapi.ApiException;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * CRUD operations for Versatile Data Kit deployments on kubernetes.
+ *
+ * <p>This class is in a transition from operating against Kubernetes to operating against the
+ * database. Currently, only the enabled flag is stored in the database. Eventually, all deployment
+ * information will be stored (and retrieved) from a database from a dedicated table.
+ */
+@Service
+@RequiredArgsConstructor
+public class DeploymentServiceV2 {
+  private static final Logger log = LoggerFactory.getLogger(DeploymentServiceV2.class);
+
+  private final DockerRegistryService dockerRegistryService;
+  private final DeploymentProgress deploymentProgress;
+  private final JobImageBuilder jobImageBuilder;
+  private final JobImageDeployerV2 jobImageDeployer;
+  private final JobsRepository jobsRepository;
+  private final SupportedPythonVersions supportedPythonVersions;
+
+  /**
+   * Updates or creates a Kubernetes CronJob based on the provided configuration.
+   * <p>
+   * This method takes a CronJob configuration and checks if a CronJob with the same name
+   * already exists in the Kubernetes cluster. If the CronJob exists, it will be updated
+   * with the new configuration; otherwise, a new CronJob will be created. The method ensures
+   * that the CronJob in the cluster matches the desired state specified in the configuration.
+   *
+   * @param dataJob   The data job to update or create.
+   * @param sendNotification if it is true the method will send a notification to the end user.
+   * @param dataJobDeploymentNames list of actual data job deployment names returned by Kubernetes.
+   */
+  public void updateDeployment(
+          DataJob dataJob,
+          Boolean sendNotification,
+          Set<String> dataJobDeploymentNames) {
+    DataJobDeployment dataJobDeployment = dataJob.getDataJobDeployment();
+
+    if (dataJobDeployment == null) {
+      log.debug("Skipping the data job [job_name={}] deployment due to the missing deployment data", dataJob.getName());
+      return;
+    }
+
+    JobDeployment jobDeployment = DeploymentModelConverter.toJobDeployment(
+            dataJob.getJobConfig().getTeam(), dataJob.getName(), dataJobDeployment);
+
+    try {
+      log.info("Starting deployment of job {}", jobDeployment.getDataJobName());
+      deploymentProgress.started(dataJob.getJobConfig(), jobDeployment);
+
+      if (jobDeployment.getPythonVersion() == null) {
+        jobDeployment.setPythonVersion(supportedPythonVersions.getDefaultPythonVersion());
+      }
+
+      String imageName =
+              dockerRegistryService.dataJobImage(
+                      jobDeployment.getDataJobName(), jobDeployment.getGitCommitSha());
+      jobDeployment.setImageName(imageName);
+
+      if (jobImageBuilder.buildImage(imageName, dataJob, jobDeployment, sendNotification)) {
+        log.info(
+                "Image {} has been built. Will now schedule job {} for execution",
+                imageName,
+                dataJob.getName());
+        jobDeployment.setImageName(imageName);
+        if (jobImageDeployer.scheduleJob(
+                dataJob, jobDeployment, sendNotification, dataJobDeployment.getLastDeployedBy(), dataJobDeploymentNames)) {
+          log.info(
+                  String.format(
+                          "Successfully updated job: %s with version: %s",
+                          jobDeployment.getDataJobName(), jobDeployment.getGitCommitSha()));
+
+          saveDeployment(dataJob, jobDeployment);
+
+          deploymentProgress.completed(dataJob, sendNotification);
+        }
+      }
+    } catch (ApiException e) {
+      handleException(dataJob, jobDeployment, sendNotification, new KubernetesException("", e));
+    } catch (Exception e) {
+      handleException(dataJob, jobDeployment, sendNotification, e);
+    }
+  }
+
+  private void saveDeployment(DataJob dataJob, JobDeployment jobDeployment) {
+    // Currently, store only 'enabled' in the database
+    if (!Objects.equals(dataJob.getEnabled(), jobDeployment.getEnabled())) {
+      dataJob.setEnabled(jobDeployment.getEnabled());
+      jobsRepository.save(dataJob);
+
+      log.info(
+          "The deployment of the data job {} has been {}",
+          dataJob.getName(),
+          Boolean.TRUE.equals(dataJob.getEnabled()) ? "ENABLED" : "DISABLED");
+    }
+  }
+
+  private void handleException(
+      DataJob dataJob, JobDeployment jobDeployment, Boolean sendNotification, Throwable e) {
+    ErrorMessage message =
+        new ErrorMessage(
+            String.format(
+                "An error occurred while trying to deploy job: %s with version: %s",
+                jobDeployment.getDataJobName(), jobDeployment.getGitCommitSha()),
+            "See exception message below for possible reason.",
+            "Most likely the deployment has failed. It is possible that deployment may have"
+                + " succeeded (or failed with User error) but there was communication issue. Since"
+                + " we do not know we assume that it was platform error and SRE team need to"
+                + " investigate. End user deploying the job would get notification for deploy"
+                + " failure due to platform error",
+            "End user may verify which version is currently deployed and re-try if necessary. "
+                + "SRE team may investigate by looking at the logs or in kubernetes.");
+    log.error(message.toString(), e);
+    deploymentProgress.failed(
+        dataJob,
+        DeploymentStatus.PLATFORM_ERROR,
+        NotificationContent.getPlatformErrorBody(),
+        sendNotification);
+  }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
@@ -140,11 +140,7 @@ public class JobImageDeployer {
                     "Please fix the job's configuration");
             log.error(msg);
           }
-          deploymentProgress.failed(
-              dataJob,
-              DeploymentStatus.USER_ERROR,
-              msg,
-              sendNotification);
+          deploymentProgress.failed(dataJob, DeploymentStatus.USER_ERROR, msg, sendNotification);
           return false;
         } catch (Exception ignored) {
           log.debug("Failed to parse ApiException body, re-throwing it.: ", ignored);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployer.java
@@ -141,8 +141,7 @@ public class JobImageDeployer {
             log.error(msg);
           }
           deploymentProgress.failed(
-              dataJob.getJobConfig(),
-              jobDeployment,
+              dataJob,
               DeploymentStatus.USER_ERROR,
               msg,
               sendNotification);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployerV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployerV2.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.deploy;
+
+import com.google.gson.Gson;
+import com.vmware.taurus.controlplane.model.data.DataJobResources;
+import com.vmware.taurus.exception.KubernetesException;
+import com.vmware.taurus.service.KubernetesService;
+import com.vmware.taurus.service.credentials.JobCredentialsService;
+import com.vmware.taurus.service.kubernetes.DataJobsKubernetesService;
+import com.vmware.taurus.service.model.*;
+import com.vmware.taurus.service.notification.NotificationContent;
+import io.kubernetes.client.openapi.ApiException;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+import java.util.*;
+
+/**
+ * Takes care of deploying a Data Job in Kubernetes and scheduling it to run. Currently this is
+ * deployed as CronJob. For more details see #updateCronJob doc.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JobImageDeployerV2 {
+
+  @Value("${datajobs.docker.registrySecret:}")
+  private String dockerRegistrySecret = "";
+
+  @Value("${datajobs.vdk.docker.registrySecret:}")
+  private String vdkSdkDockerRegistrySecret = "";
+
+  @Value("${datajobs.deployment.readOnlyRootFilesystem:}")
+  private boolean readOnlyRootFilesystem;
+
+  @Value("${datajobs.deployment.jobImagePullPolicy:IfNotPresent}")
+  private String jobImagePullPolicy;
+
+  private static final String VOLUME_NAME = "vdk";
+  private static final String VOLUME_MOUNT_PATH = "/vdk";
+  private static final String EPHEMERAL_VOLUME_NAME = "tmpfs";
+  private static final String EPHEMERAL_VOLUME_MOUNT_PATH = "/var/tmp";
+  private static final String KEYTAB_PRINCIPAL_ENV = "VDK_KEYTAB_PRINCIPAL";
+  private static final String KEYTAB_FOLDER_ENV = "VDK_KEYTAB_FOLDER";
+  private static final String KEYTAB_FILENAME_ENV = "VDK_KEYTAB_FILENAME";
+  private static final String ATTEMPT_ID = "VDK_ATTEMPT_ID";
+  private static final String BASE_CONFIG_FOLDER = "VDK_BASE_CONFIG_FOLDER";
+  private static final String VDK_TEMPORARY_WRITE_DIRECTORY = "VDK_TEMPORARY_WRITE_DIRECTORY";
+  private static final String TEMPORARY_WRITE_DIRECTORY_PATH = EPHEMERAL_VOLUME_MOUNT_PATH;
+  private static final String KEYTAB_FOLDER = "/credentials";
+
+  private final JobCredentialsService jobCredentialsService;
+  private final DataJobsKubernetesService dataJobsKubernetesService;
+  private final VdkOptionsReader vdkOptionsReader;
+  private final DataJobDefaultConfigurations defaultConfigurations;
+  private final DeploymentProgress deploymentProgress;
+  private final KubernetesResources kubernetesResources;
+  private final JobCommandProvider jobCommandProvider;
+  private final SupportedPythonVersions supportedPythonVersions;
+
+  /**
+   * Schedules for execution a data job at kubernetes cluster.
+   *
+   * @param dataJob the data job to be updated or created.
+   * @param jobDeployment the deployment information necessary to execute the deployment.
+   * @param sendNotification if it is true the method will send a notification to the end user.
+   * @param lastDeployedBy the name of the user that last deployed the data job
+   * @param dataJobDeploymentNames list of actual data job deployment names returned by Kubernetes.
+   *
+   * @return true if it is successful and false if not.
+   */
+  public boolean scheduleJob(
+      DataJob dataJob,
+      JobDeployment jobDeployment,
+      Boolean sendNotification,
+      String lastDeployedBy,
+      Set<String> dataJobDeploymentNames) {
+    Validate.notNull(jobDeployment, "jobDeployment should not be null");
+    Validate.notNull(jobDeployment.getImageName(), "Image name is expected in jobDeployment");
+    log.info("Update cron job for data job {}", dataJob.getName());
+
+    try {
+      updateCronJob(dataJob, jobDeployment, lastDeployedBy, dataJobDeploymentNames);
+      return true;
+    } catch (ApiException e) {
+      return catchApiException(dataJob, sendNotification, e);
+    }
+  }
+
+  private boolean catchApiException(DataJob dataJob, Boolean sendNotification, ApiException apiException) {
+    if (apiException.getCode() == HttpStatus.UNPROCESSABLE_ENTITY.value()) {
+      try {
+        Gson gson = new Gson();
+        String msg =
+                NotificationContent.getErrorBody(
+                        "Tried to deploy a data job",
+                        "There has been an error in the configuration of your data job.",
+                        "Your new/updated job was not deployed. Your job will run its latest successfully"
+                                + " deployed version (if any) as scheduled.",
+                        "Please fix the job's configuration");
+        Map<Object, Object> error = gson.fromJson(apiException.getResponseBody(), HashMap.class);
+        if (error != null) {
+          log.error(
+                  "Failed to schedule job due to Kubernetes client error (422). Generally input"
+                          + " validation should be done earlier. If this exception happens, most likely"
+                          + " we need to do some better input validation at client library. We are"
+                          + " assuming all k8s client error when creating cron job can be only customer"
+                          + " misconfiguration sending notification and reporting as user error",
+                  apiException);
+          msg =
+                  NotificationContent.getErrorBody(
+                          "Tried to deploy a data job",
+                          "There has been an error in the configuration of your data job : "
+                                  + error.get("message"),
+                          "Your new/updated job was not deployed. Your job will run its latest"
+                                  + " successfully deployed version (if any) as scheduled.",
+                          "Please fix the job's configuration");
+          log.error(msg);
+        }
+        deploymentProgress.failed(
+                dataJob,
+                DeploymentStatus.USER_ERROR,
+                msg,
+                sendNotification);
+        return false;
+      } catch (Exception ignored) {
+        log.debug("Failed to parse ApiException body: ", ignored);
+      }
+    }
+
+    throw new KubernetesException("Failed to schedule job", apiException);
+  }
+
+  // Public for integration testing purposes
+  public static String getCronJobName(String jobName) {
+    return jobName;
+  }
+
+  private Map<String, String> getSystemDefaults() {
+    Map<String, String> systemDefaults = new LinkedHashMap<>();
+
+    systemDefaults.put("LOG_CONFIG", "CLOUD");
+    systemDefaults.put("MONITORING_ENABLED", String.valueOf(true));
+    return systemDefaults;
+  }
+
+  /**
+   * Creates data job as CronJob against the Kubernetes API:
+   *
+   * <p>The implementation includes vdk as initContainer. The main container stores the job with its
+   * dependencies and shared emptyDir volume between the two containers.
+   *
+   * <p>Requires image with pip installed vdk so it can be found in the site-packages directory of
+   * the vdk container. This is in order for the initContainer (vdk) primitive to copy it from there
+   * into the shared folder to be used by the container which runs the job.
+   *
+   * @param dataJob The data job
+   * @param jobDeployment Deployment configuration
+   */
+  private void updateCronJob(DataJob dataJob, JobDeployment jobDeployment, String lastDeployedBy, Set<String> dataJobDeploymentNames)
+      throws ApiException {
+    log.debug("Deploy cron job for data job {}", dataJob);
+
+    String jobName = dataJob.getName();
+    String dataJobDeploymentName = getCronJobName(jobName);
+    KubernetesService.CronJob cronJob = getCronJob(dataJobDeploymentName, dataJob, jobDeployment, lastDeployedBy);
+
+    // TODO [miroslavi] store sha in annotation???
+    String cronJobSha = dataJobsKubernetesService.getCronJobSha512(cronJob, JobAnnotation.DEPLOYED_DATE);
+
+    if (dataJobDeploymentNames.contains(dataJobDeploymentName)) {
+      if (!cronJobSha.equals(dataJob.getDataJobDeployment().getDeploymentVersionSha())) {
+        dataJobsKubernetesService.updateCronJob(cronJob);
+      }
+    } else {
+      dataJobsKubernetesService.createCronJob(cronJob);
+    }
+
+    dataJob.getDataJobDeployment().setDeploymentVersionSha(cronJobSha);
+  }
+
+  /**
+   * Returns the environment variables set to vdk that are based on job configuration. Those are
+   * automatically injected during cloud runs
+   */
+  private static HashMap<String, String> jobConfigBasedEnvVars(JobConfig config) {
+    HashMap<String, String> envVars = new LinkedHashMap<>();
+    if (StringUtils.isNotBlank(config.getDbDefaultType())) {
+      envVars.put("VDK_DB_DEFAULT_TYPE", config.getDbDefaultType());
+    }
+    if (StringUtils.isNotBlank(config.getTeam())) {
+      envVars.put("VDK_JOB_TEAM", config.getTeam());
+    }
+    if (config.getEnableExecutionNotifications() != null) {
+      envVars.put(
+          "VDK_ENABLE_EXECUTION_NOTIFICATIONS",
+          config.getEnableExecutionNotifications().toString());
+    }
+    if (config.getNotifiedOnJobSuccess() != null) {
+      envVars.put(
+          "VDK_NOTIFIED_ON_JOB_SUCCESS", String.join(",", config.getNotifiedOnJobSuccess()));
+    }
+    if (config.getNotifiedOnJobFailurePlatformError() != null) {
+      envVars.put(
+          "VDK_NOTIFIED_ON_JOB_FAILURE_PLATFORM_ERROR",
+          String.join(",", config.getNotifiedOnJobFailurePlatformError()));
+    }
+    if (config.getNotifiedOnJobFailureUserError() != null) {
+      envVars.put(
+          "VDK_NOTIFIED_ON_JOB_FAILURE_USER_ERROR",
+          String.join(",", config.getNotifiedOnJobFailureUserError()));
+    }
+    if (config.getNotifiedOnJobDeploy() != null) {
+      envVars.put("VDK_NOTIFIED_ON_JOB_DEPLOY", String.join(",", config.getNotifiedOnJobDeploy()));
+    }
+    return envVars;
+  }
+
+  private Map<String, String> getJobLabels(DataJob dataJob, JobDeployment jobDeployment) {
+    Map<String, String> jobPodLabels = new HashMap<>();
+    // This label provides means during watching to select only Kubernetes jobs which represent data
+    // jobs.
+    // See DataJobStatusMonitor.watchJobs for how the label is used
+    jobPodLabels.put(JobLabel.TYPE.getValue(), "DataJob");
+    jobPodLabels.put(JobLabel.NAME.getValue(), dataJob.getName());
+    jobPodLabels.put(JobLabel.VERSION.getValue(), jobDeployment.getGitCommitSha());
+
+    return jobPodLabels;
+  }
+
+  private Map<String, String> getJobAnnotations(
+      DataJob dataJob, String deployedBy, String pythonVersion) {
+    Map<String, String> jobPodAnnotations = new HashMap<>();
+    jobPodAnnotations.put(JobAnnotation.SCHEDULE.getValue(), dataJob.getJobConfig().getSchedule());
+    jobPodAnnotations.put(JobAnnotation.EXECUTION_TYPE.getValue(), "scheduled");
+    jobPodAnnotations.put(JobAnnotation.DEPLOYED_BY.getValue(), deployedBy);
+    jobPodAnnotations.put(JobAnnotation.DEPLOYED_DATE.getValue(), OffsetDateTime.now().toString());
+    jobPodAnnotations.put(
+        JobAnnotation.STARTED_BY.getValue(), "scheduled/runtime"); // TODO are those valid?
+    jobPodAnnotations.put(
+        JobAnnotation.UNSCHEDULED.getValue(),
+        (StringUtils.isEmpty(dataJob.getJobConfig().getSchedule()) ? "true" : "false"));
+    jobPodAnnotations.put(JobAnnotation.PYTHON_VERSION.getValue(), pythonVersion);
+    return jobPodAnnotations;
+  }
+
+  private Map<String, String> getJobContainerEnvVars(String jobName, JobConfig jobConfig) {
+    String principalName = jobCredentialsService.getJobPrincipalName(jobName);
+    Map<String, String> vdkEnvs = vdkOptionsReader.readVdkOptions(jobName);
+
+    Map<String, String> jobContainerEnvVars = new HashMap<>();
+    jobContainerEnvVars.put(KEYTAB_PRINCIPAL_ENV, principalName);
+    jobContainerEnvVars.put(KEYTAB_FOLDER_ENV, KEYTAB_FOLDER);
+    jobContainerEnvVars.put(KEYTAB_FILENAME_ENV, JobCredentialsService.K8S_KEYTAB_KEY_IN_SECRET);
+    jobContainerEnvVars.put(ATTEMPT_ID, "$metadata.name");
+    jobContainerEnvVars.put(BASE_CONFIG_FOLDER, EPHEMERAL_VOLUME_MOUNT_PATH);
+    jobContainerEnvVars.put(VDK_TEMPORARY_WRITE_DIRECTORY, TEMPORARY_WRITE_DIRECTORY_PATH);
+    jobContainerEnvVars.putAll(getSystemDefaults());
+    jobContainerEnvVars.putAll(vdkEnvs);
+    jobContainerEnvVars.putAll(jobConfigBasedEnvVars(jobConfig));
+
+    return jobContainerEnvVars;
+  }
+
+  // TODO migrate to new Data Job deployment
+  private KubernetesService.CronJob getCronJob(String dataJobDeploymentName, DataJob dataJob, JobDeployment jobDeployment, String lastDeployedBy) {
+    // Schedule defaults to Feb 30 (i.e. never) if no schedule has been given.
+    String schedule =
+            StringUtils.isEmpty(dataJob.getJobConfig().getSchedule())
+                    ? "0 0 30 2 *"
+                    : dataJob.getJobConfig().getSchedule();
+
+    var jobName = dataJob.getName();
+    var volume = KubernetesService.volume(VOLUME_NAME);
+    var volumeMount = KubernetesService.volumeMount(VOLUME_NAME, VOLUME_MOUNT_PATH, false);
+    var ephemeralVolume = KubernetesService.volume(EPHEMERAL_VOLUME_NAME);
+    var ephemeralVolumeMount =
+            KubernetesService.volumeMount(EPHEMERAL_VOLUME_NAME, EPHEMERAL_VOLUME_MOUNT_PATH, false);
+    var jobContainerEnvVars = getJobContainerEnvVars(jobName, dataJob.getJobConfig());
+
+    String jobKeytabKubernetesSecretName =
+            JobCredentialsService.getJobKeytabKubernetesSecretName(jobName);
+    var secretVolume =
+            KubernetesService.volume(jobKeytabKubernetesSecretName, jobKeytabKubernetesSecretName);
+    var secretVolumeMount =
+            KubernetesService.volumeMount(jobKeytabKubernetesSecretName, KEYTAB_FOLDER, true);
+
+    var jobCommand = jobCommandProvider.getJobCommand(jobName);
+    DataJobResources resources = jobDeployment.getResources();
+    String cpuRequest = resources.getCpuRequest() != null && resources.getCpuRequest() > 0 ? String.valueOf(resources.getCpuRequest()) : defaultConfigurations.dataJobRequests().getCpu();
+    String cpuLimit = resources.getCpuLimit() != null && resources.getCpuLimit() > 0 ? String.valueOf(resources.getCpuLimit()) : defaultConfigurations.dataJobLimits().getCpu();
+    String memoryRequest = resources.getMemoryRequest() != null && resources.getMemoryRequest() > 0 ? resources.getMemoryRequest() + "Mi" : defaultConfigurations.dataJobRequests().getMemory();
+    String memoryLimit = resources.getMemoryLimit() != null && resources.getMemoryLimit() > 0 ? resources.getMemoryLimit() + "Mi" : defaultConfigurations.dataJobLimits().getMemory();
+
+    // The job name is used as the container name. This is something that we rely on later,
+    // when watching for pod modifications in DataJobStatusMonitor.watchPods
+    var jobContainer =
+            KubernetesService.container(
+                    jobName,
+                    jobDeployment.getImageName(),
+                    false,
+                    readOnlyRootFilesystem,
+                    jobContainerEnvVars,
+                    List.of(),
+                    List.of(volumeMount, secretVolumeMount, ephemeralVolumeMount),
+                    jobImagePullPolicy,
+                    new KubernetesService.Resources(cpuRequest, memoryRequest),
+                    new KubernetesService.Resources(cpuLimit, memoryLimit),
+                    null,
+                    jobCommand);
+    var vdkCommand =
+            List.of(
+                    "/bin/bash",
+                    "-c",
+                    "cp -r $(python -c \"from distutils.sysconfig import get_python_lib;"
+                            + " print(get_python_lib())\") /vdk/. && cp /usr/local/bin/vdk /vdk/.");
+    var jobVdkImage = supportedPythonVersions.getVdkImage(jobDeployment.getPythonVersion());
+    var jobInitContainer =
+            KubernetesService.container(
+                    "vdk",
+                    jobVdkImage,
+                    false,
+                    readOnlyRootFilesystem,
+                    Map.of(),
+                    List.of(),
+                    List.of(volumeMount, secretVolumeMount, ephemeralVolumeMount),
+                    jobImagePullPolicy,
+                    kubernetesResources.dataJobInitContainerRequests(),
+                    kubernetesResources.dataJobInitContainerLimits(),
+                    null,
+                    vdkCommand);
+
+    var jobLabels = getJobLabels(dataJob, jobDeployment);
+    var jobAnnotations =
+            getJobAnnotations(dataJob, lastDeployedBy, jobDeployment.getPythonVersion());
+    boolean enabled = (dataJob.getEnabled() == null || dataJob.getEnabled()) && jobDeployment.getEnabled();
+
+    return KubernetesService.CronJob.builder()
+            .name(dataJobDeploymentName)
+            .image(jobDeployment.getImageName())
+            .schedule(schedule)
+            .enable(enabled)
+            .jobContainer(jobContainer)
+            .initContainer(jobInitContainer)
+            .volumes(Arrays.asList(volume, secretVolume, ephemeralVolume))
+            .jobAnnotations(jobAnnotations)
+            .jobLabels(jobLabels)
+            .imagePullSecret(List.of(dockerRegistrySecret, vdkSdkDockerRegistrySecret))
+            .build();
+  }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
@@ -11,6 +11,7 @@ import com.vmware.taurus.exception.ExecutionCancellationFailureReason;
 import com.vmware.taurus.exception.KubernetesException;
 import com.vmware.taurus.service.KubernetesService;
 import com.vmware.taurus.service.deploy.JobCommandProvider;
+import com.vmware.taurus.service.model.JobAnnotation;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
@@ -18,14 +19,14 @@ import io.kubernetes.client.openapi.apis.BatchV1beta1Api;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1Volume;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.SerializationUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -53,6 +54,10 @@ public class DataJobsKubernetesService extends KubernetesService {
         batchV1Api,
         batchV1beta1Api,
         jobCommandProvider);
+  }
+
+  public void createCronJob(KubernetesService.CronJob cronJob) throws ApiException {
+    createCronJob(cronJob.getName(), cronJob.getImage(), cronJob.getSchedule(), cronJob.isEnable(), cronJob.getJobContainer(), cronJob.getInitContainer(), cronJob.getVolumes(), cronJob.getJobAnnotations(), cronJob.getJobLabels(), cronJob.getImagePullSecret());
   }
 
   public void createCronJob(
@@ -92,6 +97,30 @@ public class DataJobsKubernetesService extends KubernetesService {
           jobLabels,
           imagePullSecrets);
     }
+  }
+
+  public String getCronJobSha512(KubernetesService.CronJob cronJob, JobAnnotation excludeAnnotation) {
+    String cronJobString = null;
+    Map<String, String> jobAnnotations = cronJob.getJobAnnotations();
+
+    if (MapUtils.isNotEmpty(jobAnnotations) && excludeAnnotation != null) {
+      jobAnnotations = SerializationUtils.clone((HashMap) cronJob.getJobAnnotations());
+      jobAnnotations.remove(excludeAnnotation.getValue());
+    }
+
+    if (getK8sSupportsV1CronJob()) {
+      cronJobString = v1CronJobFromTemplate(
+                      cronJob.getName(), cronJob.getSchedule(), !cronJob.isEnable(), cronJob.getJobContainer(), cronJob.getInitContainer(), cronJob.getVolumes(), jobAnnotations, cronJob.getJobLabels(), cronJob.getImagePullSecret()).toString();
+    } else {
+      cronJobString = v1beta1CronJobFromTemplate(
+              cronJob.getName(), cronJob.getSchedule(), !cronJob.isEnable(), cronJob.getJobContainer(), cronJob.getInitContainer(), cronJob.getVolumes(), jobAnnotations, cronJob.getJobLabels(), cronJob.getImagePullSecret()).toString();
+    }
+
+    return DigestUtils.sha1Hex(cronJobString);
+  }
+
+  public void updateCronJob(KubernetesService.CronJob cronJob) throws ApiException {
+    updateCronJob(cronJob.getName(), cronJob.getImage(), cronJob.getSchedule(), cronJob.isEnable(), cronJob.getJobContainer(), cronJob.getInitContainer(), cronJob.getVolumes(), cronJob.getJobAnnotations(), cronJob.getJobLabels(), cronJob.getImagePullSecret());
   }
 
   public void updateCronJob(

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
@@ -57,7 +57,17 @@ public class DataJobsKubernetesService extends KubernetesService {
   }
 
   public void createCronJob(KubernetesService.CronJob cronJob) throws ApiException {
-    createCronJob(cronJob.getName(), cronJob.getImage(), cronJob.getSchedule(), cronJob.isEnable(), cronJob.getJobContainer(), cronJob.getInitContainer(), cronJob.getVolumes(), cronJob.getJobAnnotations(), cronJob.getJobLabels(), cronJob.getImagePullSecret());
+    createCronJob(
+        cronJob.getName(),
+        cronJob.getImage(),
+        cronJob.getSchedule(),
+        cronJob.isEnable(),
+        cronJob.getJobContainer(),
+        cronJob.getInitContainer(),
+        cronJob.getVolumes(),
+        cronJob.getJobAnnotations(),
+        cronJob.getJobLabels(),
+        cronJob.getImagePullSecret());
   }
 
   public void createCronJob(
@@ -99,7 +109,8 @@ public class DataJobsKubernetesService extends KubernetesService {
     }
   }
 
-  public String getCronJobSha512(KubernetesService.CronJob cronJob, JobAnnotation excludeAnnotation) {
+  public String getCronJobSha512(
+      KubernetesService.CronJob cronJob, JobAnnotation excludeAnnotation) {
     String cronJobString = null;
     Map<String, String> jobAnnotations = cronJob.getJobAnnotations();
 
@@ -109,18 +120,48 @@ public class DataJobsKubernetesService extends KubernetesService {
     }
 
     if (getK8sSupportsV1CronJob()) {
-      cronJobString = v1CronJobFromTemplate(
-                      cronJob.getName(), cronJob.getSchedule(), !cronJob.isEnable(), cronJob.getJobContainer(), cronJob.getInitContainer(), cronJob.getVolumes(), jobAnnotations, cronJob.getJobLabels(), cronJob.getImagePullSecret()).toString();
+      cronJobString =
+          v1CronJobFromTemplate(
+                  cronJob.getName(),
+                  cronJob.getSchedule(),
+                  !cronJob.isEnable(),
+                  cronJob.getJobContainer(),
+                  cronJob.getInitContainer(),
+                  cronJob.getVolumes(),
+                  jobAnnotations,
+                  cronJob.getJobLabels(),
+                  cronJob.getImagePullSecret())
+              .toString();
     } else {
-      cronJobString = v1beta1CronJobFromTemplate(
-              cronJob.getName(), cronJob.getSchedule(), !cronJob.isEnable(), cronJob.getJobContainer(), cronJob.getInitContainer(), cronJob.getVolumes(), jobAnnotations, cronJob.getJobLabels(), cronJob.getImagePullSecret()).toString();
+      cronJobString =
+          v1beta1CronJobFromTemplate(
+                  cronJob.getName(),
+                  cronJob.getSchedule(),
+                  !cronJob.isEnable(),
+                  cronJob.getJobContainer(),
+                  cronJob.getInitContainer(),
+                  cronJob.getVolumes(),
+                  jobAnnotations,
+                  cronJob.getJobLabels(),
+                  cronJob.getImagePullSecret())
+              .toString();
     }
 
     return DigestUtils.sha1Hex(cronJobString);
   }
 
   public void updateCronJob(KubernetesService.CronJob cronJob) throws ApiException {
-    updateCronJob(cronJob.getName(), cronJob.getImage(), cronJob.getSchedule(), cronJob.isEnable(), cronJob.getJobContainer(), cronJob.getInitContainer(), cronJob.getVolumes(), cronJob.getJobAnnotations(), cronJob.getJobLabels(), cronJob.getImagePullSecret());
+    updateCronJob(
+        cronJob.getName(),
+        cronJob.getImage(),
+        cronJob.getSchedule(),
+        cronJob.isEnable(),
+        cronJob.getJobContainer(),
+        cronJob.getInitContainer(),
+        cronJob.getVolumes(),
+        cronJob.getJobAnnotations(),
+        cronJob.getJobLabels(),
+        cronJob.getImagePullSecret());
   }
 
   public void updateCronJob(

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitor.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitor.java
@@ -5,8 +5,11 @@
 
 package com.vmware.taurus.service.monitoring;
 
-import com.vmware.taurus.service.repository.JobsRepository;
+import com.vmware.taurus.service.model.DataJob;
+import com.vmware.taurus.service.model.DataJobDeployment;
 import com.vmware.taurus.service.model.DeploymentStatus;
+import com.vmware.taurus.service.repository.JobDeploymentRepository;
+import com.vmware.taurus.service.repository.JobsRepository;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -33,12 +36,15 @@ public class DeploymentMonitor {
 
   private final JobsRepository jobsRepository;
 
+  private final JobDeploymentRepository jobDeploymentRepository;
+
   private final Map<String, Integer> currentStatuses = new ConcurrentHashMap<>();
 
   @Autowired
-  public DeploymentMonitor(MeterRegistry meterRegistry, JobsRepository jobsRepository) {
+  public DeploymentMonitor(MeterRegistry meterRegistry, JobsRepository jobsRepository, JobDeploymentRepository jobDeploymentRepository) {
     this.meterRegistry = meterRegistry;
     this.jobsRepository = jobsRepository;
+    this.jobDeploymentRepository = jobDeploymentRepository;
   }
 
   /**
@@ -63,16 +69,16 @@ public class DeploymentMonitor {
    * @param dataJobName
    * @param deploymentStatus
    */
-  public void recordDeploymentStatus(String dataJobName, DeploymentStatus deploymentStatus) {
+  public void recordDeploymentStatus(String dataJobName, DeploymentStatus deploymentStatus, DataJobDeployment dataJobDeployment) {
     if (StringUtils.isNotBlank(dataJobName)) {
-      boolean jobExists = saveDataJobStatus(dataJobName, deploymentStatus);
+      boolean jobExists = saveDataJobStatus(dataJobName, deploymentStatus, dataJobDeployment);
       if (jobExists || currentStatuses.containsKey(dataJobName)) {
         // TODO: Add tag for data job mode
         DistributionSummary.builder(SUMMARY_METRIC_NAME)
-            .tag("dataJob", dataJobName)
-            .tag("status", deploymentStatus.toString())
-            .register(meterRegistry)
-            .record(1);
+                .tag("dataJob", dataJobName)
+                .tag("status", deploymentStatus.toString())
+                .register(meterRegistry)
+                .record(1);
         updateDataJobStatus(dataJobName, deploymentStatus);
       }
     } else {
@@ -81,9 +87,17 @@ public class DeploymentMonitor {
   }
 
   private boolean saveDataJobStatus(
-      final String dataJobName, final DeploymentStatus deploymentStatus) {
+          final String dataJobName, final DeploymentStatus deploymentStatus, DataJobDeployment dataJobDeployment) {
     if (jobsRepository.updateDataJobLatestJobDeploymentStatusByName(dataJobName, deploymentStatus)
-        > 0) {
+            > 0) {
+      switch (deploymentStatus) {
+        case SUCCESS:
+          if (dataJobDeployment != null) {
+            jobDeploymentRepository.updateDataJobDeploymentDeploymentVersionShaByDataJobName(
+                    dataJobName,
+                    dataJobDeployment.getDeploymentVersionSha());
+          }
+      }
       return true;
     }
     log.debug("Data job: {} was deleted or hasn't been created", dataJobName);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitor.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitor.java
@@ -5,7 +5,6 @@
 
 package com.vmware.taurus.service.monitoring;
 
-import com.vmware.taurus.service.model.DataJob;
 import com.vmware.taurus.service.model.DataJobDeployment;
 import com.vmware.taurus.service.model.DeploymentStatus;
 import com.vmware.taurus.service.repository.JobDeploymentRepository;
@@ -41,7 +40,10 @@ public class DeploymentMonitor {
   private final Map<String, Integer> currentStatuses = new ConcurrentHashMap<>();
 
   @Autowired
-  public DeploymentMonitor(MeterRegistry meterRegistry, JobsRepository jobsRepository, JobDeploymentRepository jobDeploymentRepository) {
+  public DeploymentMonitor(
+      MeterRegistry meterRegistry,
+      JobsRepository jobsRepository,
+      JobDeploymentRepository jobDeploymentRepository) {
     this.meterRegistry = meterRegistry;
     this.jobsRepository = jobsRepository;
     this.jobDeploymentRepository = jobDeploymentRepository;
@@ -69,16 +71,17 @@ public class DeploymentMonitor {
    * @param dataJobName
    * @param deploymentStatus
    */
-  public void recordDeploymentStatus(String dataJobName, DeploymentStatus deploymentStatus, DataJobDeployment dataJobDeployment) {
+  public void recordDeploymentStatus(
+      String dataJobName, DeploymentStatus deploymentStatus, DataJobDeployment dataJobDeployment) {
     if (StringUtils.isNotBlank(dataJobName)) {
       boolean jobExists = saveDataJobStatus(dataJobName, deploymentStatus, dataJobDeployment);
       if (jobExists || currentStatuses.containsKey(dataJobName)) {
         // TODO: Add tag for data job mode
         DistributionSummary.builder(SUMMARY_METRIC_NAME)
-                .tag("dataJob", dataJobName)
-                .tag("status", deploymentStatus.toString())
-                .register(meterRegistry)
-                .record(1);
+            .tag("dataJob", dataJobName)
+            .tag("status", deploymentStatus.toString())
+            .register(meterRegistry)
+            .record(1);
         updateDataJobStatus(dataJobName, deploymentStatus);
       }
     } else {
@@ -87,15 +90,16 @@ public class DeploymentMonitor {
   }
 
   private boolean saveDataJobStatus(
-          final String dataJobName, final DeploymentStatus deploymentStatus, DataJobDeployment dataJobDeployment) {
+      final String dataJobName,
+      final DeploymentStatus deploymentStatus,
+      DataJobDeployment dataJobDeployment) {
     if (jobsRepository.updateDataJobLatestJobDeploymentStatusByName(dataJobName, deploymentStatus)
-            > 0) {
+        > 0) {
       switch (deploymentStatus) {
         case SUCCESS:
           if (dataJobDeployment != null) {
             jobDeploymentRepository.updateDataJobDeploymentDeploymentVersionShaByDataJobName(
-                    dataJobName,
-                    dataJobDeployment.getDeploymentVersionSha());
+                dataJobName, dataJobDeployment.getDeploymentVersionSha());
           }
       }
       return true;

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/repository/JobDeploymentRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/repository/JobDeploymentRepository.java
@@ -7,7 +7,12 @@ package com.vmware.taurus.service.repository;
 
 import com.vmware.taurus.service.model.*;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import javax.transaction.Transactional;
 
 /**
  * Spring Data / JPA Repository for DataJobDeployment objects and their members
@@ -21,4 +26,13 @@ import org.springframework.stereotype.Repository;
  * <p>JobDeploymentRepositoryIT validates some aspects of the behavior
  */
 @Repository
-public interface JobDeploymentRepository extends JpaRepository<DataJobDeployment, String> {}
+public interface JobDeploymentRepository extends JpaRepository<DataJobDeployment, String> {
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query(
+            "update DataJobDeployment d set d.deploymentVersionSha = :deploymentVersionSha where d.dataJobName ="
+                    + " :dataJobName")
+    int updateDataJobDeploymentDeploymentVersionShaByDataJobName(
+            @Param(value = "dataJobName") String dataJobName,
+            @Param(value = "deploymentVersionSha") String deploymentVersionSha);
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/repository/JobDeploymentRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/repository/JobDeploymentRepository.java
@@ -27,12 +27,12 @@ import javax.transaction.Transactional;
  */
 @Repository
 public interface JobDeploymentRepository extends JpaRepository<DataJobDeployment, String> {
-    @Transactional
-    @Modifying(clearAutomatically = true)
-    @Query(
-            "update DataJobDeployment d set d.deploymentVersionSha = :deploymentVersionSha where d.dataJobName ="
-                    + " :dataJobName")
-    int updateDataJobDeploymentDeploymentVersionShaByDataJobName(
-            @Param(value = "dataJobName") String dataJobName,
-            @Param(value = "deploymentVersionSha") String deploymentVersionSha);
+  @Transactional
+  @Modifying(clearAutomatically = true)
+  @Query(
+      "update DataJobDeployment d set d.deploymentVersionSha = :deploymentVersionSha where"
+          + " d.dataJobName = :dataJobName")
+  int updateDataJobDeploymentDeploymentVersionShaByDataJobName(
+      @Param(value = "dataJobName") String dataJobName,
+      @Param(value = "deploymentVersionSha") String deploymentVersionSha);
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentNotificationHelperTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentNotificationHelperTest.java
@@ -98,8 +98,7 @@ public class DeploymentNotificationHelperTest {
 
     verify(deploymentProgress)
         .failed(
-            testDataJob.getJobConfig(),
-            testJobDeployment,
+            testDataJob,
             DeploymentStatus.USER_ERROR,
             errorMessage,
             true);

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentNotificationHelperTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentNotificationHelperTest.java
@@ -96,11 +96,6 @@ public class DeploymentNotificationHelperTest {
         BUILDER_JOB_LOGS,
         true);
 
-    verify(deploymentProgress)
-        .failed(
-            testDataJob,
-            DeploymentStatus.USER_ERROR,
-            errorMessage,
-            true);
+    verify(deploymentProgress).failed(testDataJob, DeploymentStatus.USER_ERROR, errorMessage, true);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
@@ -174,7 +174,7 @@ public class DeploymentServiceTest {
             any(),
             anyList());
     verify(deploymentMonitor)
-        .recordDeploymentStatus(jobDeployment.getDataJobName(), DeploymentStatus.SUCCESS);
+        .recordDeploymentStatus(jobDeployment.getDataJobName(), DeploymentStatus.SUCCESS, null);
     verify(dataJobNotification).notifyJobDeploySuccess(testDataJob.getJobConfig());
 
     var dataJobCaptor = ArgumentCaptor.forClass(DataJob.class);
@@ -215,7 +215,7 @@ public class DeploymentServiceTest {
             any(),
             anyList());
     verify(deploymentMonitor)
-        .recordDeploymentStatus(jobDeployment.getDataJobName(), DeploymentStatus.SUCCESS);
+        .recordDeploymentStatus(jobDeployment.getDataJobName(), DeploymentStatus.SUCCESS, null);
     verify(dataJobNotification).notifyJobDeploySuccess(testDataJob.getJobConfig());
 
     verify(jobsRepository, never()).save(any());
@@ -265,7 +265,7 @@ public class DeploymentServiceTest {
             any());
     verify(dataJobNotification, never()).notifyJobDeploySuccess(testDataJob.getJobConfig());
     // The builder class is responsible for sending metrics and notifications on failed build.
-    verify(deploymentMonitor, never()).recordDeploymentStatus(any(), any());
+    verify(deploymentMonitor, never()).recordDeploymentStatus(any(), any(), any());
     verify(dataJobNotification, never())
         .notifyJobDeployError(eq(testDataJob.getJobConfig()), any(), any());
   }
@@ -308,7 +308,7 @@ public class DeploymentServiceTest {
             any(),
             any());
     verify(deploymentMonitor)
-        .recordDeploymentStatus(jobDeployment.getDataJobName(), DeploymentStatus.PLATFORM_ERROR);
+        .recordDeploymentStatus(jobDeployment.getDataJobName(), DeploymentStatus.PLATFORM_ERROR, null);
     verify(dataJobNotification).notifyJobDeployError(eq(testDataJob.getJobConfig()), any(), any());
   }
 
@@ -413,6 +413,6 @@ public class DeploymentServiceTest {
 
     verify(kubernetesService, never()).deleteJob(any());
     verify(kubernetesService, never()).deleteCronJob(any());
-    verify(deploymentMonitor).recordDeploymentStatus(any(), eq(DeploymentStatus.SUCCESS));
+    verify(deploymentMonitor).recordDeploymentStatus(any(), eq(DeploymentStatus.SUCCESS), any());
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceTest.java
@@ -308,7 +308,8 @@ public class DeploymentServiceTest {
             any(),
             any());
     verify(deploymentMonitor)
-        .recordDeploymentStatus(jobDeployment.getDataJobName(), DeploymentStatus.PLATFORM_ERROR, null);
+        .recordDeploymentStatus(
+            jobDeployment.getDataJobName(), DeploymentStatus.PLATFORM_ERROR, null);
     verify(dataJobNotification).notifyJobDeployError(eq(testDataJob.getJobConfig()), any(), any());
   }
 

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageDeployerTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/JobImageDeployerTest.java
@@ -139,7 +139,7 @@ public class JobImageDeployerTest {
 
     jobImageDeployer.scheduleJob(testDataJob, jobDeployment, true, TEST_PRINCIPAL_NAME);
     verify(deploymentProgress)
-        .failed(any(), any(), eq(DeploymentStatus.USER_ERROR), anyString(), anyBoolean());
+        .failed(any(), eq(DeploymentStatus.USER_ERROR), anyString(), anyBoolean());
   }
 
   /** Test that the job container name is the same as the data job name. */

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DeploymentMonitorIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DeploymentMonitorIT.java
@@ -109,7 +109,8 @@ public class DeploymentMonitorIT {
   @Order(5)
   public void testNonExistingJob() {
 
-    deploymentMonitor.recordDeploymentStatus("data-job-missing", DeploymentStatus.PLATFORM_ERROR, null);
+    deploymentMonitor.recordDeploymentStatus(
+        "data-job-missing", DeploymentStatus.PLATFORM_ERROR, null);
 
     var gauges = meterRegistry.find(DeploymentMonitor.GAUGE_METRIC_NAME).gauges();
     var summaries = meterRegistry.find(DeploymentMonitor.SUMMARY_METRIC_NAME).summaries();

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DeploymentMonitorIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/monitoring/DeploymentMonitorIT.java
@@ -38,7 +38,7 @@ public class DeploymentMonitorIT {
     var entity = new DataJob("data-job", config, DeploymentStatus.NONE);
     jobsRepository.save(entity);
 
-    deploymentMonitor.recordDeploymentStatus("data-job", DeploymentStatus.SUCCESS);
+    deploymentMonitor.recordDeploymentStatus("data-job", DeploymentStatus.SUCCESS, null);
 
     var gauges = meterRegistry.find(DeploymentMonitor.GAUGE_METRIC_NAME).gauges();
     var summaries = meterRegistry.find(DeploymentMonitor.SUMMARY_METRIC_NAME).summaries();
@@ -55,7 +55,7 @@ public class DeploymentMonitorIT {
   @Order(2)
   public void testUpdateDeploymentStatusExistingJob() {
 
-    deploymentMonitor.recordDeploymentStatus("data-job", DeploymentStatus.PLATFORM_ERROR);
+    deploymentMonitor.recordDeploymentStatus("data-job", DeploymentStatus.PLATFORM_ERROR, null);
 
     var gauges = meterRegistry.find(DeploymentMonitor.GAUGE_METRIC_NAME).gauges();
     var summaries = meterRegistry.find(DeploymentMonitor.SUMMARY_METRIC_NAME).summaries();
@@ -73,7 +73,7 @@ public class DeploymentMonitorIT {
   @Order(3)
   public void testJobNameNull() {
 
-    deploymentMonitor.recordDeploymentStatus(null, DeploymentStatus.PLATFORM_ERROR);
+    deploymentMonitor.recordDeploymentStatus(null, DeploymentStatus.PLATFORM_ERROR, null);
 
     var gauges = meterRegistry.find(DeploymentMonitor.GAUGE_METRIC_NAME).gauges();
     var summaries = meterRegistry.find(DeploymentMonitor.SUMMARY_METRIC_NAME).summaries();
@@ -91,7 +91,7 @@ public class DeploymentMonitorIT {
   @Order(4)
   public void testJobNameEmpty() {
 
-    deploymentMonitor.recordDeploymentStatus("", DeploymentStatus.PLATFORM_ERROR);
+    deploymentMonitor.recordDeploymentStatus("", DeploymentStatus.PLATFORM_ERROR, null);
 
     var gauges = meterRegistry.find(DeploymentMonitor.GAUGE_METRIC_NAME).gauges();
     var summaries = meterRegistry.find(DeploymentMonitor.SUMMARY_METRIC_NAME).summaries();
@@ -109,7 +109,7 @@ public class DeploymentMonitorIT {
   @Order(5)
   public void testNonExistingJob() {
 
-    deploymentMonitor.recordDeploymentStatus("data-job-missing", DeploymentStatus.PLATFORM_ERROR);
+    deploymentMonitor.recordDeploymentStatus("data-job-missing", DeploymentStatus.PLATFORM_ERROR, null);
 
     var gauges = meterRegistry.find(DeploymentMonitor.GAUGE_METRIC_NAME).gauges();
     var summaries = meterRegistry.find(DeploymentMonitor.SUMMARY_METRIC_NAME).summaries();


### PR DESCRIPTION
Why
As part of the VEP-2272, we have to introduce a process to synchronize the data jobs from the database to the Kubernetes.

What
The initial implementation of the Data Jobs Synchronizer provides methods for synchronizing jobs between the database and Kubernetes. It introduces new classes suffixed with 'V2' to improve the separation of the old and new approaches.

Please take note that this is just the first phase of implementation. The following enhancements are planned for future PRs:

- We will annotate the method DataJobsSynchronizer.synchronizeDataJobs() with @Scheduled.
- Improved exception handling will be integrated.
- An additional deployment table will be introduced to effectively manage the desired and actual deployment state.
- More tests will be included in subsequent updates.
- ThreadPool configuration will be tuned and exposed through the application.properties.

Testing Done
Integration tests

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com