### PR TITLE
control-service: asynchronous deployment deletion

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/service/deploy/DataJobDeploymentCrudITV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/service/deploy/DataJobDeploymentCrudITV2.java
@@ -162,8 +162,7 @@ public class DataJobDeploymentCrudITV2 extends BaseIT {
 
     // Deletes deployment
     desiredJobDeploymentRepository.deleteById(testJobName);
-    dataJobsSynchronizer.synchronizeDataJob(
-            dataJob, null, actualDataJobDeployment, true);
+    dataJobsSynchronizer.synchronizeDataJob(dataJob, null, actualDataJobDeployment, true);
     Assertions.assertFalse(deploymentService.readDeployment(testJobName).isPresent());
     Assertions.assertFalse(actualJobDeploymentRepository.findById(testJobName).isPresent());
   }

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/service/deploy/DataJobDeploymentCrudITV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/service/deploy/DataJobDeploymentCrudITV2.java
@@ -159,6 +159,13 @@ public class DataJobDeploymentCrudITV2 extends BaseIT {
     Assertions.assertNotEquals(lastDeployedDateInitial, lastDeployedDateShouldBeChanged);
     Assertions.assertNotEquals(
         deploymentVersionShaShouldNotBeChanged, deploymentVersionShaShouldBeChanged);
+
+    // Deletes deployment
+    desiredJobDeploymentRepository.deleteById(testJobName);
+    dataJobsSynchronizer.synchronizeDataJob(
+            dataJob, null, actualDataJobDeployment, true);
+    Assertions.assertFalse(deploymentService.readDeployment(testJobName).isPresent());
+    Assertions.assertFalse(actualJobDeploymentRepository.findById(testJobName).isPresent());
   }
 
   @Test

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsDeploymentController.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsDeploymentController.java
@@ -69,7 +69,6 @@ public class DataJobsDeploymentController implements DataJobsDeploymentApi {
       if (jobName != null) {
         if (dataJobDeploymentPropertiesConfig.getWriteTos().contains(WriteTo.K8S)) {
           deploymentService.deleteDeployment(jobName);
-
         }
 
         if (dataJobDeploymentPropertiesConfig.getWriteTos().contains(WriteTo.DB)) {
@@ -96,7 +95,7 @@ public class DataJobsDeploymentController implements DataJobsDeploymentApi {
             ToModelApiConverter.toJobDeployment(teamName, jobName, dataJobDeployment);
 
         if (dataJobDeploymentPropertiesConfig.getWriteTos().contains(WriteTo.K8S)) {
-            deploymentService.patchDeployment(job.get(), jobDeployment);
+          deploymentService.patchDeployment(job.get(), jobDeployment);
         }
 
         if (dataJobDeploymentPropertiesConfig.getWriteTos().contains(WriteTo.DB)) {
@@ -117,9 +116,7 @@ public class DataJobsDeploymentController implements DataJobsDeploymentApi {
       // TODO: deploymentId and mode not implemented
       List<DataJobDeploymentStatus> deployments = Collections.emptyList();
       Optional<JobDeploymentStatus> jobDeploymentStatus = Optional.empty();
-      if (dataJobDeploymentPropertiesConfig
-              .getReadDataSource()
-              .equals(ReadFrom.K8S)) {
+      if (dataJobDeploymentPropertiesConfig.getReadDataSource().equals(ReadFrom.K8S)) {
         jobDeploymentStatus = deploymentService.readDeployment(jobName.toLowerCase());
       }
       if (jobDeploymentStatus.isPresent()) {
@@ -137,9 +134,7 @@ public class DataJobsDeploymentController implements DataJobsDeploymentApi {
     if (jobsService.jobWithTeamExists(jobName, teamName)) {
       // TODO: deploymentId are not implemented.
       Optional<JobDeploymentStatus> jobDeploymentStatus = Optional.empty();
-      if (dataJobDeploymentPropertiesConfig
-              .getReadDataSource()
-              .equals(ReadFrom.K8S)) {
+      if (dataJobDeploymentPropertiesConfig.getReadDataSource().equals(ReadFrom.K8S)) {
         jobDeploymentStatus = deploymentService.readDeployment(jobName.toLowerCase());
       }
       if (jobDeploymentStatus.isPresent()) {
@@ -165,21 +160,19 @@ public class DataJobsDeploymentController implements DataJobsDeploymentApi {
         var jobDeployment =
             ToModelApiConverter.toJobDeployment(teamName, jobName.toLowerCase(), dataJobDeployment);
 
-        if (dataJobDeploymentPropertiesConfig
-                .getWriteTos()
-                .contains(WriteTo.K8S)) {
+        if (dataJobDeploymentPropertiesConfig.getWriteTos().contains(WriteTo.K8S)) {
           // TODO: Consider using a Task-oriented API approach
           deploymentService.updateDeployment(
-                  job.get(),
-                  jobDeployment,
-                  sendNotification,
-                  operationContext.getUser(),
-                  operationContext.getOpId());
+              job.get(),
+              jobDeployment,
+              sendNotification,
+              operationContext.getUser(),
+              operationContext.getOpId());
         }
 
         if (dataJobDeploymentPropertiesConfig.getWriteTos().contains(WriteTo.DB)) {
-            deploymentServiceV2.updateDesiredDbDeployment(
-                    job.get(), jobDeployment, operationContext.getUser());
+          deploymentServiceV2.updateDesiredDbDeployment(
+              job.get(), jobDeployment, operationContext.getUser());
         }
 
         return ResponseEntity.accepted().build();

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/ValidationException.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/ValidationException.java
@@ -7,7 +7,6 @@ package com.vmware.taurus.exception;
 
 import org.springframework.http.HttpStatus;
 
-
 public class ValidationException extends DomainError implements UserFacingError {
   public ValidationException(String what, String why, String consequences, String countermeasures) {
     super(what, why, consequences, countermeasures, null);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobsService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobsService.java
@@ -72,14 +72,14 @@ public class JobsService {
       credentialsService.deleteJobCredentials(name);
 
       if (dataJobDeploymentPropertiesConfig
-              .getWriteTos()
-              .contains(DataJobDeploymentPropertiesConfig.WriteTo.K8S)) {
+          .getWriteTos()
+          .contains(DataJobDeploymentPropertiesConfig.WriteTo.K8S)) {
         deploymentService.deleteDeployment(name);
       }
 
       if (dataJobDeploymentPropertiesConfig
-              .getWriteTos()
-              .contains(DataJobDeploymentPropertiesConfig.WriteTo.DB)) {
+          .getWriteTos()
+          .contains(DataJobDeploymentPropertiesConfig.WriteTo.DB)) {
         deploymentServiceV2.deleteDesiredDeployment(name);
       }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobsSynchronizer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobsSynchronizer.java
@@ -144,6 +144,8 @@ public class DataJobsSynchronizer {
           desiredDataJobDeployment,
           actualDataJobDeployment,
           isDeploymentPresentInKubernetes);
+    } else if (actualDataJobDeployment != null) {
+      deploymentService.deleteActualDeployment(dataJob.getName());
     }
   }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentServiceV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentServiceV2.java
@@ -257,6 +257,6 @@ public class DeploymentServiceV2 {
 
   private boolean deploymentExistsOrInProgress(String dataJobName) {
     return jobImageBuilder.isBuildingJobInProgress(dataJobName)
-            || readDeployment(dataJobName).isPresent();
+        || readDeployment(dataJobName).isPresent();
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentServiceV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentServiceV2.java
@@ -19,8 +19,10 @@ import com.vmware.taurus.service.model.JobDeployment;
 import com.vmware.taurus.service.notification.NotificationContent;
 import com.vmware.taurus.service.repository.ActualJobDeploymentRepository;
 import com.vmware.taurus.service.repository.DesiredJobDeploymentRepository;
+import com.vmware.taurus.service.repository.JobsRepository;
 import io.kubernetes.client.openapi.ApiException;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -50,6 +52,7 @@ public class DeploymentServiceV2 {
   private final DesiredJobDeploymentRepository desiredJobDeploymentRepository;
   private final ActualJobDeploymentRepository actualJobDeploymentRepository;
   private final DataJobsKubernetesService dataJobsKubernetesService;
+  private final JobsRepository jobsRepository;
 
   /**
    * This method updates an existing job deployment in the database. Only fields present in the job
@@ -186,6 +189,27 @@ public class DeploymentServiceV2 {
     }
   }
 
+  public void deleteDesiredDeployment(String dataJobName) {
+    if (desiredJobDeploymentRepository.existsById(dataJobName)) {
+      desiredJobDeploymentRepository.deleteById(dataJobName);
+    }
+  }
+
+  public void deleteActualDeployment(String dataJobName) {
+    if (this.deploymentExistsOrInProgress(dataJobName)) {
+      jobImageBuilder.cancelBuildingJob(dataJobName);
+      jobImageDeployer.unScheduleJob(dataJobName);
+      jobsRepository.updateDataJobEnabledByName(dataJobName, false);
+    }
+
+    actualJobDeploymentRepository.deleteById(dataJobName);
+    deploymentProgress.deleted(dataJobName);
+  }
+
+  public Optional<ActualDataJobDeployment> readDeployment(String dataJobName) {
+    return actualJobDeploymentRepository.findById(dataJobName);
+  }
+
   public void updateDeploymentEnabledStatus(String dataJobName, Boolean enabledStatus) {
     desiredJobDeploymentRepository.updateDesiredDataJobDeploymentEnabledByDataJobName(
         dataJobName, enabledStatus);
@@ -229,5 +253,10 @@ public class DeploymentServiceV2 {
         DeploymentStatus.PLATFORM_ERROR,
         NotificationContent.getPlatformErrorBody(),
         sendNotification);
+  }
+
+  private boolean deploymentExistsOrInProgress(String dataJobName) {
+    return jobImageBuilder.isBuildingJobInProgress(dataJobName)
+            || readDeployment(dataJobName).isPresent();
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployerV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployerV2.java
@@ -14,6 +14,7 @@ import com.vmware.taurus.service.kubernetes.DataJobsKubernetesService;
 import com.vmware.taurus.service.model.*;
 import com.vmware.taurus.service.notification.NotificationContent;
 import io.kubernetes.client.openapi.ApiException;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -100,6 +101,17 @@ public class JobImageDeployerV2 {
           jobImageName);
     } catch (ApiException e) {
       return catchApiException(dataJob, sendNotification, e);
+    }
+  }
+
+  public void unScheduleJob(@NonNull String dataJobName) {
+    String cronJobName = getCronJobName(dataJobName);
+    try {
+      if (dataJobsKubernetesService.listCronJobs().contains(cronJobName)) {
+        dataJobsKubernetesService.deleteCronJob(cronJobName);
+      }
+    } catch (ApiException e) {
+      throw new KubernetesException("Failed to un-schedule job", e);
     }
   }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/db/migration/V20231013120000__drop_constraint_fk_data_job_name_ref_data_job_from_actual_data_job_deployment_table.sql
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/db/migration/V20231013120000__drop_constraint_fk_data_job_name_ref_data_job_from_actual_data_job_deployment_table.sql
@@ -1,0 +1,2 @@
+alter table if exists actual_data_job_deployment
+    drop constraint if exists fk_data_job_name_ref_data_job;

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DataJobsSynchronizerTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DataJobsSynchronizerTest.java
@@ -6,6 +6,9 @@
 package com.vmware.taurus.service.deploy;
 
 import com.vmware.taurus.ServiceApp;
+import com.vmware.taurus.service.model.ActualDataJobDeployment;
+import com.vmware.taurus.service.model.DataJob;
+import com.vmware.taurus.service.model.DesiredDataJobDeployment;
 import io.kubernetes.client.openapi.ApiException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -105,6 +108,70 @@ public class DataJobsSynchronizerTest {
 
     Mockito.verify(deploymentService, Mockito.times(0))
         .findAllActualDeploymentNamesFromKubernetes();
+  }
+
+  @Test
+  void synchronizeDataJob_desiredDeploymentNullAndActualDeploymentNull_shouldSkipSynchronization() {
+    DataJob dataJob = new DataJob();
+    dataJob.setName("test-job-name");
+    boolean isDeploymentPresentInKubernetes = false;
+    DesiredDataJobDeployment desiredDataJobDeployment = null;
+    ActualDataJobDeployment actualDataJobDeployment = null;
+
+    dataJobsSynchronizer.synchronizeDataJob(dataJob, desiredDataJobDeployment, actualDataJobDeployment, isDeploymentPresentInKubernetes);
+
+    Mockito.verify(deploymentService, Mockito.times(0))
+            .updateDeployment(dataJob, desiredDataJobDeployment, actualDataJobDeployment, isDeploymentPresentInKubernetes);
+    Mockito.verify(deploymentService, Mockito.times(0))
+            .deleteActualDeployment(dataJob.getName());
+  }
+
+  @Test
+  void synchronizeDataJob_desiredDeploymentNullAndActualDeploymentNotNull_shouldDeleteJobDeployment() {
+    DataJob dataJob = new DataJob();
+    dataJob.setName("test-job-name");
+    boolean isDeploymentPresentInKubernetes = true;
+    DesiredDataJobDeployment desiredDataJobDeployment = null;
+    ActualDataJobDeployment actualDataJobDeployment = new ActualDataJobDeployment();
+
+    dataJobsSynchronizer.synchronizeDataJob(dataJob, desiredDataJobDeployment, actualDataJobDeployment, isDeploymentPresentInKubernetes);
+
+    Mockito.verify(deploymentService, Mockito.times(0))
+            .updateDeployment(dataJob, desiredDataJobDeployment, actualDataJobDeployment, isDeploymentPresentInKubernetes);
+    Mockito.verify(deploymentService, Mockito.times(1))
+            .deleteActualDeployment(dataJob.getName());
+  }
+
+  @Test
+  void synchronizeDataJob_desiredDeploymentNotNullAndActualDeploymentNotNull_shouldUpdateJobDeployment() {
+    DataJob dataJob = new DataJob();
+    dataJob.setName("test-job-name");
+    boolean isDeploymentPresentInKubernetes = true;
+    DesiredDataJobDeployment desiredDataJobDeployment = new DesiredDataJobDeployment();
+    ActualDataJobDeployment actualDataJobDeployment = new ActualDataJobDeployment();
+
+    dataJobsSynchronizer.synchronizeDataJob(dataJob, desiredDataJobDeployment, actualDataJobDeployment, isDeploymentPresentInKubernetes);
+
+    Mockito.verify(deploymentService, Mockito.times(1))
+            .updateDeployment(dataJob, desiredDataJobDeployment, actualDataJobDeployment, isDeploymentPresentInKubernetes);
+    Mockito.verify(deploymentService, Mockito.times(0))
+            .deleteActualDeployment(dataJob.getName());
+  }
+
+  @Test
+  void synchronizeDataJob_desiredDeploymentNotNullAndActualDeploymentNull_shouldUpdateJobDeployment() {
+    DataJob dataJob = new DataJob();
+    dataJob.setName("test-job-name");
+    boolean isDeploymentPresentInKubernetes = true;
+    DesiredDataJobDeployment desiredDataJobDeployment = new DesiredDataJobDeployment();
+    ActualDataJobDeployment actualDataJobDeployment = null;
+
+    dataJobsSynchronizer.synchronizeDataJob(dataJob, desiredDataJobDeployment, actualDataJobDeployment, isDeploymentPresentInKubernetes);
+
+    Mockito.verify(deploymentService, Mockito.times(1))
+            .updateDeployment(dataJob, desiredDataJobDeployment, actualDataJobDeployment, isDeploymentPresentInKubernetes);
+    Mockito.verify(deploymentService, Mockito.times(0))
+            .deleteActualDeployment(dataJob.getName());
   }
 
   void enableSynchronizationProcess() {

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DataJobsSynchronizerTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DataJobsSynchronizerTest.java
@@ -118,60 +118,91 @@ public class DataJobsSynchronizerTest {
     DesiredDataJobDeployment desiredDataJobDeployment = null;
     ActualDataJobDeployment actualDataJobDeployment = null;
 
-    dataJobsSynchronizer.synchronizeDataJob(dataJob, desiredDataJobDeployment, actualDataJobDeployment, isDeploymentPresentInKubernetes);
+    dataJobsSynchronizer.synchronizeDataJob(
+        dataJob,
+        desiredDataJobDeployment,
+        actualDataJobDeployment,
+        isDeploymentPresentInKubernetes);
 
     Mockito.verify(deploymentService, Mockito.times(0))
-            .updateDeployment(dataJob, desiredDataJobDeployment, actualDataJobDeployment, isDeploymentPresentInKubernetes);
-    Mockito.verify(deploymentService, Mockito.times(0))
-            .deleteActualDeployment(dataJob.getName());
+        .updateDeployment(
+            dataJob,
+            desiredDataJobDeployment,
+            actualDataJobDeployment,
+            isDeploymentPresentInKubernetes);
+    Mockito.verify(deploymentService, Mockito.times(0)).deleteActualDeployment(dataJob.getName());
   }
 
   @Test
-  void synchronizeDataJob_desiredDeploymentNullAndActualDeploymentNotNull_shouldDeleteJobDeployment() {
+  void
+      synchronizeDataJob_desiredDeploymentNullAndActualDeploymentNotNull_shouldDeleteJobDeployment() {
     DataJob dataJob = new DataJob();
     dataJob.setName("test-job-name");
     boolean isDeploymentPresentInKubernetes = true;
     DesiredDataJobDeployment desiredDataJobDeployment = null;
     ActualDataJobDeployment actualDataJobDeployment = new ActualDataJobDeployment();
 
-    dataJobsSynchronizer.synchronizeDataJob(dataJob, desiredDataJobDeployment, actualDataJobDeployment, isDeploymentPresentInKubernetes);
+    dataJobsSynchronizer.synchronizeDataJob(
+        dataJob,
+        desiredDataJobDeployment,
+        actualDataJobDeployment,
+        isDeploymentPresentInKubernetes);
 
     Mockito.verify(deploymentService, Mockito.times(0))
-            .updateDeployment(dataJob, desiredDataJobDeployment, actualDataJobDeployment, isDeploymentPresentInKubernetes);
-    Mockito.verify(deploymentService, Mockito.times(1))
-            .deleteActualDeployment(dataJob.getName());
+        .updateDeployment(
+            dataJob,
+            desiredDataJobDeployment,
+            actualDataJobDeployment,
+            isDeploymentPresentInKubernetes);
+    Mockito.verify(deploymentService, Mockito.times(1)).deleteActualDeployment(dataJob.getName());
   }
 
   @Test
-  void synchronizeDataJob_desiredDeploymentNotNullAndActualDeploymentNotNull_shouldUpdateJobDeployment() {
+  void
+      synchronizeDataJob_desiredDeploymentNotNullAndActualDeploymentNotNull_shouldUpdateJobDeployment() {
     DataJob dataJob = new DataJob();
     dataJob.setName("test-job-name");
     boolean isDeploymentPresentInKubernetes = true;
     DesiredDataJobDeployment desiredDataJobDeployment = new DesiredDataJobDeployment();
     ActualDataJobDeployment actualDataJobDeployment = new ActualDataJobDeployment();
 
-    dataJobsSynchronizer.synchronizeDataJob(dataJob, desiredDataJobDeployment, actualDataJobDeployment, isDeploymentPresentInKubernetes);
+    dataJobsSynchronizer.synchronizeDataJob(
+        dataJob,
+        desiredDataJobDeployment,
+        actualDataJobDeployment,
+        isDeploymentPresentInKubernetes);
 
     Mockito.verify(deploymentService, Mockito.times(1))
-            .updateDeployment(dataJob, desiredDataJobDeployment, actualDataJobDeployment, isDeploymentPresentInKubernetes);
-    Mockito.verify(deploymentService, Mockito.times(0))
-            .deleteActualDeployment(dataJob.getName());
+        .updateDeployment(
+            dataJob,
+            desiredDataJobDeployment,
+            actualDataJobDeployment,
+            isDeploymentPresentInKubernetes);
+    Mockito.verify(deploymentService, Mockito.times(0)).deleteActualDeployment(dataJob.getName());
   }
 
   @Test
-  void synchronizeDataJob_desiredDeploymentNotNullAndActualDeploymentNull_shouldUpdateJobDeployment() {
+  void
+      synchronizeDataJob_desiredDeploymentNotNullAndActualDeploymentNull_shouldUpdateJobDeployment() {
     DataJob dataJob = new DataJob();
     dataJob.setName("test-job-name");
     boolean isDeploymentPresentInKubernetes = true;
     DesiredDataJobDeployment desiredDataJobDeployment = new DesiredDataJobDeployment();
     ActualDataJobDeployment actualDataJobDeployment = null;
 
-    dataJobsSynchronizer.synchronizeDataJob(dataJob, desiredDataJobDeployment, actualDataJobDeployment, isDeploymentPresentInKubernetes);
+    dataJobsSynchronizer.synchronizeDataJob(
+        dataJob,
+        desiredDataJobDeployment,
+        actualDataJobDeployment,
+        isDeploymentPresentInKubernetes);
 
     Mockito.verify(deploymentService, Mockito.times(1))
-            .updateDeployment(dataJob, desiredDataJobDeployment, actualDataJobDeployment, isDeploymentPresentInKubernetes);
-    Mockito.verify(deploymentService, Mockito.times(0))
-            .deleteActualDeployment(dataJob.getName());
+        .updateDeployment(
+            dataJob,
+            desiredDataJobDeployment,
+            actualDataJobDeployment,
+            isDeploymentPresentInKubernetes);
+    Mockito.verify(deploymentService, Mockito.times(0)).deleteActualDeployment(dataJob.getName());
   }
 
   void enableSynchronizationProcess() {


### PR DESCRIPTION
Why:
As part of VEP-2272, we need to introduce a process for synchronizing data jobs from the database to Kubernetes. Currently, the process lacks the ability to delete deployments asynchronously.

What:
We have introduced an asynchronous method for deployment deletion. It is based on the logic that if the desired deployment is null and the actual deployment is not null, the process performs deployment deletion.

Testing done:
Integration tests.

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com