### PR TITLE
vdk-core: fix postgres and greenplum tests

### DIFF
--- a/projects/vdk-plugins/vdk-greenplum/tests/test_ingest_to_greenplum.py
+++ b/projects/vdk-plugins/vdk-greenplum/tests/test_ingest_to_greenplum.py
@@ -89,4 +89,4 @@ class IngestToGreenplumTests(TestCase):
             ]
         )
 
-        assert "UndefinedTable" in ingest_job_result.output
+        assert 'relation "test_table" does not exist' in ingest_job_result.output

--- a/projects/vdk-plugins/vdk-postgres/tests/test_ingest.py
+++ b/projects/vdk-plugins/vdk-postgres/tests/test_ingest.py
@@ -91,4 +91,4 @@ class IngestToPostgresTests(TestCase):
             ]
         )
 
-        assert "UndefinedTable" in ingest_job_result.output
+        assert 'relation "test_table" does not exist' in ingest_job_result.output


### PR DESCRIPTION
What: Due to the introduction of some vdk-core log changes, similar unit test for vdk-postgres and vdk-greenplum started failing and are breaking the CI/CD.

Why: To fix the CI/CD.

Testing Done: locally.