### PR TITLE
control-service: add pod disruption budget

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/poddisruptionbudget.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/poddisruptionbudget.yaml
@@ -17,3 +17,4 @@ spec:
   minAvailable: {{ .Values.poddisruptionbudget.minAvailable }}
   selector:
     matchLabels: { { - include "pipelines-control-service.selectorLabels" . | nindent 6 } }
+  {{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/poddisruptionbudget.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/poddisruptionbudget.yaml
@@ -11,7 +11,7 @@ metadata:
     { { - range $key, $value := .Values.poddisruptionbudget.metadata.labels } }
     { { $key } }: { { $value | quote } }
   { { - end } }
-  name: {{ .Release.Name }}-dep
+  name: {{ .Release.Name }}-pdb
   namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: {{ .Values.poddisruptionbudget.minAvailable }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/poddisruptionbudget.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/poddisruptionbudget.yaml
@@ -1,0 +1,19 @@
+{{- /*
+  Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+ */}}
+
+{{- if .Values.poddisruptionbudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels: { { - include "pipelines-control-service.labels" . | nindent 4 } }
+    { { - range $key, $value := .Values.alertmanager.metadata.labels } }
+    { { $key } }: { { $value | quote } }
+  { { - end } }
+  name: {{ .Values.poddisruptionbudget.metadata.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  minAvailable: {{ .Values.poddisruptionbudget.minAvailable }}
+  selector:
+    matchLabels: { { - include "pipelines-control-service.selectorLabels" . | nindent 6 } }

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/poddisruptionbudget.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/poddisruptionbudget.yaml
@@ -11,7 +11,7 @@ metadata:
     { { - range $key, $value := .Values.poddisruptionbudget.metadata.labels } }
     { { $key } }: { { $value | quote } }
   { { - end } }
-  name: {{ .Values.poddisruptionbudget.metadata.name }}
+  name: {{ .Release.Name }}-dep
   namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: {{ .Values.poddisruptionbudget.minAvailable }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/poddisruptionbudget.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/poddisruptionbudget.yaml
@@ -8,7 +8,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels: { { - include "pipelines-control-service.labels" . | nindent 4 } }
-    { { - range $key, $value := .Values.alertmanager.metadata.labels } }
+    { { - range $key, $value := .Values.poddisruptionbudget.metadata.labels } }
     { { $key } }: { { $value | quote } }
   { { - end } }
   name: {{ .Values.poddisruptionbudget.metadata.name }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -1192,13 +1192,13 @@ alertmanager:
 secrets:
     vault:
       enabled: false
-        ## Name of the secret which holds Vault URI and Approle RoleId and SecretId. The chart will not attempt to
-        ## create this, but will use it as is.
-        ## The secret should contain keys: URI, ROLEID, SECRETID
-        externalSecretName: ""
-        ## Alternatively provide the uri and Approle Settings here. externalSecretName takes precedence if both are set.
-        uri: "http://localhost:8200"
-        approle:
-            roleid: foo
-            secretid: foo
-        sizeLimitBytes: "1048576"
+      ## Name of the secret which holds Vault URI and Approle RoleId and SecretId. The chart will not attempt to
+      ## create this, but will use it as is.
+      ## The secret should contain keys: URI, ROLEID, SECRETID
+      externalSecretName: ""
+      ## Alternatively provide the uri and Approle Settings here. externalSecretName takes precedence if both are set.
+      uri: "http://localhost:8200"
+      approle:
+          roleid: foo
+          secretid: foo
+      sizeLimitBytes: "1048576"

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -556,6 +556,15 @@ resources:
       cpu: 500m
       memory: 500Mi
 
+# Specify Pod Disruption Budget  for the Control Service Deployment to allow for higher availability while permitting
+# the cluster administrator to manage the clusters nodes
+# see https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+poddisruptionbudget:
+  enabled: false
+  metadata:
+    name: vdk-control-service-pdb
+  minAvailable: 1
+
 ## [Required] Database configuration used by Control Plane
 ## Database is used to store Data Jobs metadata like name, team, description
 ## and some deploy specific configuration like execution schedule
@@ -1182,7 +1191,7 @@ alertmanager:
 # More information here: https://github.com/vmware/versatile-data-kit/tree/main/specs/vep-1493-vault-integration
 secrets:
     vault:
-        enabled: false
+      enabled: false
         ## Name of the secret which holds Vault URI and Approle RoleId and SecretId. The chart will not attempt to
         ## create this, but will use it as is.
         ## The secret should contain keys: URI, ROLEID, SECRETID

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -563,6 +563,7 @@ poddisruptionbudget:
   enabled: false
   metadata:
     name: vdk-control-service-pdb
+    labels: # additional labels if needed
   minAvailable: 1
 
 ## [Required] Database configuration used by Control Plane

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -562,7 +562,6 @@ resources:
 poddisruptionbudget:
   enabled: false
   metadata:
-    name: vdk-control-service-pdb
     labels: # additional labels if needed
   minAvailable: 1
 


### PR DESCRIPTION
# Why
All for higher Control Service availability while permitting the cluster administrator to manage the clusters nodes.

# What
Add optional configuration for pod disruption budget.
