### PR TITLE
vdk-jupyter: fix conversion

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/ConvertJobToNotebook.tsx
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/src/components/ConvertJobToNotebook.tsx
@@ -327,6 +327,9 @@ export const populateNotebook = async (notebookTracker: INotebookTracker) => {
           addCodeCell([cellProps.source], {
             tags: ['vdk']
           });
+          addCodeCell(['run(job_input)'], {
+            tags: ['vdk']
+          });
         }
       }
 


### PR DESCRIPTION
What:
Fixed the conversion operation to add additional cell which runs the run function coming from .py step. 

Before:
<img width="1194" alt="notebook_steps" src="https://github.com/vmware/versatile-data-kit/assets/87015481/7df960af-241a-4fd5-a0eb-89d88a518874">

After: 

<img width="1189" alt="notebook_steps" src="https://github.com/vmware/versatile-data-kit/assets/87015481/4f24cfb4-df76-4d69-bfde-52aa55b1362c">

Why:
To execute the python code in the function vdk-notebook requires it to be called (unlike how vdk generally works with .py steps).
The reason the bug was not caught is that it is only tested in the e2e tests and they are not yet added to the ci/cd.


Signed-off-by: Duygu Hasan [hduygu@vmware.com](mailto:hduygu@vmware.com)