### PR TITLE
vdk-core: remove code duplication in ingestion router

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_base.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_base.py
@@ -39,10 +39,7 @@ from vdk.internal.builtin_plugins.ingestion.ingester_configuration import (
 from vdk.internal.builtin_plugins.ingestion.ingester_utils import AtomicCounter
 from vdk.internal.builtin_plugins.ingestion.ingester_utils import DecimalJsonEncoder
 from vdk.internal.core import errors
-from vdk.internal.core.errors import PlatformServiceError
 from vdk.internal.core.errors import ResolvableBy
-from vdk.internal.core.errors import UserCodeError
-from vdk.internal.core.errors import VdkConfigurationError
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
There would some code duplication in ingester router which even cause send_object_for_ingestion and send_tabular_data to handle method different which was subtle issue.

Refactor to remove the code duplication and reduce the number of lines as a whole.