### PR TITLE
control-service: fix infinite redeployment

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -312,10 +312,6 @@ public abstract class KubernetesService {
     String cronjobTemplateString = Files.readString(datajobTemplateFile.toPath());
     // Check whether the string template is a valid datajob template.
     V1beta1CronJob cronjobTemplate = Yaml.loadAs(cronjobTemplateString, V1beta1CronJob.class);
-    log.debug(
-        "Datajob template for file '{}': \n{}",
-        datajobTemplateFile.getCanonicalPath(),
-        cronjobTemplate);
 
     return cronjobTemplate;
   }
@@ -324,10 +320,6 @@ public abstract class KubernetesService {
     String cronjobTemplateString = Files.readString(datajobTemplateFile.toPath());
     // Check whether the string template is a valid datajob template.
     V1CronJob cronjobTemplate = Yaml.loadAs(cronjobTemplateString, V1CronJob.class);
-    log.debug(
-        "Datajob template for file '{}': \n{}",
-        datajobTemplateFile.getCanonicalPath(),
-        cronjobTemplate);
 
     return cronjobTemplate;
   }
@@ -662,7 +654,7 @@ public abstract class KubernetesService {
             imagePullSecrets);
     V1beta1CronJob nsJob =
         batchV1beta1Api.createNamespacedCronJob(namespace, cronJob, null, null, null, null);
