### PR TITLE
vdk-core: remove redundant logs

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/log_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/log_config.py
@@ -61,7 +61,6 @@ def _parse_log_level_module(log_level_module):
             errors.VdkConfigurationError(
                 "Invalid logging configuration passed to LOG_LEVEL_MODULE.",
                 f"Error is: {e}. log_level_module was set to {log_level_module}.",
-                "Logging will not be initialized and exception is raised",
                 "Set correctly configuration to log_level_debug configuration in format 'module=level;module2=level2'",
             )
         )
@@ -148,7 +147,6 @@ def configure_loggers(
             errors.VdkConfigurationError(
                 f"Provided configuration variable for {SYSLOG_SOCK_TYPE} has invalid value.",
                 f"VDK was run with {SYSLOG_SOCK_TYPE}={syslog_sock_type}, however {syslog_sock_type} is invalid value for this variable.",
-                errors.MSG_CONSEQUENCE_DELEGATING_TO_CALLER__LIKELY_EXECUTION_FAILURE,
                 f"Provide a valid value for {SYSLOG_SOCK_TYPE}."
                 f"Currently possible values are {list(SYSLOG_SOCK_TYPE_VALUES_DICT.keys())}",
             )

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/impl/router.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/impl/router.py
@@ -90,7 +90,6 @@ class ManagedConnectionRouter(IManagedConnectionRegistry):
                 errors.VdkConfigurationError(
                     f"Provided configuration variable for {DB_DEFAULT_TYPE} has invalid value.",
                     f"VDK was run with {DB_DEFAULT_TYPE}={dbtype}, however {dbtype} is invalid value for this variable.",
-                    errors.MSG_CONSEQUENCE_DELEGATING_TO_CALLER__LIKELY_EXECUTION_FAILURE,
                     f"Provide either valid value for {DB_DEFAULT_TYPE} or install database plugin that supports this type. "
                     f"Currently possible values are {list(self._connection_builders.keys())}",
                 )
@@ -125,7 +124,6 @@ class ManagedConnectionRouter(IManagedConnectionRegistry):
                 errors.VdkConfigurationError(
                     f"Could not create new connection of db type {dbtype}.",
                     f"VDK was run with {DB_DEFAULT_TYPE}={dbtype}, however no valid connection was created.",
-                    errors.MSG_CONSEQUENCE_DELEGATING_TO_CALLER__LIKELY_EXECUTION_FAILURE,
                     f"Seems to be a bug in the plugin for dbtype {dbtype}. Make sure it's correctly installed. "
                     f"If upgraded recently consider reverting to previous version. Or use another db type. "
                     f"Currently possible values are {list(self._connection_builders.keys())}",

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
@@ -152,8 +152,6 @@ class ManagedConnectionBase(PEP249Connection, IManagedConnection):
                             [
                                 "Fetching all results from query FAILED.",
                                 errors.MSG_WHY_FROM_EXCEPTION(e),
-                                errors.MSG_CONSEQUENCE_DELEGATING_TO_CALLER__LIKELY_EXECUTION_FAILURE,
-                                errors.MSG_COUNTERMEASURE_FIX_PARENT_EXCEPTION,
                             ]
                         )
                     )

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
@@ -116,8 +116,6 @@ class ManagedCursor(ProxyCursor):
                         [
                             "Executing query FAILED.",
                             errors.MSG_WHY_FROM_EXCEPTION(e),
-                            errors.MSG_CONSEQUENCE_DELEGATING_TO_CALLER__LIKELY_EXECUTION_FAILURE,
-                            errors.MSG_COUNTERMEASURE_FIX_PARENT_EXCEPTION,
                         ]
                     )
                 )
@@ -142,8 +140,6 @@ class ManagedCursor(ProxyCursor):
                         [
                             "Decorating query FAILED.",
                             errors.MSG_WHY_FROM_EXCEPTION(e),
-                            errors.MSG_CONSEQUENCE_DELEGATING_TO_CALLER__LIKELY_EXECUTION_FAILURE,
-                            errors.MSG_COUNTERMEASURE_FIX_PARENT_EXCEPTION,
                         ]
                     )
                 )
@@ -162,8 +158,6 @@ class ManagedCursor(ProxyCursor):
                         [
                             "Validating query FAILED.",
                             errors.MSG_WHY_FROM_EXCEPTION(e),
-                            errors.MSG_CONSEQUENCE_DELEGATING_TO_CALLER__LIKELY_EXECUTION_FAILURE,
-                            errors.MSG_COUNTERMEASURE_FIX_PARENT_EXCEPTION,
                         ]
                     )
                 )

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_router.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_router.py
@@ -87,7 +87,6 @@ class IngesterRouter(IIngesterRegistry, IIngester):
                 VdkConfigurationError(
                     "Provided method, {method}, has invalid value.",
                     "VDK was run with method={method}, however {method} is not part of the available ingestion mechanisms.",
-                    errors.MSG_CONSEQUENCE_DELEGATING_TO_CALLER__LIKELY_EXECUTION_FAILURE,
                     f"Provide either valid value for method, or install ingestion plugin that supports this type. "
                     f"Currently possible values are {list(self._ingester_builders.keys())}",
                 )
