### PR TITLE
control-service: fix post deployment test

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudAsyncIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudAsyncIT.java
@@ -9,7 +9,6 @@ import com.vmware.taurus.ControlplaneApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsDeploymentController.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsDeploymentController.java
@@ -20,7 +20,6 @@ import com.vmware.taurus.service.deploy.DeploymentServiceV2;
 import com.vmware.taurus.service.diag.OperationContext;
 import com.vmware.taurus.service.model.JobDeploymentStatus;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -112,62 +111,57 @@ public class DataJobsDeploymentController implements DataJobsDeploymentApi {
       String teamName, String jobName, String deploymentId, DataJobMode dataJobMode) {
     // TODO: deploymentId and mode not implemented
     if (jobsService.jobWithTeamExists(jobName, teamName)) {
-      var response = deploymentAsList(jobName.toLowerCase());
-      if (response.getStatusCodeValue() == 404) {
-        List<DataJobDeploymentStatus> emptyDeploymentList = Collections.emptyList();
-        return ResponseEntity.of(Optional.of(emptyDeploymentList));
+      var responseOptional = getDeploymentStatusOptional(jobName.toLowerCase());
+      if (!responseOptional.isPresent()) {
+        return ResponseEntity.of(Optional.of(Collections.emptyList()));
       }
-      return response;
+      return ResponseEntity.ok(List.of(responseOptional.get()));
     }
     return ResponseEntity.notFound().build();
   }
 
-  private ResponseEntity<List<DataJobDeploymentStatus>> deploymentAsList(String jobName) {
-    ResponseEntity<DataJobDeploymentStatus> jobDeploymentStatus;
+  private Optional<DataJobDeploymentStatus> getDeploymentStatusOptional(String jobName) {
+    Optional<DataJobDeploymentStatus> jobDeploymentStatus = Optional.empty();
     if (dataJobDeploymentPropertiesConfig.getReadDataSource().equals(ReadFrom.DB)) {
       jobDeploymentStatus = readFromDB(jobName);
     } else if (dataJobDeploymentPropertiesConfig.getReadDataSource().equals(ReadFrom.K8S)) {
       jobDeploymentStatus = readFromK8S(jobName);
-    } else {
-      jobDeploymentStatus = ResponseEntity.notFound().build();
     }
-    var response = Arrays.asList(jobDeploymentStatus.getBody());
-    return ResponseEntity.status(jobDeploymentStatus.getStatusCode()).body(response);
+    return jobDeploymentStatus;
   }
 
   @Override
   public ResponseEntity<DataJobDeploymentStatus> deploymentRead(
       String teamName, String jobName, String deploymentId) {
     if (jobsService.jobWithTeamExists(jobName, teamName)) {
-      if (dataJobDeploymentPropertiesConfig.getReadDataSource().equals(ReadFrom.DB)) {
-        return readFromDB(jobName.toLowerCase());
-      } else if (dataJobDeploymentPropertiesConfig.getReadDataSource().equals(ReadFrom.K8S)) {
-        return readFromK8S(jobName.toLowerCase());
+      Optional<DataJobDeploymentStatus> jobDeploymentOptional = getDeploymentStatusOptional(
+          jobName);
+      if (jobDeploymentOptional.isPresent()) {
+        return ResponseEntity.ok(jobDeploymentOptional.get());
       }
     }
     return ResponseEntity.notFound().build();
   }
 
-  private ResponseEntity<DataJobDeploymentStatus> readFromK8S(String jobName) {
-    Optional<JobDeploymentStatus> jobDeploymentStatus =
-        deploymentService.readDeployment(jobName.toLowerCase());
+  private Optional<DataJobDeploymentStatus> readFromK8S(String jobName) {
+    Optional<JobDeploymentStatus> jobDeploymentStatus = deploymentService.readDeployment(jobName.toLowerCase());
     if (jobDeploymentStatus.isPresent()) {
-      return ResponseEntity.ok(
+      return Optional.of(
           ToApiModelConverter.toDataJobDeploymentStatus(jobDeploymentStatus.get()));
     }
-    return ResponseEntity.notFound().build();
+    return Optional.empty();
   }
 
-  private ResponseEntity<DataJobDeploymentStatus> readFromDB(String dataJobName) {
-    var jobDeploymentOptional = deploymentServiceV2.readDeployment(dataJobName);
+  private Optional<DataJobDeploymentStatus> readFromDB(String dataJobName) {
+    var jobDeploymentOptional = deploymentServiceV2.readDeployment(dataJobName.toLowerCase());
     var jobOptional = jobsService.getByName(dataJobName);
     if (jobDeploymentOptional.isPresent()) {
       var deploymentResponse =
           DeploymentModelConverter.toJobDeploymentStatus(
               jobDeploymentOptional.get(), jobOptional.get());
-      return ResponseEntity.ok(deploymentResponse);
+      return Optional.of(deploymentResponse);
     }
-    return ResponseEntity.notFound().build();
+    return Optional.empty();
   }
 
   @Override

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsDeploymentController.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsDeploymentController.java
@@ -134,8 +134,8 @@ public class DataJobsDeploymentController implements DataJobsDeploymentApi {
   public ResponseEntity<DataJobDeploymentStatus> deploymentRead(
       String teamName, String jobName, String deploymentId) {
     if (jobsService.jobWithTeamExists(jobName, teamName)) {
-      Optional<DataJobDeploymentStatus> jobDeploymentOptional = getDeploymentStatusOptional(
-          jobName);
+      Optional<DataJobDeploymentStatus> jobDeploymentOptional =
+          getDeploymentStatusOptional(jobName);
       if (jobDeploymentOptional.isPresent()) {
         return ResponseEntity.ok(jobDeploymentOptional.get());
       }
@@ -144,10 +144,10 @@ public class DataJobsDeploymentController implements DataJobsDeploymentApi {
   }
 
   private Optional<DataJobDeploymentStatus> readFromK8S(String jobName) {
-    Optional<JobDeploymentStatus> jobDeploymentStatus = deploymentService.readDeployment(jobName.toLowerCase());
+    Optional<JobDeploymentStatus> jobDeploymentStatus =
+        deploymentService.readDeployment(jobName.toLowerCase());
     if (jobDeploymentStatus.isPresent()) {
-      return Optional.of(
-          ToApiModelConverter.toDataJobDeploymentStatus(jobDeploymentStatus.get()));
+      return Optional.of(ToApiModelConverter.toDataJobDeploymentStatus(jobDeploymentStatus.get()));
     }
     return Optional.empty();
   }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsDeploymentController.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DataJobsDeploymentController.java
@@ -21,6 +21,7 @@ import com.vmware.taurus.service.diag.OperationContext;
 import com.vmware.taurus.service.model.JobDeploymentStatus;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
@@ -111,7 +112,12 @@ public class DataJobsDeploymentController implements DataJobsDeploymentApi {
       String teamName, String jobName, String deploymentId, DataJobMode dataJobMode) {
     // TODO: deploymentId and mode not implemented
     if (jobsService.jobWithTeamExists(jobName, teamName)) {
-      return deploymentAsList(jobName.toLowerCase());
+      var response = deploymentAsList(jobName.toLowerCase());
+      if (response.getStatusCodeValue() == 404) {
+        List<DataJobDeploymentStatus> emptyDeploymentList = Collections.emptyList();
+        return ResponseEntity.of(Optional.of(emptyDeploymentList));
+      }
+      return response;
     }
     return ResponseEntity.notFound().build();
   }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DataJobDeploymentControllerReadTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DataJobDeploymentControllerReadTest.java
@@ -69,6 +69,15 @@ public class DataJobDeploymentControllerReadTest {
     Assertions.assertEquals(404, retrievedDeploymentList.getStatusCodeValue());
   }
 
+  @WithMockUser
+  @Test
+  public void testReadJobWithNoDeployments_expectEmptyList() {
+    createTestJob("test-job", "team");
+    var retrievedDeploymentList =
+        dataJobsDeploymentController.deploymentList("team", "test-job", "", DataJobMode.RELEASE);
+    Assertions.assertTrue(retrievedDeploymentList.getBody().size() == 0);
+  }
+
   @AfterEach
   public void cleanup() {
     jobsRepository.deleteAll();


### PR DESCRIPTION
what: When calling the deploymentList method of the DataJobsDeploymentController class and a job without deployments exists, the API will now return an empty list instead of 404.

why: Recent changes in https://github.com/vmware/versatile-data-kit/pull/2800 refactored the method to return 404 instead of empty list in this situation, however this breaks the post deployment test.

testing: added unit test.