### PR TITLE
control-service: user-initiated deployment notifications

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobsSynchronizer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobsSynchronizer.java
@@ -79,15 +79,11 @@ public class DataJobsSynchronizer {
       ActualDataJobDeployment actualDataJobDeployment,
       boolean isDeploymentPresentInKubernetes) {
     if (desiredDataJobDeployment != null) {
-      boolean sendNotification =
-          true; // TODO [miroslavi] sends notification only when the deployment is initiated by the
-      // user.
       deploymentService.updateDeployment(
           dataJob,
           desiredDataJobDeployment,
           actualDataJobDeployment,
-          isDeploymentPresentInKubernetes,
-          sendNotification);
+          isDeploymentPresentInKubernetes);
     }
   }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentServiceV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentServiceV2.java
@@ -57,15 +57,13 @@ public class DeploymentServiceV2 {
    * @param actualJobDeployment the actual data job deployment has been deployed.
    * @param isJobDeploymentPresentInKubernetes if it is true the data job deployment is present in
    *     Kubernetes.
-   * @param sendNotification if it is true the method will send a notification to the end user.
    */
   @Measurable(includeArg = 0, argName = "data_job")
   public void updateDeployment(
       DataJob dataJob,
       DesiredDataJobDeployment desiredJobDeployment,
       ActualDataJobDeployment actualJobDeployment,
-      boolean isJobDeploymentPresentInKubernetes,
-      Boolean sendNotification) {
+      boolean isJobDeploymentPresentInKubernetes) {
     if (desiredJobDeployment == null) {
       log.warn(
           "Skipping the data job [job_name={}] deployment due to the missing deployment data",
@@ -82,6 +80,9 @@ public class DeploymentServiceV2 {
           desiredJobDeployment.getStatus());
       return;
     }
+
+    // Sends notification only when the deployment is initiated by the user.
+    boolean sendNotification = Boolean.TRUE.equals(desiredJobDeployment.getUserInitiated());
 
     try {
       log.info("Starting deployment of job {}", desiredJobDeployment.getDataJobName());

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DesiredDataJobDeployment.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/model/DesiredDataJobDeployment.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 
 @Getter
@@ -20,4 +21,7 @@ import javax.persistence.Entity;
 public class DesiredDataJobDeployment extends BaseDataJobDeployment {
 
   private DeploymentStatus status;
+
+  @Column(name = "is_user_initiated")
+  private Boolean userInitiated;
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitor.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitor.java
@@ -107,8 +107,9 @@ public class DeploymentMonitor {
         actualJobDeploymentRepository.save(actualDataJobDeployment);
       }
 
-      desiredJobDeploymentRepository.updateDesiredDataJobDeploymentStatusAndUserInitiatedByDataJobName(
-          dataJobName, deploymentStatus, false);
+      desiredJobDeploymentRepository
+          .updateDesiredDataJobDeploymentStatusAndUserInitiatedByDataJobName(
+              dataJobName, deploymentStatus, false);
       return true;
     }
     log.debug("Data job: {} was deleted or hasn't been created", dataJobName);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitor.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitor.java
@@ -107,8 +107,8 @@ public class DeploymentMonitor {
         actualJobDeploymentRepository.save(actualDataJobDeployment);
       }
 
-      desiredJobDeploymentRepository.updateDesiredDataJobDeploymentStatusByDataJobName(
-          dataJobName, deploymentStatus);
+      desiredJobDeploymentRepository.updateDesiredDataJobDeploymentStatusAndUserInitiatedByDataJobName(
+          dataJobName, deploymentStatus, false);
       return true;
     }
     log.debug("Data job: {} was deleted or hasn't been created", dataJobName);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/repository/DesiredJobDeploymentRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/repository/DesiredJobDeploymentRepository.java
@@ -41,8 +41,8 @@ public interface DesiredJobDeploymentRepository
   @Transactional
   @Modifying(clearAutomatically = true)
   @Query(
-      "update DesiredDataJobDeployment d set d.status = :status, d.userInitiated = :userInitiated where d.dataJobName ="
-          + " :dataJobName")
+      "update DesiredDataJobDeployment d set d.status = :status, d.userInitiated = :userInitiated"
+          + " where d.dataJobName = :dataJobName")
   int updateDesiredDataJobDeploymentStatusAndUserInitiatedByDataJobName(
       @Param(value = "dataJobName") String dataJobName,
       @Param(value = "status") DeploymentStatus status,

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/repository/DesiredJobDeploymentRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/repository/DesiredJobDeploymentRepository.java
@@ -41,9 +41,10 @@ public interface DesiredJobDeploymentRepository
   @Transactional
   @Modifying(clearAutomatically = true)
   @Query(
-      "update DesiredDataJobDeployment d set d.status = :status where d.dataJobName ="
+      "update DesiredDataJobDeployment d set d.status = :status, d.userInitiated = :userInitiated where d.dataJobName ="
           + " :dataJobName")
-  int updateDesiredDataJobDeploymentStatusByDataJobName(
+  int updateDesiredDataJobDeploymentStatusAndUserInitiatedByDataJobName(
       @Param(value = "dataJobName") String dataJobName,
-      @Param(value = "status") DeploymentStatus status);
+      @Param(value = "status") DeploymentStatus status,
+      @Param(value = "userInitiated") Boolean userInitiatedDeployment);
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/db/migration/V20231005163000__add_column_is_user_initiated_to_desired_data_job_deployment_table.sql
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/db/migration/V20231005163000__add_column_is_user_initiated_to_desired_data_job_deployment_table.sql
@@ -1,0 +1,2 @@
+alter table if exists desired_data_job_deployment
+    add column if not exists is_user_initiated boolean;

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceV2TestIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceV2TestIT.java
@@ -50,30 +50,35 @@ public class DeploymentServiceV2TestIT {
   }
 
   @Test
-  public void updateDeployment_withDesiredDeploymentUserInitiatedDeploymentTrue_shouldSendNotification()
+  public void
+      updateDeployment_withDesiredDeploymentUserInitiatedDeploymentTrue_shouldSendNotification()
           throws IOException, InterruptedException, ApiException {
     updateDeployment(DeploymentStatus.NONE, 1, true);
 
     Mockito.verify(jobImageBuilder, Mockito.times(1))
-            .buildImage(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.eq(true));
+        .buildImage(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.eq(true));
   }
 
   @Test
-  public void updateDeployment_withDesiredDeploymentUserInitiatedDeploymentFalse_shouldNotSendNotification()
+  public void
+      updateDeployment_withDesiredDeploymentUserInitiatedDeploymentFalse_shouldNotSendNotification()
           throws IOException, InterruptedException, ApiException {
     updateDeployment(DeploymentStatus.NONE, 1, false);
 
     Mockito.verify(jobImageBuilder, Mockito.times(1))
-            .buildImage(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.eq(false));
+        .buildImage(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.eq(false));
   }
 
   private void updateDeployment(
-          DeploymentStatus deploymentStatus, int deploymentProgressStartedInvocations) throws IOException, InterruptedException, ApiException {
+      DeploymentStatus deploymentStatus, int deploymentProgressStartedInvocations)
+      throws IOException, InterruptedException, ApiException {
     updateDeployment(deploymentStatus, deploymentProgressStartedInvocations, true);
   }
 
   private void updateDeployment(
-      DeploymentStatus deploymentStatus, int deploymentProgressStartedInvocations, boolean sendNotification)
+      DeploymentStatus deploymentStatus,
+      int deploymentProgressStartedInvocations,
+      boolean sendNotification)
       throws IOException, InterruptedException, ApiException {
     DesiredDataJobDeployment desiredDataJobDeployment = new DesiredDataJobDeployment();
     desiredDataJobDeployment.setStatus(deploymentStatus);

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceV2TestIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceV2TestIT.java
@@ -49,11 +49,35 @@ public class DeploymentServiceV2TestIT {
     updateDeployment(DeploymentStatus.NONE, 1);
   }
 
+  @Test
+  public void updateDeployment_withDesiredDeploymentUserInitiatedDeploymentTrue_shouldSendNotification()
+          throws IOException, InterruptedException, ApiException {
+    updateDeployment(DeploymentStatus.NONE, 1, true);
+
+    Mockito.verify(jobImageBuilder, Mockito.times(1))
+            .buildImage(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.eq(true));
+  }
+
+  @Test
+  public void updateDeployment_withDesiredDeploymentUserInitiatedDeploymentFalse_shouldNotSendNotification()
+          throws IOException, InterruptedException, ApiException {
+    updateDeployment(DeploymentStatus.NONE, 1, false);
+
+    Mockito.verify(jobImageBuilder, Mockito.times(1))
+            .buildImage(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.eq(false));
+  }
+
   private void updateDeployment(
-      DeploymentStatus deploymentStatus, int deploymentProgressStartedInvocations)
+          DeploymentStatus deploymentStatus, int deploymentProgressStartedInvocations) throws IOException, InterruptedException, ApiException {
+    updateDeployment(deploymentStatus, deploymentProgressStartedInvocations, true);
+  }
+
+  private void updateDeployment(
+      DeploymentStatus deploymentStatus, int deploymentProgressStartedInvocations, boolean sendNotification)
       throws IOException, InterruptedException, ApiException {
     DesiredDataJobDeployment desiredDataJobDeployment = new DesiredDataJobDeployment();
     desiredDataJobDeployment.setStatus(deploymentStatus);
+    desiredDataJobDeployment.setUserInitiated(sendNotification);
     DataJob dataJob = new DataJob();
     dataJob.setJobConfig(new JobConfig());
     Mockito.when(
@@ -61,7 +85,7 @@ public class DeploymentServiceV2TestIT {
         .thenReturn(false);
 
     deploymentService.updateDeployment(
-        dataJob, desiredDataJobDeployment, new ActualDataJobDeployment(), true, true);
+        dataJob, desiredDataJobDeployment, new ActualDataJobDeployment(), true);
 
     Mockito.verify(deploymentProgress, Mockito.times(deploymentProgressStartedInvocations))
         .started(dataJob.getJobConfig(), desiredDataJobDeployment);


### PR DESCRIPTION
# Why
Currently, the new deployment mechanism sends notifications every time, lacking the ability to send them only when the user initiates the deployment.

# What
We modified the method to send notifications exclusively when deployments are initiated by the User, by incorporating a check for DeploymentStatus.NONE which represents user-initiated deployments.

# Testing done:
Unit tests.

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com