### PR TITLE
vdk-core: handle fetchall errors for oracledb

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
@@ -138,6 +138,7 @@ class ManagedConnectionBase(PEP249Connection, IManagedConnection):
                     "No results.  Previous SQL was not a query.",  # message in pyodbc
                     "Trying to fetch results on an operation with no results.",  # message in impyla
                     "no results to fetch",  # psycopg: ProgrammingError: no results to fetch
+                    "DPY-1003: the executed statement does not return rows",  # oracledb
                 ):
                     self._log.debug(
                         "Fetching all results from query SUCCEEDED. Query does not produce results (e.g. DROP TABLE)."


### PR DESCRIPTION
## Why?

vdk-oracle needs to be able to execute querieswithing the vdk-framework. This requires oracle
specifics to be supported inside managed_connection_base

## What?

Add the oracle exception message for fetchall getting called after queries that do not return a result, e.g. DROP TABLE

## How was this tested?

Ran locally using the dev version of vdk-oracle

## What kind of change is this?

feature/non-breaking