### PR TITLE
control-service: write resources to db

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudAsyncIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudAsyncIT.java
@@ -59,7 +59,10 @@ public class DataJobDeploymentCrudAsyncIT extends BaseDataJobDeploymentCrudIT {
     Assertions.assertEquals("3.9", jobDeployment.getPythonVersion());
     Assertions.assertEquals("15 10 * * *", jobDeployment.getSchedule().getScheduleCron());
     Assertions.assertFalse(jobDeployment.getEnabled());
-    Assertions.assertNotNull(jobDeployment.getResources());
+    Assertions.assertEquals(1000, jobDeployment.getResources().getMemoryLimit());
+    Assertions.assertEquals(500, jobDeployment.getResources().getMemoryRequest());
+    Assertions.assertEquals(2000, jobDeployment.getResources().getCpuLimit());
+    Assertions.assertEquals(1000, jobDeployment.getResources().getCpuRequest());
     Assertions.assertNotNull(jobDeployment.getJobVersion());
     Assertions.assertNotNull(jobDeployment.getContacts());
   }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobDefaultConfigurations.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobDefaultConfigurations.java
@@ -6,6 +6,8 @@
 package com.vmware.taurus.service.deploy;
 
 import com.vmware.taurus.service.KubernetesService;
+import java.text.NumberFormat;
+import java.text.ParseException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -30,5 +32,33 @@ public class DataJobDefaultConfigurations {
 
   public KubernetesService.Resources dataJobLimits() {
     return new KubernetesService.Resources(cpuLimits, memoryLimits);
+  }
+
+  public float getCpuRequests() throws ParseException {
+    return NumberFormat.getInstance().parse(cpuRequests).floatValue();
+  }
+
+  public float getCpuLimits() throws ParseException {
+    return NumberFormat.getInstance().parse(cpuLimits).floatValue();
+  }
+
+  public int getMemoryRequests() throws ParseException {
+    var memoryRequest = NumberFormat.getInstance().parse(memoryRequests).intValue();
+    return getMemoryInMi(memoryRequests, memoryRequest);
+  }
+
+  public int getMemoryLimits() throws ParseException {
+    var memoryLimit = NumberFormat.getInstance().parse(memoryLimits).intValue();
+    return getMemoryInMi(memoryLimits, memoryLimit);
+  }
+
+  private int getMemoryInMi(String memory, int amount) {
+    if (memory.endsWith("Gi")) {
+      return amount * 1024;
+    }
+    if (memory.endsWith("G")) {
+      return amount * 1000;
+    }
+    return amount;
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobDefaultConfigurations.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobDefaultConfigurations.java
@@ -43,22 +43,12 @@ public class DataJobDefaultConfigurations {
   }
 
   public int getMemoryRequests() throws ParseException {
-    var memoryRequest = NumberFormat.getInstance().parse(memoryRequests).intValue();
-    return getMemoryInMi(memoryRequests, memoryRequest);
+    var memoryAmount = NumberFormat.getInstance().parse(memoryRequests).intValue();
+    return K8SMemoryConversionUtils.getMemoryInMi(memoryRequests, memoryAmount);
   }
 
   public int getMemoryLimits() throws ParseException {
-    var memoryLimit = NumberFormat.getInstance().parse(memoryLimits).intValue();
-    return getMemoryInMi(memoryLimits, memoryLimit);
-  }
-
-  private int getMemoryInMi(String memory, int amount) {
-    if (memory.endsWith("Gi")) {
-      return amount * 1024;
-    }
-    if (memory.endsWith("G")) {
-      return amount * 1000;
-    }
-    return amount;
+    var memoryAmount = NumberFormat.getInstance().parse(memoryLimits).intValue();
+    return K8SMemoryConversionUtils.getMemoryInMi(memoryLimits, memoryAmount);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobDefaultConfigurations.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobDefaultConfigurations.java
@@ -6,8 +6,6 @@
 package com.vmware.taurus.service.deploy;
 
 import com.vmware.taurus.service.KubernetesService;
-import java.text.NumberFormat;
-import java.text.ParseException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -32,23 +30,5 @@ public class DataJobDefaultConfigurations {
 
   public KubernetesService.Resources dataJobLimits() {
     return new KubernetesService.Resources(cpuLimits, memoryLimits);
-  }
-
-  public float getCpuRequests() throws ParseException {
-    return NumberFormat.getInstance().parse(cpuRequests).floatValue();
-  }
-
-  public float getCpuLimits() throws ParseException {
-    return NumberFormat.getInstance().parse(cpuLimits).floatValue();
-  }
-
-  public int getMemoryRequests() throws ParseException {
-    var memoryAmount = NumberFormat.getInstance().parse(memoryRequests).intValue();
-    return K8SMemoryConversionUtils.getMemoryInMi(memoryRequests, memoryAmount);
-  }
-
-  public int getMemoryLimits() throws ParseException {
-    var memoryAmount = NumberFormat.getInstance().parse(memoryLimits).intValue();
-    return K8SMemoryConversionUtils.getMemoryInMi(memoryLimits, memoryAmount);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobDefaultConfigurations.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobDefaultConfigurations.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class DataJobDefaultConfigurations {
 
-  @Value("${datajobs.job.resources.limits.memory:1G}")
+  @Value("${datajobs.job.resources.limits.memory:1000Mi}")
   private String memoryLimits;
 
   @Value("${datajobs.job.resources.limits.cpu:2000m}")

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployerV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployerV2.java
@@ -233,7 +233,8 @@ public class JobImageDeployerV2 {
     return actualJobDeployment;
   }
 
-  private void checkDefaultDeploymentResources(DesiredDataJobDeployment desiredDataJobDeployment,
+  private void checkDefaultDeploymentResources(
+      DesiredDataJobDeployment desiredDataJobDeployment,
       ActualDataJobDeployment actualDataJobDeployment) {
 
     if (actualDataJobDeployment.getResources() == null) {
@@ -291,9 +292,12 @@ public class JobImageDeployerV2 {
   }
 
   private void handleResourcesException(ParseException e) {
-    var errorMessage = new ErrorMessage("Couldn't write default resource to database",
-        "Parsing default string value failed", "The resource won't be present in the DB",
-        "Verify the string can be parsed to a number");
+    var errorMessage =
+        new ErrorMessage(
+            "Couldn't write default resource to database",
+            "Parsing default string value failed",
+            "The resource won't be present in the DB",
+            "Verify the string can be parsed to a number");
     log.error(errorMessage.toString(), e);
   }
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployerV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployerV2.java
@@ -229,13 +229,14 @@ public class JobImageDeployerV2 {
           DeploymentModelConverter.toActualJobDeployment(
               desiredDataJobDeployment, desiredDeploymentVersionSha, lastDeployedDate);
     }
-    checkDefaultDeploymentResources(desiredDataJobDeployment, actualJobDeployment);
+    checkDefaultDeploymentResources(actualJobDeployment);
     return actualJobDeployment;
   }
 
-  private void checkDefaultDeploymentResources(
-      DesiredDataJobDeployment desiredDataJobDeployment,
-      ActualDataJobDeployment actualDataJobDeployment) {
+  private void checkDefaultDeploymentResources(ActualDataJobDeployment actualDataJobDeployment) {
+    if (actualDataJobDeployment == null) {
+      return;
+    }
 
     if (actualDataJobDeployment.getResources() == null) {
       actualDataJobDeployment.setResources(new DataJobDeploymentResources());
@@ -246,9 +247,6 @@ public class JobImageDeployerV2 {
     checkDefaultMemoryRequest(deploymentResources);
     checkDefaultCpuRequest(deploymentResources);
     checkDefaultCpuLimit(deploymentResources);
-
-    actualDataJobDeployment.setResources(deploymentResources);
-    desiredDataJobDeployment.setResources(deploymentResources);
   }
 
   private void checkDefaultMemoryLimit(DataJobDeploymentResources resources) {

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployerV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployerV2.java
@@ -350,14 +350,16 @@ public class JobImageDeployerV2 {
         Optional.ofNullable(jobDeployment.getResources())
             .map(DataJobDeploymentResources::getCpuRequestCores)
             .filter(cpuRequestCores -> cpuRequestCores > 0)
-            .map(String::valueOf)
+            .map(cpuRequestM -> String.valueOf(cpuRequestM.intValue()))
+            .map(cpuRequestM -> cpuRequestM + "m")
             .orElse(defaultConfigurations.dataJobRequests().getCpu());
     checkDefaultCpuRequest(jobDeployment.getResources(), cpuRequest);
     String cpuLimit =
         Optional.ofNullable(jobDeployment.getResources())
             .map(DataJobDeploymentResources::getCpuLimitCores)
             .filter(cpuLimitCores -> cpuLimitCores > 0)
-            .map(String::valueOf)
+            .map(cpuLimitM -> String.valueOf(cpuLimitM.intValue()))
+            .map(cpuLimitM -> cpuLimitM + "m")
             .orElse(defaultConfigurations.dataJobLimits().getCpu());
     checkDefaultCpuLimit(jobDeployment.getResources(), cpuLimit);
     String memoryRequest =
@@ -447,7 +449,9 @@ public class JobImageDeployerV2 {
 
   private void checkDefaultMemoryLimit(DataJobDeploymentResources resources, String memory) {
     try {
-      resources.setMemoryLimitMi(K8SMemoryConversionUtils.getMemoryInMi(memory));
+      if (resources.getMemoryLimitMi() == null) {
+        resources.setMemoryLimitMi(K8SMemoryConversionUtils.getMemoryInMi(memory));
+      }
     } catch (ParseException e) {
       handleResourcesException(e);
     }
@@ -455,7 +459,9 @@ public class JobImageDeployerV2 {
 
   private void checkDefaultMemoryRequest(DataJobDeploymentResources resources, String memory) {
     try {
-      resources.setMemoryRequestMi(K8SMemoryConversionUtils.getMemoryInMi(memory));
+      if (resources.getMemoryRequestMi() == null) {
+        resources.setMemoryRequestMi(K8SMemoryConversionUtils.getMemoryInMi(memory));
+      }
     } catch (ParseException e) {
       handleResourcesException(e);
     }
@@ -463,7 +469,9 @@ public class JobImageDeployerV2 {
 
   private void checkDefaultCpuRequest(DataJobDeploymentResources resources, String cpu) {
     try {
-      resources.setCpuRequestCores(K8SMemoryConversionUtils.getCpuInFloat(cpu));
+      if (resources.getCpuRequestCores() == null) {
+        resources.setCpuRequestCores(K8SMemoryConversionUtils.getCpuInFloat(cpu));
+      }
     } catch (ParseException e) {
       handleResourcesException(e);
     }
@@ -471,7 +479,9 @@ public class JobImageDeployerV2 {
 
   private void checkDefaultCpuLimit(DataJobDeploymentResources resources, String cpu) {
     try {
-      resources.setCpuLimitCores(K8SMemoryConversionUtils.getCpuInFloat(cpu));
+      if (resources.getCpuLimitCores() == null) {
+        resources.setCpuLimitCores(K8SMemoryConversionUtils.getCpuInFloat(cpu));
+      }
     } catch (ParseException e) {
       handleResourcesException(e);
     }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployerV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployerV2.java
@@ -412,7 +412,8 @@ public class JobImageDeployerV2 {
         .build();
   }
 
-  private void setDesiredDeploymentResourcesIfNeeded(DesiredDataJobDeployment desiredDataJobDeployment) {
+  private void setDesiredDeploymentResourcesIfNeeded(
+      DesiredDataJobDeployment desiredDataJobDeployment) {
     if (desiredDataJobDeployment == null) {
       return;
     }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/K8SMemoryConversionUtils.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/K8SMemoryConversionUtils.java
@@ -10,23 +10,23 @@ import java.text.ParseException;
 
 public class K8SMemoryConversionUtils {
 
-  public static int getMemoryInMi(int amount, String memory) {
-    if (memory.endsWith("K")) {
+  public static int getMemoryInMi(int amount, String memoryUnit) {
+    if (memoryUnit.endsWith("K")) {
       return amount / 1000;
     }
-    if (memory.endsWith("Ki")) {
+    if (memoryUnit.endsWith("Ki")) {
       return amount / 1024;
     }
-    if (memory.endsWith("Gi")) {
+    if (memoryUnit.endsWith("Gi")) {
       return amount * 1024;
     }
-    if (memory.endsWith("G")) {
+    if (memoryUnit.endsWith("G")) {
       return amount * 1000;
     }
-    if (memory.endsWith("T")) {
+    if (memoryUnit.endsWith("T")) {
       return amount * 1000000;
     }
-    if (memory.endsWith("Ti")) {
+    if (memoryUnit.endsWith("Ti")) {
       return amount * 1048576;
     }
     return amount;

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/K8SMemoryConversionUtils.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/K8SMemoryConversionUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.deploy;
+
+public class K8SMemoryConversionUtils {
+
+  public static int getMemoryInMi(String memory, int amount) {
+    if (memory.endsWith("K")) {
+      return amount / 1000;
+    }
+    if (memory.endsWith("Ki")) {
+      return amount / 1024;
+    }
+    if (memory.endsWith("Gi")) {
+      return amount * 1024;
+    }
+    if (memory.endsWith("G")) {
+      return amount * 1000;
+    }
+    if (memory.endsWith("T")) {
+      return amount * 1000000;
+    }
+    if (memory.endsWith("Ti")) {
+      return amount * 1048576;
+    }
+    return amount;
+  }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/K8SMemoryConversionUtils.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/K8SMemoryConversionUtils.java
@@ -5,9 +5,12 @@
 
 package com.vmware.taurus.service.deploy;
 
+import java.text.NumberFormat;
+import java.text.ParseException;
+
 public class K8SMemoryConversionUtils {
 
-  public static int getMemoryInMi(String memory, int amount) {
+  public static int getMemoryInMi(int amount, String memory) {
     if (memory.endsWith("K")) {
       return amount / 1000;
     }
@@ -27,5 +30,14 @@ public class K8SMemoryConversionUtils {
       return amount * 1048576;
     }
     return amount;
+  }
+
+  public static int getMemoryInMi(String memory) throws ParseException {
+    var memoryAmount = NumberFormat.getInstance().parse(memory).intValue();
+    return getMemoryInMi(memoryAmount, memory);
+  }
+
+  public static float getCpuInFloat(String cpu) throws ParseException {
+    return NumberFormat.getInstance().parse(cpu).floatValue();
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DataJobDefaultConfigurationsTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DataJobDefaultConfigurationsTest.java
@@ -18,51 +18,63 @@ public class DataJobDefaultConfigurationsTest {
 
   @Test
   public void testDefaultMemoryRequest() throws Exception {
-    Assertions.assertEquals(500, K8SMemoryConversionUtils.getMemoryInMi(dataJobDefaultConfigurations.dataJobRequests().getMemory()));
+    Assertions.assertEquals(
+        500,
+        K8SMemoryConversionUtils.getMemoryInMi(
+            dataJobDefaultConfigurations.dataJobRequests().getMemory()));
   }
 
   @Test
   public void testDefaultMemoryLimit() throws Exception {
-    Assertions.assertEquals(1000, K8SMemoryConversionUtils.getMemoryInMi(dataJobDefaultConfigurations.dataJobLimits().getMemory()));
+    Assertions.assertEquals(
+        1000,
+        K8SMemoryConversionUtils.getMemoryInMi(
+            dataJobDefaultConfigurations.dataJobLimits().getMemory()));
   }
 
   @Test
   public void testDefaultCpuRequest() throws Exception {
-    Assertions.assertEquals(1000, K8SMemoryConversionUtils.getCpuInFloat(dataJobDefaultConfigurations.dataJobRequests().getCpu()));
+    Assertions.assertEquals(
+        1000,
+        K8SMemoryConversionUtils.getCpuInFloat(
+            dataJobDefaultConfigurations.dataJobRequests().getCpu()));
   }
 
   @Test
   public void testDefaultCpuLimit() throws Exception {
-    Assertions.assertEquals(2000, K8SMemoryConversionUtils.getCpuInFloat(dataJobDefaultConfigurations.dataJobLimits().getCpu()));
+    Assertions.assertEquals(
+        2000,
+        K8SMemoryConversionUtils.getCpuInFloat(
+            dataJobDefaultConfigurations.dataJobLimits().getCpu()));
   }
 
   @Test
   public void testKbConversion() {
-    Assertions.assertEquals(2, K8SMemoryConversionUtils.getMemoryInMi( 2000, "K"));
+    Assertions.assertEquals(2, K8SMemoryConversionUtils.getMemoryInMi(2000, "K"));
   }
 
   @Test
   public void testKiConversion() {
-    Assertions.assertEquals(2, K8SMemoryConversionUtils.getMemoryInMi( 2048, "Ki"));
+    Assertions.assertEquals(2, K8SMemoryConversionUtils.getMemoryInMi(2048, "Ki"));
   }
 
   @Test
   public void testGbConversion() {
-    Assertions.assertEquals(2000, K8SMemoryConversionUtils.getMemoryInMi( 2, "G"));
+    Assertions.assertEquals(2000, K8SMemoryConversionUtils.getMemoryInMi(2, "G"));
   }
 
   @Test
   public void testGiConversion() {
-    Assertions.assertEquals(2048, K8SMemoryConversionUtils.getMemoryInMi( 2, "Gi"));
+    Assertions.assertEquals(2048, K8SMemoryConversionUtils.getMemoryInMi(2, "Gi"));
   }
 
   @Test
   public void testTbConversion() {
-    Assertions.assertEquals(2000000, K8SMemoryConversionUtils.getMemoryInMi( 2, "T"));
+    Assertions.assertEquals(2000000, K8SMemoryConversionUtils.getMemoryInMi(2, "T"));
   }
 
   @Test
   public void testTiConversion() {
-    Assertions.assertEquals(2097152, K8SMemoryConversionUtils.getMemoryInMi( 2, "Ti"));
+    Assertions.assertEquals(2097152, K8SMemoryConversionUtils.getMemoryInMi(2, "Ti"));
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DataJobDefaultConfigurationsTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DataJobDefaultConfigurationsTest.java
@@ -18,51 +18,51 @@ public class DataJobDefaultConfigurationsTest {
 
   @Test
   public void testDefaultMemoryRequest() throws Exception {
-    Assertions.assertEquals(500, dataJobDefaultConfigurations.getMemoryRequests());
+    Assertions.assertEquals(500, K8SMemoryConversionUtils.getMemoryInMi(dataJobDefaultConfigurations.dataJobRequests().getMemory()));
   }
 
   @Test
   public void testDefaultMemoryLimit() throws Exception {
-    Assertions.assertEquals(1000, dataJobDefaultConfigurations.getMemoryLimits());
+    Assertions.assertEquals(1000, K8SMemoryConversionUtils.getMemoryInMi(dataJobDefaultConfigurations.dataJobLimits().getMemory()));
   }
 
   @Test
   public void testDefaultCpuRequest() throws Exception {
-    Assertions.assertEquals(1000, dataJobDefaultConfigurations.getCpuRequests());
+    Assertions.assertEquals(1000, K8SMemoryConversionUtils.getCpuInFloat(dataJobDefaultConfigurations.dataJobRequests().getCpu()));
   }
 
   @Test
   public void testDefaultCpuLimit() throws Exception {
-    Assertions.assertEquals(2000, dataJobDefaultConfigurations.getCpuLimits());
+    Assertions.assertEquals(2000, K8SMemoryConversionUtils.getCpuInFloat(dataJobDefaultConfigurations.dataJobLimits().getCpu()));
   }
 
   @Test
   public void testKbConversion() {
-    Assertions.assertEquals(2, K8SMemoryConversionUtils.getMemoryInMi("K", 2000));
+    Assertions.assertEquals(2, K8SMemoryConversionUtils.getMemoryInMi( 2000, "K"));
   }
 
   @Test
   public void testKiConversion() {
-    Assertions.assertEquals(2, K8SMemoryConversionUtils.getMemoryInMi("Ki", 2048));
+    Assertions.assertEquals(2, K8SMemoryConversionUtils.getMemoryInMi( 2048, "Ki"));
   }
 
   @Test
   public void testGbConversion() {
-    Assertions.assertEquals(2000, K8SMemoryConversionUtils.getMemoryInMi("G", 2));
+    Assertions.assertEquals(2000, K8SMemoryConversionUtils.getMemoryInMi( 2, "G"));
   }
 
   @Test
   public void testGiConversion() {
-    Assertions.assertEquals(2048, K8SMemoryConversionUtils.getMemoryInMi("Gi", 2));
+    Assertions.assertEquals(2048, K8SMemoryConversionUtils.getMemoryInMi( 2, "Gi"));
   }
 
   @Test
   public void testTbConversion() {
-    Assertions.assertEquals(2000000, K8SMemoryConversionUtils.getMemoryInMi("T", 2));
+    Assertions.assertEquals(2000000, K8SMemoryConversionUtils.getMemoryInMi( 2, "T"));
   }
 
   @Test
   public void testTiConversion() {
-    Assertions.assertEquals(2097152, K8SMemoryConversionUtils.getMemoryInMi("Ti", 2));
+    Assertions.assertEquals(2097152, K8SMemoryConversionUtils.getMemoryInMi( 2, "Ti"));
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DataJobDefaultConfigurationsTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DataJobDefaultConfigurationsTest.java
@@ -14,8 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest(classes = ControlplaneApplication.class)
 public class DataJobDefaultConfigurationsTest {
 
-  @Autowired
-  private DataJobDefaultConfigurations dataJobDefaultConfigurations;
+  @Autowired private DataJobDefaultConfigurations dataJobDefaultConfigurations;
 
   @Test
   public void testDefaultMemoryRequest() throws Exception {

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DataJobDefaultConfigurationsTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DataJobDefaultConfigurationsTest.java
@@ -12,9 +12,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(classes = ControlplaneApplication.class)
-public class TestDataJobDefaultConfigurations {
+public class DataJobDefaultConfigurationsTest {
 
-  @Autowired private DataJobDefaultConfigurations dataJobDefaultConfigurations;
+  @Autowired
+  private DataJobDefaultConfigurations dataJobDefaultConfigurations;
 
   @Test
   public void testDefaultMemoryRequest() throws Exception {
@@ -34,5 +35,35 @@ public class TestDataJobDefaultConfigurations {
   @Test
   public void testDefaultCpuLimit() throws Exception {
     Assertions.assertEquals(2000, dataJobDefaultConfigurations.getCpuLimits());
+  }
+
+  @Test
+  public void testKbConversion() {
+    Assertions.assertEquals(2, K8SMemoryConversionUtils.getMemoryInMi("K", 2000));
+  }
+
+  @Test
+  public void testKiConversion() {
+    Assertions.assertEquals(2, K8SMemoryConversionUtils.getMemoryInMi("Ki", 2048));
+  }
+
+  @Test
+  public void testGbConversion() {
+    Assertions.assertEquals(2000, K8SMemoryConversionUtils.getMemoryInMi("G", 2));
+  }
+
+  @Test
+  public void testGiConversion() {
+    Assertions.assertEquals(2048, K8SMemoryConversionUtils.getMemoryInMi("Gi", 2));
+  }
+
+  @Test
+  public void testTbConversion() {
+    Assertions.assertEquals(2000000, K8SMemoryConversionUtils.getMemoryInMi("T", 2));
+  }
+
+  @Test
+  public void testTiConversion() {
+    Assertions.assertEquals(2097152, K8SMemoryConversionUtils.getMemoryInMi("Ti", 2));
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/TestDataJobDefaultConfigurations.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/TestDataJobDefaultConfigurations.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.deploy;
+
+import com.vmware.taurus.ControlplaneApplication;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(classes = ControlplaneApplication.class)
+public class TestDataJobDefaultConfigurations {
+
+  @Autowired
+  private DataJobDefaultConfigurations dataJobDefaultConfigurations;
+
+
+  @Test
+  public void testDefaultMemoryRequest() throws Exception {
+    Assertions.assertEquals(500, dataJobDefaultConfigurations.getMemoryRequests());
+  }
+
+  @Test
+  public void testDefaultMemoryLimit() throws Exception {
+    Assertions.assertEquals(1000, dataJobDefaultConfigurations.getMemoryLimits());
+  }
+
+  @Test
+  public void testDefaultCpuRequest() throws Exception {
+    Assertions.assertEquals(1000, dataJobDefaultConfigurations.getCpuRequests());
+  }
+
+  @Test
+  public void testDefaultCpuLimit() throws Exception {
+    Assertions.assertEquals(2000, dataJobDefaultConfigurations.getCpuLimits());
+  }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/TestDataJobDefaultConfigurations.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/TestDataJobDefaultConfigurations.java
@@ -14,9 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest(classes = ControlplaneApplication.class)
 public class TestDataJobDefaultConfigurations {
 
-  @Autowired
-  private DataJobDefaultConfigurations dataJobDefaultConfigurations;
-
+  @Autowired private DataJobDefaultConfigurations dataJobDefaultConfigurations;
 
   @Test
   public void testDefaultMemoryRequest() throws Exception {


### PR DESCRIPTION
what: If no resources specified when deploying data jobs with the DataJobsSynchronizer we will now write the default resources values to the DB.

why: Previously these values would only be present in K8S.

testing: added unit test, modified integration test. 