### PR TITLE
vdk-data-sources: add DataFlowInput API

### DIFF
--- a/projects/vdk-plugins/vdk-data-sources/README.md
+++ b/projects/vdk-plugins/vdk-data-sources/README.md
@@ -48,7 +48,7 @@ def run(job_input: IJobInput):
     destination = DestinationDefinition(id="auto-dest", method="memory")
 
     with DataFlowInput(job_input) as flow_input:
-        flow_input.start(source, destination)
+        flow_input.start(DataFlowMappingDefinition(source, destination))
 ```
 
 or in config.toml file
@@ -66,7 +66,7 @@ to="auto-dest"
 ```python
 def run(job_input: IJobInput):
     with DataFlowInput(job_input) as flow_input:
-        flow_input.start_flow(toml_parser.load_config("config.toml"))
+        flow_input.start_flows(toml_parser.load_config("config.toml"))
 ```
 
 ### Build and testing

--- a/projects/vdk-plugins/vdk-data-sources/README.md
+++ b/projects/vdk-plugins/vdk-data-sources/README.md
@@ -38,6 +38,37 @@ State: Contains the state of the data soruce stream as of this payload. For exam
 
 To build your own data source you can use [this data source](./src/vdk/plugin/data_sources/auto_generated.py) as an example or reference
 
+To register the source use [vdk_data_sources_register hook](./src/vdk/plugin/data_sources/hook_spec.py)
+
+Then you can use it in a data job like this:
+
+```python
+def run(job_input: IJobInput):
+    source = SourceDefinition(id="auto", name="auto-generated-data", config={})
+    destination = DestinationDefinition(id="auto-dest", method="memory")
+
+    with DataFlowInput(job_input) as flow_input:
+        flow_input.start(source, destination)
+```
+
+or in config.toml file
+```toml
+[sources.auto]
+name="auto-generated-data"
+config={}
+[destinations.auto-dest]
+method="memory"
+[[flows]]
+from="auto"
+to="auto-dest"
+```
+
+```python
+def run(job_input: IJobInput):
+    with DataFlowInput(job_input) as flow_input:
+        flow_input.start_flow(toml_parser.load_config("config.toml"))
+```
+
 ### Build and testing
 
 ```

--- a/projects/vdk-plugins/vdk-data-sources/setup.py
+++ b/projects/vdk-plugins/vdk-data-sources/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     description="Enables Versatile Data Kit (VDK) to integrate with various data sources by providing a unified interface for data ingestion and management.",
     long_description=pathlib.Path("README.md").read_text(),
     long_description_content_type="text/markdown",
-    install_requires=["vdk-core"],
+    install_requires=["vdk-core", "toml"],
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="src"),
     # This is the only vdk plugin specifc part

--- a/projects/vdk-plugins/vdk-data-sources/src/vdk/plugin/data_sources/mapping/data_flow.py
+++ b/projects/vdk-plugins/vdk-data-sources/src/vdk/plugin/data_sources/mapping/data_flow.py
@@ -1,0 +1,68 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from vdk.api.job_input import IJobInput
+from vdk.plugin.data_sources.factory import SingletonDataSourceFactory
+from vdk.plugin.data_sources.ingester import DataSourceIngester
+from vdk.plugin.data_sources.ingester import IngestDestination
+from vdk.plugin.data_sources.mapping.definitions import Definitions
+from vdk.plugin.data_sources.mapping.definitions import DestinationDefinition
+from vdk.plugin.data_sources.mapping.definitions import SourceDefinition
+
+
+class DataFlowInput:
+    """
+    Manages the data flow from source to destination using the provided job input.
+
+    :param job_input: Instance of IJobInput, providing context for the current job.
+    """
+
+    def __init__(self, job_input: IJobInput):
+        self._job_input = job_input
+        self._data_source_ingester = DataSourceIngester(job_input)
+        self._data_source_factory = SingletonDataSourceFactory()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def close(self):
+        """
+        Terminates and waits for data source ingestion to finish.
+        """
+        self._data_source_ingester.terminate_and_wait_to_finish()
+        self._data_source_ingester.raise_on_error()
+
+    def start(
+        self,
+        source_definition: SourceDefinition,
+        destination_definition: DestinationDefinition,
+    ):
+        """
+        Start data flow from a specific source to a specific destination.
+
+        :param source_definition: The definition of the source.
+        :param destination_definition: The definition of the destination.
+        """
+        source = self._data_source_factory.create_data_source(source_definition.name)
+        source_config = self._data_source_factory.create_configuration(
+            source_definition.name, source_definition.config
+        )
+        source.configure(source_config)
+
+        destination = IngestDestination(
+            method=destination_definition.method, target=destination_definition.target
+        )
+        self._data_source_ingester.start_ingestion(
+            source_definition.id, source, [destination]
+        )
+
+    def start_flow(self, definitions: Definitions):
+        """
+        Start data flows based on a list of defined mappings.
+
+        :param definitions: Definitions containing the data flow mappings.
+        """
+        for d in definitions.flows:
+            self.start(d.from_source, d.to_destination)

