### PR TITLE
control-service: data job synchronizer error handling

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
@@ -38,8 +38,7 @@ public class DeploymentModelConverter {
     return deployment;
   }
 
-  public static DesiredDataJobDeployment toDesiredDataJobDeployment(
-      JobDeployment jobDeployment) {
+  public static DesiredDataJobDeployment toDesiredDataJobDeployment(JobDeployment jobDeployment) {
     DesiredDataJobDeployment deployment = new DesiredDataJobDeployment();
     deployment.setDataJobName(jobDeployment.getDataJobName());
     deployment.setEnabled(jobDeployment.getEnabled());

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
@@ -39,12 +39,12 @@ public class DeploymentModelConverter {
   }
 
   public static DesiredDataJobDeployment toDesiredDataJobDeployment(
-      JobDeployment jobDeploymentStatus) {
+      JobDeployment jobDeployment) {
     DesiredDataJobDeployment deployment = new DesiredDataJobDeployment();
-    deployment.setDataJobName(jobDeploymentStatus.getDataJobName());
-    deployment.setEnabled(jobDeploymentStatus.getEnabled());
+    deployment.setDataJobName(jobDeployment.getDataJobName());
+    deployment.setEnabled(jobDeployment.getEnabled());
 
-    DataJobResources dataJobResources = jobDeploymentStatus.getResources();
+    DataJobResources dataJobResources = jobDeployment.getResources();
 
     if (dataJobResources != null) {
       DataJobDeploymentResources deploymentResources =
@@ -57,8 +57,8 @@ public class DeploymentModelConverter {
       deployment.setResources(deploymentResources);
     }
 
-    deployment.setGitCommitSha(jobDeploymentStatus.getGitCommitSha());
-    deployment.setPythonVersion(jobDeploymentStatus.getPythonVersion());
+    deployment.setGitCommitSha(jobDeployment.getGitCommitSha());
+    deployment.setPythonVersion(jobDeployment.getPythonVersion());
 
     return deployment;
   }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentServiceV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentServiceV2.java
@@ -6,6 +6,7 @@
 package com.vmware.taurus.service.deploy;
 
 import com.vmware.taurus.exception.*;
+import com.vmware.taurus.service.diag.methodintercept.Measurable;
 import com.vmware.taurus.service.kubernetes.DataJobsKubernetesService;
 import com.vmware.taurus.service.model.*;
 import com.vmware.taurus.service.notification.NotificationContent;
@@ -58,6 +59,7 @@ public class DeploymentServiceV2 {
    *     Kubernetes.
    * @param sendNotification if it is true the method will send a notification to the end user.
    */
+  @Measurable(includeArg = 0, argName = "data_job")
   public void updateDeployment(
       DataJob dataJob,
       DesiredDataJobDeployment desiredJobDeployment,
@@ -68,6 +70,15 @@ public class DeploymentServiceV2 {
       log.warn(
           "Skipping the data job [job_name={}] deployment due to the missing deployment data",
           dataJob.getName());
+      return;
+    }
+
+    if (DeploymentStatus.USER_ERROR.equals(desiredJobDeployment.getStatus()) ||
+            DeploymentStatus.PLATFORM_ERROR.equals(desiredJobDeployment.getStatus())) {
+      log.debug(
+          "Skipping the data job [job_name={}] deployment due to the previously failed deployment [status={}]",
+          dataJob.getName(),
+          desiredJobDeployment.getStatus());
       return;
     }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentServiceV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentServiceV2.java
@@ -73,10 +73,11 @@ public class DeploymentServiceV2 {
       return;
     }
 
-    if (DeploymentStatus.USER_ERROR.equals(desiredJobDeployment.getStatus()) ||
-            DeploymentStatus.PLATFORM_ERROR.equals(desiredJobDeployment.getStatus())) {
+    if (DeploymentStatus.USER_ERROR.equals(desiredJobDeployment.getStatus())
+        || DeploymentStatus.PLATFORM_ERROR.equals(desiredJobDeployment.getStatus())) {
       log.debug(
-          "Skipping the data job [job_name={}] deployment due to the previously failed deployment [status={}]",
+          "Skipping the data job [job_name={}] deployment due to the previously failed deployment"
+              + " [status={}]",
           dataJob.getName(),
           desiredJobDeployment.getStatus());
       return;

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployerV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployerV2.java
@@ -77,9 +77,8 @@ public class JobImageDeployerV2 {
    * @param isJobDeploymentPresentInKubernetes if it is true the data job deployment is present in
    *     Kubernetes.
    * @param jobImageName the data job docker image name.
-   *
-   * @return {@link ActualDataJobDeployment} an actual data job deployment if the data job is successfully deployed
-   * and null in case of an error.
+   * @return {@link ActualDataJobDeployment} an actual data job deployment if the data job is
+   *     successfully deployed and null in case of an error.
    */
   public ActualDataJobDeployment scheduleJob(
       DataJob dataJob,
@@ -174,9 +173,8 @@ public class JobImageDeployerV2 {
    * @param isJobDeploymentPresentInKubernetes if it is true the data job deployment is present in
    *     Kubernetes.
    * @param jobImageName the data job docker image name.
-   *
-   * @return {@link ActualDataJobDeployment} an actual data job deployment if the data job is successfully deployed
-   * and null in case of an error.
+   * @return {@link ActualDataJobDeployment} an actual data job deployment if the data job is
+   *     successfully deployed and null in case of an error.
    */
   private ActualDataJobDeployment updateCronJob(
       DataJob dataJob,
@@ -205,7 +203,9 @@ public class JobImageDeployerV2 {
     ActualDataJobDeployment actualJobDeployment = null;
 
     if (isJobDeploymentPresentInKubernetes) {
-      if (actualDataJobDeployment == null || !desiredDeploymentVersionSha.equals(actualDataJobDeployment.getDeploymentVersionSha())) {
+      if (actualDataJobDeployment == null
+          || !desiredDeploymentVersionSha.equals(
+              actualDataJobDeployment.getDeploymentVersionSha())) {
         dataJobsKubernetesService.updateCronJob(desiredCronJob);
         actualJobDeployment =
             DeploymentModelConverter.toActualJobDeployment(

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployerV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployerV2.java
@@ -77,7 +77,9 @@ public class JobImageDeployerV2 {
    * @param isJobDeploymentPresentInKubernetes if it is true the data job deployment is present in
    *     Kubernetes.
    * @param jobImageName the data job docker image name.
-   * @return true if it is successful and false if not.
+   *
+   * @return {@link ActualDataJobDeployment} an actual data job deployment if the data job is successfully deployed
+   * and null in case of an error.
    */
   public ActualDataJobDeployment scheduleJob(
       DataJob dataJob,
@@ -172,6 +174,9 @@ public class JobImageDeployerV2 {
    * @param isJobDeploymentPresentInKubernetes if it is true the data job deployment is present in
    *     Kubernetes.
    * @param jobImageName the data job docker image name.
+   *
+   * @return {@link ActualDataJobDeployment} an actual data job deployment if the data job is successfully deployed
+   * and null in case of an error.
    */
   private ActualDataJobDeployment updateCronJob(
       DataJob dataJob,
@@ -199,8 +204,8 @@ public class JobImageDeployerV2 {
 
     ActualDataJobDeployment actualJobDeployment = null;
 
-    if (isJobDeploymentPresentInKubernetes && actualDataJobDeployment != null) {
-      if (!desiredDeploymentVersionSha.equals(actualDataJobDeployment.getDeploymentVersionSha())) {
+    if (isJobDeploymentPresentInKubernetes) {
+      if (actualDataJobDeployment == null || !desiredDeploymentVersionSha.equals(actualDataJobDeployment.getDeploymentVersionSha())) {
         dataJobsKubernetesService.updateCronJob(desiredCronJob);
         actualJobDeployment =
             DeploymentModelConverter.toActualJobDeployment(

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DesiredDataJobDeployment.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DesiredDataJobDeployment.java
@@ -19,5 +19,5 @@ import javax.persistence.Entity;
 @Entity
 public class DesiredDataJobDeployment extends BaseDataJobDeployment {
 
-    private DeploymentStatus status;
+  private DeploymentStatus status;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DesiredDataJobDeployment.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DesiredDataJobDeployment.java
@@ -17,4 +17,7 @@ import javax.persistence.Entity;
 @EqualsAndHashCode(callSuper = false)
 @ToString
 @Entity
-public class DesiredDataJobDeployment extends BaseDataJobDeployment {}
+public class DesiredDataJobDeployment extends BaseDataJobDeployment {
+
+    private DeploymentStatus status;
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitor.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitor.java
@@ -100,13 +100,15 @@ public class DeploymentMonitor {
       final String dataJobName,
       final DeploymentStatus deploymentStatus,
       ActualDataJobDeployment actualDataJobDeployment) {
-    if (jobsRepository.updateDataJobLatestJobDeploymentStatusByName(dataJobName, deploymentStatus) > 0) {
+    if (jobsRepository.updateDataJobLatestJobDeploymentStatusByName(dataJobName, deploymentStatus)
+        > 0) {
 
       if (DeploymentStatus.SUCCESS.equals(deploymentStatus) && actualDataJobDeployment != null) {
         actualJobDeploymentRepository.save(actualDataJobDeployment);
       }
 
-      desiredJobDeploymentRepository.updateDesiredDataJobDeploymentStatusByDataJobName(dataJobName, deploymentStatus);
+      desiredJobDeploymentRepository.updateDesiredDataJobDeploymentStatusByDataJobName(
+          dataJobName, deploymentStatus);
       return true;
     }
     log.debug("Data job: {} was deleted or hasn't been created", dataJobName);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitor.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitor.java
@@ -8,6 +8,7 @@ package com.vmware.taurus.service.monitoring;
 import com.vmware.taurus.service.model.ActualDataJobDeployment;
 import com.vmware.taurus.service.model.DeploymentStatus;
 import com.vmware.taurus.service.repository.ActualJobDeploymentRepository;
+import com.vmware.taurus.service.repository.DesiredJobDeploymentRepository;
 import com.vmware.taurus.service.repository.JobsRepository;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Gauge;
@@ -37,16 +38,20 @@ public class DeploymentMonitor {
 
   private final ActualJobDeploymentRepository actualJobDeploymentRepository;
 
+  private final DesiredJobDeploymentRepository desiredJobDeploymentRepository;
+
   private final Map<String, Integer> currentStatuses = new ConcurrentHashMap<>();
 
   @Autowired
   public DeploymentMonitor(
       MeterRegistry meterRegistry,
       JobsRepository jobsRepository,
-      ActualJobDeploymentRepository actualJobDeploymentRepository) {
+      ActualJobDeploymentRepository actualJobDeploymentRepository,
+      DesiredJobDeploymentRepository desiredJobDeploymentRepository) {
     this.meterRegistry = meterRegistry;
     this.jobsRepository = jobsRepository;
     this.actualJobDeploymentRepository = actualJobDeploymentRepository;
+    this.desiredJobDeploymentRepository = desiredJobDeploymentRepository;
   }
 
   /**
@@ -95,14 +100,13 @@ public class DeploymentMonitor {
       final String dataJobName,
       final DeploymentStatus deploymentStatus,
       ActualDataJobDeployment actualDataJobDeployment) {
-    if (jobsRepository.updateDataJobLatestJobDeploymentStatusByName(dataJobName, deploymentStatus)
-        > 0) {
-      switch (deploymentStatus) {
-        case SUCCESS:
-          if (actualDataJobDeployment != null) {
-            actualJobDeploymentRepository.save(actualDataJobDeployment);
-          }
+    if (jobsRepository.updateDataJobLatestJobDeploymentStatusByName(dataJobName, deploymentStatus) > 0) {
+
+      if (DeploymentStatus.SUCCESS.equals(deploymentStatus) && actualDataJobDeployment != null) {
+        actualJobDeploymentRepository.save(actualDataJobDeployment);
       }
+
+      desiredJobDeploymentRepository.updateDesiredDataJobDeploymentStatusByDataJobName(dataJobName, deploymentStatus);
       return true;
     }
     log.debug("Data job: {} was deleted or hasn't been created", dataJobName);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/repository/DesiredJobDeploymentRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/repository/DesiredJobDeploymentRepository.java
@@ -5,6 +5,7 @@
 
 package com.vmware.taurus.service.repository;
 
+import com.vmware.taurus.service.model.DeploymentStatus;
 import com.vmware.taurus.service.model.DesiredDataJobDeployment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -36,4 +37,12 @@ public interface DesiredJobDeploymentRepository
           + " :dataJobName")
   int updateDesiredDataJobDeploymentEnabledByDataJobName(
       @Param(value = "dataJobName") String dataJobName, @Param(value = "enabled") Boolean enabled);
+
+  @Transactional
+  @Modifying(clearAutomatically = true)
+  @Query(
+          "update DesiredDataJobDeployment d set d.status = :status where d.dataJobName ="
+                  + " :dataJobName")
+  int updateDesiredDataJobDeploymentStatusByDataJobName(
+          @Param(value = "dataJobName") String dataJobName, @Param(value = "status") DeploymentStatus status);
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/repository/DesiredJobDeploymentRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/repository/DesiredJobDeploymentRepository.java
@@ -41,8 +41,9 @@ public interface DesiredJobDeploymentRepository
   @Transactional
   @Modifying(clearAutomatically = true)
   @Query(
-          "update DesiredDataJobDeployment d set d.status = :status where d.dataJobName ="
-                  + " :dataJobName")
+      "update DesiredDataJobDeployment d set d.status = :status where d.dataJobName ="
+          + " :dataJobName")
   int updateDesiredDataJobDeploymentStatusByDataJobName(
-          @Param(value = "dataJobName") String dataJobName, @Param(value = "status") DeploymentStatus status);
+      @Param(value = "dataJobName") String dataJobName,
+      @Param(value = "status") DeploymentStatus status);
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/db/migration/V20231002143000__add_column_status_to_desired_data_job_deployment_table.sql
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/db/migration/V20231002143000__add_column_status_to_desired_data_job_deployment_table.sql
@@ -1,0 +1,2 @@
+alter table if exists desired_data_job_deployment
+    add column if not exists status varchar;

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobsServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobsServiceTest.java
@@ -15,7 +15,6 @@ import com.vmware.taurus.service.model.DataJob;
 import com.vmware.taurus.service.model.DeploymentStatus;
 import com.vmware.taurus.service.model.JobConfig;
 import com.vmware.taurus.service.monitoring.DataJobMetrics;
-import com.vmware.taurus.service.repository.DesiredJobDeploymentRepository;
 import com.vmware.taurus.service.repository.JobsRepository;
 import com.vmware.taurus.service.webhook.WebHookRequestBodyProvider;
 import org.junit.jupiter.api.Test;

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobsServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/JobsServiceTest.java
@@ -15,6 +15,7 @@ import com.vmware.taurus.service.model.DataJob;
 import com.vmware.taurus.service.model.DeploymentStatus;
 import com.vmware.taurus.service.model.JobConfig;
 import com.vmware.taurus.service.monitoring.DataJobMetrics;
+import com.vmware.taurus.service.repository.DesiredJobDeploymentRepository;
 import com.vmware.taurus.service.repository.JobsRepository;
 import com.vmware.taurus.service.webhook.WebHookRequestBodyProvider;
 import org.junit.jupiter.api.Test;

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceV2TestIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceV2TestIT.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.deploy;
+
+import com.vmware.taurus.ControlplaneApplication;
+import com.vmware.taurus.service.model.*;
+import io.kubernetes.client.openapi.ApiException;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.io.IOException;
+
+@SpringBootTest(classes = ControlplaneApplication.class)
+public class DeploymentServiceV2TestIT {
+
+  @Autowired
+  private DeploymentServiceV2 deploymentService;
+
+  @MockBean
+  private DeploymentProgress deploymentProgress;
+
+  @MockBean
+  private JobImageBuilder jobImageBuilder;
+
+  @Test
+  public void updateDeployment_withDesiredDeploymentStatusUserError_shouldSkipDeployment() throws IOException, InterruptedException, ApiException {
+    updateDeployment(DeploymentStatus.USER_ERROR, 0);
+  }
+
+  @Test
+  public void updateDeployment_withDesiredDeploymentStatusPlatformError_shouldSkipDeployment() throws IOException, InterruptedException, ApiException {
+    updateDeployment(DeploymentStatus.PLATFORM_ERROR, 0);
+  }
+
+  @Test
+  public void updateDeployment_withDesiredDeploymentStatusSuccess_shouldStartDeployment() throws IOException, InterruptedException, ApiException {
+    updateDeployment(DeploymentStatus.SUCCESS, 1);
+  }
+
+  @Test
+  public void updateDeployment_withDesiredDeploymentStatusNone_shouldStartDeployment() throws IOException, InterruptedException, ApiException {
+    updateDeployment(DeploymentStatus.NONE, 1);
+  }
+
+  private void updateDeployment(DeploymentStatus deploymentStatus, int deploymentProgressStartedInvocations) throws IOException, InterruptedException, ApiException {
+    DesiredDataJobDeployment desiredDataJobDeployment = new DesiredDataJobDeployment();
+    desiredDataJobDeployment.setStatus(deploymentStatus);
+    DataJob dataJob = new DataJob();
+    dataJob.setJobConfig(new JobConfig());
+    Mockito.when(jobImageBuilder.buildImage(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(false);
+
+    deploymentService.updateDeployment(dataJob, desiredDataJobDeployment, new ActualDataJobDeployment(), true, true);
+
+    Mockito.verify(deploymentProgress, Mockito.times(deploymentProgressStartedInvocations)).started(dataJob.getJobConfig(), desiredDataJobDeployment);
+  }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceV2TestIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceV2TestIT.java
@@ -19,44 +19,51 @@ import java.io.IOException;
 @SpringBootTest(classes = ControlplaneApplication.class)
 public class DeploymentServiceV2TestIT {
 
-  @Autowired
-  private DeploymentServiceV2 deploymentService;
+  @Autowired private DeploymentServiceV2 deploymentService;
 
-  @MockBean
-  private DeploymentProgress deploymentProgress;
+  @MockBean private DeploymentProgress deploymentProgress;
 
-  @MockBean
-  private JobImageBuilder jobImageBuilder;
+  @MockBean private JobImageBuilder jobImageBuilder;
 
   @Test
-  public void updateDeployment_withDesiredDeploymentStatusUserError_shouldSkipDeployment() throws IOException, InterruptedException, ApiException {
+  public void updateDeployment_withDesiredDeploymentStatusUserError_shouldSkipDeployment()
+      throws IOException, InterruptedException, ApiException {
     updateDeployment(DeploymentStatus.USER_ERROR, 0);
   }
 
   @Test
-  public void updateDeployment_withDesiredDeploymentStatusPlatformError_shouldSkipDeployment() throws IOException, InterruptedException, ApiException {
+  public void updateDeployment_withDesiredDeploymentStatusPlatformError_shouldSkipDeployment()
+      throws IOException, InterruptedException, ApiException {
     updateDeployment(DeploymentStatus.PLATFORM_ERROR, 0);
   }
 
   @Test
-  public void updateDeployment_withDesiredDeploymentStatusSuccess_shouldStartDeployment() throws IOException, InterruptedException, ApiException {
+  public void updateDeployment_withDesiredDeploymentStatusSuccess_shouldStartDeployment()
+      throws IOException, InterruptedException, ApiException {
     updateDeployment(DeploymentStatus.SUCCESS, 1);
   }
 
   @Test
-  public void updateDeployment_withDesiredDeploymentStatusNone_shouldStartDeployment() throws IOException, InterruptedException, ApiException {
+  public void updateDeployment_withDesiredDeploymentStatusNone_shouldStartDeployment()
+      throws IOException, InterruptedException, ApiException {
     updateDeployment(DeploymentStatus.NONE, 1);
   }
 
-  private void updateDeployment(DeploymentStatus deploymentStatus, int deploymentProgressStartedInvocations) throws IOException, InterruptedException, ApiException {
+  private void updateDeployment(
+      DeploymentStatus deploymentStatus, int deploymentProgressStartedInvocations)
+      throws IOException, InterruptedException, ApiException {
     DesiredDataJobDeployment desiredDataJobDeployment = new DesiredDataJobDeployment();
     desiredDataJobDeployment.setStatus(deploymentStatus);
     DataJob dataJob = new DataJob();
     dataJob.setJobConfig(new JobConfig());
-    Mockito.when(jobImageBuilder.buildImage(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(false);
+    Mockito.when(
+            jobImageBuilder.buildImage(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+        .thenReturn(false);
 
-    deploymentService.updateDeployment(dataJob, desiredDataJobDeployment, new ActualDataJobDeployment(), true, true);
+    deploymentService.updateDeployment(
+        dataJob, desiredDataJobDeployment, new ActualDataJobDeployment(), true, true);
 
-    Mockito.verify(deploymentProgress, Mockito.times(deploymentProgressStartedInvocations)).started(dataJob.getJobConfig(), desiredDataJobDeployment);
+    Mockito.verify(deploymentProgress, Mockito.times(deploymentProgressStartedInvocations))
+        .started(dataJob.getJobConfig(), desiredDataJobDeployment);
   }
 }


### PR DESCRIPTION
Why
As part of VEP-2272, we need to introduce a process for synchronizing data jobs from the database to Kubernetes. In the event of a data job deployment failure (due to user or platform errors), the current implementation attempts to deploy the data job during every synchronization cycle.

What
We have added a data job deployment status field to the desired_data_job_deployment table. This status is used to determine whether the deployment failed in the previous cycle and should be skipped in the current one. The failed deployment status can be reset by invocation of updateDeployment API event without a job code change (it will be implemented as part of https://github.com/vmware/versatile-data-kit/pull/2731/files).

This is just the third phase of implementation. The following enhancements are planned for future PRs:

- We will annotate the method DataJobsSynchronizer.synchronizeDataJobs() with @scheduled.
- Improved exception handling will be integrated.
- More tests will be included in subsequent updates.
- ThreadPool configuration will be tuned and exposed through the application.properties.

Testing done
Unit tests

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com