### PR TITLE
control-service: Enhance Exception Handling for DataJobsSynchronizer

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobsSynchronizer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobsSynchronizer.java
@@ -53,9 +53,13 @@ public class DataJobsSynchronizer {
 
     Set<String> dataJobDeploymentNamesFromKubernetes;
     try {
-      dataJobDeploymentNamesFromKubernetes = deploymentService.findAllActualDeploymentNamesFromKubernetes();
+      dataJobDeploymentNamesFromKubernetes =
+          deploymentService.findAllActualDeploymentNamesFromKubernetes();
     } catch (ApiException e) {
-      log.error("Skipping data job deployment synchronization because deployment names cannot be loaded from Kubernetes.", new KubernetesException("Cannot load cron jobs", e));
+      log.error(
+          "Skipping data job deployment synchronization because deployment names cannot be loaded"
+              + " from Kubernetes.",
+          new KubernetesException("Cannot load cron jobs", e));
       return;
     }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobsSynchronizer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobsSynchronizer.java
@@ -5,12 +5,14 @@
 
 package com.vmware.taurus.service.deploy;
 
+import com.vmware.taurus.exception.KubernetesException;
 import com.vmware.taurus.service.JobsService;
 import com.vmware.taurus.service.model.ActualDataJobDeployment;
 import com.vmware.taurus.service.model.DataJob;
 import com.vmware.taurus.service.model.DesiredDataJobDeployment;
 import io.kubernetes.client.openapi.ApiException;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
 
@@ -28,6 +30,7 @@ import java.util.Set;
  * <p>Usage: - Create an instance of this class and call the `synchronizeDataJobs` method to
  * initiate the synchronization process.
  */
+@Slf4j
 @AllArgsConstructor
 @Component
 public class DataJobsSynchronizer {
@@ -43,15 +46,20 @@ public class DataJobsSynchronizer {
    * <p>This method retrieves job information from the database, compares it with the current state
    * of Kubernetes CronJobs in the cluster, and takes the necessary actions to synchronize them.
    * This can include creating new CronJobs, updating existing CronJobs, etc.
-   *
-   * @throws ApiException
    */
-  public void synchronizeDataJobs() throws ApiException {
+  public void synchronizeDataJobs() {
     ThreadPoolTaskExecutor taskExecutor = initializeTaskExecutor();
     Iterable<DataJob> dataJobsFromDB = jobsService.findAllDataJobs();
 
-    Set<String> dataJobDeploymentNamesFromKubernetes =
-        deploymentService.findAllActualDeploymentNamesFromKubernetes();
+    Set<String> dataJobDeploymentNamesFromKubernetes;
+    try {
+      dataJobDeploymentNamesFromKubernetes = deploymentService.findAllActualDeploymentNamesFromKubernetes();
+    } catch (ApiException e) {
+      log.error("Skipping data job deployment synchronization because deployment names cannot be loaded from Kubernetes.", new KubernetesException("Cannot load cron jobs", e));
+      return;
+    }
+
+    Set<String> finalDataJobDeploymentNamesFromKubernetes = dataJobDeploymentNamesFromKubernetes;
 
     Map<String, DesiredDataJobDeployment> desiredDataJobDeploymentsFromDBMap =
         deploymentService.findAllDesiredDataJobDeployments();
@@ -67,7 +75,7 @@ public class DataJobsSynchronizer {
                         dataJob,
                         desiredDataJobDeploymentsFromDBMap.get(dataJob.getName()),
                         actualDataJobDeploymentsFromDBMap.get(dataJob.getName()),
-                        dataJobDeploymentNamesFromKubernetes.contains(dataJob.getName()))));
+                        finalDataJobDeploymentNamesFromKubernetes.contains(dataJob.getName()))));
 
     taskExecutor.shutdown();
   }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DataJobsSynchronizerTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DataJobsSynchronizerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.deploy;
