### PR TITLE
vdk-core: test ingestion with multiple threads

### DIFF
--- a/projects/vdk-core/tests/functional/ingestion/jobs/ingest-multiple-threads-job/ingest_multi_threads.py
+++ b/projects/vdk-core/tests/functional/ingestion/jobs/ingest-multiple-threads-job/ingest_multi_threads.py
@@ -1,0 +1,49 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import random
+import threading
+import time
+
+from vdk.api.job_input import IJobInput
+
+
+def run(job_input: IJobInput):
+    methods = ["memory1"] * 50 + ["memory2"] * 50
+    random.shuffle(methods)
+
+    threads = []
+    for chosen_method in methods:
+        thread = threading.Thread(
+            target=ingest_data,
+            args=(
+                job_input,
+                chosen_method,
+            ),
+        )
+        threads.append(thread)
+        thread.start()
+
+    for thread in threads:
+        thread.join()
+
+
+def ingest_data(job_input: IJobInput, method: str):
+    time.sleep(random.uniform(0, 0.1))
+    obj = dict(
+        int_key=42,
+        str_key="example_str",
+        bool_key=True,
+        float_key=1.23,
+        nested=dict(key="value"),
+    )
+    job_input.send_object_for_ingestion(
+        payload=obj, destination_table="object_table", method=method
+    )
+
+    rows = [["two", 2], ["twenty-two", 22], ["one-eleven", 111]]
+    job_input.send_tabular_data_for_ingestion(
+        rows=rows,
+        column_names=["first", "second"],
+        destination_table="tabular_table",
+        method=method,
+    )


### PR DESCRIPTION
The IIngester methods (send_xxx_for_ingestion) should allow being called from multiple threads. But it's never explicitly tested. This test is far from perfect. Testing something is thread safe is not very easy. 

But it's good to have it because

A) it's an indication of this thread-safe contract for future developers  
B) If there is some serious regression this should catch it even if it doesn't catch some more subtle regressions.