--- a/projects/vdk-plugins/vdk-data-sources/src/vdk/plugin/data_sources/mapping/definitions.py
+++ b/projects/vdk-plugins/vdk-data-sources/src/vdk/plugin/data_sources/mapping/definitions.py
@@ -1,0 +1,72 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from vdk.plugin.data_sources.ingester import DataSourceIngester
+
+
+@dataclass
+class SourceDefinition:
+    """
+    SourceDefinition class that defines the metadata and configuration for a data source.
+
+    :param id: User provided identifier for the source "instance" which can be used to refer to that source later
+    :param name: The name of the source. Must be the same name as the DataSource has been registered with (see vdk data-sources --list)
+    :param config: The configuration for the source. Refer to documented data source config options (see vdk data-sources --config).
+    """
+
+    id: str
+    name: str
+    config: Dict[str, Any] = field(default_factory=dict)
+    # TODO might be good idea to include initial state for first run
+    # initial_state: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class DestinationDefinition:
+    """
+    Describes the attributes and methods for a data destination.
+
+    :param id: User provided identifier for the destination "instance" which can be used to refer to that source later.
+    :param method: The ingestion method. Refer to IIngester for more information .
+    :param target: The ingestion target. Refer to IIngester for more information .
+    """
+
+    id: str
+    method: str
+    target: Optional[str] = None
+    # TODO: config when destination targets support being passed configs
+
+
+@dataclass
+class DataFlowMappingDefinition:
+    """
+    Defines how data flows from a source to a destination and the optional transformation in between.
+
+    :param from_source: The source definition from where data originates.
+    :param to_destination: The destination definition where data will be sent.
+    """
+
+    from_source: SourceDefinition
+    to_destination: DestinationDefinition
+    # TODO add configuration for mappings tables and columns or function
+
+
+@dataclass
+class Definitions:
+    """
+    Aggregates all the source, destination, and flow definitions for an ingestion pipeline.
+
+    :param sources: Dictionary of source definitions.
+    :param destinations: Dictionary of destination definitions.
+    :param flows: List of data flow mapping definitions.
+    """
+
+    sources: Dict[str, SourceDefinition]
+    destinations: Dict[str, DestinationDefinition]
+    flows: List[DataFlowMappingDefinition]

--- a/projects/vdk-plugins/vdk-data-sources/src/vdk/plugin/data_sources/mapping/definitions.py
+++ b/projects/vdk-plugins/vdk-data-sources/src/vdk/plugin/data_sources/mapping/definitions.py
@@ -3,10 +3,12 @@
 from dataclasses import dataclass
 from dataclasses import field
 from typing import Any
+from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
 
+from vdk.plugin.data_sources.data_source import DataSourcePayload
 from vdk.plugin.data_sources.ingester import DataSourceIngester
 
 
@@ -50,10 +52,15 @@ class DataFlowMappingDefinition:
 
     :param from_source: The source definition from where data originates.
     :param to_destination: The destination definition where data will be sent.
