### PR TITLE
vdk-dag: fix failing validation tests

### DIFF
--- a/projects/vdk-plugins/vdk-dag/tests/test_dag.py
+++ b/projects/vdk-plugins/vdk-dag/tests/test_dag.py
@@ -226,8 +226,9 @@ class TestDAG:
             self.env_vars,
         ):
             assert isinstance(result.exception, error)
+            # only the request that fetches the job info should be present
             # no other request should be tried as the DAG fails
-            assert len(self.httpserver.log) == 0
+            assert len(self.httpserver.log) == 1
 
     def test_dag(self):
         dag = "dag"
@@ -427,7 +428,7 @@ class TestDAG:
             self.httpserver.stop()
 
     def _test_dag_validation(self, dag_name):
-        self._set_up()
+        self._set_up(dag_name=dag_name)
         with mock.patch.dict(
             os.environ,
             self.env_vars,


### PR DESCRIPTION
## Why?

Tests started failing after https://github.com/vmware/versatile-data-kit/pull/2666 Most likely due to not wrapping errors in UserCodeError anymore

## What?

Pass the dag name to the dag validation test fixture

Expect just one request in the dag, as we do a GET request to fetch the job info before doing validation

## How was this tested?

Ran test suite locally

## What kind of change is this?

Bugfix