### PR TITLE
vdk-jupyter: improve init message

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/initVDKConfigCell.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/initVDKConfigCell.ts
@@ -33,6 +33,7 @@ export function initVDKConfigCell(notebookTracker: INotebookTracker) {
         cell: {
           cell_type: 'code',
           source: [
+            '"""\n',
             'vdk.plugin.ipython extension introduces a magic command for Jupyter.\n',
             'The command enables the user to load VDK for the current notebook.\n',
             'VDK provides the job_input API, which has methods for:\n',
@@ -40,6 +41,7 @@ export function initVDKConfigCell(notebookTracker: INotebookTracker) {
             '    * ingesting data into a database;\n',
             '    * processing data into a database.\n',
             'Type help(job_input) to see its documentation.\n\n',
+            '"""\n',
             '%reload_ext vdk.plugin.ipython\n',
             '%reload_VDK\n',
             'job_input = VDK.get_initialized_job_input()'

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/initVDKConfigCell.ts
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/initVDKConfigCell.ts
@@ -11,34 +11,74 @@ import { INotebookTracker } from '@jupyterlab/notebook';
 export function initVDKConfigCell(notebookTracker: INotebookTracker) {
   const notebookPanel = notebookTracker.currentWidget;
   if (notebookPanel) {
-    const initCell =
-      notebookPanel.content.model?.contentFactory?.createCodeCell({
+    // Create Markdown Cell
+    const markdownCell =
+      notebookPanel.content.model?.contentFactory?.createMarkdownCell({
+        // eslint-disable-next-line prettier/prettier
         cell: {
-          cell_type: 'code',
+          cell_type: 'markdown',
           source: [
-            `"""\n`,
-            `This cell must be executed to load VDK job_input variable .\n\n`,
-            `vdk.plugin.ipython extension introduces a magic command for Jupyter.\n`,
-            `The command enables the user to load VDK for the current notebook.\n`,
-            `VDK provides the job_input API, which has methods for:\n`,
-            `    * executing queries to an OLAP database;\n`,
-            `    * ingesting data into a database;\n`,
-            `    * processing data into a database.\n`,
-            `Type help(job_input) to see its documentation.\n`,
-            `"""\n`,
-            `%reload_ext vdk.plugin.ipython\n`,
-            `%reload_VDK\n`,
-            `job_input = VDK.get_initialized_job_input()`
+            'You are running in environment where VDK Jupyter extension is installed.<br/>',
+            'If you are not using VDK, you can delete and ignore this and below cell.<br/><br/>',
+            'To learn more check out [VDK Notebook Getting Started](https://bit.ly/vdk-notebook).<br/><br/>',
+            '**IMPORTANT: Please execute the cell below to load the VDK job_input variable.**'
           ],
           metadata: { editable: false }
         }
       });
-    const cells = notebookTracker.currentWidget?.content.model?.cells;
+
+    // Create Code Cell
+    const codeCell =
+      notebookPanel.content.model?.contentFactory?.createCodeCell({
+        cell: {
+          cell_type: 'code',
+          source: [
+            'vdk.plugin.ipython extension introduces a magic command for Jupyter.\n',
+            'The command enables the user to load VDK for the current notebook.\n',
+            'VDK provides the job_input API, which has methods for:\n',
+            '    * executing queries to an OLAP database;\n',
+            '    * ingesting data into a database;\n',
+            '    * processing data into a database.\n',
+            'Type help(job_input) to see its documentation.\n\n',
+            '%reload_ext vdk.plugin.ipython\n',
+            '%reload_VDK\n',
+            'job_input = VDK.get_initialized_job_input()'
+          ],
+          metadata: { editable: false }
+        }
+      });
+
+    const emptyCodeCell =
+      notebookPanel.content.model?.contentFactory?.createCodeCell({
+        cell: {
+          cell_type: 'code',
+          source: [],
+          metadata: { tags: ['vdk'] }
+        }
+      });
+
+    const cells = notebookPanel.content.model?.cells;
     const cellContent = cells?.get(0).value.text;
-    // check if the notebook has only 1 empty cell, which is how we judge if it is a new notebook or not
-    if (cells && initCell && cells.length <= 1 && cellContent == '') {
-      cells.insert(0, initCell);
-      cells.remove(1);
+
+    // Check if the notebook has only 1 empty cell
+    if (
+      cells &&
+      markdownCell &&
+      codeCell &&
+      emptyCodeCell &&
+      cells.length <= 1 &&
+      cellContent === ''
+    ) {
+      // Insert Markdown Cell at position 0
+      cells.insert(0, markdownCell);
+
+      // Insert Code Cell at position 1
+      cells.insert(1, codeCell);
+
+      cells.insert(2, emptyCodeCell);
+
+      // Remove the old empty cell at position 3
+      cells.remove(3);
     }
   }
 }


### PR DESCRIPTION
It seems the instructions to run the first cell are being missed often.

So I've created a markdown cell where we can put in bold the instructions so they are more noticeable.

Beyound that since we always "edit" a new notebook if hte plugin is installed. It's good idea to explain why so if a user create a notebook but doesn't know the plugin is installed , they understand why do they have all those extra things inside.

Also added an empty cell so user can get stared. Without an empty cell and , there are only 2 non-editable cells and if the user doesn't know how to create a new cell or just tries to edit the non-ediable cells, he would be very confused what to do.


Screenshot: 
![image](https://github.com/vmware/versatile-data-kit/assets/2536458/c1c0db6a-7d47-4185-bf80-09b0803211cf)
