### PR TITLE
vdk-core: pass execution result through context

### DIFF
--- a/projects/vdk-core/src/vdk/internal/core/statestore.py
+++ b/projects/vdk-core/src/vdk/internal/core/statestore.py
@@ -70,6 +70,21 @@ class CommonStoreKeys:
     VDK_VERSION: StoreKey[str] = ImmutableStoreKey[str]("vdk.vdk_version")
 
     """
+    Execution status flag, e.g. success/failure/skip
+    """
+    EXECUTION_STATUS: StoreKey[str] = StoreKey[str]("vdk.execution_status")
+    """
+
+    The full data job execution result
+    """
+    EXECUTION_RESULT: StoreKey[str] = StoreKey[str]("vdk.execution_result")
+
+    """
+    Results for each executed step
+    """
+    STEP_RESULTS: StoreKey[str] = StoreKey[str]("vdk.step_results")
+
+    """
     Write data job directory, to be used if job needs to write files to local
     storage during cloud execution (since writing to any directory might be
     restricted on a deployment basis:

--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_plugin.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/impala_plugin.py
@@ -12,11 +12,13 @@ from vdk.api.plugin.plugin_registry import HookCallResult
 from vdk.api.plugin.plugin_registry import IPluginRegistry
 from vdk.internal.builtin_plugins.connection.decoration_cursor import DecorationCursor
 from vdk.internal.builtin_plugins.connection.recovery_cursor import RecoveryCursor
+from vdk.internal.builtin_plugins.run.execution_results import StepResult
 from vdk.internal.builtin_plugins.run.job_context import JobContext
 from vdk.internal.builtin_plugins.run.step import Step
 from vdk.internal.core.config import ConfigurationBuilder
 from vdk.internal.core.errors import ErrorMessage
 from vdk.internal.core.errors import UserCodeError
+from vdk.internal.core.statestore import CommonStoreKeys
 from vdk.plugin.impala.impala_configuration import add_definitions
 from vdk.plugin.impala.impala_configuration import ImpalaPluginConfiguration
 from vdk.plugin.impala.impala_connection import ImpalaConnection
@@ -115,7 +117,13 @@ class ImpalaPlugin:
         out: HookCallResult
         out = yield
 
-        exception = out.get_result().exception
+        result: StepResult
+        if out.excinfo:
+            result = context.core_context.state.get(CommonStoreKeys.STEP_RESULTS)[-1]
+        else:
+            result = out.get_result()
+
+        exception = result.exception
         if exception:
             exception = (
                 exception.__cause__

--- a/projects/vdk-plugins/vdk-lineage/src/vdk/plugin/lineage/plugin_lineage.py
+++ b/projects/vdk-plugins/vdk-lineage/src/vdk/plugin/lineage/plugin_lineage.py
@@ -97,7 +97,13 @@ class OpenLineagePlugin:
         out: HookCallResult
         out = yield
         if self.__client:
-            result: ExecutionResult = out.get_result()
+            result: ExecutionResult
+            if out.excinfo:
+                result = context.core_context.state.get(
+                    CommonStoreKeys.EXECUTION_RESULT
+                )
+            else:
+                result = out.get_result()
             self.__execution_id = context.core_context.state.get(
                 CommonStoreKeys.EXECUTION_ID
             )


### PR DESCRIPTION
## Why?

We'd like to have just one exit point for data jobs where error logging happens and propagate all errors up to it.

## What?

Pass execution result in job context when exceptions are thrown. This way, we still get to throw the exception and have the result at a later hook, e.g. we have the execution result from run_job inside the run method, even if an exception was thrown during the run. If an exception was thrown, we can catch and log it at the exit point.

The side effect is that plugins have to check the job context for hook implementations that are wrapping if an exception was thrown.

## How was this tested?

Ran tests locally
Ran plugin tests in CI/CD

## What kind of change is this?

Potentially breaking change