+    :param map_function: An optional callable to transform data as it moves from source to destination.
+                It accepts a payload and returns a payload or None. Returning None means skippping the payload ingestion!
     """
 
     from_source: SourceDefinition
     to_destination: DestinationDefinition
+    map_function: Optional[
+        Callable[[DataSourcePayload], Optional[DataSourcePayload]]
+    ] = None
     # TODO add configuration for mappings tables and columns or function
 
 

--- a/projects/vdk-plugins/vdk-data-sources/src/vdk/plugin/data_sources/mapping/toml_parser.py
+++ b/projects/vdk-plugins/vdk-data-sources/src/vdk/plugin/data_sources/mapping/toml_parser.py
@@ -1,0 +1,52 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from dataclasses import fields
+from dataclasses import is_dataclass
+from typing import Any
+from typing import Dict
+from typing import Type
+from typing import TypeVar
+
+import toml
+from vdk.plugin.data_sources.mapping.definitions import DataFlowMappingDefinition
+from vdk.plugin.data_sources.mapping.definitions import Definitions
+from vdk.plugin.data_sources.mapping.definitions import DestinationDefinition
+from vdk.plugin.data_sources.mapping.definitions import SourceDefinition
+
+T = TypeVar("T")
+
+
+def definitions_from_dict(data: Dict) -> Definitions:
+    sources = {
+        k: SourceDefinition(id=k, **v) for k, v in data.get("sources", {}).items()
+    }
+    destinations = {
+        k: DestinationDefinition(id=k, **v)
+        for k, v in data.get("destinations", {}).items()
+    }
+    flows_list = []
+    for flow in data.get("flows", []):
+        if flow["from"] not in sources:
+            raise ValueError(
+                f"Data source {flow['from']} is not defined and cannot be used in a flow.\n"
+                f"Please define it first in the [sources] section of the configuration.\n"
+                f"Currenty defined surces: {list(sources.keys())}"
+            )
+        if flow["to"] not in destinations:
+            raise ValueError(
+                f"Data destination {flow['to']} is not defined and cannot be used in a flow.\n"
+                f"Please define it first in the [destinations] section of the configuration.\n"
+                f"Currenty defined destinations: {list(destinations.keys())}"
+            )
+
+        flow_obj = DataFlowMappingDefinition(
+            from_source=sources[flow["from"]], to_destination=destinations[flow["to"]]
+        )
+        flows_list.append(flow_obj)
+
+    return Definitions(sources=sources, destinations=destinations, flows=flows_list)
+
+
+def load_config(file_path: str) -> Definitions:
+    parsed_toml = toml.load(file_path)
+    return definitions_from_dict(parsed_toml)

--- a/projects/vdk-plugins/vdk-data-sources/src/vdk/plugin/data_sources/plugin_entry.py
+++ b/projects/vdk-plugins/vdk-data-sources/src/vdk/plugin/data_sources/plugin_entry.py
@@ -36,6 +36,9 @@ class DataSourcesPlugin:
                 )
 
 
+# TODO: add ingest.toml type of job step which would automatically execute ingestion flows declared in TOML wihtout any python code
+
+
 @hookimpl
 def vdk_start(plugin_registry: IPluginRegistry, command_line_args: List):
     plugin_registry.add_hook_specs(DataSourcesHookSpec)

--- a/projects/vdk-plugins/vdk-data-sources/tests/functional/jobs/ingest-data-flow-job/step.py
+++ b/projects/vdk-plugins/vdk-data-sources/tests/functional/jobs/ingest-data-flow-job/step.py
@@ -1,0 +1,14 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from vdk.api.job_input import IJobInput
+from vdk.plugin.data_sources.mapping.data_flow import DataFlowInput
+from vdk.plugin.data_sources.mapping.definitions import DestinationDefinition
+from vdk.plugin.data_sources.mapping.definitions import SourceDefinition
+
+
+def run(job_input: IJobInput):
+    source = SourceDefinition(id="auto", name="auto-generated-data", config={})
+    destination = DestinationDefinition(id="auto-dest", method="memory")
+
+    with DataFlowInput(job_input) as flow_input:
+        flow_input.start(source, destination)

--- a/projects/vdk-plugins/vdk-data-sources/tests/functional/jobs/ingest-data-flow-map-func-job/step.py
+++ b/projects/vdk-plugins/vdk-data-sources/tests/functional/jobs/ingest-data-flow-map-func-job/step.py
@@ -1,6 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 from vdk.api.job_input import IJobInput
+from vdk.plugin.data_sources.data_source import DataSourcePayload
 from vdk.plugin.data_sources.mapping.data_flow import DataFlowInput
 from vdk.plugin.data_sources.mapping.definitions import DataFlowMappingDefinition
 from vdk.plugin.data_sources.mapping.definitions import DestinationDefinition
@@ -11,5 +12,9 @@ def run(job_input: IJobInput):
     source = SourceDefinition(id="auto", name="auto-generated-data", config={})
     destination = DestinationDefinition(id="auto-dest", method="memory")
 
+    def map_func(p: DataSourcePayload):
+        p.data["new_column"] = "new_column"
+        return p
+
     with DataFlowInput(job_input) as flow_input:
-        flow_input.start(DataFlowMappingDefinition(source, destination))
+        flow_input.start(DataFlowMappingDefinition(source, destination, map_func))

--- a/projects/vdk-plugins/vdk-data-sources/tests/functional/jobs/ingest-data-flow-toml-job/ingest.toml
+++ b/projects/vdk-plugins/vdk-data-sources/tests/functional/jobs/ingest-data-flow-toml-job/ingest.toml
@@ -1,0 +1,9 @@
+[sources.s1]
+name="auto-generated-data"
+
+[destinations.d1]
+method="memory"
+
+[[flows]]
+from="s1"
+to="d1"

--- a/projects/vdk-plugins/vdk-data-sources/tests/functional/jobs/ingest-data-flow-toml-job/step.py
+++ b/projects/vdk-plugins/vdk-data-sources/tests/functional/jobs/ingest-data-flow-toml-job/step.py
@@ -1,0 +1,16 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import os
+
+from vdk.api.job_input import IJobInput
+from vdk.plugin.data_sources.mapping import toml_parser
+from vdk.plugin.data_sources.mapping.data_flow import DataFlowInput
+
+
+def run(job_input: IJobInput):
+    with DataFlowInput(job_input) as flow_input:
+        flow_input.start_flows(
+            toml_parser.load_config(
+                os.path.join(job_input.get_job_directory(), "ingest.toml")
+            )
+        )

--- a/projects/vdk-plugins/vdk-data-sources/tests/functional/test_run_ingest_sources.py
+++ b/projects/vdk-plugins/vdk-data-sources/tests/functional/test_run_ingest_sources.py
@@ -49,6 +49,22 @@ def test_run_ingest_data_flow_sources_toml():
     assert len(ingest_plugin.payloads) > 0
 
 
+def test_run_ingest_data_flow_with_map_function():
+    ingest_plugin = IngestIntoMemoryPlugin()
+    runner = CliEntryBasedTestRunner(ingest_plugin, plugin_entry)
+
+    result: Result = runner.invoke(
+        ["run", jobs_path_from_caller_directory("ingest-data-flow-map-func-job")]
+    )
+
+    cli_assert_equal(0, result)
+
+    assert ingest_plugin.payloads[0].payload == [
+        {"id": 1, "name": "Stream_0_Name_0", "new_column": "new_column", "stream": 0},
+        {"id": 2, "name": "Stream_0_Name_1", "new_column": "new_column", "stream": 0},
+    ]
+
+
 def test_run_ingest_sources_error_no_such_method():
     runner = CliEntryBasedTestRunner(plugin_entry)
 

--- a/projects/vdk-plugins/vdk-data-sources/tests/functional/test_run_ingest_sources.py
+++ b/projects/vdk-plugins/vdk-data-sources/tests/functional/test_run_ingest_sources.py
@@ -36,6 +36,19 @@ def test_run_ingest_data_flow_sources():
     assert len(ingest_plugin.payloads) > 0
 
 
+def test_run_ingest_data_flow_sources_toml():
+    ingest_plugin = IngestIntoMemoryPlugin()
+    runner = CliEntryBasedTestRunner(ingest_plugin, plugin_entry)
+
+    result: Result = runner.invoke(
+        ["run", jobs_path_from_caller_directory("ingest-data-flow-toml-job")]
+    )
+
+    cli_assert_equal(0, result)
+
+    assert len(ingest_plugin.payloads) > 0
+
+
 def test_run_ingest_sources_error_no_such_method():
     runner = CliEntryBasedTestRunner(plugin_entry)
 

--- a/projects/vdk-plugins/vdk-data-sources/tests/mapping/test_toml_parser.py
+++ b/projects/vdk-plugins/vdk-data-sources/tests/mapping/test_toml_parser.py
@@ -1,0 +1,88 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import toml
+from vdk.plugin.data_sources.mapping.definitions import DataFlowMappingDefinition
+from vdk.plugin.data_sources.mapping.definitions import Definitions
+from vdk.plugin.data_sources.mapping.definitions import DestinationDefinition
+from vdk.plugin.data_sources.mapping.definitions import SourceDefinition
+from vdk.plugin.data_sources.mapping.toml_parser import definitions_from_dict
+
+
+def write_tmp_toml(tmp_path, content):
+    p = tmp_path / "config.toml"
+    p.write_text(content)
+    return p
+
+
+def test_empty_toml_file(tmp_path):
+    p = write_tmp_toml(tmp_path, "")
+    parsed_toml = toml.load(p)
+    assert definitions_from_dict(parsed_toml) == Definitions({}, {}, [])
+
+
+def sample_toml_data():
+    return """
+    [sources.source1]
+    name = "source_one"
+    config = { key = "value" }
+
+    [sources.source2]
+    name = "source_two"
+    config = { key = "value2" }
+
+    [destinations.dest1]
+    method = "POST"
+    target = "target_one"
+
+    [destinations.dest2]
+    method = "GET"
+    target = "target_two"
+
+    [[flows]]
+    from="source1"
+    to="dest1"
+    [[flows]]
+    from="source2"
+    to="dest2"
+    """
+
+
+def get_expected():
+    s1 = SourceDefinition("source1", "source_one", {"key": "value"})
+    s2 = SourceDefinition("source2", "source_two", {"key": "value2"})
+    d1 = DestinationDefinition("dest1", "POST", "target_one")
+    d2 = DestinationDefinition("dest2", "GET", "target_two")
+    return Definitions(
+        sources={
+            "source1": s1,
+            "source2": s2,
+        },
+        destinations={
+            "dest1": d1,
+            "dest2": d2,
+        },
+        flows=[DataFlowMappingDefinition(s1, d1), DataFlowMappingDefinition(s2, d2)],
+    )
+
+
+def test_load_config_ingest_definitions(tmp_path):
+    p = write_tmp_toml(tmp_path, sample_toml_data())
+    parsed_toml = toml.load(p)
+    assert definitions_from_dict(parsed_toml) == get_expected()
+
+
+def test_only_sources(tmp_path):
+    data = """
+    sources.source1.name = "source_one"
+    sources.source1.config = { key = "value" }
+    """
+    p = write_tmp_toml(tmp_path, data)
+    parsed_toml = toml.load(p)
+    expected = Definitions(
+        sources={
+            "source1": SourceDefinition("source1", "source_one", {"key": "value"})
+        },
+        destinations={},
+        flows=[],
+    )
+    assert definitions_from_dict(parsed_toml) == expected


### PR DESCRIPTION
Data source can be used in this way:

```python
def run(job_input: IJobInput):
    source = SourceDefinition(id="auto", name="auto-generated-data", config={})
    destination = DestinationDefinition(id="auto-dest", method="memory")

    with DataFlowInput(job_input) as flow_input:
        flow_input.start(source, destination)
```

or in config.toml file
```toml
[sources.auto]
name="auto-generated-data"
config={}
[destinations.auto-dest]
method="memory"
[[flows]]
from="auto"
to="auto-dest"
```

```python
def run(job_input: IJobInput):
    with DataFlowInput(job_input) as flow_input:
        flow_input.start_flow(toml_parser.load_config("config.toml"))
```