### PR TITLE
vdk-core: change jobs behavior when logging unavailable

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/log_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/log_config.py
@@ -284,8 +284,8 @@ class LoggingPlugin:
                 what_happened="Failed to initialize logging",
                 why_it_happened=errors.MSG_WHY_FROM_EXCEPTION(e),
                 consequences="Failed to initialize data job logging."
-                             " Will proceed with basic local logging on"
-                             " DEBUG level.",
+                " Will proceed with basic local logging on"
+                " DEBUG level.",
                 countermeasures="Depending on stacktrace.",
                 exception=e,
             )

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/log_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/log_config.py
@@ -278,12 +278,14 @@ class LoggingPlugin:
                 "Trying to send telemetry for Job attempt: %s"
                 % (log_config_type, attempt_id)
             )
-            errors.log_and_rethrow(
+            errors.log_exception(
                 errors.find_whom_to_blame_from_exception(e),
                 log=logging.getLogger(__name__),
                 what_happened="Failed to initialize logging",
                 why_it_happened=errors.MSG_WHY_FROM_EXCEPTION(e),
-                consequences="Logging is critical VDK component. VDK will now exit.",
-                countermeasures="Depending on stacktrace",
+                consequences="Failed to initialize data job logging."
+                             " Will proceed with basic local logging on"
+                             " DEBUG level.",
+                countermeasures="Depending on stacktrace.",
                 exception=e,
             )

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_log_config.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_log_config.py
@@ -112,7 +112,9 @@ def test_configure_logger():
 
 def test_log_plugin_exception():
     print("This")
-    with mock.patch("vdk.internal.builtin_plugins.config.log_config.configure_loggers") as mocked_log_config:
+    with mock.patch(
+        "vdk.internal.builtin_plugins.config.log_config.configure_loggers"
+    ) as mocked_log_config:
         try:
             mocked_log_config.side_effect = Exception("foo")
 

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_log_config.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_log_config.py
@@ -108,3 +108,27 @@ def test_configure_logger():
             configured_loggers = mock_dict_config.call_args[0][0]["loggers"]
             assert configured_loggers["a.b.c"]["level"] == "INFO"
             assert configured_loggers["foo.bar"]["level"] == "ERROR"
+
+
+def test_log_plugin_exception():
+    print("This")
+    with mock.patch("vdk.internal.builtin_plugins.config.log_config.configure_loggers") as mocked_log_config:
+        try:
+            mocked_log_config.side_effect = Exception("foo")
+
+            log_plugin = LoggingPlugin()
+
+            # Mock configuration since we wont be needing any.
+            job_context = mock.MagicMock(spec=JobContext)
+            job_context.name = mock.MagicMock()
+            job_context.core_context = mock.MagicMock()
+            job_context.core_context.configuration = mock.MagicMock()
+            job_context.core_context.state = mock.MagicMock()
+            job_context.core_context.state.get = mock.MagicMock()
+            job_context.core_context.configuration.get_value = mock.MagicMock()
+
+            # Test except: section in initialize_job and expect no exceptions
+            log_plugin.initialize_job(job_context)
+        finally:
+            logging.getLogger().setLevel(logging.INFO)
+            logging.getLogger("vdk").setLevel(logging.INFO)


### PR DESCRIPTION
what:
Data jobs won't fail if logging fails to initialize.

why:
If logging level is set to cloud and the configuration connects to an external service logging service such as log insight which happens to be unavailable to whole cloud cluster of data jobs will experience an outage. Instead of failing the data job, execution should now proceed with local logging on DEBUG level.

testing:
added unit test.