### PR TITLE
vdk-structlog: create structured logging plugin

### DIFF
--- a/projects/vdk-plugins/vdk-structlog/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-structlog/.plugin-ci.yml
@@ -1,0 +1,22 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+image: "python:3.7"
+
+.build-vdk-structlog:
+  variables:
+    PLUGIN_NAME: vdk-structlog
+  extends: .build-plugin
+
+build-py37-vdk-structlog:
+  extends: .build-vdk-structlog
+  image: "python:3.7"
+
+build-py311-vdk-structlog:
+  extends: .build-vdk-structlog
+  image: "python:3.11"
+
+release-vdk-structlog:
+  variables:
+    PLUGIN_NAME: vdk-structlog
+  extends: .release-plugin

--- a/projects/vdk-plugins/vdk-structlog/README.md
+++ b/projects/vdk-plugins/vdk-structlog/README.md
@@ -1,0 +1,121 @@
+# Structured Logging For VDK
+
+This plugin allows users to:
+- select the log output format
+- configure the logging metadata
+- display metadata added by bound loggers
+
+## Usage
+
+```
+pip install vdk-structlog
+```
+
+### Configuration
+
+(`vdk config-help` is useful command to browse all config options of your installation of vdk)
+
+| Name             | Description                                                           | (example)  Value                                                                                                   |
+| ---------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| logging_metadata | Configure the metadata that will be output along with the log message | "timestamp, level, logger_name, file_name, line_number, function_name, vdk_job_name, vdk_step_name, vdk_step_type" |
+| logging_format   | Configure the logging output format. Available formats: json, console | "console"                                                                                                          |
+
+### Example: Configure metadata
+
+Create a data job and add the following config options
+
+```
+[vdk]
+logging_metadata=timestamp,level,file_name,vdk_job_name
+logging_format=console
+```
+
+Then run the data job. You should see just the configured tags where relevant.
+For example, you won't see the vdk_job_name outside of log statements directly
+related to job execution.
+
+ ```
+2023-10-17 11:20:59,202 [VDK] [INFO ]    managed_cursor.py ingest-from-db-example-job - Executing query SUCCEEDED. Query duration 00h:00m:00s
+2023-10-17 11:20:59,202 [VDK] [INFO ] managed_connection_b ingest-from-db-example-job - Fetching query result...
+2023-10-17 11:20:59,202 [VDK] [INFO ]    managed_cursor.py ingest-from-db-example-job - Fetching all results from query ...
+2023-10-17 11:20:59,202 [VDK] [INFO ]    managed_cursor.py ingest-from-db-example-job - Fetching all results from query SUCCEEDED.
+2023-10-17 11:20:59,202 [VDK] [INFO ]    managed_cursor.py ingest-from-db-example-job - Closing DB cursor ...
+2023-10-17 11:20:59,202 [VDK] [INFO ]    managed_cursor.py ingest-from-db-example-job - Closing DB cursor SUCCEEDED.
+2023-10-17 11:20:59,203 [VDK] [INFO ]   file_based_step.py ingest-from-db-example-job - Entering 30_ingest_to_table.py#run(...) ...
+2023-10-17 11:20:59,203 [VDK] [INFO ]   ingester_router.py ingest-from-db-example-job - Sending tabular data for ingestion with method: sqlite and target: None
+2023-10-17 11:20:59,204 [VDK] [INFO ]   file_based_step.py ingest-from-db-example-job - Exiting  30_ingest_to_table.py#run(...) SUCCESS
+```
+
+Now, let's remove the timestamp from the configuration and add the line number
+
+```
+logging_metadata=level,file_name,line_number,vdk_job_name
+logging_format=console
+```
+
+And run the job again
+
+```
+[INFO ]    managed_cursor.py :97   ingest-from-db-example-job - Executing query SUCCEEDED. Query duration 00h:00m:00s
+[INFO ] managed_connection_b :133  ingest-from-db-example-job - Fetching query result...
+[INFO ]    managed_cursor.py :193  ingest-from-db-example-job - Fetching all results from query ...
+[INFO ]    managed_cursor.py :196  ingest-from-db-example-job - Fetching all results from query SUCCEEDED.
+[INFO ]    managed_cursor.py :203  ingest-from-db-example-job - Closing DB cursor ...
+[INFO ]    managed_cursor.py :205  ingest-from-db-example-job - Closing DB cursor SUCCEEDED.
+[INFO ]   file_based_step.py :103  ingest-from-db-example-job - Entering 30_ingest_to_table.py#run(...) ...
+[INFO ]   ingester_router.py :106  ingest-from-db-example-job - Sending tabular data for ingestion with method: sqlite and target: None
+[INFO ]   file_based_step.py :109  ingest-from-db-example-job - Exiting  30_ingest_to_table.py#run(...) SUCCESS
+```
+
+### Example: Configure logging format
+
+Create a data job and add the following config options
+
+```
+[vdk]
+logging_metadata=timestamp,level,file_name,vdk_job_name
+logging_format=json
+```
+
+And you should see json-formatted logs.
+
+```
+{"filename": "managed_cursor.py", "lineno": 97, "vdk_job_name": "ingest-from-db-example-job", "message": "Executing query SUCCEEDED. Query duration 00h:00m:00s", "vdk_step_name": "20_create_table.sql", "vdk_step_type": "sql", "timestamp": 1697532608.968082, "level": "INFO"}
+{"filename": "managed_connection_base.py", "lineno": 133, "vdk_job_name": "ingest-from-db-example-job", "message": "Fetching query result...", "vdk_step_name": "20_create_table.sql", "vdk_step_type": "sql", "timestamp": 1697532608.9681149, "level": "INFO"}
+{"filename": "managed_cursor.py", "lineno": 193, "vdk_job_name": "ingest-from-db-example-job", "message": "Fetching all results from query ...", "vdk_step_name": "20_create_table.sql", "vdk_step_type": "sql", "timestamp": 1697532608.968137, "level": "INFO"}
+{"filename": "managed_cursor.py", "lineno": 196, "vdk_job_name": "ingest-from-db-example-job", "message": "Fetching all results from query SUCCEEDED.", "vdk_step_name": "20_create_table.sql", "vdk_step_type": "sql", "timestamp": 1697532608.9681568, "level": "INFO"}
+{"filename": "managed_cursor.py", "lineno": 203, "vdk_job_name": "ingest-from-db-example-job", "message": "Closing DB cursor ...", "vdk_step_name": "20_create_table.sql", "vdk_step_type": "sql", "timestamp": 1697532608.968405, "level": "INFO"}
+{"filename": "managed_cursor.py", "lineno": 205, "vdk_job_name": "ingest-from-db-example-job", "message": "Closing DB cursor SUCCEEDED.", "vdk_step_name": "20_create_table.sql", "vdk_step_type": "sql", "timestamp": 1697532608.9684658, "level": "INFO"}
+{"filename": "file_based_step.py", "lineno": 103, "vdk_job_name": "ingest-from-db-example-job", "message": "Entering 30_ingest_to_table.py#run(...) ...", "vdk_step_name": "30_ingest_to_table.py", "vdk_step_type": "python", "timestamp": 1697532608.9734771, "level": "INFO"}
+{"filename": "ingester_router.py", "lineno": 106, "vdk_job_name": "ingest-from-db-example-job", "message": "Sending tabular data for ingestion with method: sqlite and target: None", "vdk_step_name": "30_ingest_to_table.py", "vdk_step_type": "python", "timestamp": 1697532608.975029, "level": "INFO"}
+{"filename": "file_based_step.py", "lineno": 109, "vdk_job_name": "ingest-from-db-example-job", "message": "Exiting  30_ingest_to_table.py#run(...) SUCCESS", "vdk_step_name": "30_ingest_to_table.py", "vdk_step_type": "python", "timestamp": 1697532608.976068, "level": "INFO"}
+```
+
+### Example: Bound loggers
+
+TODO: Add an example once bound loggers are part of vdk-core
+
+### Example: Passing custom metadata fields with extra_params
+
+TODO: Add an example
+
+### Build and test
+
+```
+pip install -r requirements.txt
+pip install -e .
+pytest
+```
+
+In VDK repo [../build-plugin.sh](https://github.com/vmware/versatile-data-kit/tree/main/projects/vdk-plugins/build-plugin.sh) script can be used also.
+
+
+#### Note about the CICD:
+
+.plugin-ci.yaml is needed only for plugins part of [Versatile Data Kit Plugin repo](https://github.com/vmware/versatile-data-kit/tree/main/projects/vdk-plugins).
+
+The CI/CD is separated in two stages, a build stage and a release stage.
+The build stage is made up of a few jobs, all which inherit from the same
+job configuration and only differ in the Python version they use (3.7, 3.8, 3.9 and 3.10).
+They run according to rules, which are ordered in a way such that changes to a
+plugin's directory trigger the plugin CI, but changes to a different plugin does not.

--- a/projects/vdk-plugins/vdk-structlog/requirements.txt
+++ b/projects/vdk-plugins/vdk-structlog/requirements.txt
@@ -1,0 +1,6 @@
+# this file is used to provide testing requirements
+# for requirements (dependencies) needed during and after installation of the plugin see (and update) setup.py install_requires section
+
+pytest
+vdk-core
+vdk-test-utils

--- a/projects/vdk-plugins/vdk-structlog/setup.py
+++ b/projects/vdk-plugins/vdk-structlog/setup.py
@@ -1,0 +1,42 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import pathlib
+
+import setuptools
+
+"""
+Builds a package with the help of setuptools in order for this package to be imported in other projects
+"""
+
+__version__ = "0.1.0"
+
+setuptools.setup(
+    name="vdk-structlog",
+    version=__version__,
+    url="https://github.com/vmware/versatile-data-kit",
+    description="Structured logging for versatile data kit",
+    long_description=pathlib.Path("README.md").read_text(),
+    long_description_content_type="text/markdown",
+    install_requires=["vdk-core", "python-json-logger"],
+    package_dir={"": "src"},
+    packages=setuptools.find_namespace_packages(where="src"),
+    # This is the only vdk plugin specifc part
+    # Define entry point called "vdk.plugin.run" with name of plugin and module to act as entry point.
+    entry_points={
+        "vdk.plugin.run": ["vdk-structlog = vdk.plugin.structlog.structlog_plugin"]
+    },
+    classifiers=[
+        "Development Status :: 2 - Pre-Alpha",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+    ],
+    project_urls={
+        "Documentation": "https://github.com/vmware/versatile-data-kit/tree/main/projects/vdk-plugins/vdk-structlog",
+        "Source Code": "https://github.com/vmware/versatile-data-kit/tree/main/projects/vdk-plugins/vdk-structlog",
+        "Bug Tracker": "https://github.com/vmware/versatile-data-kit/issues/new/choose",
+    },
+)

--- a/projects/vdk-plugins/vdk-structlog/src/vdk/plugin/structlog/constants.py
+++ b/projects/vdk-plugins/vdk-structlog/src/vdk/plugin/structlog/constants.py
@@ -1,0 +1,64 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+STRUCTLOG_LOGGING_METADATA_KEY = "logging_metadata"
+STRUCTLOG_LOGGING_FORMAT_KEY = "logging_format"
+
+STRUCTLOG_LOGGING_FORMAT_POSSIBLE_VALUES = ["console", "json"]
+STRUCTLOG_LOGGING_FORMAT_DEFAULT = "console"
+
+STRUCTLOG_LOGGING_METADATA_JOB = {
+    "vdk_job_name": "%(vdk_job_name)s",
+    "vdk_step_name": "%(vdk_step_name)s",
+    "vdk_step_type": "%(vdk_step_type)s",
+}
+
+STRUCTLOG_METADATA_FIELDS = {
+    "timestamp": "created",
+    "level": "levelname",
+    "logger_name": "name",
+    "file_name": "filename",
+    "line_number": "lineno",
+    "function_name": "funcName",
+}
+
+JSON_STRUCTLOG_LOGGING_METADATA_DEFAULT = {
+    "timestamp": "%(timestamp)s",
+    "level": "%(level)s",
+    "logger_name": "%(name)s",
+    "file_name": "%(filename)s",
+    "line_number": "%(lineno)s",
+    "function_name": "%(funcName)s",
+}
+
+CONSOLE_STRUCTLOG_LOGGING_METADATA_DEFAULT = {
+    "timestamp": "%(asctime)s [VDK]",
+    "level": "[%(levelname)-5.5s]",
+    "logger_name": "%(name)-30.30s",
+    "file_name": "%(filename)20.20s",
+    "line_number": ":%(lineno)-4.4s",
+    "function_name": "%(funcName)-16.16s",
+}
+
+CONSOLE_STRUCTLOG_LOGGING_METADATA_JOB = {
+    "vdk_job_name": "%(vdk_job_name)s",
+    "vdk_step_name": "%(vdk_step_name)s",
+    "vdk_step_type": "%(vdk_step_type)s",
+}
+
+CONSOLE_STRUCTLOG_LOGGING_METADATA_ALL = {
+    **CONSOLE_STRUCTLOG_LOGGING_METADATA_DEFAULT,
+    **CONSOLE_STRUCTLOG_LOGGING_METADATA_JOB,
+}
+
+STRUCTLOG_LOGGING_METADATA_ALL = {
+    **JSON_STRUCTLOG_LOGGING_METADATA_DEFAULT,
+    **STRUCTLOG_LOGGING_METADATA_JOB,
+}
+
+STRUCTLOG_LOGGING_METADATA_ALL_KEYS = set(
+    JSON_STRUCTLOG_LOGGING_METADATA_DEFAULT.keys()
+) | set(STRUCTLOG_LOGGING_METADATA_JOB.keys())
+
+RECORD_DEFAULT_FIELDS = set(vars(logging.LogRecord("", "", "", "", "", "", "")))

--- a/projects/vdk-plugins/vdk-structlog/src/vdk/plugin/structlog/filters.py
+++ b/projects/vdk-plugins/vdk-structlog/src/vdk/plugin/structlog/filters.py
@@ -1,0 +1,68 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from logging import Filter
+from logging import LogRecord
+from typing import Set
+
+from vdk.plugin.structlog.constants import RECORD_DEFAULT_FIELDS
+
+
+class JsonMetadataFilter(Filter):
+    """
+    Modifies log records when json formatting is used.
+    Removes the metadata fields that are not part of the metadata config.
+    The json formatter displays all custom fields by default, so if they're not
+    part of the metadata config, they should be removed in order for filtering
+    to work.
+    """
+
+    def __init__(self, key_set: Set):
+        super().__init__()
+        self._key_set = key_set
+
+    def filter(self, record: LogRecord) -> LogRecord:
+        fields = vars(record)
+        for field in fields:
+            if field not in self._key_set and field not in RECORD_DEFAULT_FIELDS:
+                # not sure if we want to delete, e.g. delattr(record, field) or just set to empty
+                setattr(record, field, "")
+        return record
+
+
+class ConsoleMetadataFilter(Filter):
+    """
+    Modifies log records when console formatting is used
+    Sets metadata fields that are in the config set but not in the log record to empty string.
+    This prevents the formatter from breaking for different records, e.g. some records have vdk_job_name and some don't
+    and records that don't have vdk_job_name should still have vdk_job_name in order not to break the formatter.
+    """
+
+    def __init__(self, key_set: Set):
+        super().__init__()
+        temp = [
+            RECORD_DEFAULT_FIELDS[x] if x in RECORD_DEFAULT_FIELDS else x
+            for x in key_set
+        ]
+        self._key_set = set(temp)
+
+    def filter(self, record: LogRecord) -> LogRecord:
+        fields = vars(record)
+        for field in self._key_set:
+            if field not in fields and field not in RECORD_DEFAULT_FIELDS:
+                setattr(record, field, "")
+        return record
+
+
+class AttributeAdder(Filter):
+    """
+    Adds attributes to log records.
+    """
+
+    def __init__(self, attr_key: str, attr_value: str):
+        super().__init__()
+        self._attr_key = attr_key
+        self._attr_value = attr_value
+
+    def filter(self, record: LogRecord) -> LogRecord:
+        setattr(record, self._attr_key, self._attr_value)
+        return record

--- a/projects/vdk-plugins/vdk-structlog/src/vdk/plugin/structlog/formatters.py
+++ b/projects/vdk-plugins/vdk-structlog/src/vdk/plugin/structlog/formatters.py
@@ -1,0 +1,129 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from logging import Filter
+from logging import Formatter
+from logging import LogRecord
+from typing import Any
+from typing import Dict
+
+from pythonjsonlogger import jsonlogger
+from vdk.plugin.structlog.constants import CONSOLE_STRUCTLOG_LOGGING_METADATA_ALL
+from vdk.plugin.structlog.constants import STRUCTLOG_LOGGING_METADATA_ALL
+from vdk.plugin.structlog.filters import ConsoleMetadataFilter
+from vdk.plugin.structlog.filters import JsonMetadataFilter
+
+
+class JsonFormatter(jsonlogger.JsonFormatter):
+    """
+    Json formatter. Shows all log record fields by default.
+    Removes log record fields that are empty. Adds timestamp
+    and level fields to the log output.
+    """
+
+    def add_fields(
+        self,
+        log_record: Dict[str, Any],
+        record: LogRecord,
+        message_dict: Dict[str, Any],
+    ) -> None:
+        super().add_fields(log_record, record, message_dict)
+
+        # remove log record fields that are set to empty string
+        keys = [x for x in log_record.keys() if not log_record[x]]
+        for key in keys:
+            del log_record[key]
+
+        if not log_record.get("timestamp"):
+            now = record.created
+            log_record["timestamp"] = now
+        if log_record.get("level"):
+            log_record["level"] = log_record["level"].upper()
+        else:
+            log_record["level"] = record.levelname
+
+
+class ConsoleFormatter(Formatter):
+    """
+    Console formatter. Basically the same as logging.Formatter.
+    Log records should be modified in filters. Message and exception
+    formatting should be modified here.
+    """
+
+    def format(self, record: LogRecord) -> LogRecord:
+        record.message = record.getMessage()
+        if self.usesTime():
+            record.asctime = self.formatTime(record, self.datefmt)
+        s = self.formatMessage(record)
+        if record.exc_info:
+            # Cache the traceback text to avoid converting it multiple times
+            # (it's constant anyway)
+            if not record.exc_text:
+                record.exc_text = self.formatException(record.exc_info)
+        if record.exc_text:
+            if s[-1:] != "\n":
+                s = s + "\n"
+            s = s + record.exc_text
+        if record.stack_info:
+            if s[-1:] != "\n":
+                s = s + "\n"
+            s = s + self.formatStack(record.stack_info)
+        return s
+
+
+class StructlogMetadataBuilder:
+    """
+    Builds output format strings in % style for
+    different formats.
+
+    For json, it appends %({key}s) formatting strings
+
+    For console, it takes into account the actual
+    record field names and appends those to the output
+    format string
+    """
+
+    def __init__(self, metadata_keys: str):
+        self._metadata_keys = metadata_keys.split(",")
+
+    def build_json_format(self) -> str:
+        out = []
+        for key in self._metadata_keys:
+            if key in STRUCTLOG_LOGGING_METADATA_ALL:
+                out.append(STRUCTLOG_LOGGING_METADATA_ALL[key])
+            else:
+                out.append(f"%({key})s")
+        out.append("%(message)s")
+        return " ".join(out)
+
+    def build_console_format(self) -> str:
+        out = []
+        for key in self._metadata_keys:
+            if key in CONSOLE_STRUCTLOG_LOGGING_METADATA_ALL:
+                out.append(CONSOLE_STRUCTLOG_LOGGING_METADATA_ALL[key])
+            else:
+                out.append(f"%({key})s")
+        out.append("- %(message)s")
+        return " ".join(out)
+
+
+def create_formatter(logging_format: str, metadata_keys: str) -> [Formatter, Filter]:
+    """
+    Creates a formatter and a filter based on the logging format configuration
+    and metadata_keys configuration that are passed. The formatter takes care
+    of the output format and the filter makes sure that only the provided
+    metadata keys' values are displayed in log output.
+    """
+    key_set = set(metadata_keys.split(","))
+    formatter = None
+    custom_key_filter = None
+    if logging_format == "json":
+        formatter = JsonFormatter(
+            StructlogMetadataBuilder(metadata_keys).build_json_format()
+        )
+        custom_key_filter = JsonMetadataFilter(key_set)
+    else:
+        formatter = ConsoleFormatter(
+            fmt=StructlogMetadataBuilder(metadata_keys).build_console_format()
+        )
+        custom_key_filter = ConsoleMetadataFilter(key_set)
+    return formatter, custom_key_filter

--- a/projects/vdk-plugins/vdk-structlog/src/vdk/plugin/structlog/structlog_plugin.py
+++ b/projects/vdk-plugins/vdk-structlog/src/vdk/plugin/structlog/structlog_plugin.py
@@ -1,0 +1,178 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+import sys
+from typing import List
+from typing import Optional
+
+from pythonjsonlogger import jsonlogger
+from vdk.api.plugin.hook_markers import hookimpl
+from vdk.api.plugin.plugin_registry import HookCallResult
+from vdk.api.plugin.plugin_registry import IPluginRegistry
+from vdk.internal.builtin_plugins.run.execution_results import ExecutionResult
+from vdk.internal.builtin_plugins.run.execution_results import StepResult
+from vdk.internal.builtin_plugins.run.job_context import JobContext
+from vdk.internal.builtin_plugins.run.step import Step
+from vdk.internal.core.config import ConfigurationBuilder
+from vdk.internal.core.context import CoreContext
+from vdk.plugin.structlog.constants import JSON_STRUCTLOG_LOGGING_METADATA_DEFAULT
+from vdk.plugin.structlog.constants import STRUCTLOG_LOGGING_FORMAT_DEFAULT
+from vdk.plugin.structlog.constants import STRUCTLOG_LOGGING_FORMAT_KEY
+from vdk.plugin.structlog.constants import STRUCTLOG_LOGGING_FORMAT_POSSIBLE_VALUES
+from vdk.plugin.structlog.constants import STRUCTLOG_LOGGING_METADATA_ALL_KEYS
+from vdk.plugin.structlog.constants import STRUCTLOG_LOGGING_METADATA_KEY
+from vdk.plugin.structlog.filters import AttributeAdder
+from vdk.plugin.structlog.formatters import create_formatter
+
+"""
+Handlers
+https://docs.python.org/3/library/logging.html#handler-objects
+https://docs.python.org/3/howto/logging-cookbook.html#imparting-contextual-information-in-handlers
+
+Filters
+https://docs.python.org/3/library/logging.html#filter-objects
+
+LogRecords
+https://docs.python.org/3/library/logging.html#logrecord-objects
+
+Additional reading
+
+https://docs.python.org/3/howto/logging.html
+https://realpython.com/python-logging/
+https://realpython.com/python-logging-source-code/
+
+Logging adapters a.k.a. bound loggers
+https://docs.python.org/3/howto/logging-cookbook.html#context-info
+
+Example:
+
+class BoundLogger(logging.LoggerAdapter):
+    def process(self, msg, kwargs):
+        # merge bound extra dict with existing exra dict if any
+        if "extra" in kwargs:
+            kwargs["extra"] = {**self.extra, **kwargs["extra"]}
+        else:
+            kwargs["extra"] = self.extra
+        return msg, kwargs
+
+
+log = logging.getLogger(__name__)
+bound = BoundLogger(log, {"bound_key": "bound_value"})
+bound.warning("From vdk_initialize", extra={"first": "first_value", "second": "second_value"})
+bound.warning("Something else from vdk_initialize")
+
+"""
+
+
+class StructlogPlugin:
+    @hookimpl(tryfirst=True)
+    def vdk_configure(self, config_builder: ConfigurationBuilder):
+        config_builder.add(
+            key=STRUCTLOG_LOGGING_METADATA_KEY,
+            default_value=",".join(
+                list(JSON_STRUCTLOG_LOGGING_METADATA_DEFAULT.keys())
+            ),
+            description=(
+                f"Possible values: {STRUCTLOG_LOGGING_METADATA_ALL_KEYS}"
+                "User-defined key-value pairs added to the logger's context will be displayed after the metadata, but before the message"
+            ),
+        )
+
+        config_builder.add(
+            key=STRUCTLOG_LOGGING_FORMAT_KEY,
+            default_value=STRUCTLOG_LOGGING_FORMAT_DEFAULT,
+            description=(
+                f"Controls the logging output format. Possible values: {STRUCTLOG_LOGGING_FORMAT_POSSIBLE_VALUES}"
+            ),
+        )
+
+    @hookimpl
+    def vdk_initialize(self, context: CoreContext):
+        metadata_keys = context.configuration.get_value(STRUCTLOG_LOGGING_METADATA_KEY)
+        logging_formatter = context.configuration.get_value(
+            STRUCTLOG_LOGGING_FORMAT_KEY
+        )
+
+        formatter, metadata_filter = create_formatter(logging_formatter, metadata_keys)
+
+        root_logger = logging.getLogger()
+        root_logger.removeHandler(root_logger.handlers[0])
+
+        handler = logging.StreamHandler(sys.stderr)
+        handler.addFilter(metadata_filter)
+        handler.setFormatter(formatter)
+
+        root_logger.addHandler(handler)
+
+    @hookimpl(hookwrapper=True)
+    def initialize_job(self, context: JobContext) -> None:
+        logging_formatter = context.core_context.configuration.get_value(
+            STRUCTLOG_LOGGING_FORMAT_KEY
+        )
+        metadata_keys = context.core_context.configuration.get_value(
+            STRUCTLOG_LOGGING_METADATA_KEY
+        )
+
+        formatter, metadata_filter = create_formatter(logging_formatter, metadata_keys)
+        job_name_adder = AttributeAdder("vdk_job_name", context.name)
+
+        root_logger = logging.getLogger()
+        root_logger.removeHandler(root_logger.handlers[0])
+
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(formatter)
+        handler.addFilter(metadata_filter)
+        handler.addFilter(job_name_adder)
+
+        root_logger.addHandler(handler)
+
+        out: HookCallResult
+        out = yield
+
+        root_logger.removeHandler(handler)
+
+    @hookimpl(hookwrapper=True)
+    def run_job(self, context: JobContext) -> Optional[ExecutionResult]:
+        logging_formatter = context.core_context.configuration.get_value(
+            STRUCTLOG_LOGGING_FORMAT_KEY
+        )
+        metadata_keys = context.core_context.configuration.get_value(
+            STRUCTLOG_LOGGING_METADATA_KEY
+        )
+
+        formatter, metadata_filter = create_formatter(logging_formatter, metadata_keys)
+        job_name_adder = AttributeAdder("vdk_job_name", context.name)
+
+        root_logger = logging.getLogger()
+        root_logger.removeHandler(root_logger.handlers[0])
+
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(formatter)
+        handler.addFilter(metadata_filter)
+        handler.addFilter(job_name_adder)
+
+        root_logger.addHandler(handler)
+
+        out: HookCallResult
+        out = yield
+
+        # do not remove the handler, we need it until the end
+
+    @hookimpl(hookwrapper=True)
+    def run_step(self, context: JobContext, step: Step) -> Optional[StepResult]:
+        root_logger = logging.getLogger()
+        step_name_adder = AttributeAdder("vdk_step_name", step.name)
+        step_type_adder = AttributeAdder("vdk_step_type", step.type)
+        for handler in root_logger.handlers:
+            handler.addFilter(step_name_adder)
+            handler.addFilter(step_type_adder)
+        out: HookCallResult
+        out = yield
+        for handler in root_logger.handlers:
+            handler.removeFilter(step_name_adder)
+            handler.removeFilter(step_type_adder)
+
+
+@hookimpl
+def vdk_start(plugin_registry: IPluginRegistry, command_line_args: List):
+    plugin_registry.load_plugin_with_hooks_impl(StructlogPlugin(), "StructlogPlugin")

--- a/projects/vdk-plugins/vdk-structlog/tests/jobs/job-using-a-plugin/10_dummy.py
+++ b/projects/vdk-plugins/vdk-structlog/tests/jobs/job-using-a-plugin/10_dummy.py
@@ -1,0 +1,11 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+from vdk.api.job_input import IJobInput
+
+log = logging.getLogger(__name__)
+
+
+def run(job_input: IJobInput):
+    log.info(f"Dummy arguments {job_input.get_arguments()}")

--- a/projects/vdk-plugins/vdk-structlog/tests/test_plugin.py
+++ b/projects/vdk-plugins/vdk-structlog/tests/test_plugin.py
@@ -1,0 +1,33 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import os
+import pathlib
+from unittest import mock
+
+from click.testing import Result
+from vdk.plugin.structlog import structlog_plugin
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_funcs import jobs_path_from_caller_directory
+
+"""
+This is a sample test file showing a recommended way to test new plugins.
+A good way to test a new plugin is how it would be used in the command that it extends.
+"""
+
+
+def test_dummy():
+    with mock.patch.dict(
+        os.environ,
+        {
+            # mock the vdk configuration needed for our test
+        },
+    ):
+        # CliEntryBasedTestRunner (provided by vdk-test-utils) gives a away to simulate vdk command
+        # and mock large parts of it - e.g passed our own plugins
+        runner = CliEntryBasedTestRunner(structlog_plugin)
+
+        result: Result = runner.invoke(
+            ["run", jobs_path_from_caller_directory("job-using-a-plugin")]
+        )
+        cli_assert_equal(0, result)


### PR DESCRIPTION
## Why?

As part of VEP-2448, we'd like to make structured logging pluggable

## What?

Create a vdk-structlog plugin. The plugin allows users to configure logging metadata and logging format. It also works with bound loggers.

## How was this tested?

Installed the plugin and ran a data job locally with different configurations

## White kind of change is this?

feature/non-breaking

## Follow-up

- https://github.com/vmware/versatile-data-kit/issues/2802
- https://github.com/vmware/versatile-data-kit/issues/2803
- https://github.com/vmware/versatile-data-kit/issues/2810
- https://github.com/vmware/versatile-data-kit/issues/2811
- https://github.com/vmware/versatile-data-kit/issues/2812
- https://github.com/vmware/versatile-data-kit/issues/2813
- https://github.com/vmware/versatile-data-kit/issues/2814
