### PR TITLE
vdk-jupyter: VDK menu fix

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/schema/plugin.json
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/schema/plugin.json
@@ -13,6 +13,9 @@
             "command": "jp-vdk:menu-login"
           },
           {
+            "type": "separator"
+          },
+          {
             "command": "jp-vdk:menu-run"
           },
           {


### PR DESCRIPTION
What: added separator between run and login in the VDK menu
![Screenshot 2023-09-04 at 12 51 03](https://github.com/vmware/versatile-data-kit/assets/87015481/077a5c9d-15b0-48c2-8e02-a76c693f3e20)

Why: these two operations are not in the same class and should not be in the same area

Signed-off-by: Duygu Hasan [hduygu@vmware.com](mailto:hduygu@vmware.com)