### PR TITLE
vdk-dag, vdk-control-cli, airflow-provider-vdk: step using deprecated field

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/command_groups/login_group/login.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/command_groups/login_group/login.py
@@ -120,7 +120,6 @@ def login(
                 auth_discovery_url=oauth2_discovery_url,
                 authorization_url=oauth2_exchange_url,
                 auth_type=auth_type,
-                cache_locally=True,
             )
             auth.authenticate()
             click.echo("Login Successful")
@@ -149,7 +148,6 @@ def login(
                 authorization_url=api_token_authorization_url,
                 token=api_token,
                 auth_type=auth_type,
-                cache_locally=True,
             )
             try:
                 apikey_auth.authenticate()

--- a/projects/vdk-control-cli/src/vdk/internal/control/rest_lib/factory.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/rest_lib/factory.py
@@ -41,7 +41,7 @@ class ApiClientFactory:
         self.config.client_side_validation = False
         self.config.verify_ssl = self.vdk_config.http_verify_ssl
 
-        auth = Authentication(cache_locally=True)
+        auth = Authentication()
         # For now there's no need to add auto-update since this is called usually in a shell script
         # and each command will have short execution life even when multiple requests to API are made.
         self.config.access_token = auth.read_access_token()

--- a/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/hooks/vdk.py
+++ b/projects/vdk-plugins/airflow-provider-vdk/vdk_provider/hooks/vdk.py
@@ -19,7 +19,9 @@ from taurus_datajob_api import DataJobExecution
 from taurus_datajob_api import DataJobExecutionRequest
 from taurus_datajob_api import DataJobsExecutionApi
 from urllib3 import Retry
+from vdk.plugin.control_api_auth.auth_config import SingletonInMemoryCredentialsCache
 from vdk.plugin.control_api_auth.authentication import Authentication
+
 
 if sys.version_info >= (3, 8):
     from functools import cached_property
@@ -248,7 +250,7 @@ class VDKHook(HttpHook):
             token=self.conn.extra_dejson.get("token", None),
             authorization_url=self.conn.extra_dejson.get("auth_server", None),
             auth_type=self.conn.extra_dejson.get("auth_type", None),
-            cache_locally=False,
+            credentials_cache=SingletonInMemoryCredentialsCache(),
         )
         self.auth.authenticate()
 

--- a/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/remote_data_job.py
+++ b/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/remote_data_job.py
@@ -249,5 +249,5 @@ class RemoteDataJob:
             return self.auth.read_access_token()
 
     def _login(self) -> None:
-        self.auth = Authentication(cache_locally=True)
+        self.auth = Authentication()
         # self.auth.authenticate()


### PR DESCRIPTION
cache_locally was deprecated in favour of credentials_cache
    
Since the credentials_cache default is LocalFolderCredentialsCache we can leave the default 
    
This is really 3 changes in single PR - but the change would be merged in 3 separate commits for each plugin

Testing Done: existing tests passed, showing no regression