### PR TITLE
vdk-core: ingest logging formatting bug

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_router.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_router.py
@@ -85,10 +85,10 @@ class IngesterRouter(IIngesterRegistry, IIngester):
         else:
             errors.report_and_throw(
                 VdkConfigurationError(
-                    "Provided method, {method}, has invalid value.",
-                    "VDK was run with method={method}, however {method} is not part of the available ingestion mechanisms.",
+                    f"Provided method, {method}, has invalid value."
+                    f"VDK was run with method={method}, however {method} is not part of the available ingestion methods."
                     f"Provide either valid value for method, or install ingestion plugin that supports this type. "
-                    f"Currently possible values are {list(self._ingester_builders.keys())}",
+                    f"Currently possible values are {list(self._ingester_builders.keys())}"
                 )
             )
 
@@ -217,15 +217,9 @@ class IngesterRouter(IIngesterRegistry, IIngester):
         if processor_plugin is None:
             errors.report_and_throw(
                 VdkConfigurationError(
-                    "Could not create new processor plugin of type" f" {method}.",
-                    f"VDK was run with method={method}, however "
-                    "no valid ingestion processor plugin was "
-                    "created.",
-                    "Seems to be a bug in the plugin for method"
-                    f" {method}. Make sure it's correctly "
-                    f"installed. If upgraded recently, consider"
-                    " reverting to previous version. Or use "
-                    "another method type.",
+                    "Could not create new processor plugin of method: " f"{method}.",
+                    f"Currently possible processor methods are {list(self._ingester_builders.keys())}. "
+                    "Make sure the processing configuration value are correct and the plugin is installed. ",
                 )
             )
         return processor_plugin

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/ingestion/test_ingester_router.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/ingestion/test_ingester_router.py
@@ -142,6 +142,4 @@ def test_router_raise_error_chained_ingest_plugins_not_registered():
         router.send_tabular_data_for_ingestion(rows=["b"], column_names=["a"])
 
     error_msg = exc_info.value
-    assert "Could not create new processor plugin of type pre-ingest-test" in str(
-        error_msg
-    )
+    assert "method: pre-ingest-test" in str(error_msg)


### PR DESCRIPTION
The logs were not replacing the method name because the f-string was missing the `f"` so this is fixed.

Slightly simplified the error message to make it easier to understand I hope