### PR TITLE
support: update the ci notification

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ end:
 notify_failure:
   stage: end
   script:
-    - ./cicd/notify.sh "The pipeline for the $CI_COMMIT_BRANCH branch has failed.\nPlease take the necessary steps to fix it. https://gitlab.com/vmware-analytics/versatile-data-kit/-/pipelines/$CI_PIPELINE_ID" $VDK_SLACK_NOTIFICATION_HOOK
+    - ./cicd/notify.sh "https://gitlab.com/vmware-analytics/versatile-data-kit/-/pipelines/$CI_PIPELINE_ID \nThe pipeline for the $CI_COMMIT_BRANCH branch has failed.\nPlease take the necessary steps to fix it and document the resolution\n$VDK_CI_FAILURES_PAGE" $VDK_SLACK_NOTIFICATION_HOOK
   allow_failure: true
   rules:
     - if: '$CI_COMMIT_BRANCH != "main"'


### PR DESCRIPTION
## Why?

VDK team recently started tracking CI failures and resolutions

## What?

Add the resolutions page link to the CI failure Slack notification for convenience

## How was this tested?

Dry run in CI https://gitlab.com/vmware-analytics/versatile-data-kit/-/pipelines/1070030579

![Screenshot 2023-11-13 at 12 24 42](https://github.com/vmware/versatile-data-kit/assets/91800778/0c21646d-28b3-463d-b269-b3a19db72bc4)

## What kind of change is this?

Feature/non-breaking