### PR TITLE
control-service: reduce logging

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
@@ -227,7 +227,7 @@ public class DataJobsKubernetesService extends KubernetesService {
       if (e.getCode()
           == 404) { // as soon as the minimum supported k8s version is >=1.21 then we should remove
         // this.
-        log.debug("Unable to query for v1 batch jobs", e);
+        log.trace("Unable to query for v1 batch jobs", e);
       } else {
         throw e;
       }


### PR DESCRIPTION
```
2023-11-01 09:11:34,975 DEBUG [OpId:] thread-5   .t.s.k.DataJobsKubernetesService Unable to query for v1 batch jobs
io.kubernetes.client.openapi.ApiException:
	at io.kubernetes.client.openapi.ApiClient.handleResponse(ApiClient.java:973)
	at io.kubernetes.client.openapi.ApiClient.execute(ApiClient.java:885)
	at io.kubernetes.client.openapi.apis.BatchV1Api.listNamespacedCronJobWithHttpInfo(BatchV1Api.java:3986)
	at io.kubernetes.client.openapi.apis.BatchV1Api.listNamespacedCronJob(BatchV1Api.java:3875)
	at com.vmware.taurus.service.kubernetes.DataJobsKubernetesService.listCronJobs(DataJobsKubernetesService.java:219)
	at com.vmware.taurus.service.deploy.DeploymentServiceV2.findAllActualDeploymentNamesFromKubernetes(DeploymentServiceV2.java:229)
	at com.vmware.taurus.service.deploy.DeploymentServiceV2$$FastClassBySpringCGLIB$$ce2e2cd7.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:793)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763)
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763)
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:708)
	at com.vmware.taurus.service.deploy.DeploymentServiceV2$$EnhancerBySpringCGLIB$$1468a1ee.findAllActualDeploymentNamesFromKubernetes(<generated>)
	at com.vmware.taurus.service.deploy.DataJobsSynchronizer.synchronizeDataJobs(DataJobsSynchronizer.java:86)
	at com.vmware.taurus.service.deploy.DataJobsSynchronizer$$FastClassBySpringCGLIB$$724b43b7.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:793)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763)
	at net.javacrumbs.shedlock.core.DefaultLockingTaskExecutor.executeWithLock(DefaultLockingTaskExecutor.java:72)
	at net.javacrumbs.shedlock.spring.aop.MethodProxyScheduledLockAdvisor$LockingInterceptor.invoke(MethodProxyScheduledLockAdvisor.java:83)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763)
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:708)
	at com.vmware.taurus.service.deploy.DataJobsSynchronizer$$EnhancerBySpringCGLIB$$f1e3e051.synchronizeDataJobs(<generated>)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:84)
	at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com