### PR TITLE
vdk-control-cli: fix CI/CD tests

### DIFF
--- a/projects/vdk-control-cli/.gitlab-ci.yml
+++ b/projects/vdk-control-cli/.gitlab-ci.yml
@@ -18,7 +18,7 @@
   artifacts:
     when: always
     reports:
-      junit: tests.xml
+      junit: ./projects/vdk-control-cli/tests.xml
 
 
 # Run in different environments
@@ -49,7 +49,7 @@ vdk-control-cli-release-acceptance-test:
   artifacts:
     when: always
     reports:
-      junit: tests.xml
+      junit: ./projects/vdk-control-cli/tests.xml
   only:
     refs:
       - main


### PR DESCRIPTION
What: The generated tests.xml XML report can not be found in the current working directory. This change fixes the directory where the XML report would be outputted to.

Why: Fix the CI/CD.

Testing Done: The pipeline is green. The tests.xml file is found.
