### PR TITLE
vdk-core: remove log and re-throw pattern

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_router.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_router.py
@@ -172,9 +172,7 @@ class IngesterRouter(IIngesterRegistry, IIngester):
                 payload, destination_table, method, target, collection_id
             )
         except Exception as e:
-            self._log.error(
-                "Failed to send object for ingestion." f"Exception was: {e}"
-            )
+            self._log.warn("Failed to send object for ingestion." f"Exception was: {e}")
 
     def __ingest_tabular_data(
         self,
@@ -191,9 +189,6 @@ class IngesterRouter(IIngesterRegistry, IIngester):
                 rows, column_names, destination_table, method, target, collection_id
             )
         except Exception as e:
-            self._log.error(
-                "Failed to send tabular data for ingestion." f"Exception was: {e}"
-            )
             errors.log_and_rethrow(
                 ResolvableBy.USER_ERROR,
                 self._log,

--- a/projects/vdk-core/tests/vdk/internal/core/test_errors.py
+++ b/projects/vdk-core/tests/vdk/internal/core/test_errors.py
@@ -156,12 +156,10 @@ class ErrorsTest(unittest.TestCase):
             )
         )
 
-    def test_log_and_rethrow(self):
-        log = MagicMock(spec=logging.Logger)
+    def test_add_to_context_and_rethrow(self):
         with pytest.raises(IndexError):
-            errors.log_and_rethrow(
+            errors.add_to_context_and_rethrow(
                 errors.ResolvableBy.USER_ERROR,
-                log,
                 "w",
                 "w",
                 "c",
@@ -169,70 +167,30 @@ class ErrorsTest(unittest.TestCase):
                 IndexError("foo"),
                 False,
             )
-        log.exception.assert_called_once()
+        assert errors.ResolvableByActual.USER in errors.resolvable_context().resolvables
+        assert (
+            len(errors.resolvable_context().resolvables[errors.ResolvableByActual.USER])
+            is 1
+        )
 
-    def test_log_and_rethrow_and_log_once_only(self):
-        log = MagicMock(spec=logging.Logger)
-        error = IndexError("foo")
-        with pytest.raises(IndexError):
-            errors.log_and_rethrow(
-                errors.ResolvableBy.USER_ERROR,
-                log,
-                "w",
-                "w",
-                "c",
-                "c",
-                error,
-                False,
-            )
-
-        with pytest.raises(IndexError):
-            errors.log_and_rethrow(
-                errors.ResolvableBy.USER_ERROR,
-                log,
-                "w",
-                "w",
-                "c",
-                "c",
-                error,
-                False,
-            )
-
-        log.exception.assert_called_once()
-
-    def test_log_and_rethrow_wrap(self):
-        log = MagicMock(spec=logging.Logger)
-
-        with pytest.raises(UserCodeError):
-            errors.log_and_rethrow(
-                errors.ResolvableBy.USER_ERROR,
-                log,
-                "w",
-                "w",
-                "c",
-                "c",
-                IndexError("foo"),
-                True,
-            )
-        with pytest.raises(PlatformServiceError):
-            errors.log_and_rethrow(
+    def test_add_to_context_and_throw(self):
+        with pytest.raises(errors.BaseVdkError):
+            errors.add_to_context_and_throw(
                 errors.ResolvableBy.PLATFORM_ERROR,
-                log,
                 "w",
                 "w",
                 "c",
                 "c",
-                IndexError("foo"),
-                True,
             )
-        with pytest.raises(VdkConfigurationError):
-            errors.log_and_rethrow(
-                errors.ResolvableBy.CONFIG_ERROR,
-                log,
-                "w",
-                "w",
-                "c",
-                "c",
-                IndexError("foo"),
-                True,
+        assert (
+            errors.ResolvableByActual.PLATFORM
+            in errors.resolvable_context().resolvables
+        )
+        assert (
+            len(
+                errors.resolvable_context().resolvables[
+                    errors.ResolvableByActual.PLATFORM
+                ]
             )
+            is 1
+        )


### PR DESCRIPTION
## Why?

Remove the log and re-throw pattern to reduce the output logs size and increase readability

## What?

Remove loggign from log_and_throw and log_and_rethrow methods in the errors module. Create new methods that just add to the resolvable context and throw or re-throw the exception. Keep the api as is, but make the old methods call the new ones. This prevents plugins that use older versions of vdk-core from breaking.

## How has this been tested?

Before: https://pastebin.com/TCk4qsMC
After: https://pastebin.com/eJ7X4UcE

Ran locally, CI tests

## What type of change are you making?

Non-breaking change