### PR TITLE
control-service: Add GraphQL read from DB

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
@@ -317,6 +317,28 @@ public class DeploymentModelConverter {
     return contacts;
   }
 
+  public static JobDeploymentStatus toJobDeploymentStatus(
+          ActualDataJobDeployment deploymentStatus) {
+    JobDeploymentStatus jobDeploymentStatus = new JobDeploymentStatus();
+
+    jobDeploymentStatus.setDataJobName(deploymentStatus.getDataJobName());
+    jobDeploymentStatus.setPythonVersion(deploymentStatus.getPythonVersion());
+    jobDeploymentStatus.setGitCommitSha(deploymentStatus.getGitCommitSha());
+    jobDeploymentStatus.setEnabled(deploymentStatus.getEnabled());
+    jobDeploymentStatus.setLastDeployedBy(deploymentStatus.getLastDeployedBy());
+    jobDeploymentStatus.setLastDeployedDate(
+            deploymentStatus.getLastDeployedDate() == null
+                    ? null
+                    : deploymentStatus.getLastDeployedDate().toString());
+    jobDeploymentStatus.setResources(getResourcesFromDeployment(deploymentStatus));
+    // The ActualDataJobDeployment does not have a mode attribute, which is required by the
+    // JobDeploymentStatus,
+    // so we need to set something in order to avoid errors.
+    jobDeploymentStatus.setMode("release");
+
+    return jobDeploymentStatus;
+  }
+
   private static DataJobResources getResourcesFromDeployment(ActualDataJobDeployment deployment) {
     DataJobResources resources = new DataJobResources();
     var deploymentResources = deployment.getResources();

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
@@ -318,7 +318,7 @@ public class DeploymentModelConverter {
   }
 
   public static JobDeploymentStatus toJobDeploymentStatus(
-          ActualDataJobDeployment deploymentStatus) {
+      ActualDataJobDeployment deploymentStatus) {
     JobDeploymentStatus jobDeploymentStatus = new JobDeploymentStatus();
 
     jobDeploymentStatus.setDataJobName(deploymentStatus.getDataJobName());
@@ -327,9 +327,9 @@ public class DeploymentModelConverter {
     jobDeploymentStatus.setEnabled(deploymentStatus.getEnabled());
     jobDeploymentStatus.setLastDeployedBy(deploymentStatus.getLastDeployedBy());
     jobDeploymentStatus.setLastDeployedDate(
-            deploymentStatus.getLastDeployedDate() == null
-                    ? null
-                    : deploymentStatus.getLastDeployedDate().toString());
+        deploymentStatus.getLastDeployedDate() == null
+            ? null
+            : deploymentStatus.getLastDeployedDate().toString());
     jobDeploymentStatus.setResources(getResourcesFromDeployment(deploymentStatus));
     // The ActualDataJobDeployment does not have a mode attribute, which is required by the
     // JobDeploymentStatus,

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLDataFetchers.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLDataFetchers.java
@@ -215,7 +215,9 @@ public class GraphQLDataFetchers {
   private List<V2DataJob> populateDeployments(
       List<V2DataJob> allDataJob, Map<String, DataJob> dataJobs) {
     Map<String, JobDeploymentStatus> deploymentStatuses =
-            (dataJobDeploymentPropertiesConfig.getReadDataSource().equals(ReadFrom.DB)) ? readJobDeploymentsFromDb() : readJobDeploymentsFromK8s();
+        (dataJobDeploymentPropertiesConfig.getReadDataSource().equals(ReadFrom.DB))
+            ? readJobDeploymentsFromDb()
+            : readJobDeploymentsFromK8s();
 
     allDataJob.forEach(
         dataJob -> {
@@ -236,22 +238,22 @@ public class GraphQLDataFetchers {
 
   private Map<String, JobDeploymentStatus> readJobDeploymentsFromK8s() {
     return deploymentService.readDeployments().stream()
-            .collect(Collectors.toMap(JobDeploymentStatus::getDataJobName, cronJob -> cronJob));
+        .collect(Collectors.toMap(JobDeploymentStatus::getDataJobName, cronJob -> cronJob));
   }
 
   private Map<String, JobDeploymentStatus> readJobDeploymentsFromDb() {
-    var deployments = StreamSupport.stream(actualJobDeploymentRepository.findAll().spliterator(), false)
-            .collect(Collectors.toMap(ActualDataJobDeployment::getDataJobName,
-                    cronjob -> cronjob));
+    var deployments =
+        StreamSupport.stream(actualJobDeploymentRepository.findAll().spliterator(), false)
+            .collect(Collectors.toMap(ActualDataJobDeployment::getDataJobName, cronjob -> cronjob));
 
     return deployments.entrySet().stream()
-            .collect(Collectors.toMap(
-                    Map.Entry::getKey,
-                    entry -> convertToJobDeploymentStatus(entry.getValue())
-            ));
+        .collect(
+            Collectors.toMap(
+                Map.Entry::getKey, entry -> convertToJobDeploymentStatus(entry.getValue())));
   }
 
-  private JobDeploymentStatus convertToJobDeploymentStatus(ActualDataJobDeployment deploymentStatus) {
+  private JobDeploymentStatus convertToJobDeploymentStatus(
+      ActualDataJobDeployment deploymentStatus) {
     JobDeploymentStatus jobDeploymentStatus = new JobDeploymentStatus();
     jobDeploymentStatus.setDataJobName(deploymentStatus.getDataJobName());
     jobDeploymentStatus.setPythonVersion(deploymentStatus.getPythonVersion());
@@ -260,7 +262,8 @@ public class GraphQLDataFetchers {
     jobDeploymentStatus.setLastDeployedBy(deploymentStatus.getLastDeployedBy());
     jobDeploymentStatus.setLastDeployedDate(deploymentStatus.getLastDeployedDate().toString());
     jobDeploymentStatus.setResources(getDataJobResources(deploymentStatus.getResources()));
-    // The ActualDataJobDeployment does not have a mode attribute, which is required by the JobDeploymentStatus,
+    // The ActualDataJobDeployment does not have a mode attribute, which is required by the
+    // JobDeploymentStatus,
     // so we need to set something in order to avoid errors.
     jobDeploymentStatus.setMode("release");
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLDataFetchers.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLDataFetchers.java
@@ -30,13 +30,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -212,10 +206,15 @@ public class GraphQLDataFetchers {
 
   private List<V2DataJob> populateDeployments(
       List<V2DataJob> allDataJob, Map<String, DataJob> dataJobs) {
-    Map<String, JobDeploymentStatus> deploymentStatuses =
-        (dataJobDeploymentPropertiesConfig.getReadDataSource().equals(ReadFrom.DB))
-            ? readJobDeploymentsFromDb()
-            : readJobDeploymentsFromK8s();
+    Map<String, JobDeploymentStatus> deploymentStatuses;
+
+    if (dataJobDeploymentPropertiesConfig.getReadDataSource().equals(ReadFrom.DB)) {
+      deploymentStatuses = readJobDeploymentsFromDb();
+    } else if (dataJobDeploymentPropertiesConfig.getReadDataSource().equals(ReadFrom.K8S)) {
+      deploymentStatuses = readJobDeploymentsFromK8s();
+    } else {
+      deploymentStatuses = Collections.emptyMap();
+    }
 
     allDataJob.forEach(
         dataJob -> {

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLDataFetchers.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLDataFetchers.java
@@ -9,7 +9,6 @@ import com.vmware.taurus.datajobs.DeploymentModelConverter;
 import com.vmware.taurus.datajobs.ToApiModelConverter;
 import com.vmware.taurus.service.deploy.DeploymentServiceV2;
 import com.vmware.taurus.service.repository.JobsRepository;
-import com.vmware.taurus.service.repository.ActualJobDeploymentRepository;
 import com.vmware.taurus.service.deploy.DataJobDeploymentPropertiesConfig;
 import com.vmware.taurus.service.deploy.DataJobDeploymentPropertiesConfig.ReadFrom;
 import com.vmware.taurus.service.deploy.DeploymentService;
@@ -244,10 +243,9 @@ public class GraphQLDataFetchers {
     return deploymentServiceV2.findAllActualDataJobDeployments().entrySet().stream()
         .collect(
             Collectors.toMap(
-                Map.Entry::getKey, entry -> DeploymentModelConverter.toJobDeploymentStatus(entry.getValue())));
+                Map.Entry::getKey,
+                entry -> DeploymentModelConverter.toJobDeploymentStatus(entry.getValue())));
   }
-
-
 
   private static DataJobPage buildResponse(int pageSize, int count, List pageList) {
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLDataFetchers.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLDataFetchers.java
@@ -7,6 +7,7 @@ package com.vmware.taurus.service.graphql;
 
 import com.vmware.taurus.datajobs.ToApiModelConverter;
 import com.vmware.taurus.service.repository.JobsRepository;
+import com.vmware.taurus.service.repository.ActualJobDeploymentRepository;
 import com.vmware.taurus.service.deploy.DeploymentService;
 import com.vmware.taurus.service.graphql.model.Criteria;
 import com.vmware.taurus.service.graphql.model.DataJobPage;

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLDataFetchersTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLDataFetchersTest.java
@@ -81,7 +81,12 @@ class GraphQLDataFetchersTest {
         new JobFieldStrategyFactory(collectSupportedFieldStrategies());
     GraphQLDataFetchers graphQLDataFetchers =
         new GraphQLDataFetchers(
-            strategyFactory, jobsRepository, deploymentService, executionDataFetcher, actualJobDeploymentRepository, dataJobDeploymentPropertiesConfig);
+            strategyFactory,
+            jobsRepository,
+            deploymentService,
+            executionDataFetcher,
+            actualJobDeploymentRepository,
+            dataJobDeploymentPropertiesConfig);
     findDataJobs = graphQLDataFetchers.findAllAndBuildDataJobPage();
   }
 
@@ -257,7 +262,7 @@ class GraphQLDataFetchersTest {
     when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(100);
     when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
     when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT.getPath()))
-            .thenReturn(true);
+        .thenReturn(true);
 
     DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
 
@@ -271,10 +276,10 @@ class GraphQLDataFetchersTest {
     var job4 = (V2DataJob) dataJobPage.getContent().get(3);
     assertThat(job4.getDeployments()).hasSize(1);
     assertThat(job4.getDeployments().get(0).getLastExecutionStatus())
-            .isEqualTo(DataJobExecution.StatusEnum.SUCCEEDED);
+        .isEqualTo(DataJobExecution.StatusEnum.SUCCEEDED);
     assertThat(job4.getDeployments().get(0).getLastExecutionTime())
-            .isEqualTo(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
-    assertThat(job4.getDeployments().get(0).getLastExecutionDuration()).isEqualTo(1000);
+            .isNull();
+    assertThat(job4.getDeployments().get(0).getLastExecutionDuration()).isEqualTo(0);
     assertThat(job4.getDeployments().get(0).getJobPythonVersion()).isEqualTo("3.9-secure");
   }
 
@@ -500,12 +505,14 @@ class GraphQLDataFetchersTest {
     return status;
   }
 
-  private ActualDataJobDeployment mockSampleActualJobDeployment(String jobName, boolean enabled, String pythonVersion) {
+  private ActualDataJobDeployment mockSampleActualJobDeployment(
+      String jobName, boolean enabled, String pythonVersion) {
     ActualDataJobDeployment actualJobDeployment = new ActualDataJobDeployment();
     actualJobDeployment.setDataJobName(jobName);
     actualJobDeployment.setEnabled(enabled);
     actualJobDeployment.setPythonVersion(pythonVersion);
-    actualJobDeployment.setLastDeployedDate(OffsetDateTime.of(2023, 10, 25, 16, 30, 42, 42, ZoneOffset.UTC));
+    actualJobDeployment.setLastDeployedDate(
+        OffsetDateTime.of(2023, 10, 25, 16, 30, 42, 42, ZoneOffset.UTC));
 
     DataJobDeploymentResources resources = new DataJobDeploymentResources();
     resources.setCpuLimitCores(1f);

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLDataFetchersTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLDataFetchersTest.java
@@ -277,8 +277,7 @@ class GraphQLDataFetchersTest {
     assertThat(job4.getDeployments()).hasSize(1);
     assertThat(job4.getDeployments().get(0).getLastExecutionStatus())
         .isEqualTo(DataJobExecution.StatusEnum.SUCCEEDED);
-    assertThat(job4.getDeployments().get(0).getLastExecutionTime())
-            .isNull();
+    assertThat(job4.getDeployments().get(0).getLastExecutionTime()).isNull();
     assertThat(job4.getDeployments().get(0).getLastExecutionDuration()).isEqualTo(0);
     assertThat(job4.getDeployments().get(0).getJobPythonVersion()).isEqualTo("3.9-secure");
   }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLDataFetchersTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLDataFetchersTest.java
@@ -86,7 +86,7 @@ class GraphQLDataFetchersTest {
             deploymentService,
             executionDataFetcher,
             dataJobDeploymentPropertiesConfig,
-                deploymentServiceV2);
+            deploymentServiceV2);
     findDataJobs = graphQLDataFetchers.findAllAndBuildDataJobPage();
   }
 
@@ -257,7 +257,8 @@ class GraphQLDataFetchersTest {
   void testPopulateDeployments_readFromDB() throws Exception {
     when(dataJobDeploymentPropertiesConfig.getReadDataSource()).thenReturn(ReadFrom.DB);
     when(jobsRepository.findAll()).thenReturn(mockListOfDataJobsWithLastExecution());
-    when(deploymentServiceV2.findAllActualDataJobDeployments()).thenReturn(mockMapOfActualJobDeployments());
+    when(deploymentServiceV2.findAllActualDataJobDeployments())
+        .thenReturn(mockMapOfActualJobDeployments());
     when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
     when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(100);
     when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
@@ -426,12 +427,11 @@ class GraphQLDataFetchersTest {
 
   private Map<String, ActualDataJobDeployment> mockMapOfActualJobDeployments() {
     return Map.of(
-            "sample-job-1", mockSampleActualJobDeployment("sample-job-1", true, "3.8-secure"),
-            "sample-job-2", mockSampleActualJobDeployment("sample-job-2", false, "3.8-secure"),
-            "sample-job-3", mockSampleActualJobDeployment("sample-job-3", true, "3.9-secure"),
-            "sample-job-4", mockSampleActualJobDeployment("sample-job-4", false, "3.9-secure"),
-            "sample-job-5", mockSampleActualJobDeployment("sample-job-5", true, "3.9-secure")
-    );
+        "sample-job-1", mockSampleActualJobDeployment("sample-job-1", true, "3.8-secure"),
+        "sample-job-2", mockSampleActualJobDeployment("sample-job-2", false, "3.8-secure"),
+        "sample-job-3", mockSampleActualJobDeployment("sample-job-3", true, "3.9-secure"),
+        "sample-job-4", mockSampleActualJobDeployment("sample-job-4", false, "3.9-secure"),
+        "sample-job-5", mockSampleActualJobDeployment("sample-job-5", true, "3.9-secure"));
   }
 
   private List<DataJob> mockListOfDataJobsWithLastExecution() {

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLDataFetchersTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/GraphQLDataFetchersTest.java
@@ -6,6 +6,10 @@
 package com.vmware.taurus.service.graphql;
 
 import com.vmware.taurus.controlplane.model.data.DataJobExecution;
+import com.vmware.taurus.service.deploy.DataJobDeploymentPropertiesConfig;
+import com.vmware.taurus.service.deploy.DataJobDeploymentPropertiesConfig.ReadFrom;
+import com.vmware.taurus.service.model.*;
+import com.vmware.taurus.service.repository.ActualJobDeploymentRepository;
 import com.vmware.taurus.service.repository.JobsRepository;
 import com.vmware.taurus.service.deploy.DeploymentService;
 import com.vmware.taurus.service.graphql.model.Filter;
@@ -22,11 +26,7 @@ import com.vmware.taurus.service.graphql.strategy.datajob.JobFieldStrategyByNext
 import com.vmware.taurus.service.graphql.strategy.datajob.JobFieldStrategyByScheduleCron;
 import com.vmware.taurus.service.graphql.strategy.datajob.JobFieldStrategyBySourceUrl;
 import com.vmware.taurus.service.graphql.strategy.datajob.JobFieldStrategyByTeam;
-import com.vmware.taurus.service.model.DataJob;
 import com.vmware.taurus.service.graphql.model.DataJobPage;
-import com.vmware.taurus.service.model.ExecutionStatus;
-import com.vmware.taurus.service.model.JobConfig;
-import com.vmware.taurus.service.model.JobDeploymentStatus;
 import graphql.GraphQLException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -47,6 +47,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.time.OffsetDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -68,6 +69,10 @@ class GraphQLDataFetchersTest {
 
   @Mock private DataFetchingFieldSelectionSet dataFetchingFieldSelectionSet;
 
+  @Mock private ActualJobDeploymentRepository actualJobDeploymentRepository;
+
+  @Mock private DataJobDeploymentPropertiesConfig dataJobDeploymentPropertiesConfig;
+
   private DataFetcher<Object> findDataJobs;
 
   @BeforeEach
@@ -76,12 +81,13 @@ class GraphQLDataFetchersTest {
         new JobFieldStrategyFactory(collectSupportedFieldStrategies());
     GraphQLDataFetchers graphQLDataFetchers =
         new GraphQLDataFetchers(
-            strategyFactory, jobsRepository, deploymentService, executionDataFetcher);
+            strategyFactory, jobsRepository, deploymentService, executionDataFetcher, actualJobDeploymentRepository, dataJobDeploymentPropertiesConfig);
     findDataJobs = graphQLDataFetchers.findAllAndBuildDataJobPage();
   }
 
   @Test
   void testDataFetcherOfJobs_whenGettingFullList_shouldReturnAllDataJobs() throws Exception {
+    when(dataJobDeploymentPropertiesConfig.getReadDataSource()).thenReturn(ReadFrom.K8S);
     when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
     when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(10);
     when(jobsRepository.findAll()).thenReturn(mockListOfDataJobs());
@@ -99,6 +105,7 @@ class GraphQLDataFetchersTest {
 
   @Test
   void testDataFetcherOfJobs_whenGettingPagedResult_shouldReturnPagedJobs() throws Exception {
+    when(dataJobDeploymentPropertiesConfig.getReadDataSource()).thenReturn(ReadFrom.K8S);
     when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(2);
     when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(2);
     when(jobsRepository.findAll()).thenReturn(mockListOfDataJobs());
@@ -136,6 +143,7 @@ class GraphQLDataFetchersTest {
 
   @Test
   void testDataFetcherOfJobs_whenSearchingSpecificJob_shouldReturnSearchedJob() throws Exception {
+    when(dataJobDeploymentPropertiesConfig.getReadDataSource()).thenReturn(ReadFrom.K8S);
     when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
     when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(10);
     when(dataFetchingEnvironment.getArgument("search")).thenReturn("sample-job-2");
@@ -156,6 +164,7 @@ class GraphQLDataFetchersTest {
 
   @Test
   void testDataFetcherOfJobs_whenSearchingByPattern_shouldReturnMatchingJobs() throws Exception {
+    when(dataJobDeploymentPropertiesConfig.getReadDataSource()).thenReturn(ReadFrom.K8S);
     when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
     when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(10);
     when(dataFetchingEnvironment.getArgument("search")).thenReturn("sample-job-2");
@@ -213,6 +222,7 @@ class GraphQLDataFetchersTest {
 
   @Test
   void testPopulateDeployments() throws Exception {
+    when(dataJobDeploymentPropertiesConfig.getReadDataSource()).thenReturn(ReadFrom.K8S);
     when(jobsRepository.findAll()).thenReturn(mockListOfDataJobsWithLastExecution());
     when(deploymentService.readDeployments()).thenReturn(mockListOfDeployments());
     when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
@@ -239,7 +249,38 @@ class GraphQLDataFetchersTest {
   }
 
   @Test
+  void testPopulateDeployments_readFromDB() throws Exception {
+    when(dataJobDeploymentPropertiesConfig.getReadDataSource()).thenReturn(ReadFrom.DB);
+    when(jobsRepository.findAll()).thenReturn(mockListOfDataJobsWithLastExecution());
+    when(actualJobDeploymentRepository.findAll()).thenReturn(mockListOfActualJobDeployments());
+    when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
+    when(dataFetchingEnvironment.getArgument("pageSize")).thenReturn(100);
+    when(dataFetchingEnvironment.getSelectionSet()).thenReturn(dataFetchingFieldSelectionSet);
+    when(dataFetchingFieldSelectionSet.contains(JobFieldStrategyBy.DEPLOYMENT.getPath()))
+            .thenReturn(true);
+
+    DataJobPage dataJobPage = (DataJobPage) findDataJobs.get(dataFetchingEnvironment);
+
+    assertThat(dataJobPage.getContent()).hasSize(5);
+    var job2 = (V2DataJob) dataJobPage.getContent().get(1);
+    assertThat(job2.getDeployments()).hasSize(1);
+    assertThat(job2.getDeployments().get(0).getLastExecutionStatus()).isNull();
+    assertThat(job2.getDeployments().get(0).getLastExecutionTime()).isNull();
+    assertThat(job2.getDeployments().get(0).getLastExecutionDuration()).isNull();
+    assertThat(job2.getDeployments().get(0).getJobPythonVersion()).isEqualTo("3.8-secure");
+    var job4 = (V2DataJob) dataJobPage.getContent().get(3);
+    assertThat(job4.getDeployments()).hasSize(1);
+    assertThat(job4.getDeployments().get(0).getLastExecutionStatus())
+            .isEqualTo(DataJobExecution.StatusEnum.SUCCEEDED);
+    assertThat(job4.getDeployments().get(0).getLastExecutionTime())
+            .isEqualTo(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
+    assertThat(job4.getDeployments().get(0).getLastExecutionDuration()).isEqualTo(1000);
+    assertThat(job4.getDeployments().get(0).getJobPythonVersion()).isEqualTo("3.9-secure");
+  }
+
+  @Test
   void testFilterByLastExecutionStatus() throws Exception {
+    when(dataJobDeploymentPropertiesConfig.getReadDataSource()).thenReturn(ReadFrom.K8S);
     when(jobsRepository.findAll()).thenReturn(mockListOfDataJobsWithLastExecution());
     when(deploymentService.readDeployments()).thenReturn(mockListOfDeployments());
     when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
@@ -263,6 +304,7 @@ class GraphQLDataFetchersTest {
 
   @Test
   void testSortingByLastExecutionStatus() throws Exception {
+    when(dataJobDeploymentPropertiesConfig.getReadDataSource()).thenReturn(ReadFrom.K8S);
     when(jobsRepository.findAll()).thenReturn(mockListOfDataJobsWithLastExecution());
     when(deploymentService.readDeployments()).thenReturn(mockListOfDeployments());
     when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
@@ -296,6 +338,7 @@ class GraphQLDataFetchersTest {
 
   @Test
   void testSortingByLastExecutionTime() throws Exception {
+    when(dataJobDeploymentPropertiesConfig.getReadDataSource()).thenReturn(ReadFrom.K8S);
     when(jobsRepository.findAll()).thenReturn(mockListOfDataJobsWithLastExecution());
     when(deploymentService.readDeployments()).thenReturn(mockListOfDeployments());
     when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
@@ -327,6 +370,7 @@ class GraphQLDataFetchersTest {
 
   @Test
   void testSortingByLastExecutionDuration() throws Exception {
+    when(dataJobDeploymentPropertiesConfig.getReadDataSource()).thenReturn(ReadFrom.K8S);
     when(jobsRepository.findAll()).thenReturn(mockListOfDataJobsWithLastExecution());
     when(deploymentService.readDeployments()).thenReturn(mockListOfDeployments());
     when(dataFetchingEnvironment.getArgument("pageNumber")).thenReturn(1);
@@ -374,6 +418,18 @@ class GraphQLDataFetchersTest {
     dataJobs.add(mockSampleDataJob("sample-job-3", "Delete users", "0 4 8-14 * *"));
 
     return dataJobs;
+  }
+
+  private List<ActualDataJobDeployment> mockListOfActualJobDeployments() {
+    List<ActualDataJobDeployment> actualJobDeployments = new ArrayList<>();
+
+    actualJobDeployments.add(mockSampleActualJobDeployment("sample-job-1", true, "3.8-secure"));
+    actualJobDeployments.add(mockSampleActualJobDeployment("sample-job-2", false, "3.8-secure"));
+    actualJobDeployments.add(mockSampleActualJobDeployment("sample-job-3", true, "3.9-secure"));
+    actualJobDeployments.add(mockSampleActualJobDeployment("sample-job-4", false, "3.9-secure"));
+    actualJobDeployments.add(mockSampleActualJobDeployment("sample-job-5", true, "3.9-secure"));
+
+    return actualJobDeployments;
   }
 
   private List<DataJob> mockListOfDataJobsWithLastExecution() {
@@ -442,6 +498,23 @@ class GraphQLDataFetchersTest {
     status.setCronJobName(jobName + "-latest");
     status.setMode("release");
     return status;
+  }
+
+  private ActualDataJobDeployment mockSampleActualJobDeployment(String jobName, boolean enabled, String pythonVersion) {
+    ActualDataJobDeployment actualJobDeployment = new ActualDataJobDeployment();
+    actualJobDeployment.setDataJobName(jobName);
+    actualJobDeployment.setEnabled(enabled);
+    actualJobDeployment.setPythonVersion(pythonVersion);
+    actualJobDeployment.setLastDeployedDate(OffsetDateTime.of(2023, 10, 25, 16, 30, 42, 42, ZoneOffset.UTC));
+
+    DataJobDeploymentResources resources = new DataJobDeploymentResources();
+    resources.setCpuLimitCores(1f);
+    resources.setCpuRequestCores(1f);
+    resources.setMemoryLimitMi(100);
+    resources.setMemoryRequestMi(100);
+
+    actualJobDeployment.setResources(resources);
+    return actualJobDeployment;
   }
 
   static ArrayList<LinkedHashMap<String, String>> constructFilter(Filter... filters) {


### PR DESCRIPTION
Currently, when using the GraphQL API, the data job deployment data is read from the kubernetes
cronjobs. This works fine in general, but it also means that the kubernetes resources become the
single point of truth, which is not ideal.
    
As part of VEP-2272, the deployment information is moved to the DB, which improves speed and
reliability. This means that we need a way to read data from the DB, instead of the kubernetes.
   
This change adds support for reading deployment data from the database when using the GrapgQL
API. The option to read from the k8s remains.
    
Testing Done: Added test.