### PR TITLE
control-service: implement Webhook APIs authentication

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -156,6 +156,10 @@ spec:
               value: "{{ .Values.security.authorization.webhookUri }}"
             - name: DATAJOBS_AUTHORIZATION_WEBHOOK_AUTHENTICATION_ENABLED
               value: "{{ .Values.security.authorization.webhookAuthenticationEnabled }}"
+            - name: DATAJOBS_AUTHORIZATION_WEBHOOK_AUTHORIZATION_SERVER_ENDPOINT
+              value: "{{ .Values.security.authorization.webhookAuthorizationServerEndpoint }}"
+            - name: DATAJOBS_AUTHORIZATION_WEBHOOK_AUTHORIZATION_REFRESH_TOKEN
+              value: "{{ .Values.security.authorization.webhookAuthorizationRefreshToken }}"
             - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI
               value: "{{ .Values.security.oauth2.jwtIssuerUrl }}"
             - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URIS
@@ -174,12 +178,20 @@ spec:
               value: "{{ .Values.webHooks.postCreate.internalErrorsRetries }}"
             - name: DATAJOBS_POST_CREATE_WEBHOOK_AUTHENTICATION_ENABLED
               value: "{{ .Values.webHooks.postCreate.authenticationEnabled }}"
+            - name: DATAJOBS_POST_CREATE_WEBHOOK_AUTHORIZATION_SERVER_ENDPOINT
+              value: "{{ .Values.webHooks.postCreate.authorizationServerEndpoint }}"
+            - name: DATAJOBS_POST_CREATE_WEBHOOK_AUTHORIZATION_REFRESH_TOKEN
+              value: "{{ .Values.webHooks.postCreate.authorizationRefreshToken }}"
             - name: DATAJOBS_POST_DELETE_WEBHOOK_ENDPOINT
               value: "{{ .Values.webHooks.postDelete.webhookUri }}"
             - name: DATAJOBS_POST_DELETE_WEBHOOK_INTERNAL_ERRORS_RETRIES
               value: "{{ .Values.webHooks.postDelete.internalErrorsRetries }}"
             - name: DATAJOBS_POST_DELETE_WEBHOOK_AUTHENTICATION_ENABLED
               value: "{{ .Values.webHooks.postDelete.authenticationEnabled }}"
+            - name: DATAJOBS_POST_DELETE_WEBHOOK_AUTHORIZATION_SERVER_ENDPOINT
+              value: "{{ .Values.webHooks.postDelete.authorizationServerEndpoint }}"
+            - name: DATAJOBS_POST_DELETE_WEBHOOK_AUTHORIZATION_REFRESH_TOKEN
+              value: "{{ .Values.webHooks.postDelete.authorizationRefreshToken }}"
             - name: DATAJOBS_AUTHORIZATION_JWT_CLAIM_USERNAME
               value: "{{ .Values.security.authorization.jwtClaimUsername }}"
             - name: DATAJOBS_DEPLOYMENT_JOB_IMAGE_PULL_POLICY

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -402,16 +402,20 @@ webHooks:
    ## 4xx response content is shown to end user as an error message.
    ## 5xx responses will be retried (number of retries is based on configuration, defaults to 3)
    ##
-   ## In case authenticationEnabled is set to true, the Control Service (CS) will transmit the oAuth2 access token
-   ## to the WebHook API. This access token serves the purpose of authenticating the client against the CS.
+   ## In case authenticationEnabled is set to true, the Control Service (CS) will obtain the oAuth2 access token from
+   ## authorizationServerEndpoint using the authorizationRefreshToken. After that the access token will be transmitted to the WebHook API.
    postCreate:
       webhookUri: ""
       internalErrorsRetries: 3
       authenticationEnabled: false
+      authorizationServerEndpoint: ""
+      authorizationRefreshToken: ""
    postDelete:
       webhookUri: ""
       internalErrorsRetries: 3
       authenticationEnabled: false
