### PR TITLE
vdk-jupyterlab-extensions: update dependencies

### DIFF
--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/pyproject.toml
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/pyproject.toml
@@ -26,8 +26,8 @@ dependencies = [
     "jupyter_server>=1.6,<3",
     "jupyterlab==3.6.3",
     "traitlets==5.9.0",
-    "vdk-control-cli",
-    "vdk-core"
+    "vdk-control-cli>=1.0.11",
+    "vdk-core>=0.3.1057638781"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 


### PR DESCRIPTION
# What

Upgrade dependencies so a build will will always create a runnnable jupyter lab. 

# How was this tested?
Tested the build locally and everything works good. 