+
+import com.vmware.taurus.ServiceApp;
+import io.kubernetes.client.openapi.ApiException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Collections;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+        classes = ServiceApp.class)
+public class DataJobsSynchronizerTest {
+
+    @Autowired
+    private DataJobsSynchronizer dataJobsSynchronizer;
+
+    @MockBean
+    private DeploymentServiceV2 deploymentService;
+
+    @Test
+    void synchronizeDataJobs_loadDeploymentNamesFromKubernetesReturnsValue_shouldFinishSynchronization() throws ApiException {
+        Mockito.when(deploymentService.findAllActualDeploymentNamesFromKubernetes()).thenReturn(Collections.emptySet());
+
+        dataJobsSynchronizer.synchronizeDataJobs();
+
+        Mockito.verify(deploymentService, Mockito.times(1))
+                .findAllActualDeploymentNamesFromKubernetes();
+
+        Mockito.verify(deploymentService, Mockito.times(1))
+                .findAllActualDataJobDeployments();
+    }
+
+    @Test
+    void synchronizeDataJobs_loadDeploymentNamesFromKubernetesThrowsApiException_shouldSkipSynchronization() throws ApiException {
+        Mockito.when(deploymentService.findAllActualDeploymentNamesFromKubernetes()).thenThrow(new ApiException());
+
+        dataJobsSynchronizer.synchronizeDataJobs();
+
+        Mockito.verify(deploymentService, Mockito.times(1))
+                .findAllActualDeploymentNamesFromKubernetes();
+
+        Mockito.verify(deploymentService, Mockito.times(0))
+                .findAllActualDataJobDeployments();
+    }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DataJobsSynchronizerTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DataJobsSynchronizerTest.java
@@ -18,40 +18,40 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.util.Collections;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(
-        webEnvironment = SpringBootTest.WebEnvironment.MOCK,
-        classes = ServiceApp.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = ServiceApp.class)
 public class DataJobsSynchronizerTest {
 
-    @Autowired
-    private DataJobsSynchronizer dataJobsSynchronizer;
+  @Autowired private DataJobsSynchronizer dataJobsSynchronizer;
 
-    @MockBean
-    private DeploymentServiceV2 deploymentService;
+  @MockBean private DeploymentServiceV2 deploymentService;
 
-    @Test
-    void synchronizeDataJobs_loadDeploymentNamesFromKubernetesReturnsValue_shouldFinishSynchronization() throws ApiException {
-        Mockito.when(deploymentService.findAllActualDeploymentNamesFromKubernetes()).thenReturn(Collections.emptySet());
+  @Test
+  void
+      synchronizeDataJobs_loadDeploymentNamesFromKubernetesReturnsValue_shouldFinishSynchronization()
+          throws ApiException {
+    Mockito.when(deploymentService.findAllActualDeploymentNamesFromKubernetes())
+        .thenReturn(Collections.emptySet());
 
-        dataJobsSynchronizer.synchronizeDataJobs();
+    dataJobsSynchronizer.synchronizeDataJobs();
 
-        Mockito.verify(deploymentService, Mockito.times(1))
-                .findAllActualDeploymentNamesFromKubernetes();
+    Mockito.verify(deploymentService, Mockito.times(1))
+        .findAllActualDeploymentNamesFromKubernetes();
 
-        Mockito.verify(deploymentService, Mockito.times(1))
-                .findAllActualDataJobDeployments();
-    }
+    Mockito.verify(deploymentService, Mockito.times(1)).findAllActualDataJobDeployments();
+  }
 
-    @Test
-    void synchronizeDataJobs_loadDeploymentNamesFromKubernetesThrowsApiException_shouldSkipSynchronization() throws ApiException {
-        Mockito.when(deploymentService.findAllActualDeploymentNamesFromKubernetes()).thenThrow(new ApiException());
+  @Test
+  void
+      synchronizeDataJobs_loadDeploymentNamesFromKubernetesThrowsApiException_shouldSkipSynchronization()
+          throws ApiException {
+    Mockito.when(deploymentService.findAllActualDeploymentNamesFromKubernetes())
+        .thenThrow(new ApiException());
 
-        dataJobsSynchronizer.synchronizeDataJobs();
+    dataJobsSynchronizer.synchronizeDataJobs();
 
-        Mockito.verify(deploymentService, Mockito.times(1))
-                .findAllActualDeploymentNamesFromKubernetes();
+    Mockito.verify(deploymentService, Mockito.times(1))
+        .findAllActualDeploymentNamesFromKubernetes();
 
-        Mockito.verify(deploymentService, Mockito.times(0))
-                .findAllActualDataJobDeployments();
-    }
+    Mockito.verify(deploymentService, Mockito.times(0)).findAllActualDataJobDeployments();
+  }
 }


### PR DESCRIPTION
Why
DataJobsSynchronizer does not catch ApiException.

What
We handled ApiException in DataJobsSynchronizer.

Testing done:
Unit tests.

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com