+      authorizationServerEndpoint: ""
+      authorizationRefreshToken: ""
 
 ### Security configuration
 
@@ -499,9 +503,11 @@ security:
       ## 4xx response content is shown to end user as an error message.
       ## 5xx responses will be retried
       webhookUri: ""
-      ## In case webhookAuthenticationEnabled is set to true, the Control Service (CS) will transmit the oAuth2 access token
-      ## to the WebHook API. This access token serves the purpose of authenticating the client against the CS.
+      ## In case authenticationEnabled is set to true, the Control Service (CS) will obtain the oAuth2 access token from
+      ## authorizationServerEndpoint using the authorizationRefreshToken. After that the access token will be transmitted to the WebHook API.
       webhookAuthenticationEnabled: false
+      webhookAuthorizationServerEndpoint: ""
+      webhookAuthorizationRefreshToken: ""
       ## What JWT token claim (aka attribute/field) will fetch the username from.
       jwtClaimUsername: "username"
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/provider/AuthorizationProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/provider/AuthorizationProvider.java
@@ -103,26 +103,26 @@ public class AuthorizationProvider {
     final MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
     map.add(OAuth2ParameterNames.REFRESH_TOKEN, refreshToken);
 
-    final ResponseEntity<String> responseEntity = restTemplate.exchange(
-            cspAuthEndpoint,
-            HttpMethod.POST,
-            new HttpEntity<>(map, headers),
-            String.class);
+    final ResponseEntity<String> responseEntity =
+        restTemplate.exchange(
+            cspAuthEndpoint, HttpMethod.POST, new HttpEntity<>(map, headers), String.class);
 
     try {
       final JSONObject jsonResponse = new JSONObject(responseEntity.getBody());
       if (jsonResponse.has(OAuth2ParameterNames.ACCESS_TOKEN)) {
         return jsonResponse.getString(OAuth2ParameterNames.ACCESS_TOKEN);
       }
-      throw new AuthorizationError("Response from Authorization Server doesn't contain needed access_token",
-              "Cannot determine whether a user is authorized to do this request",
-              "Configure the authorization webhook property or disable the feature altogether",
-              null);
+      throw new AuthorizationError(
+          "Response from Authorization Server doesn't contain needed access_token",
+          "Cannot determine whether a user is authorized to do this request",
+          "Configure the authorization webhook property or disable the feature altogether",
+          null);
     } catch (JSONException e) {
-      throw new AuthorizationError("Unable to parse response to json while fetching access token",
-              "Cannot determine whether a user is authorized to do this request",
-              "Configure the authorization webhook property or disable the feature altogether",
-              e);
+      throw new AuthorizationError(
+          "Unable to parse response to json while fetching access token",
+          "Cannot determine whether a user is authorized to do this request",
+          "Configure the authorization webhook property or disable the feature altogether",
+          e);
     }
   }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/webhook/AuthorizationWebHookProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/webhook/AuthorizationWebHookProvider.java
