### PR TITLE
control-service: ingress allow for multiple hosts

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/ingress.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/ingress.yaml
@@ -7,6 +7,7 @@
 kind: Ingress
 metadata:
   name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
   annotations: {{- toYaml .Values.ingress.annotations | nindent 4 }}
 apiVersion: networking.k8s.io/v1
@@ -15,29 +16,26 @@ spec:
   ingressClassName: {{ .Values.ingress.className }}
 {{- end }}
   rules:
-  - host: {{ .Values.ingress.host | quote }}
-    http:
-      paths:
-{{- if .Values.operationsUi.enabled }}
-      - path: {{ .Values.ingress.path | default "/" }}
-        pathType: "ImplementationSpecific"
-        backend:
-          service:
-            name: {{ .Release.Name }}-ui
-            port:
-              number: 8091
-{{- end }}
-      - path: {{ .Values.ingress.path | default "/data-jobs" }}
-        pathType: "ImplementationSpecific"
-        backend:
-          service:
-            name: {{ .Release.Name }}-svc
-            port:
-              number: {{ .Values.service.internalPort }}
-{{- if .Values.ingress.tls_secret }}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .name }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ default "/" .path | quote }}
+            pathType: "ImplementationSpecific"
+            backend:
+              service:
+                name: {{ tpl .serviceName $ }}
+                port:
+                  number: {{ .servicePort }}
+          {{- end }}
+    {{- end }}
   tls:
-    - hosts:
-      - {{ .Values.ingress.host | quote}}
-      secretName: {{ .Values.ingress.tls_secret }}
-{{- end }}
-{{- end }}
+    {{- range .Values.ingress.hosts }}
+    {{- if .tls }}
+      - hosts:
+          - {{ .name }}
+        secretName: {{ .tlsSecretName }}
+    {{- end }}
+    {{- end }}
+  {{- end -}}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -75,7 +75,7 @@ deploymentBuilder:
 
 ## Service configuration
 service:
-   internalPort: 8092
+   internalPort: &controlServicePort 8092
    type: LoadBalancer # NodePort
    externalTrafficPolicy: Cluster
    # nodePort:
@@ -104,17 +104,21 @@ ingress:
   annotations: {}
   # kubernetes.io/ingress.class: nginx
   ## Configure hostname to use in named-based virtual host.
-  host:
+  ## hosts:
+  ##  - name: "sc-dp-cs-stg.vdp-stg.oc.vmware.com"
+  ##    paths:
   ## URI path/endpoint to the service
   ## This should be unique path to instruct the ingress controller which path is served by the downstream service.
   ## Defaults to '/'
-  ## This allows the service to co-exist and share the same hostname with other services.
-  path: ""
+  ##      - path: /data-jobs
+  ##        serviceName: "{{ .Release.Name }}-svc"
+  ##        servicePort: *controlServicePort
+  ##    tls: true
   ## Provide existing secret which holds TLS certificate/key.
   ## This is will instruct the ingress controller to use specific TLS certificate on this ingress resource. By default,
   ## we use community Nginx controller which supports SNI, thus a signle IP could terminate all connections.
   ## https://github.com/kubernetes/ingress-nginx/
-  tls_secret: ""
+  ##    tlsSecretName: "tpcs-test-tls-secret"
   ## It is used to associate an Ingress resource with a specific Ingress controller or implementation.
   className: ""
 


### PR DESCRIPTION
Why:
Our Helm chart currently lacks the functionality to specify multiple Ingress hosts.

What:
Enhance the Ingress template to support multiple hosts.

Testing done:
helm template

before:
```yaml
kind: Ingress
metadata:
  name: release-name-pipelines-control-service
  labels:
    app.kubernetes.io/name: pipelines-control-service
    helm.sh/chart: pipelines-control-service-0.0.1-SNAPSHOT
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
  annotations:
    {}
apiVersion: networking.k8s.io/v1
spec:
  ingressClassName: class
  rules:
    - host: "vdk.com"
      http:
        paths:
          - path: data-jobs
            pathType: "ImplementationSpecific"
            backend:
              service:
                name: release-name-ui
                port:
                  number: 8091
          - path: data-jobs
            pathType: "ImplementationSpecific"
            backend:
              service:
                name: release-name-svc
                port:
                  number: 8092
  tls:
    - hosts:
        - "vdk.com"
      secretName: secret
```

after:
```yaml
kind: Ingress
metadata:
  name: release-name-pipelines-control-service
  labels:
    app.kubernetes.io/name: pipelines-control-service
    helm.sh/chart: pipelines-control-service-0.0.1-SNAPSHOT
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
  annotations:
    {}
apiVersion: networking.k8s.io/v1
spec:
  ingressClassName: class
  rules:
    - host: vdk.com
      http:
        paths:
          - path: "/data-jobs"
            backend:
              service:
                name: release-name-svc
                port:
                  number: 8092
          - path: "/"
            backend:
              service:
                name: release-name-ui
                port:
                  number: 8091
  tls:
      - hosts:
          - vdk.com
        secretName: secret
```

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com