### PR TITLE
vdk-core: create config option for logging execution result

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/vdk_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/vdk_config.py
@@ -21,6 +21,7 @@ LOG_CONFIG = "LOG_CONFIG"
 LOG_LEVEL_VDK = "LOG_LEVEL_VDK"
 LOG_LEVEL_MODULE = "LOG_LEVEL_MODULE"
 LOG_STACK_TRACE_ON_EXIT = "LOG_STACK_TRACE_ON_EXIT"
+LOG_EXECUTION_RESULT = "LOG_EXECUTION_RESULT"
 LOG_EXCEPTION_FORMATTER = "LOG_EXCEPTION_FORMATTER"
 WORKING_DIR = "WORKING_DIR"
 ATTEMPT_ID = "ATTEMPT_ID"
@@ -93,6 +94,13 @@ class CoreConfigDefinitionPlugin:
             False,
             True,
             "Controls whether the full stack trace is displayed again on exit code 1. "
+            "False by default, shoud be set to true in production environments for more debug output. ",
+        )
+        config_builder.add(
+            LOG_EXECUTION_RESULT,
+            False,
+            True,
+            "Controls whether the job execution result is logged on job completion. "
             "False by default, shoud be set to true in production environments for more debug output. ",
         )
         config_builder.add(


### PR DESCRIPTION
## Why?

User reasearch indicates that the execution result is too verbose for local runs. Users don't expect a lot of output for successful jobs and expect error output for failing jobs.

## What?

Introduce the LOG_EXECUTION_RESULT config option that enables/disables displaying the end result. Enabling and disabling the end result will be implemented in a separate PR. 

https://github.com/vmware/versatile-data-kit/pull/2831

## How was this tested?

CI

## What kind of change is this?

Feature/non-breaking