### PR TITLE
control-service: fix control service post deployment test

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitor.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitor.java
@@ -99,9 +99,9 @@ public class DeploymentMonitor {
   }
 
   public boolean saveDataJobStatus(
-          final String dataJobName,
-          final DeploymentStatus deploymentStatus,
-          ActualDataJobDeployment actualDataJobDeployment) {
+      final String dataJobName,
+      final DeploymentStatus deploymentStatus,
+      ActualDataJobDeployment actualDataJobDeployment) {
     if (jobsRepository.updateDataJobLatestJobDeploymentStatusByName(dataJobName, deploymentStatus)
         > 0) {
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitor.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitor.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -76,6 +77,7 @@ public class DeploymentMonitor {
    * @param dataJobName
    * @param deploymentStatus
    */
+  @Transactional
   public void recordDeploymentStatus(
       String dataJobName,
       DeploymentStatus deploymentStatus,
@@ -96,10 +98,10 @@ public class DeploymentMonitor {
     }
   }
 
-  private boolean saveDataJobStatus(
-      final String dataJobName,
-      final DeploymentStatus deploymentStatus,
-      ActualDataJobDeployment actualDataJobDeployment) {
+  public boolean saveDataJobStatus(
+          final String dataJobName,
+          final DeploymentStatus deploymentStatus,
+          ActualDataJobDeployment actualDataJobDeployment) {
     if (jobsRepository.updateDataJobLatestJobDeploymentStatusByName(dataJobName, deploymentStatus)
         > 0) {
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/repository/DesiredJobDeploymentRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/repository/DesiredJobDeploymentRepository.java
@@ -13,8 +13,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import javax.transaction.Transactional;
-
 /**
  * Spring Data / JPA Repository for DesiredDataJobDeployment objects and their members
  *
@@ -30,16 +28,14 @@ import javax.transaction.Transactional;
 public interface DesiredJobDeploymentRepository
     extends JpaRepository<DesiredDataJobDeployment, String> {
 
-  @Transactional
-  @Modifying(clearAutomatically = true)
+  @Modifying
   @Query(
       "update DesiredDataJobDeployment d set d.enabled = :enabled where d.dataJobName ="
           + " :dataJobName")
   int updateDesiredDataJobDeploymentEnabledByDataJobName(
       @Param(value = "dataJobName") String dataJobName, @Param(value = "enabled") Boolean enabled);
 
-  @Transactional
-  @Modifying(clearAutomatically = true)
+  @Modifying
   @Query(
       "update DesiredDataJobDeployment d set d.status = :status, d.userInitiated = :userInitiated"
           + " where d.dataJobName = :dataJobName")


### PR DESCRIPTION
# Why
We observed the following post-deployment test failure: https://gitlab.com/vmware-analytics/versatile-data-kit/-/jobs/5192553226. 

This change is the culprit https://github.com/vmware/versatile-data-kit/pull/2714
It’s the first pipeline that started having this issue https://gitlab.com/vmware-analytics/versatile-data-kit/-/jobs/5210024385
The previous change for the control service that triggered the same tests passed fine. There weren’t any changes to heartbeat or control-cli in between, as far as I can tell. You can see from the logs that the schedule is written to the data job table for the previous control service change that triggered the same tests.

https://gitlab.com/vmware-analytics/versatile-data-kit/-/pipelines/1020826286
https://gitlab.com/vmware-analytics/versatile-data-kit/-/jobs/5192553226

The control-cli does a PUT request after creating the data job. This updates the config, which includes the schedule. For some reason, the config doesn’t get updated. The change touches some of the update code, namely, it passes the new DesiredJobDeployment entity into the JobImageBuilder, which is used in the JobService update method, which gets called when we do a PUT request to update the job.

# What
Removed the unnecessary @Transactional annotation from the DesiredJobDeploymentRepository methods which prevent from committing the transaction started in JobsService.updateJob().

# Testing done
Manually created data job through the DataJob API and then updated it through the DataJob API.

create: localhost:8092/data-jobs/for-team/taurus/jobs
```json
{
	"job_name": "miroslavi-test6",
	"team": "taurus",
        "config": {
          "schedule": {
	          "schedule_cron": "* * * * *"
          }
	}
}
```

update: localhost:8092/data-jobs/for-team/taurus/jobs/miroslavi-test6
```json
{
	"team": "taurus",
	"config": {
          "schedule": {
	          "schedule_cron": "* * * * 1"
          }
	}
}
```

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com