### PR TITLE
vdk-jupyter: pin traitlets to 5.9

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/pyproject.toml
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 dependencies = [
     "jupyter_server>=1.6,<3",
     "jupyterlab==3.6.3",
+    "traitlets==5.9.0",
     "vdk-control-cli",
     "vdk-core"
 ]


### PR DESCRIPTION
Latest release of traitlets (5.10) is breaking jupyter server - https://github.com/jupyter/notebook/issues/7048  which is causing jupyter server to fail to start

So we are pinning temporarily to 5.9 to fix that.