### PR TITLE
vdk-heartbeat: Introduce additional sleep when checking deployments

### DIFF
--- a/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
+++ b/projects/vdk-heartbeat/src/vdk/internal/heartbeat/job_controller.py
@@ -206,6 +206,12 @@ class JobController:
             if not deployments:
                 log.info("No deployments so far. Will wait 30 seconds and try again.")
                 time.sleep(30)
+            elif deployments[0]["enabled"] != enabled:
+                log.info(
+                    "Job deployment should be disabled, but is still enabled. Will wait for 30 seconds and try again."
+                )
+                time.sleep(30)
+                deployments = None
         assert deployments, f"Job {self.config.job_name} deployment is missing"
         assert (
             deployments[0]["enabled"] == enabled


### PR DESCRIPTION
With the introduction of the deployment synchronizer, the behaviour of the Control Service, when a data job is deployed, has changed slightly. Now, there is a slight delay between a job status changing from Enabled to Disabled, and the status being reflected in the output of the `vdk deploy --show` command. This causes the vdk heartbeat to fail, as it expects the changes to be applied immediately.

This change adds a new check when the `check_deployments()` method is called, whose purpose is to verify that the job status has changed from enabled to disabled, and sleep for a bit if this is not the case.

Testing Done: Executed the heartbeat locally with the command
```bash
vdk-heartbeat -f test_basic_config.ini
```