### PR TITLE
control-service: force aws cred provider refresh

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/credentials/AWSCredentialsService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/credentials/AWSCredentialsService.java
@@ -77,6 +77,7 @@ public class AWSCredentialsService {
           "",
           awsCredentialsServiceConfig.getRegion());
     }
+    credentialsProvider.refresh();
     AWSSessionCredentials serviceAccountCredentials = credentialsProvider.getCredentials();
     var accessKeyId = serviceAccountCredentials.getAWSAccessKeyId();
     var secretAccessKey = serviceAccountCredentials.getAWSSecretKey();


### PR DESCRIPTION
what: Forced the AWS credentials service to refresh credentials before passing them to the data job builder task.

why: Users of the control-service noticed that the job builder task would occasionally fail with 401 unauthorized when attempting to push images to aws ecr repository. Since some builders take longer to build the images, it is possible that a passed valid credential expired during build. As per the aws documentation: "This credentials provider uses a background thread to refresh credentials." though it is unclear when credentials are rotated. Note this behaviour of the provider was changed in a aws update, previously the credentials were generated before every request.

testing: existing tests should cover this.