-    log.debug("Created k8s V1beta1 cron job: {}", nsJob);
+    log.debug("Created k8s V1beta1 cron job: {}", cronJob);
     log.debug(
         "Created k8s cron job name: {}, api_version:{}, uid:{}, link:{}",
         nsJob.getMetadata().getName(),
@@ -699,7 +691,7 @@ public abstract class KubernetesService {
             imagePullSecrets);
     V1CronJob nsJob =
         batchV1Api.createNamespacedCronJob(namespace, cronJob, null, null, null, null);
-    log.debug("Created k8s V1 cron job: {}", nsJob);
+    log.debug("Created k8s V1 cron job: {}", cronJob);
     log.debug(
         "Created k8s cron job name: {}, api_version: {}, uid:{}, link:{}",
         nsJob.getMetadata().getName(),
@@ -734,6 +726,7 @@ public abstract class KubernetesService {
 
     V1beta1CronJob nsJob =
         batchV1beta1Api.replaceNamespacedCronJob(name, namespace, cronJob, null, null, null, null);
+    log.debug("Updated k8s V1 cron job: {}", cronJob);
     log.debug(
         "Updated k8s V1beta1 cron job status for name:{}, image:{}, uid:{}, link:{}",
         name,
@@ -767,6 +760,7 @@ public abstract class KubernetesService {
             imagePullSecrets);
     V1CronJob nsJob =
         batchV1Api.replaceNamespacedCronJob(name, namespace, cronJob, null, null, null, null);
+    log.debug("Updated k8s V1 cron job: {}", cronJob);
     log.debug(
         "Updated k8s V1 cron job status for name:{}, image:{}, uid:{}, link:{}",
         name,
@@ -1849,11 +1843,11 @@ public abstract class KubernetesService {
   }
 
   private static Map<String, Quantity> resources(Resources resources) {
-    return Map.of(
-        "cpu",
-        Quantity.fromString(resources.getCpu()),
-        "memory",
-        Quantity.fromString(resources.getMemory()));
+    Map<String, Quantity> resourcesMap = new LinkedHashMap<>();
+    resourcesMap.put("cpu", Quantity.fromString(resources.getCpu()));
+    resourcesMap.put("memory", Quantity.fromString(resources.getMemory()));
+
+    return resourcesMap;
   }
 
   private static V1EnvVar envVar(Map.Entry<String, String> entry) {

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentServiceV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentServiceV2.java
@@ -149,7 +149,6 @@ public class DeploymentServiceV2 {
     boolean sendNotification = Boolean.TRUE.equals(desiredJobDeployment.getUserInitiated());
 
     try {
-      log.info("Starting deployment of job {}", desiredJobDeployment.getDataJobName());
       deploymentProgress.started(dataJob.getJobConfig(), desiredJobDeployment);
 
       if (desiredJobDeployment.getPythonVersion() == null) {
@@ -161,11 +160,6 @@ public class DeploymentServiceV2 {
               desiredJobDeployment.getDataJobName(), desiredJobDeployment.getGitCommitSha());
 
       if (jobImageBuilder.buildImage(imageName, dataJob, desiredJobDeployment, sendNotification)) {
-        log.info(
-            "Image {} has been built. Will now schedule job {} for execution",
-            imageName,
-            dataJob.getName());
-
         ActualDataJobDeployment actualJobDeploymentResult =
             jobImageDeployer.scheduleJob(
                 dataJob,

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
@@ -238,9 +238,9 @@ public class JobImageBuilder {
     } else {
       log.info("Builder job {} finished successfully. Will delete it now", builderJobName);
       log.info(
-              "Image {} has been built. Will now schedule job {} for execution",
-              imageName,
-              dataJob.getName());
+          "Image {} has been built. Will now schedule job {} for execution",
+          imageName,
+          dataJob.getName());
       try {
         controlKubernetesService.deleteJob(builderJobName);
       } catch (Exception e) {

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageBuilder.java
@@ -237,6 +237,10 @@ public class JobImageBuilder {
           builderJobName, dataJob, jobDeployment, condition, logs, sendNotification);
     } else {
       log.info("Builder job {} finished successfully. Will delete it now", builderJobName);
+      log.info(
+              "Image {} has been built. Will now schedule job {} for execution",
+              imageName,
+              dataJob.getName());
       try {
         controlKubernetesService.deleteJob(builderJobName);
       } catch (Exception e) {

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployerV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployerV2.java
@@ -90,7 +90,6 @@ public class JobImageDeployerV2 {
       String jobImageName) {
     Validate.notNull(desiredDataJobDeployment, "desiredDataJobDeployment should not be null");
     Validate.notNull(jobImageName, "Image name is expected in jobDeployment");
-    log.info("Update cron job for data job {}", dataJob.getName());
 
     try {
       return updateCronJob(
@@ -195,8 +194,6 @@ public class JobImageDeployerV2 {
       boolean isJobDeploymentPresentInKubernetes,
       String jobImageName)
       throws ApiException {
-    log.debug("Deploy cron job for data job {}", dataJob);
-
     String jobName = dataJob.getName();
     String desiredDataJobDeploymentName = getCronJobName(jobName);
     OffsetDateTime lastDeployedDate = OffsetDateTime.now();
@@ -218,12 +215,14 @@ public class JobImageDeployerV2 {
       if (actualDataJobDeployment == null
           || !desiredDeploymentVersionSha.equals(
               actualDataJobDeployment.getDeploymentVersionSha())) {
+        log.info("Starting deployment of job {}", jobName);
         dataJobsKubernetesService.updateCronJob(desiredCronJob);
         actualJobDeployment =
             DeploymentModelConverter.toActualJobDeployment(
                 desiredDataJobDeployment, desiredDeploymentVersionSha, lastDeployedDate);
       }
     } else {
+      log.info("Starting deployment of job {}", jobName);
       dataJobsKubernetesService.createCronJob(desiredCronJob);
       actualJobDeployment =
           DeploymentModelConverter.toActualJobDeployment(

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitor.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitor.java
@@ -19,7 +19,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitor.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/monitoring/DeploymentMonitor.java
@@ -77,7 +77,6 @@ public class DeploymentMonitor {
    * @param dataJobName
    * @param deploymentStatus
    */
-  @Transactional
   public void recordDeploymentStatus(
       String dataJobName,
       DeploymentStatus deploymentStatus,

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/repository/ActualJobDeploymentRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/repository/ActualJobDeploymentRepository.java
@@ -8,6 +8,7 @@ package com.vmware.taurus.service.repository;
 import com.vmware.taurus.service.model.ActualDataJobDeployment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Spring Data / JPA Repository for ActualDataJobDeployment objects and their members
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Repository;
  *
  * <p>JobDeploymentRepositoryIT validates some aspects of the behavior
  */
+@Transactional
 @Repository
 public interface ActualJobDeploymentRepository
     extends JpaRepository<ActualDataJobDeployment, String> {}

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/repository/DesiredJobDeploymentRepository.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/repository/DesiredJobDeploymentRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Spring Data / JPA Repository for DesiredDataJobDeployment objects and their members
@@ -24,6 +25,7 @@ import org.springframework.stereotype.Repository;
  *
  * <p>JobDeploymentRepositoryIT validates some aspects of the behavior
  */
+@Transactional
 @Repository
 public interface DesiredJobDeploymentRepository
     extends JpaRepository<DesiredDataJobDeployment, String> {


### PR DESCRIPTION
# Why:
The data job synchronizer was stuck in an infinite redeployment loop for all data jobs, occurring every minute. This issue was caused by the random generation of job resources in the cron job definition, where SHA-512 hashing is performed. When we had two instances of the control service running, they generated different SHA codes due to differences in resources order.

```
    resources: class V1ResourceRequirements {
        limits: {cpu=Quantity{number=0.500, format=DECIMAL_SI}, memory=Quantity{number=1000000000, format=DECIMAL_SI}}
        requests: {cpu=Quantity{number=0.500, format=DECIMAL_SI}, memory=Quantity{number=1000000000, format=DECIMAL_SI}}
    }
```

```
    resources: class V1ResourceRequirements {
        limits: {memory=Quantity{number=1000000000, format=DECIMAL_SI}, cpu=Quantity{number=0.500, format=DECIMAL_SI}}
        requests: {memory=Quantity{number=1000000000, format=DECIMAL_SI}, cpu=Quantity{number=0.500, format=DECIMAL_SI}}
    }
```
# What:
We made the following changes to address this issue:

- Replaced the resources map with a LinkedHashMap implementation to ensure consistent order on every run. 
- Reduced the level of logging, as it was overly verbose for one-minute executions.

# Testing done:
I conducted local manual testing to ensure the changes function as intended.

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com