### PR TITLE
vdk-control-cli: pin werkzeug to version 2.3.8 or less

### DIFF
--- a/projects/vdk-control-cli/requirements.txt
+++ b/projects/vdk-control-cli/requirements.txt
@@ -28,3 +28,4 @@ urllib3>=1.26.5
 vdk-control-api-auth
 
 vdk-control-service-api==1.0.11
+werkzeug<=2.3.8


### PR DESCRIPTION
## Why?

A test is failing due to changes in the werkzeug API.

https://gitlab.com/vmware-analytics/versatile-data-kit/-/jobs/5203253935

```
Traceback (most recent call last):
  File "/Users/mdilyan/Projects/versatile-data-kit/projects/vdk-control-cli/venv/lib/python3.11/site-packages/werkzeug/serving.py", line 362, in run_wsgi
    execute(self.server.app)
  File "/Users/mdilyan/Projects/versatile-data-kit/projects/vdk-control-cli/venv/lib/python3.11/site-packages/werkzeug/serving.py", line 323, in execute
    application_iter = app(environ, start_response)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mdilyan/Projects/versatile-data-kit/projects/vdk-control-cli/venv/lib/python3.11/site-packages/werkzeug/wrappers/request.py", line 189, in application
    resp = f(*args[:-2] + (request,))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mdilyan/Projects/versatile-data-kit/projects/vdk-control-cli/venv/lib/python3.11/site-packages/pytest_httpserver/httpserver.py", line 841, in application
    response = self.dispatch(request)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mdilyan/Projects/versatile-data-kit/projects/vdk-control-cli/venv/lib/python3.11/site-packages/pytest_httpserver/httpserver.py", line 1225, in dispatch
    handler = self.handlers.match(request)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mdilyan/Projects/versatile-data-kit/projects/vdk-control-cli/venv/lib/python3.11/site-packages/pytest_httpserver/httpserver.py", line 575, in match
    if requesthandler.matcher.match(request):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mdilyan/Projects/versatile-data-kit/projects/vdk-control-cli/venv/lib/python3.11/site-packages/pytest_httpserver/httpserver.py", line 458, in match
    difference = self.difference(request)
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mdilyan/Projects/versatile-data-kit/projects/vdk-control-cli/venv/lib/python3.11/site-packages/pytest_httpserver/httpserver.py", line 432, in difference
    if not self.query_matcher.match(request.query_string):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mdilyan/Projects/versatile-data-kit/projects/vdk-control-cli/venv/lib/python3.11/site-packages/pytest_httpserver/httpserver.py", line 171, in match
    values = self.get_comparing_values(request_query_string)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mdilyan/Projects/versatile-data-kit/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_list.py", line 271, in get_comparing_values
    query_string = werkzeug.urls.url_decode(request_query_string)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'werkzeug.urls' has no attribute 'url_decode'
```

## What?

Pin the werkzeug version to 2.3.8 or less, where the API we use in the test is still supported.

## How was this tested?

Ran test locally and confirmed that it passes

## What kind of change is this

Bugfix