### PR TITLE
vdk-core: test exception propagation to user code

### DIFF
--- a/projects/vdk-core/tests/functional/run/jobs/job-using-risky-templates/01_read_csv.py
+++ b/projects/vdk-core/tests/functional/run/jobs/job-using-risky-templates/01_read_csv.py
@@ -1,0 +1,17 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+import pandas as pd
+from vdk.api.job_input import IJobInput
+
+log = logging.getLogger(__name__)
+
+
+def run(job_input: IJobInput):
+    args = dict()
+    try:
+        job_input.execute_template("csv-risky", args)
+    except pd.errors.EmptyDataError as e:
+        log.info("Handling empty data error")
+        log.exception(e)

--- a/projects/vdk-core/tests/functional/run/jobs/template-csv-risky/01_read_empty_csv.py
+++ b/projects/vdk-core/tests/functional/run/jobs/template-csv-risky/01_read_empty_csv.py
@@ -1,0 +1,10 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from io import StringIO
+
+import pandas as pd
+from vdk.api.job_input import IJobInput
+
+
+def run(job_input: IJobInput):
+    pd.read_csv(StringIO())

--- a/projects/vdk-core/tests/functional/run/test_run_templates.py
+++ b/projects/vdk-core/tests/functional/run/test_run_templates.py
@@ -88,3 +88,14 @@ def test_run_job_with_cancelled_template():
     assert "Step Cancel 3." not in result.output
 
     cli_assert_equal(0, result)
+
+
+def test_exception_propagated_to_user():
+    test_runner = CliEntryBasedTestRunner(
+        TemplatePlugin("csv-risky", pathlib.Path(util.job_path("template-csv-risky")))
+    )
+    result: Result = test_runner.invoke(
+        ["run", util.job_path("job-using-risky-templates")]
+    )
+    cli_assert_equal(0, result)
+    assert "Handling empty data error" in result.output


### PR DESCRIPTION
## Why

As part of our run logs initiative, we stopped wrapping non-vdk errors in vdk errors. This should result in errors coming from libraries, templates, etc. being propagated to user code. Users should then be able to handle those errors. This behaviour has not been tested, however.

## What

Add a functional test that creates a template and runs it. The templates tries to read an empty csv using pandas, which results in a pandas-specific exception. The exception is then handled in a data job that executes the template.

## How was this tested

Ran the test locally

## What kind of change is this

Feature/non-breaking