### PR TITLE
control-service: add resource constraints

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/limitrange_datajobs.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/limitrange_datajobs.yaml
@@ -1,0 +1,18 @@
+{{- /*
+    Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+    */}}
+
+{{- if .Values.datajobslimitrange.enabled }}
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: data-jobs-limit-range
+  namespace: {{ template "pipelines-control-service.deploymentK8sNamespace" . }}
+spec:
+  limits:
+    - max:
+        cpu: {{ default "4" .Values.datajobslimitrange.max.cpu }}
+        memory: {{ default "8gi" .Values.datajobslimitrange.max.memory }}
+      type: Pod
+{{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/resourcequota_datajobs.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/resourcequota_datajobs.yaml
@@ -1,0 +1,18 @@
+{{- /*
+    Copyright 2021-2023 VMware, Inc.
+  SPDX-License-Identifier: Apache-2.0
+    */}}
+
+{{- if .Values.datajobslimitrange.enabled }}
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: data-jobs-resource-quota
+  namespace: {{ template "pipelines-control-service.deploymentK8sNamespace" . }}
+spec:
+  hard:
+    limits.cpu: {{ default "100" .Values.datajobsresourcequota.limits.cpu }}
+    limits.memory: {{ default "200Gi" .Values.datajobsresourcequota.limits.memory }}
+    requests.cpu: {{ default "50" .Values.datajobsresourcequota.requests.cpu }}
+    requests.memory: {{ default "100Gi" .Values.datajobsresourcequota.requests.memory }}
+{{- end }}

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -569,6 +569,26 @@ poddisruptionbudget:
     labels: # additional labels if needed
   minAvailable: 1
 
+# Specify Limit Range for the data jobs namespace to limit the maximum allowed cpu and memory resources for a data job
+# see https://kubernetes.io/docs/concepts/policy/limit-range/
+datajobslimitrange:
+  enabled: false
+  max:
+    cpu: 2
+    memory: 8gi
+
+# Specify Resource Quota for the data jobs namespace to limit the maximum cpu and memory resources available to all
+# data jobs
+# see https://kubernetes.io/docs/concepts/policy/resource-quotas/
+datajobsresourcequota:
+    enabled: false
+    limits:
+      cpu: "100"
+      memory: 200Gi
+    requests:
+      cpu: "50"
+      memory: 100Gi
+
 ## [Required] Database configuration used by Control Plane
 ## Database is used to store Data Jobs metadata like name, team, description
 ## and some deploy specific configuration like execution schedule


### PR DESCRIPTION
**Why:**
Add resource quota and range limits for the data jobs namespace for better resource control.
see:
https://kubernetes.io/docs/concepts/policy/resource-quotas/
https://kubernetes.io/docs/concepts/policy/limit-range

**What:**
Add Limit Range and Resource Quota templates.

**Testing done:**
helm template


