### PR TITLE
vdk-jupyter: fix ci/cd 

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
@@ -15,7 +15,9 @@
     - pip install -U pip setuptools pre-commit
     - apk --no-cache add npm libffi-dev curl musl-dev
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.72.0
-    - apk add gcc python3-dev
+    - export PATH="$HOME/.cargo/bin:$PATH"
+    - rustc --version
+    - cargo --version
     - pip install jupyter
   retry: !reference [.retry, retry_options]
   rules:

--- a/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
@@ -13,7 +13,8 @@
   before_script:
     - cd projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension || exit 1
     - pip install -U pip setuptools pre-commit
-    - apk --no-cache add npm rust cargo libffi-dev
+    - apk --no-cache add npm libffi-dev curl
+    - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.72.0
     - pip install jupyter
   retry: !reference [.retry, retry_options]
   rules:

--- a/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
@@ -15,6 +15,7 @@
     - pip install -U pip setuptools pre-commit
     - apk --no-cache add npm libffi-dev curl
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.72.0
+    - apk add gcc python3-dev
     - pip install jupyter
   retry: !reference [.retry, retry_options]
   rules:

--- a/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
@@ -13,7 +13,7 @@
   before_script:
     - cd projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension || exit 1
     - pip install -U pip setuptools pre-commit
-    - apk --no-cache add npm libffi-dev curl musl-dev
+    - apk --no-cache add npm libffi-dev curl musl-dev gcc
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.72.0
     - export PATH="$HOME/.cargo/bin:$PATH"
     - rustc --version

--- a/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
@@ -13,7 +13,7 @@
   before_script:
     - cd projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension || exit 1
     - pip install -U pip setuptools pre-commit
-    - apk --no-cache add npm libffi-dev curl
+    - apk --no-cache add npm libffi-dev curl musl-dev
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.72.0
     - apk add gcc python3-dev
     - pip install jupyter

--- a/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
@@ -15,9 +15,6 @@
     - pip install -U pip setuptools pre-commit
     - apk --no-cache add npm libffi-dev curl musl-dev gcc
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.72.0
-    - export PATH="$HOME/.cargo/bin:$PATH"
-    - rustc --version
-    - cargo --version
     - pip install jupyter
   retry: !reference [.retry, retry_options]
   rules:

--- a/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jupyter/.plugin-ci.yml
@@ -15,6 +15,7 @@
     - pip install -U pip setuptools pre-commit
     - apk --no-cache add npm libffi-dev curl musl-dev gcc
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.72.0
+    - export PATH="$HOME/.cargo/bin:$PATH"
     - pip install jupyter
   retry: !reference [.retry, retry_options]
   rules:


### PR DESCRIPTION
We had problems with the build: 

>      Building wheels for collected packages: y-py
>         Building wheel for y-py (pyproject.toml): started
>         Building wheel for y-py (pyproject.toml): finished with status 'error'
>         error: subprocess-exited-with-error
>       
>         × Building wheel for y-py (pyproject.toml) did not run successfully.
>         │ exit code: 1
>         ╰─> [9 lines of output]
>             Running `maturin pep517 build-wheel -i /usr/local/bin/python --compatibility off`
>             🔗 Found pyo3 bindings
>             🐍 Found CPython 3.8 at /usr/local/bin/python
>             error: package `y-py v0.6.2 (/tmp/pip-install-f40jsas6/y-py_d9865fc7363a49f684156a1cc9619ea2)` cannot be built because it requires rustc 1.72 or newer, while the currently active rustc version is 1.71.1

Updated the version of rustc adn added two additional dependencies.