### PR TITLE
control-service: add amazon rds ca certificates to data job image

### DIFF
--- a/projects/control-service/projects/job-base-image-secure/Dockerfile-data-job-base
+++ b/projects/control-service/projects/job-base-image-secure/Dockerfile-data-job-base
@@ -97,10 +97,8 @@ FROM photon:latest
 # excluding build dependencies.
 COPY --from=build /usr/local/ /usr/local/
 
-# Installs Python dependencies
-RUN yum install libffi-devel -y
-
-# Download amazon AWS RDS certificates
+# Installs Python dependencies and downloads AWS RDS certificates
 RUN : \
+ && yum install libffi-devel -y \
  && echo "Downloading AWS RDS certificate bundle..." \
  && wget https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -O /etc/ssl/certs/global-bundle.pem

--- a/projects/control-service/projects/job-base-image-secure/Dockerfile-data-job-base
+++ b/projects/control-service/projects/job-base-image-secure/Dockerfile-data-job-base
@@ -99,3 +99,8 @@ COPY --from=build /usr/local/ /usr/local/
 
 # Installs Python dependencies
 RUN yum install libffi-devel -y
+
+# Download amazon AWS RDS certificates
+RUN : \
+ && echo "Downloading AWS RDS certificate bundle..." \
+ && wget https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -O /etc/ssl/certs/global-bundle.pem

--- a/projects/control-service/projects/job-builder-secure/Dockerfile.python.vdk
+++ b/projects/control-service/projects/job-builder-secure/Dockerfile.python.vdk
@@ -51,7 +51,9 @@ RUN : \
           && yum autoremove build-essential gcc glibc-devel git unzip -y;  fi \
     && echo "Installing native dependencies ..." \
     && yum install libffi-devel libstdc++ findutils openssl-c_rehash -y \
-    && echo "Refreshing CA certificates ..." \
+    && echo "Downloading AWS RDS certificate bundle..." \
+    && wget https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -O /etc/ssl/certs/global-bundle.pem \
+    && echo "Refreshing CA certificates" \
     && /usr/bin/rehash_ca_certificates.sh \
     && echo "Deleting system packages ..." \
     && yum autoremove shadow toybox openssl-c_rehash -y \

--- a/projects/control-service/projects/job-builder-secure/Dockerfile.python.vdk
+++ b/projects/control-service/projects/job-builder-secure/Dockerfile.python.vdk
@@ -51,7 +51,7 @@ RUN : \
           && yum autoremove build-essential gcc glibc-devel git unzip -y;  fi \
     && echo "Installing native dependencies ..." \
     && yum install libffi-devel libstdc++ findutils openssl-c_rehash -y \
-    && echo "Refreshing CA certificates" \
+    && echo "Refreshing CA certificates ..." \
     && /usr/bin/rehash_ca_certificates.sh \
     && echo "Deleting system packages ..." \
     && yum autoremove shadow toybox openssl-c_rehash -y \

--- a/projects/control-service/projects/job-builder-secure/Dockerfile.python.vdk
+++ b/projects/control-service/projects/job-builder-secure/Dockerfile.python.vdk
@@ -51,8 +51,6 @@ RUN : \
           && yum autoremove build-essential gcc glibc-devel git unzip -y;  fi \
     && echo "Installing native dependencies ..." \
     && yum install libffi-devel libstdc++ findutils openssl-c_rehash -y \
-    && echo "Downloading AWS RDS certificate bundle..." \
-    && wget https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -O /etc/ssl/certs/global-bundle.pem \
     && echo "Refreshing CA certificates" \
     && /usr/bin/rehash_ca_certificates.sh \
     && echo "Deleting system packages ..." \


### PR DESCRIPTION
what:
Adding amazon rds ca certificates to secure job image

why:
Data job users require ca certificates to connect to amazon databases

testing:
building images locally and inspecting certificate output:
List truncated because of 100+ certificates
`38.45 subject=C = US, O = "Amazon Web Services, Inc.", OU = Amazon RDS, ST = WA, CN = Amazon RDS eu-west-1 Root CA RSA4096 G1, L = Seattle

38.46 subject=C = US, O = "Amazon Web Services, Inc.", OU = Amazon RDS, ST = WA, CN = Amazon RDS eu-central-1 Root CA RSA4096 G1, L = Seattle

38.46 subject=C = US, O = "Amazon Web Services, Inc.", OU = Amazon RDS, ST = WA, CN = Amazon RDS eu-north-1 Root CA RSA2048 G1, L = Seattle
`