### PR TITLE
control-service: update DataJobsController with account deployment data

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsController.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsController.java
@@ -18,6 +18,9 @@ import com.vmware.taurus.service.credentials.JobCredentialsService;
 import com.vmware.taurus.service.upload.JobUpload;
 import graphql.GraphQLError;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.net.URI;
+import java.util.List;
+import java.util.function.Supplier;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
@@ -31,10 +34,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriBuilder;
-
-import java.net.URI;
-import java.util.List;
-import java.util.function.Supplier;
 
 /**
  * REST controller for operations on data jobs
@@ -97,6 +96,7 @@ public class DataJobsController implements DataJobsApi {
     }
 
     var apiJob = ToModelApiConverter.toDataJob(dataJob);
+    apiJob.setDataJobDeployment(generateDeploymentInfo(apiJob));
     var operationResult = jobsService.createJob(apiJob);
     if (webHookResultExists(operationResult)) {
       propagateWebHookResult("Create", operationResult);
@@ -217,6 +217,14 @@ public class DataJobsController implements DataJobsApi {
     var dataJobQueryResponse = ToApiModelConverter.toDataJobPage(executionResult);
 
     return buildGraphQLResponseEntity(dataJobQueryResponse);
+  }
+
+  private com.vmware.taurus.service.model.DataJobDeployment generateDeploymentInfo(
+      com.vmware.taurus.service.model.DataJob dataJob) {
+    var jobDeployment = new com.vmware.taurus.service.model.DataJobDeployment();
+    jobDeployment.setDataJobName(dataJob.getName());
+    jobDeployment.setDataJob(dataJob);
+    return jobDeployment;
   }
 
   private boolean webHookResultExists(JobOperationResult operationResult) {

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobsService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobsService.java
@@ -140,6 +140,8 @@ public class JobsService {
    */
   public boolean updateJob(DataJob jobInfo) {
     if (jobsRepository.existsById(jobInfo.getName())) {
+      var job = jobsRepository.findById(jobInfo.getName()).get();
+      jobInfo.setDataJobDeployment(job.getDataJobDeployment());
       dataJobMetrics.updateInfoGauges(jobsRepository.save(jobInfo));
       return true;
     }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/DataJobsControllerDeploymentIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/DataJobsControllerDeploymentIT.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.datajobs;
+
+import com.vmware.taurus.ControlplaneApplication;
+import com.vmware.taurus.service.credentials.JobCredentialsService;
+import com.vmware.taurus.service.deploy.DeploymentService;
+import com.vmware.taurus.service.model.DeploymentStatus;
+import com.vmware.taurus.service.repository.JobDeploymentRepository;
+import com.vmware.taurus.service.repository.JobsRepository;
+import com.vmware.taurus.service.upload.GitWrapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+
+@SpringBootTest(
+    classes = ControlplaneApplication.class)
+public class DataJobsControllerDeploymentIT {
+
+  @Autowired
+  JobDeploymentRepository jobDeploymentRepository;
+  @Autowired
+  DataJobsController dataJobsController;
+  @Autowired
+  JobsRepository jobsRepository;
+
+  @MockBean
+  JobCredentialsService jobCredentialsService;
+  @MockBean
+  DeploymentService deploymentService;
+  @MockBean
+  GitWrapper gitWrapper;
+
+  private final String TEST_JOB_NAME = "foo-job";
+  private final String TEST_TEAM_NAME = "bar-team";
+
+  @AfterEach
+  public void cleanup() {
+    jobsRepository.deleteAll();
+  }
+
+  @Test
+  @WithMockUser
+  public void testWriteToDB_fromDataJobCreate() {
+    var job = TestUtils.getDataJob(TEST_TEAM_NAME, TEST_JOB_NAME);
+    dataJobsController.dataJobCreate(TEST_TEAM_NAME,
+        job, TEST_JOB_NAME);
+    var deploymentEntity = jobDeploymentRepository.findById(TEST_JOB_NAME);
+    Assertions.assertEquals(TEST_JOB_NAME, deploymentEntity.get().getDataJobName());
+  }
+
+  @Test
+  @WithMockUser
+  public void testDelete_fromDataJobDelete() {
+    var job = TestUtils.getDataJob(TEST_TEAM_NAME, TEST_JOB_NAME);
+    dataJobsController.dataJobCreate(TEST_TEAM_NAME,
+        job, TEST_JOB_NAME);
+    dataJobsController.dataJobDelete(TEST_TEAM_NAME, TEST_JOB_NAME);
+    Assertions.assertTrue(jobDeploymentRepository.findAll().size() == 0);
+  }
+
+  @Test
+  @WithMockUser
+  public void testUpdate_fromUpdateTeam() {
+    var job = TestUtils.getDataJob(TEST_TEAM_NAME, TEST_JOB_NAME);
+    dataJobsController.dataJobCreate(TEST_TEAM_NAME,
+        job, TEST_JOB_NAME);
+
+    var updatedDelpoyment = jobsRepository.findById(TEST_JOB_NAME).get().getDataJobDeployment();
+    updatedDelpoyment.setGitCommitSha("TEST");
+    jobDeploymentRepository.save(updatedDelpoyment);
+
+    dataJobsController.dataJobTeamUpdate(TEST_TEAM_NAME, "new-team", TEST_JOB_NAME);
+    var retrievedDeployment = jobDeploymentRepository.findById(TEST_JOB_NAME).get();
+    Assertions.assertEquals("TEST", retrievedDeployment.getGitCommitSha());
+
+  }
+
+  @Test
+  @WithMockUser
+  public void testUpdate_formDataJobUpdate() {
+    var job = TestUtils.getDataJob(TEST_TEAM_NAME, TEST_JOB_NAME);
+    dataJobsController.dataJobCreate(TEST_TEAM_NAME,
+        job, TEST_JOB_NAME);
+
+    var updatedJob = jobsRepository.findById(TEST_JOB_NAME).get();
+    updatedJob.setLatestJobDeploymentStatus(DeploymentStatus.PLATFORM_ERROR);
+    jobsRepository.save(updatedJob);
+
+    var updatedDelpoyment = updatedJob.getDataJobDeployment();
+    updatedDelpoyment.setGitCommitSha("TEST");
+    jobDeploymentRepository.save(updatedDelpoyment);
+
+    dataJobsController.dataJobUpdate(TEST_TEAM_NAME, TEST_JOB_NAME, ToApiModelConverter.toDataJob(updatedJob));
+
+    var retrievedDeployment = jobDeploymentRepository.findById(TEST_JOB_NAME).get();
+    Assertions.assertEquals("TEST", retrievedDeployment.getGitCommitSha());
+
+  }
+
+}

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/DataJobsControllerDeploymentIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/DataJobsControllerDeploymentIT.java
@@ -20,23 +20,16 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
 
-@SpringBootTest(
-    classes = ControlplaneApplication.class)
+@SpringBootTest(classes = ControlplaneApplication.class)
 public class DataJobsControllerDeploymentIT {
 
-  @Autowired
-  JobDeploymentRepository jobDeploymentRepository;
-  @Autowired
-  DataJobsController dataJobsController;
-  @Autowired
-  JobsRepository jobsRepository;
+  @Autowired JobDeploymentRepository jobDeploymentRepository;
+  @Autowired DataJobsController dataJobsController;
+  @Autowired JobsRepository jobsRepository;
 
-  @MockBean
-  JobCredentialsService jobCredentialsService;
-  @MockBean
-  DeploymentService deploymentService;
-  @MockBean
-  GitWrapper gitWrapper;
+  @MockBean JobCredentialsService jobCredentialsService;
+  @MockBean DeploymentService deploymentService;
+  @MockBean GitWrapper gitWrapper;
 
   private final String TEST_JOB_NAME = "foo-job";
   private final String TEST_TEAM_NAME = "bar-team";
@@ -50,8 +43,7 @@ public class DataJobsControllerDeploymentIT {
   @WithMockUser
   public void testWriteToDB_fromDataJobCreate() {
     var job = TestUtils.getDataJob(TEST_TEAM_NAME, TEST_JOB_NAME);
-    dataJobsController.dataJobCreate(TEST_TEAM_NAME,
-        job, TEST_JOB_NAME);
+    dataJobsController.dataJobCreate(TEST_TEAM_NAME, job, TEST_JOB_NAME);
     var deploymentEntity = jobDeploymentRepository.findById(TEST_JOB_NAME);
     Assertions.assertEquals(TEST_JOB_NAME, deploymentEntity.get().getDataJobName());
   }
@@ -60,8 +52,7 @@ public class DataJobsControllerDeploymentIT {
   @WithMockUser
   public void testDelete_fromDataJobDelete() {
     var job = TestUtils.getDataJob(TEST_TEAM_NAME, TEST_JOB_NAME);
-    dataJobsController.dataJobCreate(TEST_TEAM_NAME,
-        job, TEST_JOB_NAME);
+    dataJobsController.dataJobCreate(TEST_TEAM_NAME, job, TEST_JOB_NAME);
     dataJobsController.dataJobDelete(TEST_TEAM_NAME, TEST_JOB_NAME);
     Assertions.assertTrue(jobDeploymentRepository.findAll().size() == 0);
   }
@@ -70,8 +61,7 @@ public class DataJobsControllerDeploymentIT {
   @WithMockUser
   public void testUpdate_fromUpdateTeam() {
     var job = TestUtils.getDataJob(TEST_TEAM_NAME, TEST_JOB_NAME);
-    dataJobsController.dataJobCreate(TEST_TEAM_NAME,
-        job, TEST_JOB_NAME);
+    dataJobsController.dataJobCreate(TEST_TEAM_NAME, job, TEST_JOB_NAME);
 
     var updatedDelpoyment = jobsRepository.findById(TEST_JOB_NAME).get().getDataJobDeployment();
     updatedDelpoyment.setGitCommitSha("TEST");
@@ -80,15 +70,13 @@ public class DataJobsControllerDeploymentIT {
     dataJobsController.dataJobTeamUpdate(TEST_TEAM_NAME, "new-team", TEST_JOB_NAME);
     var retrievedDeployment = jobDeploymentRepository.findById(TEST_JOB_NAME).get();
     Assertions.assertEquals("TEST", retrievedDeployment.getGitCommitSha());
-
   }
 
   @Test
   @WithMockUser
   public void testUpdate_formDataJobUpdate() {
     var job = TestUtils.getDataJob(TEST_TEAM_NAME, TEST_JOB_NAME);
-    dataJobsController.dataJobCreate(TEST_TEAM_NAME,
-        job, TEST_JOB_NAME);
+    dataJobsController.dataJobCreate(TEST_TEAM_NAME, job, TEST_JOB_NAME);
 
     var updatedJob = jobsRepository.findById(TEST_JOB_NAME).get();
     updatedJob.setLatestJobDeploymentStatus(DeploymentStatus.PLATFORM_ERROR);
@@ -98,11 +86,10 @@ public class DataJobsControllerDeploymentIT {
     updatedDelpoyment.setGitCommitSha("TEST");
     jobDeploymentRepository.save(updatedDelpoyment);
 
-    dataJobsController.dataJobUpdate(TEST_TEAM_NAME, TEST_JOB_NAME, ToApiModelConverter.toDataJob(updatedJob));
+    dataJobsController.dataJobUpdate(
+        TEST_TEAM_NAME, TEST_JOB_NAME, ToApiModelConverter.toDataJob(updatedJob));
 
     var retrievedDeployment = jobDeploymentRepository.findById(TEST_JOB_NAME).get();
     Assertions.assertEquals("TEST", retrievedDeployment.getGitCommitSha());
-
   }
-
 }


### PR DESCRIPTION
what: Updated the DataJobsController and and associated service code, so that when a deployment is made or updated, the relevant data is written to the DB.

why:
Part of the Data Job configuration persistence initiative.

testing:
added test