### PR TITLE
vdk-heartbeat: Add python version configuration

### DIFF
--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/config.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/config.py
@@ -114,6 +114,12 @@ class Config:
             "VDK_HEARTBEAT_DEPLOY_JOB_VDK_VERSION", is_required=False
         )
 
+        # Deploy the job with a specific python version (optional). By default, the default python
+        # version set by the Control Service is used.
+        self.deploy_job_python_version = self.get_value(
+            "DATAJOB_DEPLOYMENT_PYTHON_VERSION", is_required=False
+        )
+
         # Job name deployed during the test
         self.job_name = self.get_value(
             "JOB_NAME", f"vdk-heartbeat-data-job-{job_suffix}"[0:45]

--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
@@ -406,6 +406,10 @@ class JobController:
         config_ini.set("owner", "team", self.config.job_team)
         config_ini.set("job", "schedule_cron", "* * * * *")
         config_ini.set("job", "db_default_type", self.config.db_default_type)
+        if self.config.deploy_job_python_version:
+            config_ini.set(
+                "job", "python_version", self.config.deploy_job_python_version
+            )
         if self.config.job_notification_mail:
             config_ini.add_section("contacts")
             config_ini.set(


### PR DESCRIPTION
Currently, it is not possible to set a specific python version, with which a test data job to be deployed. As a result the heartbeat can be executed only against the default python version specified in the Control Service configuration.

This change adds the ability to set a specific python version in the ini file for a test case.

Testing Done: Executed vdk-heartbeat with a simple test config.ini and verified that the test data job was deployed with thhe correct python version.