@@ -32,17 +32,20 @@ import org.springframework.web.client.RestTemplate;
 public class AuthorizationWebHookProvider extends WebHookService<AuthorizationBody> {
 
   public AuthorizationWebHookProvider(
-      @Value("${datajobs.authorization.webhook.endpoint}") String webHookEndpoint,
-      @Value("${datajobs.authorization.webhook.internal.errors.retries:1}") int retriesOn5xxErrors,
-      @Value("${datajobs.authorization.webhook.authentication.enabled:false}")
-          boolean authenticationEnabled,
-      RestTemplate restTemplate,
-      FeatureFlags featureFlags,
-      AuthorizationProvider authorizationProvider) {
+          @Value("${datajobs.authorization.webhook.endpoint}") String webHookEndpoint,
+          @Value("${datajobs.authorization.webhook.internal.errors.retries:1}") int retriesOn5xxErrors,
+          @Value("${datajobs.authorization.webhook.authentication.enabled:false}") boolean authenticationEnabled,
+          @Value("${datajobs.authorization.webhook.authorization.server.endpoint:''}") String authorizationServerEndpoint,
+          @Value("${datajobs.authorization.webhook.authorization.refresh.token:''}") String refreshToken,
+          RestTemplate restTemplate,
+          FeatureFlags featureFlags,
+          AuthorizationProvider authorizationProvider) {
     super(
         webHookEndpoint,
         retriesOn5xxErrors,
         authenticationEnabled,
+        authorizationServerEndpoint,
+        refreshToken,
         log,
         restTemplate,
         featureFlags,

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/webhook/AuthorizationWebHookProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/webhook/AuthorizationWebHookProvider.java
@@ -32,14 +32,17 @@ import org.springframework.web.client.RestTemplate;
 public class AuthorizationWebHookProvider extends WebHookService<AuthorizationBody> {
 
   public AuthorizationWebHookProvider(
-          @Value("${datajobs.authorization.webhook.endpoint}") String webHookEndpoint,
-          @Value("${datajobs.authorization.webhook.internal.errors.retries:1}") int retriesOn5xxErrors,
-          @Value("${datajobs.authorization.webhook.authentication.enabled:false}") boolean authenticationEnabled,
-          @Value("${datajobs.authorization.webhook.authorization.server.endpoint:''}") String authorizationServerEndpoint,
-          @Value("${datajobs.authorization.webhook.authorization.refresh.token:''}") String refreshToken,
-          RestTemplate restTemplate,
-          FeatureFlags featureFlags,
-          AuthorizationProvider authorizationProvider) {
+      @Value("${datajobs.authorization.webhook.endpoint}") String webHookEndpoint,
+      @Value("${datajobs.authorization.webhook.internal.errors.retries:1}") int retriesOn5xxErrors,
+      @Value("${datajobs.authorization.webhook.authentication.enabled:false}")
+          boolean authenticationEnabled,
+      @Value("${datajobs.authorization.webhook.authorization.server.endpoint:''}")
+          String authorizationServerEndpoint,
+      @Value("${datajobs.authorization.webhook.authorization.refresh.token:''}")
+          String refreshToken,
+      RestTemplate restTemplate,
+      FeatureFlags featureFlags,
+      AuthorizationProvider authorizationProvider) {
     super(
         webHookEndpoint,
         retriesOn5xxErrors,

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostCreateWebHookProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostCreateWebHookProvider.java
@@ -28,8 +28,10 @@ public class PostCreateWebHookProvider extends WebHookService<WebHookRequestBody
   public PostCreateWebHookProvider(
       @Value("${datajobs.post.create.webhook.endpoint}") String webHookEndpoint,
       @Value("${datajobs.post.create.webhook.internal.errors.retries:-1}") int retriesOn5xxErrors,
-      @Value("${datajobs.post.create.webhook.authentication.enabled:false}") boolean authenticationEnabled,
-      @Value("${datajobs.post.create.webhook.authorization.server.endpoint:''}") String authorizationServerEndpoint,
+      @Value("${datajobs.post.create.webhook.authentication.enabled:false}")
+          boolean authenticationEnabled,
+      @Value("${datajobs.post.create.webhook.authorization.server.endpoint:''}")
+          String authorizationServerEndpoint,
       @Value("${datajobs.post.create.webhook.authorization.refresh.token:''}") String refreshToken,
       RestTemplate restTemplate,
       FeatureFlags featureFlags,

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostCreateWebHookProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostCreateWebHookProvider.java
@@ -28,8 +28,9 @@ public class PostCreateWebHookProvider extends WebHookService<WebHookRequestBody
   public PostCreateWebHookProvider(
       @Value("${datajobs.post.create.webhook.endpoint}") String webHookEndpoint,
       @Value("${datajobs.post.create.webhook.internal.errors.retries:-1}") int retriesOn5xxErrors,
-      @Value("${datajobs.post.create.webhook.authentication.enabled:false}")
-          boolean authenticationEnabled,
+      @Value("${datajobs.post.create.webhook.authentication.enabled:false}") boolean authenticationEnabled,
+      @Value("${datajobs.post.create.webhook.authorization.server.endpoint:''}") String authorizationServerEndpoint,
+      @Value("${datajobs.post.create.webhook.authorization.refresh.token:''}") String refreshToken,
       RestTemplate restTemplate,
       FeatureFlags featureFlags,
       AuthorizationProvider authorizationProvider) {
@@ -37,6 +38,8 @@ public class PostCreateWebHookProvider extends WebHookService<WebHookRequestBody
         webHookEndpoint,
         retriesOn5xxErrors,
         authenticationEnabled,
+        authorizationServerEndpoint,
+        refreshToken,
         log,
         restTemplate,
         featureFlags,

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostDeleteWebHookProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostDeleteWebHookProvider.java
@@ -28,8 +28,10 @@ public class PostDeleteWebHookProvider extends WebHookService<WebHookRequestBody
   public PostDeleteWebHookProvider(
       @Value("${datajobs.post.delete.webhook.endpoint}") String webHookEndpoint,
       @Value("${datajobs.post.delete.webhook.internal.errors.retries:-1}") int retriesOn5xxErrors,
-      @Value("${datajobs.post.delete.webhook.authentication.enabled:false}") boolean authenticationEnabled,
-      @Value("${datajobs.post.delete.webhook.authorization.server.endpoint:''}") String authorizationServerEndpoint,
+      @Value("${datajobs.post.delete.webhook.authentication.enabled:false}")
+          boolean authenticationEnabled,
+      @Value("${datajobs.post.delete.webhook.authorization.server.endpoint:''}")
+          String authorizationServerEndpoint,
       @Value("${datajobs.post.delete.webhook.authorization.refresh.token:''}") String refreshToken,
       RestTemplate restTemplate,
       FeatureFlags featureFlags,

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostDeleteWebHookProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/webhook/PostDeleteWebHookProvider.java
@@ -28,8 +28,9 @@ public class PostDeleteWebHookProvider extends WebHookService<WebHookRequestBody
   public PostDeleteWebHookProvider(
       @Value("${datajobs.post.delete.webhook.endpoint}") String webHookEndpoint,
       @Value("${datajobs.post.delete.webhook.internal.errors.retries:-1}") int retriesOn5xxErrors,
-      @Value("${datajobs.post.delete.webhook.authentication.enabled:false}")
-          boolean authenticationEnabled,
+      @Value("${datajobs.post.delete.webhook.authentication.enabled:false}") boolean authenticationEnabled,
+      @Value("${datajobs.post.delete.webhook.authorization.server.endpoint:''}") String authorizationServerEndpoint,
+      @Value("${datajobs.post.delete.webhook.authorization.refresh.token:''}") String refreshToken,
       RestTemplate restTemplate,
       FeatureFlags featureFlags,
       AuthorizationProvider authorizationProvider) {
@@ -37,6 +38,8 @@ public class PostDeleteWebHookProvider extends WebHookService<WebHookRequestBody
         webHookEndpoint,
         retriesOn5xxErrors,
         authenticationEnabled,
+        authorizationServerEndpoint,
+        refreshToken,
         log,
         restTemplate,
         featureFlags,

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/webhook/WebHookService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/webhook/WebHookService.java
@@ -38,6 +38,10 @@ public abstract class WebHookService<T extends WebHookRequestBody> implements In
 
   private final boolean authenticationEnabled;
 
+  private final String authorizationServerEndpoint;
+
+  private final String refreshToken;
+
   private final Logger log;
 
   private final RestTemplate restTemplate;
@@ -182,7 +186,7 @@ public abstract class WebHookService<T extends WebHookRequestBody> implements In
     HttpEntity<WebHookRequestBody> request = null;
 
     if (featureFlags.isSecurityEnabled() && authenticationEnabled) {
-      String accessToken = authorizationProvider.getAccessToken();
+      String accessToken = authorizationProvider.getAccessToken(authorizationServerEndpoint, refreshToken);
 
       if (StringUtils.isNotEmpty(accessToken)) {
         HttpHeaders httpHeaders = new HttpHeaders();

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/webhook/WebHookService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/webhook/WebHookService.java
@@ -186,7 +186,8 @@ public abstract class WebHookService<T extends WebHookRequestBody> implements In
     HttpEntity<WebHookRequestBody> request = null;
 
     if (featureFlags.isSecurityEnabled() && authenticationEnabled) {
-      String accessToken = authorizationProvider.getAccessToken(authorizationServerEndpoint, refreshToken);
+      String accessToken =
+          authorizationProvider.getAccessToken(authorizationServerEndpoint, refreshToken);
 
       if (StringUtils.isNotEmpty(accessToken)) {
         HttpHeaders httpHeaders = new HttpHeaders();

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -77,6 +77,8 @@ spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${SPRING_SECURITY_OAUTH2_R
 featureflag.authorization.enabled=false
 datajobs.authorization.webhook.endpoint=
 datajobs.authorization.webhook.authentication.enabled=false
+datajobs.authorization.webhook.authorization.server.endpoint=
+datajobs.authorization.webhook.authorization.refresh.token=
 datajobs.authorization.jwt.claim.username=username
 
 
@@ -84,9 +86,13 @@ datajobs.authorization.jwt.claim.username=username
 datajobs.post.create.webhook.endpoint=
 datajobs.post.create.webhook.internal.errors.retries=3
 datajobs.post.create.webhook.authentication.enabled=false
+datajobs.post.create.webhook.authorization.server.endpoint=
+datajobs.post.create.webhook.authorization.refresh.token=
 datajobs.post.delete.webhook.endpoint=
 datajobs.post.delete.webhook.internal.errors.retries=3
 datajobs.post.delete.webhook.authentication.enabled=false
+datajobs.post.delete.webhook.authorization.server.endpoint=
+datajobs.post.delete.webhook.authorization.refresh.token=
 
 # The owner name and email address that will be used to send all Versatile Data Kit related email notifications.
 datajobs.notification.owner.email=versatiledatakit@groups.vmware.com

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/authorization/provider/AuthorizationProviderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/authorization/provider/AuthorizationProviderTest.java
@@ -6,9 +6,6 @@
 package com.vmware.taurus.authorization.provider;
 
 import com.vmware.taurus.authorization.webhook.AuthorizationBody;
-import com.vmware.taurus.service.JobsRepository;
-import com.vmware.taurus.service.model.DataJob;
-import com.vmware.taurus.service.model.DeploymentStatus;
 import com.vmware.taurus.service.model.JobConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,7 +25,6 @@ import org.springframework.web.client.RestTemplate;
 import javax.servlet.http.HttpServletRequest;
 import java.util.Map;
 
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/authorization/provider/AuthorizationProviderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/authorization/provider/AuthorizationProviderTest.java
@@ -23,6 +23,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Map;
@@ -34,7 +35,7 @@ import static org.mockito.Mockito.mock;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class AuthorizationProviderTest {
 
-  @Mock private JobsRepository repository;
+  @Mock private RestTemplate restTemplate;
 
   @InjectMocks private AuthorizationProvider provider;
 
@@ -43,14 +44,12 @@ public class AuthorizationProviderTest {
     ReflectionTestUtils.setField(provider, "usernameField", "username");
     JobConfig config = new JobConfig();
     config.setTeam("job-repo-example-team");
-    DataJob job = new DataJob("job-repo-example", config, DeploymentStatus.NONE);
-    Mockito.when(repository.findById(anyString())).thenReturn(java.util.Optional.of(job));
     MockitoAnnotations.initMocks(this);
   }
 
   @Test
   public void testParsePropertyFromURI() {
-    var provider = new AuthorizationProvider(repository);
+    var provider = new AuthorizationProvider(restTemplate);
     String createJob =
         provider.parsePropertyFromURI("", "/data-jobs/for-team/example-team/jobs", 5);
     String createJobSlash =
@@ -94,7 +93,7 @@ public class AuthorizationProviderTest {
 
   @Test
   public void testParseJobNameFromURIContext() {
-    var provider = new AuthorizationProvider(repository);
+    var provider = new AuthorizationProvider(restTemplate);
     String createJob =
         provider.parsePropertyFromURI("/api/v1", "/data-jobs/for-team/example-team/jobs", 5);
     String createJobSlash =

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/BaseWebHookProviderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/BaseWebHookProviderTest.java
@@ -29,6 +29,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
@@ -200,7 +201,7 @@ public abstract class BaseWebHookProviderTest {
 
     ReflectionTestUtils.setField(getWebHookProvider(), "authenticationEnabled", true);
     when(featureFlags.isSecurityEnabled()).thenReturn(true);
-    when(authorizationProvider.getAccessToken()).thenReturn(expectedAccessToken);
+    when(authorizationProvider.getAccessToken(anyString(), anyString())).thenReturn(expectedAccessToken);
 
     ResponseEntity re = new ResponseEntity<>("Good request", null, HttpStatus.ACCEPTED);
     when(restTemplate.exchange(
@@ -234,7 +235,7 @@ public abstract class BaseWebHookProviderTest {
 
     ReflectionTestUtils.setField(getWebHookProvider(), "authenticationEnabled", false);
     when(featureFlags.isSecurityEnabled()).thenReturn(true);
-    when(authorizationProvider.getAccessToken()).thenReturn(expectedAccessToken);
+    when(authorizationProvider.getAccessToken(anyString(), anyString())).thenReturn(expectedAccessToken);
 
     ResponseEntity re = new ResponseEntity<>("Good request", null, HttpStatus.ACCEPTED);
     when(restTemplate.exchange(

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/BaseWebHookProviderTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/webhook/BaseWebHookProviderTest.java
@@ -201,7 +201,8 @@ public abstract class BaseWebHookProviderTest {
 
     ReflectionTestUtils.setField(getWebHookProvider(), "authenticationEnabled", true);
     when(featureFlags.isSecurityEnabled()).thenReturn(true);
-    when(authorizationProvider.getAccessToken(anyString(), anyString())).thenReturn(expectedAccessToken);
+    when(authorizationProvider.getAccessToken(anyString(), anyString()))
+        .thenReturn(expectedAccessToken);
 
     ResponseEntity re = new ResponseEntity<>("Good request", null, HttpStatus.ACCEPTED);
     when(restTemplate.exchange(
@@ -235,7 +236,8 @@ public abstract class BaseWebHookProviderTest {
 
     ReflectionTestUtils.setField(getWebHookProvider(), "authenticationEnabled", false);
     when(featureFlags.isSecurityEnabled()).thenReturn(true);
-    when(authorizationProvider.getAccessToken(anyString(), anyString())).thenReturn(expectedAccessToken);
+    when(authorizationProvider.getAccessToken(anyString(), anyString()))
+        .thenReturn(expectedAccessToken);
 
     ResponseEntity re = new ResponseEntity<>("Good request", null, HttpStatus.ACCEPTED);
     when(restTemplate.exchange(


### PR DESCRIPTION
Why
If a data job authenticates against the Control Service via Kerberos, the Control Service won't be able to forward the access token to webhook APIs, because it does not exist.

What
Implemented method for obtaining oAuth2 access token via refresh token.

Testing Done:
Locally against real oAuth2 Authorization Server.

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com