### PR TITLE
control-service: update ingress

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/ingress.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/ingress.yaml
@@ -11,10 +11,14 @@ metadata:
   annotations: {{- toYaml .Values.ingress.annotations | nindent 4 }}
 apiVersion: networking.k8s.io/v1
 spec:
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+{{- end }}
   rules:
   - host: {{ .Values.ingress.host | quote }}
     http:
       paths:
+{{- if .Values.operationsUi.enabled }}
       - path: {{ .Values.ingress.path | default "/" }}
         pathType: "ImplementationSpecific"
         backend:
@@ -22,6 +26,7 @@ spec:
             name: {{ .Release.Name }}-ui
             port:
               number: 8091
+{{- end }}
       - path: {{ .Values.ingress.path | default "/data-jobs" }}
         pathType: "ImplementationSpecific"
         backend:

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -115,6 +115,8 @@ ingress:
   ## we use community Nginx controller which supports SNI, thus a signle IP could terminate all connections.
   ## https://github.com/kubernetes/ingress-nginx/
   tls_secret: ""
+  ## It is used to associate an Ingress resource with a specific Ingress controller or implementation.
+  className: ""
 
 # Embedded server settings
 server:


### PR DESCRIPTION
Why
Currently, there is no way to exclude the user interface (UI) from the Ingress configuration.

What
To address this issue, we introduced a new check within the Ingress configuration. This check allows for determining whether the UI is enabled or not

Testing done:
helm template

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com