### PR TITLE
vdk-structlog: LTSV formatting

### DIFF
--- a/projects/vdk-plugins/vdk-structlog/tests/test_structlog.py
+++ b/projects/vdk-plugins/vdk-structlog/tests/test_structlog.py
@@ -31,6 +31,12 @@ STOCK_FIELD_REPRESENTATIONS = {
         "line_number": ":[0-9]+",
         "vdk_job_name": JOB_NAME,
     },
+    "ltsv": {
+        "level": r"level:INFO",
+        "file_name": r"file_name:10_dummy\.py",
+        "line_number": "line_number:[0-9]+",
+        "vdk_job_name": f"job_name:{JOB_NAME}",
+    },
     "json": {
         "level": '"level": "INFO"',
         "file_name": '"filename:":"10_dummy.py"',
@@ -41,8 +47,8 @@ STOCK_FIELD_REPRESENTATIONS = {
 
 
 @pytest.mark.parametrize(
-    "log_format", ["console"]
-)  # TODO: replace with ["console","json"] once the issue where fields can't be excluded in JSON is fixed
+    "log_format", ["console, ltsv"]
+)  # TODO: replace with ["console","ltsv", "json"] once the issue where fields can't be excluded in JSON is fixed
 def test_structlog(log_format):
     with mock.patch.dict(
         os.environ,
@@ -71,8 +77,8 @@ def test_structlog(log_format):
 
 
 @pytest.mark.parametrize(
-    "log_format", ["console"]
-)  # TODO: replace with ["console", "json"] once the issue where fields can't be excluded in JSON is fixed
+    "log_format", ["console", "ltsv"]
+)  # TODO: replace with ["console", "ltsv", "json"] once the issue where fields can't be excluded in JSON is fixed
 def test_stock_fields_removal(log_format):
     stock_field_reps = STOCK_FIELD_REPRESENTATIONS[log_format]
 


### PR DESCRIPTION
This PR incorporates the LTSV formatting which was present in the vdk-logging-format plugin to vdk-structlog, rendering vdk-logging- format unneccessary.

Testing done: unit tests cover LTSV formatting