@@ -177,7 +176,6 @@ class IngesterRouter(IIngesterRegistry, IIngester):
                 VdkConfigurationError(
                     f"Could not create new ingester plugin of type {method}.",
                     f"VDK was run with method={method}, however no valid ingester plugin was created.",
-                    errors.MSG_CONSEQUENCE_DELEGATING_TO_CALLER__LIKELY_EXECUTION_FAILURE,
                     f"Seems to be a bug in the plugin for method {method}. Make sure it's correctly installed. "
                     f"If upgraded recently consider reverting to previous version. Or use another method type.",
                 )
@@ -223,7 +221,6 @@ class IngesterRouter(IIngesterRegistry, IIngester):
                     f"VDK was run with method={method}, however "
                     "no valid ingestion processor plugin was "
                     "created.",
-                    errors.MSG_CONSEQUENCE_DELEGATING_TO_CALLER__LIKELY_EXECUTION_FAILURE,
                     "Seems to be a bug in the plugin for method"
                     f" {method}. Make sure it's correctly "
                     f"installed. If upgraded recently, consider"
@@ -257,9 +254,6 @@ class IngesterRouter(IIngesterRegistry, IIngester):
                 f"On close some following ingest queues types reported errors:  {list(errors_list.keys())}.",
                 f"There were errors while closing ingestion. Exceptions were: {errors_list}.",
                 "Some data was partially ingested or not ingested at all.",
