### PR TITLE
vdk-core: tests passing custom iterator to ingestion methods

### DIFF
--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/run/job_input_error_classifier_test.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/run/job_input_error_classifier_test.py
@@ -43,50 +43,6 @@ class ErrorClassifierTest(unittest.TestCase):
         ),
     ]
 
-    USER_ERROR_USER_PROVIDED_ITERATOR = [
-        """
-        File "{}", line 9, in run
-        """.format(
-            os.path.join("job", "moonshine-ri", "21-find-ri-optimal.py")
-        ),
-        """
-        File "{}/job_input.py", line 155, in send_tabular_data_for_ingestion
-        """.format(
-            EXECUTOR_MODULE_DIR
-        ),
-        """
-        File "{}", line 5, in run
-        """.format(
-            os.path.join("job", "moonshine-ri", "21-find-ri-optimal.py")
-        ),
-        """
-        File "{}/ingester_router.py", line 142, in send_tabular_data_for_ingestion
-        """.format(
-            INGESTOR_MODULE_DIR
-        ),
-    ]
-
-    USER_ERROR_USER_PROVIDED_ITERATOR_EXTERNAL_LIBRARY = [
-        """
-        File "/opt/homebrew/lib/python3.11/site-packages/pandas/io/parsers/readers.py", line 912, in read_csv
-        """,
-        """
-        File "{}/job_input.py", line 155, in send_tabular_data_for_ingestion
-        """.format(
-            EXECUTOR_MODULE_DIR
-        ),
-        """
-        File "{}", line 5, in run
-        """.format(
-            os.path.join("job", "moonshine-ri", "21-find-ri-optimal.py")
-        ),
-        """
-        File "{}/ingester_router.py", line 142, in send_tabular_data_for_ingestion
-        """.format(
-            INGESTOR_MODULE_DIR
-        ),
-    ]
-
     USER_ERROR_STACKTRACE = [
         """File "{exec_module}", line 123, in _run_step
       step_executed = runner_func(file_path)""".format(
@@ -180,30 +136,6 @@ class ErrorClassifierTest(unittest.TestCase):
             errors.ResolvableBy.USER_ERROR,
             whom_to_blame(exception, self.EXECUTOR_MODULE, data_job_path),
         )
-
-    # TODO: https://github.com/vmware/versatile-data-kit/issues/2620
-    # Test error for user-provided iterator
-    #    @patch(f"{traceback.format_tb.__module__}.{traceback.format_tb.__name__}")
-    #    def test_error_user_provided_iterator(self, mock_traceback_format_tb):
-    #        exception = Exception("User Error")
-    #
-    #        mock_traceback_format_tb.return_value = self.USER_ERROR_USER_PROVIDED_ITERATOR
-    #        self.assertEqual(
-    #            errors.ResolvableBy.USER_ERROR,
-    #            whom_to_blame(exception, self.EXECUTOR_MODULE),
-    #        )
-
-    # TODO: https://github.com/vmware/versatile-data-kit/issues/2620
-    # Test error for user-provided iterator that uses external library
-    #    @patch(f"{traceback.format_tb.__module__}.{traceback.format_tb.__name__}")
-    #    def test_error_user_provided_iterator_external_library(self, mock_traceback_format_tb):
-    #        exception = Exception("User Error")
-    #
-    #        mock_traceback_format_tb.return_value = self.USER_ERROR_USER_PROVIDED_ITERATOR_EXTERNAL_LIBRARY
-    #        self.assertEqual(
-    #            errors.ResolvableBy.USER_ERROR,
-    #            whom_to_blame(exception, self.EXECUTOR_MODULE),
-    #        )
 
     # Test errors in user code that cannot be recognised by VDK due to lack of valid job_path.
     @patch(f"{traceback.format_tb.__module__}.{traceback.format_tb.__name__}")


### PR DESCRIPTION
 
In https://github.com/vmware/versatile-data-kit/issues/2620 the described use scenario is when user using
`send_tabular_data_for_ingeston(rows=BrokenIterator())`

The user-provided broken iterator is called within plaform code and the question is: is it recognized as  an user error?

It is correct. There was a test already covering that scenario [test_run_user_error_fail_job_ingest_iterator](https://github.com/vmware/versatile-data-kit/blob/634febe37cab75ffc36cd88ef186b7c910b8e03c/projects/vdk-core/tests/functional/run/test_run_errors.py#L77)

The test ErrorClassifierTest are not needed because the logic that classifies that type of error as user error is not done by stack trace but by handling the exception directly [here](https://github.com/vmware/versatile-data-kit/blob/634febe37cab75ffc36cd88ef186b7c910b8e03c/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_router.py#L201)