### PR TITLE
vdk-logging-format: Deprecate plugin

### DIFF
--- a/projects/vdk-plugins/vdk-logging-format/README.md
+++ b/projects/vdk-plugins/vdk-logging-format/README.md
@@ -1,3 +1,5 @@
+# This plugin has been deprecated; please use vdk-structlog instead.
+
 This plugins allows for the configuration of the format of VDK logs.
 
 # TEXT

--- a/projects/vdk-plugins/vdk-logging-format/src/vdk/plugin/logging_format/logging_format.py
+++ b/projects/vdk-plugins/vdk-logging-format/src/vdk/plugin/logging_format/logging_format.py
@@ -79,9 +79,15 @@ def vdk_configure(config_builder: ConfigurationBuilder):
 @hookimpl(tryfirst=True)
 def vdk_start(plugin_registry: IPluginRegistry, command_line_args: List):
     log = logging.getLogger(__name__)
-    log.warning("-------------------------------------------------------------------------")
-    log.warning("Vdk-logging-format has been deprecated; please use vdk-structlog instead.")
-    log.warning("-------------------------------------------------------------------------")
+    log.warning(
+        "-------------------------------------------------------------------------"
+    )
+    log.warning(
+        "Vdk-logging-format has been deprecated; please use vdk-structlog instead."
+    )
+    log.warning(
+        "-------------------------------------------------------------------------"
+    )
 
     logging_format = os.getenv("VDK_LOGGING_FORMAT")
     if (

--- a/projects/vdk-plugins/vdk-logging-format/src/vdk/plugin/logging_format/logging_format.py
+++ b/projects/vdk-plugins/vdk-logging-format/src/vdk/plugin/logging_format/logging_format.py
@@ -78,6 +78,11 @@ def vdk_configure(config_builder: ConfigurationBuilder):
 
 @hookimpl(tryfirst=True)
 def vdk_start(plugin_registry: IPluginRegistry, command_line_args: List):
+    log = logging.getLogger(__name__)
+    log.warning("-------------------------------------------------------------------------")
+    log.warning("Vdk-logging-format has been deprecated; please use vdk-structlog instead.")
+    log.warning("-------------------------------------------------------------------------")
+
     logging_format = os.getenv("VDK_LOGGING_FORMAT")
     if (
         logging_format == "JSON"


### PR DESCRIPTION
This PR deprecates the vdk-logging-format plugin in favour of vdk-structlog.