### PR TITLE
vdk-notebook: [bug fix] ignore missing id field in cell

### DIFF
--- a/projects/vdk-plugins/vdk-notebook/src/vdk/plugin/notebook/cell.py
+++ b/projects/vdk-plugins/vdk-notebook/src/vdk/plugin/notebook/cell.py
@@ -17,7 +17,7 @@ class Cell:
     def __init__(self, jupyter_cell):
         self.tags = jupyter_cell["metadata"].get("tags", {})
         self.source, self.source_type = self.__extract_source_code(jupyter_cell)
-        self.id = jupyter_cell["id"]
+        self.id = jupyter_cell.get("id")
 
     @staticmethod
     def __extract_source_code(jupyter_cell):


### PR DESCRIPTION
Currently, when the cells of an IPython notebook are loaded, it is assumed that each cell has an `id` field. However, this is true only for vdk specific notebooks, not regular ones that users may use to execute vdk commands like create, deploy, etc. In cases, where the notebook is a regular one, the job execution fails abruptly at the plugin loading stage without any meaningful message, because only json-specific errors are being handled.

Example job termination logs:

```bash
2023-09-28 19:55:51,215 [VDK] test-job [ERROR] vdk.internal.builtin_plugins.r   cli_run.py:172
create_and_run_d[id:510b0034-2249-4840-8589-1c9a3f58bc59-1695920149-24c96]- Failed executing job.
'id'
The provided Data Job will not be executed. Terminating application.
See contents of the exception and fix the problem that causes it. Most likely a prerequisite
or plugin of one of the key VDK components failed, see logs for details and ensure the
prerequisite for the failed component (details in stacktrace).

Process finished with exit code 1
```

This change makes the `id` field not required, so that regular notebooks can be ignored and not fail job executions.

Testing Done: Locally with a test data job that contained a regular IPython notebook and other regular python steps.