### PR TITLE
vdk-singer: Singer.io plugin for data sources

### DIFF
--- a/projects/vdk-plugins/vdk-singer/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-singer/.plugin-ci.yml
@@ -1,0 +1,22 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+image: "python:3.7"
+
+.build-vdk-singer:
+  variables:
+    PLUGIN_NAME: vdk-singer
+  extends: .build-plugin
+
+build-py37-vdk-singer:
+  extends: .build-vdk-singer
+  image: "python:3.7"
+
+build-py311-vdk-singer:
+  extends: .build-vdk-singer
+  image: "python:3.11"
+
+release-vdk-singer:
+  variables:
+    PLUGIN_NAME: vdk-singer
+  extends: .release-plugin

--- a/projects/vdk-plugins/vdk-singer/README.md
+++ b/projects/vdk-plugins/vdk-singer/README.md
@@ -1,0 +1,89 @@
+# singer
+
+The vdk-singer plugin provides an easy way to integrate Singer Taps as data sources within the Versatile Data Kit (VDK).
+This allows you to pull data from various external systems that have Singer Taps available and use them seamlessly
+within your VDK pipelines.
+
+
+
+
+## Usage
+
+```
+pip install vdk-singer
+```
+
+### Configuration
+
+(`vdk config-help` is useful command to browse all config options of your installation of vdk)
+
+
+You can configure the Singer data source via the SingerDataSourceConfiguration class. The configuration options include:
+
+* tap_name: The name of the Singer Tap you are using.
+* tap_config: A dictionary containing configuration specific to the Singer Tap.
+* tap_auto_discover_schema: A boolean to indicate whether to auto-discover the schema.
+
+```python
+config = SingerDataSourceConfiguration(
+    tap_name="tap-gitlab",
+    tap_config={
+        "api_url": "https://gitlab.com/api/v4",
+        "private_token": "your_token_here",
+        # ... other tap specific configurations
+    },
+    tap_auto_discover_schema=True,
+
+```
+
+### Example
+
+This will change as we will introduce more user frinedly way of defining sources but currently it looks like this:
+
+```python
+from vdk.api.job_input import IJobInput
+from vdk.internal.builtin_plugins.ingestion.source.factory import SingletonDataSourceFactory
+from vdk.plugin.singer.singer_data_source import SingerDataSourceConfiguration
+
+def run(job_input: IJobInput):
+    data_source = SingletonDataSourceFactory().create_data_source("singer-tap")
+    config = SingerDataSourceConfiguration(
+        tap_name="tap-gitlab",
+        tap_config={
+            "api_url": "https://gitlab.com/api/v4",
+            "private_token": "your_token_here",
+            # ... other configurations
+        },
+        tap_auto_discover_schema=True,
+    )
+    data_source.connect(config, None)
+    # ... rest of the job logic
+
+```
+
+#### List all likely available taps
+
+```shell
+vdk singer --list-taps
+```
+
+### Build and testing
+
+```
+pip install -r requirements.txt
+pip install -e .
+pytest
+```
+
+In VDK repo [../build-plugin.sh](https://github.com/vmware/versatile-data-kit/tree/main/projects/vdk-plugins/build-plugin.sh) script can be used also.
+
+
+#### Note about the CICD:
+
+.plugin-ci.yaml is needed only for plugins part of [Versatile Data Kit Plugin repo](https://github.com/vmware/versatile-data-kit/tree/main/projects/vdk-plugins).
+
+The CI/CD is separated in two stages, a build stage and a release stage.
+The build stage is made up of a few jobs, all which inherit from the same
+job configuration and only differ in the Python version they use (3.7, 3.8, 3.9 and 3.10).
+They run according to rules, which are ordered in a way such that changes to a
+plugin's directory trigger the plugin CI, but changes to a different plugin does not.

--- a/projects/vdk-plugins/vdk-singer/requirements.txt
+++ b/projects/vdk-plugins/vdk-singer/requirements.txt
@@ -1,0 +1,10 @@
+# this file is used to provide testing requirements
+# for requirements (dependencies) needed during and after installation of the plugin see (and update) setup.py install_requires section
+
+httpretty
+pytest
+pytest-httpserver
+tap-rest-api-msdk
+vdk-core
+vdk-sqlite
+vdk-test-utils

--- a/projects/vdk-plugins/vdk-singer/setup.py
+++ b/projects/vdk-plugins/vdk-singer/setup.py
@@ -1,0 +1,46 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import pathlib
+
+import setuptools
+
+"""
+Builds a package with the help of setuptools in order for this package to be imported in other projects
+"""
+
+__version__ = "0.1.0"
+
+setuptools.setup(
+    name="vdk-singer",
+    version=__version__,
+    url="https://github.com/vmware/versatile-data-kit",
+    description="The plugin provides seamless configuration and execution of Singer Taps and Targets.",
+    long_description=pathlib.Path("README.md").read_text(),
+    long_description_content_type="text/markdown",
+    install_requires=[
+        "vdk-core",
+        "simplejson",
+        "pytz",
+        "vdk-control-cli",
+        "vdk-data-sources",
+    ],
+    package_dir={"": "src"},
+    packages=setuptools.find_namespace_packages(where="src"),
+    # This is the only vdk plugin specifc part
+    # Define entry point called "vdk.plugin.run" with name of plugin and module to act as entry point.
+    entry_points={"vdk.plugin.run": ["vdk-singer = vdk.plugin.singer.plugin_entry"]},
+    classifiers=[
+        "Development Status :: 2 - Pre-Alpha",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+    ],
+    project_urls={
+        "Documentation": "https://github.com/vmware/versatile-data-kit/tree/main/projects/vdk-plugins/vdk-singer",
+        "Source Code": "https://github.com/vmware/versatile-data-kit/tree/main/projects/vdk-plugins/vdk-singer",
+        "Bug Tracker": "https://github.com/vmware/versatile-data-kit/issues/new/choose",
+    },
+)

--- a/projects/vdk-plugins/vdk-singer/src/vdk/plugin/singer/adapter.py
+++ b/projects/vdk-plugins/vdk-singer/src/vdk/plugin/singer/adapter.py
@@ -1,0 +1,424 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from datetime import datetime
+
+import pytz
+import simplejson as json
+
+# Due to conflicts with different versions of singer-python and taps and singer-python logger complexity
+# it's better to adapt necessary singer classes here.
+# Changes from original
+# Logging is changed/removed
+# For parsing dates we are using datetime.isofomat and fromisoformat instead singer custom solution
+
+# These are standard keys defined in the JSON Schema spec
+STANDARD_KEYS = [
+    "selected",
+    "inclusion",
+    "description",
+    "minimum",
+    "maximum",
+    "exclusiveMinimum",
+    "exclusiveMaximum",
+    "multipleOf",
+    "maxLength",
+    "minLength",
+    "format",
+    "type",
+    "additionalProperties",
+    "anyOf",
+    "patternProperties",
+]
+
+
+class Schema:  # pylint: disable=too-many-instance-attributes
+    """Object model for JSON Schema.
+
+    Tap and Target authors may find this to be more convenient than
+    working directly with JSON Schema data structures.
+
+    """
+
+    # pylint: disable=too-many-locals
+    def __init__(
+        self,
+        type=None,
+        format=None,
+        properties=None,
+        items=None,
+        selected=None,
+        inclusion=None,
+        description=None,
+        minimum=None,
+        maximum=None,
+        exclusiveMinimum=None,
+        exclusiveMaximum=None,
+        multipleOf=None,
+        maxLength=None,
+        minLength=None,
+        additionalProperties=None,
+        anyOf=None,
+        patternProperties=None,
+    ):
+        self.type = type
+        self.properties = properties
+        self.items = items
+        self.selected = selected
+        self.inclusion = inclusion
+        self.description = description
+        self.minimum = minimum
+        self.maximum = maximum
+        self.exclusiveMinimum = exclusiveMinimum
+        self.exclusiveMaximum = exclusiveMaximum
+        self.multipleOf = multipleOf
+        self.maxLength = maxLength
+        self.minLength = minLength
+        self.anyOf = anyOf
+        self.format = format
+        self.additionalProperties = additionalProperties
+        self.patternProperties = patternProperties
+
+    def __str__(self):
+        return json.dumps(self.to_dict())
+
+    def __repr__(self):
+        pairs = [k + "=" + repr(v) for k, v in self.__dict__.items()]
+        args = ", ".join(pairs)
+        return "Schema(" + args + ")"
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
+    def to_dict(self):
+        """Return the raw JSON Schema as a (possibly nested) dict."""
+        result = {}
+
+        if self.properties is not None:
+            result["properties"] = {
+                k: v.to_dict()
+                for k, v in self.properties.items()  # pylint: disable=no-member
+            }
+
+        if self.items is not None:
+            result["items"] = self.items.to_dict()  # pylint: disable=no-member
+
+        for key in STANDARD_KEYS:
+            if self.__dict__.get(key) is not None:
+                result[key] = self.__dict__[key]
+
+        return result
+
+    @classmethod
+    def from_dict(cls, data, **schema_defaults):
+        """Initialize a Schema object based on the JSON Schema structure.
+
+        :param schema_defaults: The default values to the Schema
+        constructor."""
+        kwargs = schema_defaults.copy()
+        properties = data.get("properties")
+        items = data.get("items")
+
+        if properties is not None:
+            kwargs["properties"] = {
+                k: Schema.from_dict(v, **schema_defaults) for k, v in properties.items()
+            }
+        if items is not None:
+            kwargs["items"] = Schema.from_dict(items, **schema_defaults)
+        for key in STANDARD_KEYS:
+            if key in data:
+                kwargs[key] = data[key]
+        return Schema(**kwargs)
+
+
+class Message:
+    """Base class for messages."""
+
+    def asdict(self):  # pylint: disable=no-self-use
+        raise Exception("Not implemented")
+
+    def __eq__(self, other):
+        return isinstance(other, Message) and self.asdict() == other.asdict()
+
+    def __repr__(self):
+        pairs = [f"{k}={v}" for k, v in self.asdict().items()]
+        attrstr = ", ".join(pairs)
+        return f"{self.__class__.__name__}({attrstr})"
+
+    def __str__(self):
+        return str(self.asdict())
+
+
+class StateMessage(Message):
+    """STATE message.
+
+    The STATE message has one field:
+
+      * value (dict) - The value of the state.
+
+    msg = singer.StateMessage(
+        value={'users': '2017-06-19T00:00:00'})
+
+    """
+
+    def __init__(self, value):
+        self.value = value
+
+    def asdict(self):
+        return {"type": "STATE", "value": self.value}
+
+
+class SchemaMessage(Message):
+    """SCHEMA message.
+
+    The SCHEMA message has these fields:
+
+      * stream (string) - The name of the stream this schema describes.
+      * schema (dict) - The JSON schema.
+      * key_properties (list of strings) - List of primary key properties.
+
+    msg = singer.SchemaMessage(
+        stream='users',
+        schema={'type': 'object',
+                'properties': {
+                    'id': {'type': 'integer'},
+                    'name': {'type': 'string'}
+                }
+               },
+        key_properties=['id'])
+
+    """
+
+    def __init__(self, stream, schema, key_properties, bookmark_properties=None):
+        self.stream = stream
+        self.schema = schema
+        self.key_properties = key_properties
+
+        if isinstance(bookmark_properties, (str, bytes)):
+            bookmark_properties = [bookmark_properties]
+        if bookmark_properties and not isinstance(bookmark_properties, list):
+            raise Exception("bookmark_properties must be a string or list of strings")
+
+        self.bookmark_properties = bookmark_properties
+
+    def asdict(self):
+        result = {
+            "type": "SCHEMA",
+            "stream": self.stream,
+            "schema": self.schema,
+            "key_properties": self.key_properties,
+        }
+        if self.bookmark_properties:
+            result["bookmark_properties"] = self.bookmark_properties
+        return result
+
+
+class RecordMessage(Message):
+    """RECORD message.
+
+    The RECORD message has these fields:
+
+      * stream (string) - The name of the stream the record belongs to.
+      * record (dict) - The raw data for the record
+      * version (optional, int) - For versioned streams, the version
+        number. Note that this feature is experimental and most Taps and
+        Targets should not need to use versioned streams.
+
+    msg = singer.RecordMessage(
+        stream='users',
+        record={'id': 1, 'name': 'Mary'})
+
+    """
+
+    def __init__(self, stream, record, version=None, time_extracted=None):
+        self.stream = stream
+        self.record = record
+        self.version = version
+        self.time_extracted = time_extracted
+        if time_extracted and not time_extracted.tzinfo:
+            raise ValueError(
+                "'time_extracted' must be either None "
+                + "or an aware datetime (with a time zone)"
+            )
+
+    def asdict(self):
+        result = {
+            "type": "RECORD",
+            "stream": self.stream,
+            "record": self.record,
+        }
+        if self.version is not None:
+            result["version"] = self.version
+        if self.time_extracted:
+            as_utc = self.time_extracted.astimezone(pytz.utc)
+            result["time_extracted"] = as_utc.isoformat()
+        return result
+
+    def __str__(self):
+        return str(self.asdict())
+
+
+class CatalogEntry:
+    def __init__(
+        self,
+        tap_stream_id=None,
+        stream=None,
+        key_properties=None,
+        schema=None,
+        replication_key=None,
+        is_view=None,
+        database=None,
+        table=None,
+        row_count=None,
+        stream_alias=None,
+        metadata=None,
+        replication_method=None,
+    ):
+        self.tap_stream_id = tap_stream_id
+        self.stream = stream
+        self.key_properties = key_properties
+        self.schema = schema
+        self.replication_key = replication_key
+        self.replication_method = replication_method
+        self.is_view = is_view
+        self.database = database
+        self.table = table
+        self.row_count = row_count
+        self.stream_alias = stream_alias
+        self.metadata = metadata
+
+    def __str__(self):
+        return str(self.__dict__)
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
+    def to_dict(self):
+        result = {}
+        if self.tap_stream_id:
+            result["tap_stream_id"] = self.tap_stream_id
+        if self.database:
+            result["database_name"] = self.database
+        if self.table:
+            result["table_name"] = self.table
+        if self.replication_key is not None:
+            result["replication_key"] = self.replication_key
+        if self.replication_method is not None:
+            result["replication_method"] = self.replication_method
+        if self.key_properties is not None:
+            result["key_properties"] = self.key_properties
+        if self.schema is not None:
+            schema = self.schema.to_dict()  # pylint: disable=no-member
+            result["schema"] = schema
+        if self.is_view is not None:
+            result["is_view"] = self.is_view
+        if self.stream is not None:
+            result["stream"] = self.stream
+        if self.row_count is not None:
+            result["row_count"] = self.row_count
+        if self.stream_alias is not None:
+            result["stream_alias"] = self.stream_alias
+        if self.metadata is not None:
+            result["metadata"] = self.metadata
+        return result
+
+
+class Catalog:
+    def __init__(self, streams):
+        self.streams = streams
+
+    def __str__(self):
+        return str(self.__dict__)
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
+    @classmethod
+    def load(cls, filename):
+        with open(filename) as fp:  # pylint: disable=invalid-name
+            return Catalog.from_dict(json.load(fp))
+
+    @classmethod
+    def from_dict(cls, data):
+        # TODO: We may want to store streams as a dict where the key is a
+        # tap_stream_id and the value is a CatalogEntry. This will allow
+        # faster lookup based on tap_stream_id. This would be a breaking
+        # change, since callers typically access the streams property
+        # directly.
+        streams = []
+        for stream in data["streams"]:
+            entry = CatalogEntry()
+            entry.tap_stream_id = stream.get("tap_stream_id")
+            entry.stream = stream.get("stream")
+            entry.replication_key = stream.get("replication_key")
+            entry.key_properties = stream.get("key_properties")
+            entry.database = stream.get("database_name")
+            entry.table = stream.get("table_name")
+            entry.schema = Schema.from_dict(stream.get("schema"))
+            entry.is_view = stream.get("is_view")
+            entry.stream_alias = stream.get("stream_alias")
+            entry.metadata = stream.get("metadata")
+            entry.replication_method = stream.get("replication_method")
+            streams.append(entry)
+        return Catalog(streams)
+
+    def to_dict(self):
+        return {"streams": [stream.to_dict() for stream in self.streams]}
+
+    def get_stream(self, tap_stream_id):
+        for stream in self.streams:
+            if stream.tap_stream_id == tap_stream_id:
+                return stream
+        return None
+
+
+def parse_message(msg):
+    """Parse a message string into a Message object."""
+
+    def _required_key(msg, k):
+        if k not in msg:
+            raise Exception(f"Message is missing required key '{k}': {msg}")
+
+        return msg[k]
+
+    # We are not using Decimals for parsing here.
+    # We recognize that exposes data to potentially
+    # lossy conversions.  However, this will affect
+    # very few data points and we have chosen to
+    # leave conversion as is for now.
+    obj = json.loads(msg, use_decimal=True)
+    msg_type = _required_key(obj, "type")
+
+    if msg_type == "RECORD":
+        time_extracted = obj.get("time_extracted")
+        if time_extracted:
+            try:
+                time_extracted = datetime.fromisoformat(time_extracted).astimezone(
+                    pytz.utc
+                )
+            except:
+                time_extracted = None
+
+        return RecordMessage(
+            stream=_required_key(obj, "stream"),
+            record=_required_key(obj, "record"),
+            version=obj.get("version"),
+            time_extracted=time_extracted,
+        )
+
+    elif msg_type == "SCHEMA":
+        return SchemaMessage(
+            stream=_required_key(obj, "stream"),
+            schema=_required_key(obj, "schema"),
+            key_properties=_required_key(obj, "key_properties"),
+            bookmark_properties=obj.get("bookmark_properties"),
+        )
+
+    elif msg_type == "STATE":
+        return StateMessage(value=_required_key(obj, "value"))
+
+    elif msg_type == "ACTIVATE_VERSION":
+        return ActivateVersionMessage(
+            stream=_required_key(obj, "stream"), version=_required_key(obj, "version")
+        )
+    else:
+        return None

--- a/projects/vdk-plugins/vdk-singer/src/vdk/plugin/singer/message_utils.py
+++ b/projects/vdk-plugins/vdk-singer/src/vdk/plugin/singer/message_utils.py
@@ -1,0 +1,36 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+from typing import cast
+
+from vdk.plugin.data_sources.data_source import DataSourcePayload
+from vdk.plugin.singer.adapter import CatalogEntry
+from vdk.plugin.singer.adapter import Message
+from vdk.plugin.singer.adapter import RecordMessage
+from vdk.plugin.singer.adapter import Schema
+from vdk.plugin.singer.adapter import SchemaMessage
+from vdk.plugin.singer.adapter import StateMessage
+
+log = logging.getLogger(__name__)
+
+
+def message_to_catalog_entry(msg: SchemaMessage):
+    entry = CatalogEntry()
+    entry.tap_stream_id = msg.stream
+    entry.stream = msg.stream
+    entry.key_properties = msg.key_properties
+    entry.schema = Schema.from_dict(msg.schema)
+    return entry
+
+
+def convert_message_to_payload(message: Message) -> DataSourcePayload:
+    if isinstance(message, RecordMessage):
+        return DataSourcePayload(
+            data=message.record, metadata={"time_extracted": message.time_extracted}
+        )
+    elif isinstance(message, StateMessage):
+        return DataSourcePayload(
+            data=None, metadata=None, state=cast(StateMessage, message).value
+        )
+    else:
+        log.warning(f"Unexpected message type: {message}")

--- a/projects/vdk-plugins/vdk-singer/src/vdk/plugin/singer/plugin_entry.py
+++ b/projects/vdk-plugins/vdk-singer/src/vdk/plugin/singer/plugin_entry.py
@@ -1,0 +1,31 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import click
+from vdk.api.plugin.hook_markers import hookimpl
+from vdk.plugin.singer.singer_command import singer
+from vdk.plugin.singer.singer_data_source import SingerDataSource
+
+"""
+Entry point for singer plugins implementations.
+"""
+
+
+# TODO:
+# It is very difficult ot install two or more different taps in teh same environment
+# They almost certainly use conflicting libraries of singer-python and possibly others.
+# This likely means we need a mechanism where those taps would be installed inseparate virtual environments
+# possibility is to use pipx or similar tool as we treat singer taps as applications /CLIs and not libraries.
+#
+# An idea is to add `vdk build` and vkd_build hook in vdk-core.
+# It will be called before vdk run (if not called) when running locally
+# And it can be called by the Control Service Deployer to install taps in the job docker image.
+
+
+@hookimpl
+def vdk_data_sources_register(data_source_factory: "IDataSourceFactory"):
+    data_source_factory.register_data_source_class(SingerDataSource)
+
+
+@hookimpl
+def vdk_command_line(root_command: click.Group):
+    root_command.add_command(singer)

--- a/projects/vdk-plugins/vdk-singer/src/vdk/plugin/singer/singer_command.py
+++ b/projects/vdk-plugins/vdk-singer/src/vdk/plugin/singer/singer_command.py
@@ -1,0 +1,57 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from typing import List
+
+import click
+import requests
+from vdk.internal.control.utils import cli_utils
+from vdk.internal.control.utils import output_printer
+
+
+def find_packages_starting_with(prefix: str) -> List[str]:
+    url = "https://pypi.org/simple/"
+    headers = {"Accept": "application/vnd.pypi.simple.v1+json"}
+    response = requests.get(url, headers=headers)
+    if response.status_code == 200:
+        projects = response.json()["projects"]
+        filtered_packages = [pkg["name"] for pkg in projects if prefix in pkg["name"]]
+        return filtered_packages
+    else:
+        return []
+
+
+def list_all_likely_taps() -> List[dict]:
+    likely_taps = find_packages_starting_with("tap-")  # get_likely_singer_packages()
+    likely_taps.sort()
+    taps = []
+    for tap_package in likely_taps:
+        taps.append(
+            dict(name=tap_package, url=f"https://pypi.org/project/{tap_package}")
+        )
+    return taps
+
+
+@click.command(
+    name="singer",
+    help="Explore singer sources (taps) and targets."
+    """This command allows you to discover available likely Singer taps (data sources)
+and provides relevant information including their PyPI URLs.
+Use the --list-taps flag to list all likely tap packages.
+
+Example:
+#To list all taps, run:
+`vdk singer --list-taps`""",
+)
+@click.option(
+    "--list-taps",
+    is_flag=True,
+    help="List possible taps that can be used. "
+    "It simply searches Python index for possible taps. "
+    "Their quality and maturity should be verified separately.",
+)
+@click.pass_context
+@cli_utils.output_option()
+def singer(ctx: click.Context, list_taps: bool, output: str):
+    if list_taps:
+        taps = list_all_likely_taps()
+        output_printer.create_printer(output).print_table(taps)

--- a/projects/vdk-plugins/vdk-singer/src/vdk/plugin/singer/singer_data_source.py
+++ b/projects/vdk-plugins/vdk-singer/src/vdk/plugin/singer/singer_data_source.py
@@ -1,0 +1,137 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+from typing import Iterable
+from typing import List
+from typing import Optional
+
+from vdk.plugin.data_sources.config import config_class
+from vdk.plugin.data_sources.config import config_field
+from vdk.plugin.data_sources.data_source import DataSourcePayload
+from vdk.plugin.data_sources.data_source import IDataSource
+from vdk.plugin.data_sources.data_source import (
+    IDataSourceConfiguration,
+)
+from vdk.plugin.data_sources.data_source import IDataSourceStream
+from vdk.plugin.data_sources.factory import data_source
+from vdk.plugin.data_sources.state import IDataSourceState
+from vdk.plugin.singer import message_utils
+from vdk.plugin.singer.adapter import Catalog
+from vdk.plugin.singer.adapter import CatalogEntry
+from vdk.plugin.singer.adapter import Schema
+from vdk.plugin.singer.tap_command import TapCommandRunner
+
+log = logging.getLogger(__name__)
+
+DESCRIPTION = """Singer Taps as data sources within the Versatile Data Kit.
+To see list of Singer taps use vdk singer --list-taps.
+For more check documentation at https://github.com/vmware/versatile-data-kit/tree/main/projects/vdk-plugins/vdk-singer
+"""
+
+
+@config_class("singer-tap", DESCRIPTION)
+class SingerDataSourceConfiguration(IDataSourceConfiguration):
+    tap_name: str = config_field(
+        description="The tap name of the singer data source for example tap-salesforce or tap-postgres"
+    )
+    tap_config: dict = config_field(
+        description="Configuration values as per the official documentation of the singer tap."
+    )
+    tap_auto_discover_schema: bool = config_field(
+        description="On run it will automatically discover the schema if the tap supports",
+        default=True,
+    )
+
+
+class SingerDataSourceStream(IDataSourceStream):
+    def __init__(
+        self,
+        tap_name: str,
+        stream_name: str,
+        config: dict,
+        catalog: Optional[dict] = None,
+        state: Optional[dict] = None,
+    ):
+        self._tap_name = tap_name
+        self._stream_name = stream_name
+        self._config = config
+        self._catalog = catalog
+        self._state = state
+
+    def name(self) -> str:
+        return self._stream_name
+
+    def read(self) -> Iterable[DataSourcePayload]:
+        log.debug(
+            f"Starting to read data source {self._tap_name} stream {self._stream_name}."
+        )
+        with TapCommandRunner() as tap_command:
+            tap_command: TapCommandRunner
+            messages = tap_command.sync(
+                self._tap_name,
+                config=self._config,
+                catalog=self._catalog,
+                state=self._state,
+            )
+            for msg in messages:
+                payload = message_utils.convert_message_to_payload(msg)
+                if payload:
+                    yield payload
+
+
+@data_source(name="singer-tap", config_class=SingerDataSourceConfiguration)
+class SingerDataSource(IDataSource):
+    def __init__(self):
+        self._config = None
+        self._streams: List[SingerDataSourceStream] = []
+
+    def configure(self, config: SingerDataSourceConfiguration):
+        self._config = config
+
+    def connect(self, state: IDataSourceState):
+        if self._streams:
+            log.warning(
+                f"Ignoring second call to {SingerDataSource.__name__}.connect method"
+            )
+            return None
+
+        catalog = Catalog([])
+        # TODO get catalog from state
+        if self._config.tap_auto_discover_schema:
+            catalog = self.__discover_schema(self._config)
+            # save catalog in state
+
+        for stream in catalog.streams:
+            data_stream = SingerDataSourceStream(
+                tap_name=self._config.tap_name,
+                stream_name=stream.tap_stream_id,
+                config=self._config.tap_config,
+                catalog={"streams": [stream.to_dict()]},
+            )
+            self._streams.append(data_stream)
+
+    @staticmethod
+    def __discover_schema(config: SingerDataSourceConfiguration) -> Catalog:
+        with TapCommandRunner() as runner:
+            catalog = runner.discover(config.tap_name, config=config.tap_config)
+
+        if not catalog.streams:
+            log.info(
+                f"No streams discovered  in the tap {config.tap_name}."
+                f" Will create single data stream for all the data"
+            )
+            entry = CatalogEntry()
+            entry.tap_stream_id = config.tap_name
+            entry.stream = config.tap_name
+            entry.key_properties = {}
+            entry.schema = Schema()  # TODO: auto infer it from the data
+            catalog = Catalog([entry])
+
+        return catalog
+
+    def disconnect(self):
+        # TODO? or not needed?
+        pass
+
+    def streams(self) -> List[IDataSourceStream]:
+        return self._streams.copy()

--- a/projects/vdk-plugins/vdk-singer/src/vdk/plugin/singer/tap_command.py
+++ b/projects/vdk-plugins/vdk-singer/src/vdk/plugin/singer/tap_command.py
@@ -1,0 +1,112 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import json
+import logging
+import pathlib
+import subprocess
+from contextlib import contextmanager
+from tempfile import NamedTemporaryFile
+from typing import Iterator
+from typing import Optional
+
+from vdk.plugin.singer.adapter import Catalog
+from vdk.plugin.singer.adapter import Message
+from vdk.plugin.singer.adapter import parse_message
+from vdk.plugin.singer.adapter import SchemaMessage
+from vdk.plugin.singer.message_utils import message_to_catalog_entry
+
+log = logging.getLogger(__name__)
+
+
+class TapCommandRunner:
+    def __init__(self):
+        self._process: Optional[subprocess.Popen] = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()
+
+    def stop(self):
+        if self._process is not None:
+            self._process.terminate()
+            self._process = None
+
+    @contextmanager
+    def _temp_file(self, data: dict) -> pathlib.Path:
+        with NamedTemporaryFile() as file:
+            if data:
+                file.write(json.dumps(data).encode())
+                file.flush()
+            yield pathlib.Path(file.name)
+
+    def _run_discover_catalog(self, config, tap) -> Catalog:
+        with self._temp_file(config) as temp_file:
+            cmd_args = [tap, "--config", str(temp_file), "--discover"]
+            with subprocess.Popen(
+                cmd_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+            ) as process:
+                stdout_data, stderr_data = process.communicate()
+                if stderr_data:
+                    log.debug(f"Command {cmd_args} logs: {stderr_data}")
+                return Catalog.from_dict(json.loads(stdout_data))
+
+    def _run_command(self, cmd_args) -> Iterator[Message]:
+        if not self._process:
+            self._process = subprocess.Popen(
+                cmd_args, stdout=subprocess.PIPE, text=True
+            )
+        for line in iter(self._process.stdout.readline, ""):
+            stderr_line = self._process.stderr
+            if stderr_line:
+                log.debug(stderr_line)
+
+            # log.info(f"tap command line: {line}")
+            yield parse_message(line.strip())
+
+    def _run_discover_command(self, tap: str, config: dict) -> Iterator[Message]:
+        with self._temp_file(config) as temp_file:
+            cmd_args = [tap, "--config", str(temp_file), "--discover"]
+            yield from self._run_command(cmd_args)
+
+    def discover(self, tap: str, config: dict) -> Catalog:
+        try:
+            return self._discover_from_schema_messages(config, tap)
+        except Exception as e:
+            log.debug(
+                f"Could not discover schema using schema messages from the tap. Message: {e}"
+            )
+        try:
+            return self._run_discover_catalog(config, tap)
+        except Exception as e:
+            log.debug(f"Could not discover schema catalog from the tap. Message: {e}")
+        return Catalog([])
+
+    def _discover_from_schema_messages(self, config, tap):
+        try:
+            entries = []
+            for message in self._run_discover_command(tap, config):
+                if isinstance(message, SchemaMessage):
+                    entries.append(message_to_catalog_entry(message))
+                else:
+                    break
+            return Catalog(entries)
+        finally:
+            self.stop()
+
+    def sync(
+        self, tap: str, config: dict, state: dict = None, catalog: dict = None
+    ) -> Iterator[Message]:
+        with self._temp_file(config) as config_file, self._temp_file(
+            state
+        ) as state_file, self._temp_file(catalog) as catalog_file:
+            cmd_args = [tap, "--config", str(config_file)]
+
+            if state:
+                cmd_args.extend(["--state", str(state_file)])
+
+            if catalog:
+                cmd_args.extend(["--catalog", str(catalog_file)])
+
+            yield from self._run_command(cmd_args)

--- a/projects/vdk-plugins/vdk-singer/tests/jobs/ingest-singer-tap-api-job/ingest_api_step.py
+++ b/projects/vdk-plugins/vdk-singer/tests/jobs/ingest-singer-tap-api-job/ingest_api_step.py
@@ -1,0 +1,46 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from vdk.api.job_input import IJobInput
+from vdk.plugin.data_sources.factory import (
+    SingletonDataSourceFactory,
+)
+from vdk.plugin.data_sources.ingester import DataSourceIngester
+from vdk.plugin.singer.singer_data_source import SingerDataSourceConfiguration
+
+
+def run(job_input: IJobInput):
+    data_source = SingletonDataSourceFactory().create_data_source("singer-tap")
+    config = SingerDataSourceConfiguration(
+        tap_name="tap-rest-api-msdk",
+        tap_config={
+            "api_url": job_input.get_arguments().get("api_url"),
+            "streams": [
+                {
+                    "name": "some_data",
+                    "path": "/fake_data",
+                    "records_path": "$.[*]",
+                    "num_inference_records": 200,
+                },
+                {
+                    "name": "some_nested_data",
+                    "path": "/nested_fake_data",
+                    "records_path": "$.[*]",
+                    "num_inference_records": 200,
+                },
+            ],
+        },
+        tap_auto_discover_schema=True,
+    )
+
+    data_source.configure(config)
+
+    data_source_ingester = DataSourceIngester(job_input)
+
+    data_source_ingester.ingest_data_source(
+        "fake-api",
+        data_source,
+        method=job_input.get_arguments().get("method", "sqlite"),
+    )
+
+    data_source_ingester.terminate_and_wait_to_finish()
+    data_source_ingester.raise_on_error()

--- a/projects/vdk-plugins/vdk-singer/tests/jobs/ingest-singer-tap-api-job/requirements.txt
+++ b/projects/vdk-plugins/vdk-singer/tests/jobs/ingest-singer-tap-api-job/requirements.txt
@@ -1,0 +1,1 @@
+tap-gitlab

--- a/projects/vdk-plugins/vdk-singer/tests/jobs/ingest-singer-tap-job/ingest_singer_tap_step.py
+++ b/projects/vdk-plugins/vdk-singer/tests/jobs/ingest-singer-tap-job/ingest_singer_tap_step.py
@@ -1,0 +1,32 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from vdk.api.job_input import IJobInput
+from vdk.plugin.data_sources.factory import (
+    SingletonDataSourceFactory,
+)
+from vdk.plugin.data_sources.ingester import DataSourceIngester
+from vdk.plugin.singer.singer_data_source import SingerDataSourceConfiguration
+
+
+def run(job_input: IJobInput):
+    data_source = SingletonDataSourceFactory().create_data_source("singer-tap")
+    config = SingerDataSourceConfiguration(
+        tap_name="tap-gitlab",
+        tap_config={
+            "api_url": "https://gitlab.com/api/v4",
+            "private_token": "",  # TODO
+            "groups": "vmware-analytics",
+            "projects": "vmware-analytics/versatile-data-kit",
+            "start_date": "2018-01-01T00:00:00Z",
+        },
+        tap_auto_discover_schema=True,
+    )
+
+    data_source.configure(config)
+
+    data_source_ingester = DataSourceIngester(job_input)
+
+    data_source_ingester.ingest_data_source("gitlab", data_source, method="memory")
+
+    data_source_ingester.terminate_and_wait_to_finish()
+    data_source_ingester.raise_on_error()

--- a/projects/vdk-plugins/vdk-singer/tests/jobs/ingest-singer-tap-job/requirements.txt
+++ b/projects/vdk-plugins/vdk-singer/tests/jobs/ingest-singer-tap-job/requirements.txt
@@ -1,0 +1,1 @@
+tap-gitlab

--- a/projects/vdk-plugins/vdk-singer/tests/test_run_ingest_singer.py
+++ b/projects/vdk-plugins/vdk-singer/tests/test_run_ingest_singer.py
@@ -1,0 +1,158 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import json
+import os
+from unittest import mock
+
+import click
+import pytest
+from click.testing import Result
+from pytest_httpserver import HTTPServer
+from vdk.plugin.data_sources import plugin_entry as data_sources_plugin_entry
+from vdk.plugin.singer import plugin_entry
+from vdk.plugin.sqlite import sqlite_plugin
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_funcs import jobs_path_from_caller_directory
+from vdk.plugin.test_utils.util_plugins import IngestIntoMemoryPlugin
+
+
+@pytest.mark.skip
+def test_run_ingest_gitlab_data_singer():
+    ingest_plugin = IngestIntoMemoryPlugin()
+    runner = CliEntryBasedTestRunner(
+        ingest_plugin, plugin_entry, data_sources_plugin_entry
+    )
+
+    result: Result = runner.invoke(
+        ["run", jobs_path_from_caller_directory("ingest-singer-tap-job")]
+    )
+
+    cli_assert_equal(0, result)
+
+    assert len(ingest_plugin.payloads) > 0
+    payload = ingest_plugin.payloads[0]
+    assert payload.destination_table
+    assert len(payload.payload) > 0
+
+
+def test_run_api_ingest(httpserver: HTTPServer, tmpdir):
+    fake_data = simple_fake_json_data()
+    nested_fake_data = nested_fake_json_data()
+
+    api_url = httpserver.url_for("")
+    httpserver.expect_request("/fake_data").respond_with_json(fake_data)
+    httpserver.expect_request("/nested_fake_data").respond_with_json(nested_fake_data)
+
+    with mock.patch.dict(
+        os.environ,
+        {
+            "VDK_DB_DEFAULT_TYPE": "SQLITE",
+            "VDK_SQLITE_FILE": str(tmpdir) + "vdk-sqlite.db",
+        },
+    ):
+        runner = CliEntryBasedTestRunner(
+            sqlite_plugin, plugin_entry, data_sources_plugin_entry
+        )
+
+        result: Result = runner.invoke(
+            [
+                "run",
+                jobs_path_from_caller_directory("ingest-singer-tap-api-job"),
+                "--arguments",
+                json.dumps(dict(api_url=api_url)),
+            ]
+        )
+
+        cli_assert_equal(0, result)
+
+        check_result = query_table(runner, "some_data")
+        assert json.loads(check_result.stdout) == fake_data
+
+        check_result = query_table(runner, "some_nested_data")
+        assert json.loads(check_result.stdout) == get_expected_nested_table_data()
+
+
+def query_table(runner: CliEntryBasedTestRunner, table_name: str):
+    check_result = runner.invoke(
+        ["sql-query", "--output", "json", "--query", f"SELECT * FROM {table_name}"],
+        runner=click.testing.CliRunner(
+            mix_stderr=False
+        ),  # TODO: replace when CliEntryBasedTestRunner add support for it
+    )
+    return check_result
+
+
+def get_expected_nested_table_data():
+    return [
+        {
+            "address_city": "Gwenborough",
+            "address_geo_lat": "-37.3159",
+            "address_geo_lng": "81.1496",
+            "id": 1,
+            "username": "Bret",
+        },
+        {
+            "address_city": "Wisokyburgh",
+            "address_geo_lat": "-43.9509",
+            "address_geo_lng": "-34.4618",
+            "id": 2,
+            "username": "Antonette",
+        },
+        {
+            "address_city": "McKenziehaven",
+            "address_geo_lat": "-68.6102",
+            "address_geo_lng": "-47.0653",
+            "id": 3,
+            "username": "Samantha",
+        },
+    ]
+
+
+def nested_fake_json_data():
+    data = [
+        {
+            "id": 1,
+            "username": "Bret",
+            "address": {
+                "city": "Gwenborough",
+                "geo": {"lat": "-37.3159", "lng": "81.1496"},
+            },
+        },
+        {
+            "id": 2,
+            "username": "Antonette",
+            "address": {
+                "city": "Wisokyburgh",
+                "geo": {"lat": "-43.9509", "lng": "-34.4618"},
+            },
+        },
+        {
+            "id": 3,
+            "username": "Samantha",
+            "address": {
+                "city": "McKenziehaven",
+                "geo": {"lat": "-68.6102", "lng": "-47.0653"},
+            },
+        },
+    ]
+    return data
+
+
+def simple_fake_json_data():
+    return [
+        {
+            "str_col": "str_data",
+            "int_col": 11,
+            "bool_col": True,
+            # "float_col": 1.23, sqlite doesn't support Decimal
+            "extra_col": None,
+        },
+        {
+            "str_col": "str_data",
+            "int_col": 11,
+            "bool_col": True,
+            # "float_col": 1.23, sqlite doesn't support Decimal
+            "extra_col": 1,
+        },
+    ]

--- a/projects/vdk-plugins/vdk-singer/tests/test_singer_command.py
+++ b/projects/vdk-plugins/vdk-singer/tests/test_singer_command.py
@@ -1,0 +1,30 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import json
+
+import httpretty
+from click.testing import Result
+from vdk.plugin.singer import plugin_entry
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
+
+
+@httpretty.activate
+def test_singer_command():
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://pypi.org/simple/",
+        body='{"meta":{"api-version":"1.1"},'
+        '"projects":[{"name":"sqlite"},{"name":"tap-postgres"},{"name":"requests"},{"name":"tap-rest-api"}]}',
+    )
+
+    runner = CliEntryBasedTestRunner(plugin_entry)
+
+    result: Result = runner.invoke(["singer", "--list-taps", "-o", "json"])
+
+    cli_assert_equal(0, result)
+
+    assert json.loads(result.stdout) == [
+        {"name": "tap-postgres", "url": "https://pypi.org/project/tap-postgres"},
+        {"name": "tap-rest-api", "url": "https://pypi.org/project/tap-rest-api"},
+    ]


### PR DESCRIPTION
This is adding a data source plugin for singer.io.

So now users can specify singer taps as data sources

They can also list all singer taps that can be found with `vdk singer --list-taps`

The change depends on https://github.com/vmware/versatile-data-kit/pull/2805