### PR TITLE
control-service: job resources validation on job deployment

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudIT.java
@@ -176,14 +176,13 @@ public class DataJobDeploymentCrudIT extends BaseIT {
 
     // Execute build and deploy job with job resources
     mockMvc
-          .perform(
-              post(String.format(
-                      "/data-jobs/for-team/%s/jobs/%s/deployments",
-                      TEST_TEAM_NAME, testJobName))
-                      .with(user("user"))
-                      .content(getDataJobDeploymentRequestBodyWithJobResources(testJobVersionSha))
-                      .contentType(MediaType.APPLICATION_JSON))
-          .andExpect(status().isBadRequest());
+        .perform(
+            post(String.format(
+                    "/data-jobs/for-team/%s/jobs/%s/deployments", TEST_TEAM_NAME, testJobName))
+                .with(user("user"))
+                .content(getDataJobDeploymentRequestBodyWithJobResources(testJobVersionSha))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
 
     String jobDeploymentName = JobImageDeployer.getCronJobName(testJobName);
     // Verify job deployment created
@@ -397,7 +396,8 @@ public class DataJobDeploymentCrudIT extends BaseIT {
         .andExpect(status().isOk());
   }
 
-  private String getDataJobDeploymentRequestBodyWithJobResources(String jobVersionSha) throws JsonProcessingException {
+  private String getDataJobDeploymentRequestBodyWithJobResources(String jobVersionSha)
+      throws JsonProcessingException {
     var jobDeployment = new com.vmware.taurus.controlplane.model.data.DataJobDeployment();
     jobDeployment.setJobVersion(jobVersionSha);
     jobDeployment.setMode(DataJobMode.RELEASE);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsDeploymentController.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsDeploymentController.java
@@ -146,16 +146,17 @@ public class DataJobsDeploymentController implements DataJobsDeploymentApi {
   }
 
   private void validateJobResources(DataJobDeployment dataJobDeployment) {
-    if (dataJobDeployment != null && dataJobDeployment.getResources() != null &&
-            (dataJobDeployment.getResources().getCpuRequest() != null ||
-                    dataJobDeployment.getResources().getCpuLimit() != null ||
-                    dataJobDeployment.getResources().getMemoryRequest() != null &&
-                            dataJobDeployment.getResources().getMemoryLimit() != null)) {
+    if (dataJobDeployment != null
+        && dataJobDeployment.getResources() != null
+        && (dataJobDeployment.getResources().getCpuRequest() != null
+            || dataJobDeployment.getResources().getCpuLimit() != null
+            || dataJobDeployment.getResources().getMemoryRequest() != null
+                && dataJobDeployment.getResources().getMemoryLimit() != null)) {
       throw new ValidationException(
-                "The setting of job resources like CPU and memory is not allowed.",
-                "The setting of job resources like CPU and memory is not supported by the platform.",
-                "The deployment of the data job will not proceed.",
-                "To deploy the data job, please do not configure job resources.");
+          "The setting of job resources like CPU and memory is not allowed.",
+          "The setting of job resources like CPU and memory is not supported by the platform.",
+          "The deployment of the data job will not proceed.",
+          "To deploy the data job, please do not configure job resources.");
     }
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/ValidationException.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/ValidationException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.exception;
+
+import org.springframework.http.HttpStatus;
+
+import java.util.Set;
+
+public class ValidationException extends DomainError implements UserFacingError {
+    public ValidationException(String what, String why, String consequences, String countermeasures) {
+        super(what, why, consequences, countermeasures, null);
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/ValidationException.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/exception/ValidationException.java
@@ -7,15 +7,14 @@ package com.vmware.taurus.exception;
 
 import org.springframework.http.HttpStatus;
 
-import java.util.Set;
 
 public class ValidationException extends DomainError implements UserFacingError {
-    public ValidationException(String what, String why, String consequences, String countermeasures) {
-        super(what, why, consequences, countermeasures, null);
-    }
+  public ValidationException(String what, String why, String consequences, String countermeasures) {
+    super(what, why, consequences, countermeasures, null);
+  }
 
-    @Override
-    public HttpStatus getHttpStatus() {
-        return HttpStatus.BAD_REQUEST;
-    }
+  @Override
+  public HttpStatus getHttpStatus() {
+    return HttpStatus.BAD_REQUEST;
+  }
 }


### PR DESCRIPTION
Why:
Unlike the old deployment approach, the new one propagates job resources to the job deployment process.

What:
Added validation of job resources during job deployment. If any job resources, such as CPU or memory, are provided, the job deployment will fail.

Testing done:
Integration tests.

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com