### PR TITLE
vdk-smarter: pin openai version to 0.28

### DIFF
--- a/projects/vdk-plugins/vdk-smarter/requirements.txt
+++ b/projects/vdk-plugins/vdk-smarter/requirements.txt
@@ -1,7 +1,7 @@
 # this file is used to provide testing requirements
 # for requirements (dependencies) needed during and after installation of the plugin see (and update) setup.py install_requires section
 
-openai
+openai==0.28
 
 pytest
 pytest-httpserver


### PR DESCRIPTION
What: OpenAI introduced v1.0.0 of their Python API library. This new major SDK version comes with some breaking changes. The idea of this change is to pin openai version to 0.28 in order to have green CI/CD pipelines until we migrate.

Why: To fix the pipeline.

Testing Done: locally.

Reference for future migration: https://github.com/openai/openai-python/discussions/742