### PR TITLE
vdk-core: Replacement of imp module with importlib (#1353)

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/file_based_step.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/file_based_step.py
@@ -1,6 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 import importlib
+import types
 import inspect
 import logging
 import pathlib
@@ -80,7 +81,8 @@ class StepFuncFactory:
             try:
                 log.debug("Loading %s ..." % filename)
                 loader = importlib.machinery.SourceFileLoader(namespace, str(step.file_path))
-                python_module = loader.load_module()
+                python_module = types.ModuleType(loader)
+                loader.exec_module(python_module)
                 log.debug("Loading %s SUCCESS" % filename)
             except BaseException as e:
                 log.info("Loading %s FAILURE" % filename)

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/file_based_step.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/file_based_step.py
@@ -1,6 +1,6 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
-import imp
+import importlib
 import inspect
 import logging
 import pathlib
@@ -79,7 +79,8 @@ class StepFuncFactory:
 
             try:
                 log.debug("Loading %s ..." % filename)
-                python_module = imp.load_source(namespace, str(step.file_path))
+                loader = importlib.machinery.SourceFileLoader(namespace, str(step.file_path))
+                python_module = loader.load_module()
                 log.debug("Loading %s SUCCESS" % filename)
             except BaseException as e:
                 log.info("Loading %s FAILURE" % filename)

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/file_based_step.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/file_based_step.py
@@ -1,11 +1,11 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 import importlib
-import types
 import inspect
 import logging
 import pathlib
 import sys
+import types
 from typing import Callable
 from typing import List
 
@@ -80,7 +80,9 @@ class StepFuncFactory:
 
             try:
                 log.debug("Loading %s ..." % filename)
-                loader = importlib.machinery.SourceFileLoader(namespace, str(step.file_path))
+                loader = importlib.machinery.SourceFileLoader(
+                    namespace, str(step.file_path)
+                )
                 python_module = types.ModuleType(loader)
                 loader.exec_module(python_module)
                 log.debug("Loading %s SUCCESS" % filename)


### PR DESCRIPTION
- [x] Repacled imp module with importlib
- [x] used exec_module method as loader.load_module is deprecated