### PR TITLE
vdk-core: add error formatter configuration

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/vdk_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/vdk_config.py
@@ -21,6 +21,7 @@ LOG_CONFIG = "LOG_CONFIG"
 LOG_LEVEL_VDK = "LOG_LEVEL_VDK"
 LOG_LEVEL_MODULE = "LOG_LEVEL_MODULE"
 LOG_STACK_TRACE_ON_EXIT = "LOG_STACK_TRACE_ON_EXIT"
+LOG_EXCEPTION_FORMATTER = "LOG_EXCEPTION_FORMATTER"
 WORKING_DIR = "WORKING_DIR"
 ATTEMPT_ID = "ATTEMPT_ID"
 EXECUTION_ID = "EXECUTION_ID"
@@ -91,6 +92,14 @@ class CoreConfigDefinitionPlugin:
             "Controls whether the full stack trace is displayed again on exit code 1. "
             "False by default, shoud be set to true in production environments for more debug output. ",
         )
+        config_builder.add(
+            LOG_EXCEPTION_FORMATTER,
+            "pretty",
+            True,
+            "Determines the exception format. Possible values are [pretty | plain]. Default is 'pretty'"
+            "When set to pretty, it draws a box around VDK exceptions and add news lines and wrapping",
+        )
+
         config_builder.add(JOB_GITHASH, "unknown")
         config_builder.add(
             OP_ID,

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/file_based_step.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/file_based_step.py
@@ -110,7 +110,7 @@ class StepFuncFactory:
                             errors.resolvable_context().mark_all_resolved()
                         else:
                             log.error("Exiting  %s#run(...) FAILURE" % filename)
-            log.warn(
+            log.warning(
                 "File %s does not contain a valid run() method. Nothing to execute. Skipping %s,"
                 + " and continuing with other files (if present).",
                 filename,


### PR DESCRIPTION
## Prerequisites

Stacked on top of https://github.com/vmware/versatile-data-kit/pull/2774

## Why?
    
Different exception message formats are required for different use cases, e.g. CLI vs. Jupyter vs. Cloud
    
## What?
    
Add a flag to vdk-core configuration that lets the user pick the formatter. Initial choices are "pretty" and "plain". The plain
format should be good enough for Jupyter and Cloud deployments. The pretty formatter is enabled by default, because CLI needs to work out of the box.
    
Formatters have been exported to fuctions in errors.py, which makes it easy to write a new formatter if necessary. Exceptions are logged only at the exit point in the `run` method, which is also where formatting takes place.
    
## How was this tested?
    
Caused some config and user errors in local runs and looked at the output
    
CI tests
    
## What kind of change is this?
    
Feature/non-breaking
    
Signed-off-by: Dilyan Marinov <mdilyan@vmware.com>