### PR TITLE
vdk-jupyter: fix bug in detecting run functions

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/tests/test_convert_job_directory_processor.py
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/vdk_jupyterlab_extension/tests/test_convert_job_directory_processor.py
@@ -13,20 +13,45 @@ class TestConvertJobDirectoryProcessor(unittest.TestCase):
         self.temp_dir = tempfile.mkdtemp()
         self.sql_content = "SELECT * FROM table"
         self.py_content_run = """
-        def run(job_input: IJobInput):
-            print("Hello, World!")
+def run(job_input: IJobInput):
+    print("Hello, World!")
         """
         self.py_content_without_run = """
-        def hello():
-            print("Hello, World!")
+def hello():
+    print("Hello, World!")
+'''
+commented out def run
+def run(job_input)
+'''
+        """
+        self.py_content_run_multiline = """
+def run(
+    job_input: IJobInput
+):
+    print('Hello, World!')
+        """
+        self.py_content_run_spaces = """
+def run(  job_input: IJobInput):
+    print('Hello, World!')
+        """
+        self.py_content_run_in_a_class = """
+class X:
+    def run(job_input: IJobInput):
+        print("Hello, World!")
         """
 
-        with open(os.path.join(self.temp_dir, "test.sql"), "w") as f:
+        with open(os.path.join(self.temp_dir, "10_test.sql"), "w") as f:
             f.write(self.sql_content)
-        with open(os.path.join(self.temp_dir, "test_run.py"), "w") as f:
+        with open(os.path.join(self.temp_dir, "20_test_run.py"), "w") as f:
             f.write(self.py_content_run)
-        with open(os.path.join(self.temp_dir, "test_without_run.py"), "w") as f:
+        with open(os.path.join(self.temp_dir, "30_test_without_run.py"), "w") as f:
             f.write(self.py_content_without_run)
+        with open(os.path.join(self.temp_dir, "40_test_multi_line_run.py"), "w") as f:
+            f.write(self.py_content_run_multiline)
+        with open(os.path.join(self.temp_dir, "50_test_spaces.py"), "w") as f:
+            f.write(self.py_content_run_spaces)
+        with open(os.path.join(self.temp_dir, "60_run_in_a_class.py"), "w") as f:
+            f.write(self.py_content_run_in_a_class)
         with open(os.path.join(self.temp_dir, "config.ini"), "w") as f:
             pass
 
@@ -35,42 +60,74 @@ class TestConvertJobDirectoryProcessor(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.temp_dir)
 
-    def test_process_files(self):
+    def test_process_non_step_files_remain(self):
         self.processor.process_files()
-        expected_code_structure = [
-            f'job_input.execute_query("""{self.sql_content}""")',
-            self.py_content_run,
-        ]
-        self.assertEqual(self.processor.get_code_structure(), expected_code_structure)
-        self.assertFalse(os.path.exists(os.path.join(self.temp_dir, "test.sql")))
-        self.assertFalse(os.path.exists(os.path.join(self.temp_dir, "test_run.py")))
         self.assertTrue(
-            os.path.exists(os.path.join(self.temp_dir, "test_without_run.py"))
+            os.path.exists(os.path.join(self.temp_dir, "30_test_without_run.py"))
+        )
+        self.assertTrue(
+            os.path.exists(os.path.join(self.temp_dir, "60_run_in_a_class.py"))
         )
         self.assertTrue(os.path.exists(os.path.join(self.temp_dir, "config.ini")))
-
-        expected_removed_files = ["test.sql", "test_run.py"]
-        self.assertEqual(
-            set(self.processor.get_removed_files()), set(expected_removed_files)
-        )
 
     def test_cleanup(self):
         self.processor.process_files()
         self.processor.cleanup()
-        self.assertFalse(os.path.exists(os.path.join(self.temp_dir, "test.sql")))
-        self.assertFalse(os.path.exists(os.path.join(self.temp_dir, "test_run.py")))
+        self.assertFalse(os.path.exists(os.path.join(self.temp_dir, "10_test.sql")))
+        self.assertFalse(os.path.exists(os.path.join(self.temp_dir, "20_test_run.py")))
+        self.assertFalse(
+            os.path.exists(os.path.join(self.temp_dir, "40_test_multi_line_run.py"))
+        )
+        self.assertFalse(
+            os.path.exists(os.path.join(self.temp_dir, "50_test_spaces.py"))
+        )
+
+        self.assertTrue(
+            os.path.exists(os.path.join(self.temp_dir, "30_test_without_run.py"))
+        )
+        self.assertTrue(
+            os.path.exists(os.path.join(self.temp_dir, "60_run_in_a_class.py"))
+        )
+        self.assertTrue(os.path.exists(os.path.join(self.temp_dir, "config.ini")))
 
     def test_get_code_structure(self):
         self.processor.process_files()
         expected_code_structure = [
             f'job_input.execute_query("""{self.sql_content}""")',
             self.py_content_run,
+            self.py_content_run_multiline,
+            self.py_content_run_spaces,
         ]
         self.assertEqual(self.processor.get_code_structure(), expected_code_structure)
 
     def test_get_removed_files(self):
         self.processor.process_files()
-        expected_removed_files = ["test.sql", "test_run.py"]
+        expected_removed_files = [
+            "10_test.sql",
+            "20_test_run.py",
+            "40_test_multi_line_run.py",
+            "50_test_spaces.py",
+        ]
         self.assertEqual(
             set(self.processor.get_removed_files()), set(expected_removed_files)
         )
+
+    def test_get_bad_python_file(self):
+        bad_job_dir = tempfile.mkdtemp()
+        try:
+            py_content_with_incorrect_syntax = """
+    def run(job_input: IJobInput
+
+        print(' Hello, World!')
+            """
+            with open(os.path.join(bad_job_dir, "50_test_spaces.py"), "w") as f:
+                f.write(py_content_with_incorrect_syntax)
+            processor = ConvertJobDirectoryProcessor(bad_job_dir)
+
+            try:
+                processor.process_files()
+                assert False, "Expected SyntaxError exception"
+            except SyntaxError as e:
+                assert "50_test_spaces.py" in e.filename
+        finally:
+            shutil.rmtree(bad_job_dir)


### PR DESCRIPTION
We are using `re.search(r"def run\(job_input", content)` which is very bad practice. Never use regex unless you have a official contract or specification that promises the regex will work.

The regex breaks in so many cases :
- put some space anywhere `def run<space>(job_input)` ,
- def run is defined on multiple lines
- coments .
- def run ins in string literal and not really a method
- and probably much more I cannot think of.

In general rule, I really think it's bad idea to do parsing (regex is type of parsing) without implement strict contract and specification.

The solution to the problem here  simple fortunately. It is to use Python's ast (Abstract Syntax Tree) module to parse Python code.