### PR TITLE
control-service: resolve dependabot alert

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/test/resources/filter-job/requirements.txt
+++ b/projects/control-service/projects/pipelines_control_service/src/test/resources/filter-job/requirements.txt
@@ -2,4 +2,4 @@
 # See https://pip.readthedocs.io/en/stable/user_guide/#requirements-files
 # The file is optional and can be deleted if no extra library dependencies are necessary.
 requests
-urllib3==1.26.7
+urllib3


### PR DESCRIPTION
https://github.com/vmware/versatile-data-kit/security/dependabot/23 

It alserts on using old version of urllib3. So updating it.