-                "Follow the instructions in the error messages and log warnings. "
-                "Make sure to inspect any errors or warning logs generated"
-                "Re-try the job if necessary",
             ]
 
             if any(

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/job_properties/properties_router.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/job_properties/properties_router.py
@@ -92,7 +92,6 @@ class PropertiesRouter(IPropertiesRegistry, IProperties):
                 errors.VdkConfigurationError(
                     f"properties default type was configured to be {properties_type} "
                     f"no such properties api implementation has been registered",
-                    f"",
                     f"Check if the job has not been mis-configured - for example misspelling error. "
                     f"See config-help for help on configuration. Existing properties types are: {list(self.__properties_builders.keys())} "
                     f"Alternatively make sure the correct plugin has been installed "

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/job_secrets/secrets_router.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/job_secrets/secrets_router.py
@@ -90,7 +90,6 @@ class SecretsRouter(ISecretsRegistry, ISecrets):
                 errors.VdkConfigurationError(
                     f"secrets default type was configured to be {secrets_type} "
                     "no such secrets api implementation has been registered",
-                    "",
                     "Check if the job has not been mis-configured - for example misspelling error. "
                     f"See config-help for help on configuration. Existing secrets types are: {list(self.__secrets_builders.keys())} "
                     "Alternatively make sure the correct plugin has been installed "

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/cli_run.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/cli_run.py
@@ -45,8 +45,6 @@ class CliRunImpl:
                     [
                         "Failed to validate job arguments.",
                         errors.MSG_WHY_FROM_EXCEPTION(e),
-                        errors.MSG_CONSEQUENCE_TERMINATING_APP,
-                        errors.MSG_COUNTERMEASURE_FIX_PARENT_EXCEPTION,
                     ]
                 )
             )
@@ -104,14 +102,16 @@ class CliRunImpl:
                     log.warning(
                         f"""
                         {os.linesep + (' ' * 20) + ('*' * 80)}
-                        What: Python version mismatch between local python and configure python.
-                        Why: The Python version specified in the job's config.ini file  is ({configured_python_version})
+                        Python version mismatch between local python and configure python.
+                        The Python version specified in the job's config.ini file  is ({configured_python_version})
                         while the local python version used to execute the data job is ({local_py_version}).
-                        Consequences: Developing a data job using one Python version and deploying
+
+                        Developing a data job using one Python version and deploying
                         it with a different version can result in unexpected and
                         difficult-to-troubleshoot errors like module incompatibilities, or
                         unexpected behavior during execution.
-                        Countermeasures: To resolve this issue, ensure that the Python version
+
+                        To resolve this issue, ensure that the Python version
                         specified in the python_version property of the config.ini file matches
                         the Python version of your execution environment by either editing the
                         python_version property in config.ini, or switching local environment
@@ -165,10 +165,8 @@ class CliRunImpl:
                     [
                         "Failed executing job.",
                         errors.MSG_WHY_FROM_EXCEPTION(e),
-                        errors.MSG_CONSEQUENCE_TERMINATING_APP,
-                        errors.MSG_COUNTERMEASURE_FIX_PARENT_EXCEPTION
-                        + " Most likely a prerequisite or plugin of one of the key VDK components failed, see"
-                        + " logs for details and ensure the prerequisite for the failed component (details in stacktrace).",
+                        " Most likely a prerequisite or plugin of one of the key VDK components failed, see"
+                        + " logs for details and ensure the prerequisite for the failed component.",
                     ]
                 )
             )

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/data_job.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/data_job.py
@@ -121,7 +121,6 @@ class DataJobDefaultHookImplPlugin:
                 errors.UserCodeError(
                     "Data Job execution has failed.",
                     "Data Job has no steps.",
-                    "Data job execution will not continue.",
                     "Please include at least 1 valid step in your Data Job. Also make sure you are passing the correct data job directory.",
                 )
             )

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/file_based_step.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/file_based_step.py
@@ -88,10 +88,8 @@ class StepFuncFactory:
                         [
                             "Failed loading job sources of %s" % filename,
                             errors.MSG_WHY_FROM_EXCEPTION(e),
-                            errors.MSG_CONSEQUENCE_TERMINATING_APP,
-                            errors.MSG_COUNTERMEASURE_FIX_PARENT_EXCEPTION
-                            + " Most likely importing a dependency or data job step failed, see"
-                            + " logs for details and fix the failed step (details in stacktrace).",
+                            " Most likely importing a dependency or data job step failed, see"
+                            + " logs for details and fix the failed step.",
                         ]
                     )
                 )

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/templates/template_impl.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/templates/template_impl.py
@@ -77,7 +77,6 @@ class TemplatesImpl(ITemplateRegistry, ITemplate):
                 errors.UserCodeError(
                     f"No registered template with name: {name}.",
                     "Template with that name has not been registered",
-                    errors.MSG_CONSEQUENCE_DELEGATING_TO_CALLER__LIKELY_EXECUTION_FAILURE,
                     "Make sure you have not misspelled the name of the template "
                     "or the plugin(s) providing the template is installed. "
                     f"Current list of templated is: {list(self._registered_templates.keys())}",

--- a/projects/vdk-core/src/vdk/internal/core/errors.py
+++ b/projects/vdk-core/src/vdk/internal/core/errors.py
@@ -10,6 +10,8 @@ It defines classes and methods for handling exceptions, and ensuring that there 
 """
 from __future__ import annotations
 
+from logging import Logger
+
 from vdk.internal.core.error_classifiers import *
 
 # Due to the expansion of this file's responsibilities over time,

--- a/projects/vdk-core/src/vdk/internal/plugin/plugin.py
+++ b/projects/vdk-core/src/vdk/internal/plugin/plugin.py
@@ -97,19 +97,15 @@ class PluginRegistry(IPluginRegistry):
                     f"Failed to register plugin {name}. Most likely the plugin name has been forbidden"
                 )
         except Exception as e:
-            message = ErrorMessage(
-                summary=f"Failed to load plugin ",
-                what=f"Failed to load plugin with name  '{name}' and module/class '{module_or_class_with_hook_impls}'",
-                why="Most likely a bug in the plugin",
-                consequences="The CLI tool will likely abort.",
-                countermeasures="Re-try again. "
-                "Revert to previous stable version of the plugin or CLI "
-                "plugin (pip install vdk-plugin-name==version) "
-                "Or see what plugins are installed (use `pip list` command) and if "
-                "there are not issues. "
-                "Or try to reinstall the app in a new clean environment  ",
-            )
-            raise PluginException(message) from e
+            raise PluginException(
+                f"""Failed to load plugin
+                Failed to load plugin with name  '{name}' and module/class '{module_or_class_with_hook_impls}'
+                Troubleshooting options:
+                1. Check what plugins are installed (use `pip list` command) and see if there are any issues.
+                2. Revert to previous stable version of the plugin or CLI plugin (pip install vdk-plugin-name==version)
+                3. Reinstall the app in a new clean environment
+                """
+            ) from e
 
     def add_hook_specs(self, module_or_class_with_hookspecs: object):
         self.__plugin_manager.add_hookspecs(module_or_class_with_hookspecs)


### PR DESCRIPTION
## Why

As part of the run logs initiative, we should audit all log statements and error messages in vdk-core and make sure there aren't any redundancies, e.g. overly verbose messages or messages that don't add value.

## What

Remove usage of the below constants wherever possible

```
MSG_CONSEQUENCE_DELEGATING_TO_CALLER__LIKELY_EXECUTION_FAILURE
MSG_COUNTERMEASURE_FIX_PARENT_EXCEPTION 
MSG_CONSEQUENCE_TERMINATING_APP
```

Re-word log statements and exception messages that are too verbose

## How was this tested?

CI

## What kind of change is this?

Feature/non-breaking