### PR TITLE
vdk-structlog: incorporate vdk-core built-in logging plugin into vdk-structlog

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/log_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/log_config.py
@@ -5,6 +5,7 @@ import os
 import re
 import socket
 import types
+import warnings
 from sys import modules
 from typing import cast
 
@@ -81,13 +82,19 @@ def configure_initial_logging_before_anything():
     3. When initialize_job hook (applicable for vdk run only) is executed then below configure_loggers function
         is run which adds more context to the logs and initializes syslog handler (if configured to do so)
     """
-    log_level = "WARNING"
-    if os.environ.get(LOG_LEVEL_VDK, None):
-        log_level = os.environ.get(LOG_LEVEL_VDK)
-    elif os.environ.get("VDK_LOG_LEVEL_VDK", None):
-        log_level = os.environ.get("VDK_LOG_LEVEL_VDK")
+    warnings.warn(
+        "The vdk-core logging configuration is deprecated and will be removed in a future version. "
+        "Please use vdk-structlog for logging configuration.",
+        DeprecationWarning,
+    )
+    if not os.environ.get("VDK_USE_STRUCTLOG"):
+        log_level = "WARNING"
+        if os.environ.get(LOG_LEVEL_VDK, None):
+            log_level = os.environ.get(LOG_LEVEL_VDK)
+        elif os.environ.get("VDK_LOG_LEVEL_VDK", None):
+            log_level = os.environ.get("VDK_LOG_LEVEL_VDK")
 
-    logging.basicConfig(format="%(message)s", level=logging.getLevelName(log_level))
+        logging.basicConfig(format="%(message)s", level=logging.getLevelName(log_level))
 
 
 def configure_loggers(

--- a/projects/vdk-plugins/vdk-structlog/src/vdk/plugin/structlog/constants.py
+++ b/projects/vdk-plugins/vdk-structlog/src/vdk/plugin/structlog/constants.py
@@ -1,6 +1,9 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 import logging
+import socket
+
+from vdk.internal.core import errors
 
 STRUCTLOG_LOGGING_METADATA_KEY = "logging_metadata"
 STRUCTLOG_LOGGING_FORMAT_KEY = "logging_format"
@@ -62,3 +65,51 @@ STRUCTLOG_LOGGING_METADATA_ALL_KEYS = set(
 ) | set(STRUCTLOG_LOGGING_METADATA_JOB.keys())
 
 RECORD_DEFAULT_FIELDS = set(vars(logging.LogRecord("", "", "", "", "", "", "")))
+
+SYSLOG_URL = "SYSLOG_URL"
+SYSLOG_PORT = "SYSLOG_PORT"
+SYSLOG_SOCK_TYPE = "SYSLOG_SOCK_TYPE"
+SYSLOG_ENABLED = "SYSLOG_ENABLED"
+
+SYSLOG_SOCK_TYPE_VALUES_DICT = {"UDP": socket.SOCK_DGRAM, "TCP": socket.SOCK_STREAM}
+
+
+def parse_log_level_module(log_level_module):
+    valid_logging_levels = [
+        "NOTSET",
+        "DEBUG",
+        "INFO",
+        "WARN",
+        "WARNING",
+        "ERROR",
+        "FATAL",
+        "CRITICAL",
+    ]
+    try:
+        if log_level_module and log_level_module.strip():
+            modules = log_level_module.split(";")
+            result = {}
+            for module in modules:
+                if module:
+                    module_and_level = module.split("=")
+                    if not re.search("[a-zA-Z0-9_.-]+", module_and_level[0].lower()):
+                        raise ValueError(
+                            f"Invalid logging module name: '{module_and_level[0]}'. "
+                            f"Must be alphanumerical/underscore characters."
+                        )
+                    if module_and_level[1].upper() not in valid_logging_levels:
+                        raise ValueError(
+                            f"Invalid logging level: '{module_and_level[1]}'. Must be one of {valid_logging_levels}."
+                        )
+                    result[module_and_level[0]] = {"level": module_and_level[1].upper()}
+            return result
+        else:
+            return {}
+    except Exception as e:
+        errors.report_and_throw(
+            errors.VdkConfigurationError(
+                "Invalid logging configuration passed to LOG_LEVEL_MODULE.",
+                f"Error is: {e}. log_level_module was set to {log_level_module}.",
+                "Set correctly configuration to log_level_debug configuration in format 'module=level;module2=level2'",
+            )
+        )

--- a/projects/vdk-plugins/vdk-structlog/src/vdk/plugin/structlog/constants.py
+++ b/projects/vdk-plugins/vdk-structlog/src/vdk/plugin/structlog/constants.py
@@ -1,6 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 import logging
+import re
 import socket
 
 from vdk.internal.core import errors

--- a/projects/vdk-plugins/vdk-structlog/src/vdk/plugin/structlog/structlog_plugin.py
+++ b/projects/vdk-plugins/vdk-structlog/src/vdk/plugin/structlog/structlog_plugin.py
@@ -1,28 +1,155 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 import logging
+import os
 import sys
 from typing import List
 from typing import Optional
 
-from pythonjsonlogger import jsonlogger
 from vdk.api.plugin.hook_markers import hookimpl
 from vdk.api.plugin.plugin_registry import HookCallResult
 from vdk.api.plugin.plugin_registry import IPluginRegistry
+from vdk.internal.builtin_plugins.config import vdk_config
 from vdk.internal.builtin_plugins.run.execution_results import ExecutionResult
 from vdk.internal.builtin_plugins.run.execution_results import StepResult
 from vdk.internal.builtin_plugins.run.job_context import JobContext
 from vdk.internal.builtin_plugins.run.step import Step
+from vdk.internal.core import errors
 from vdk.internal.core.config import ConfigurationBuilder
 from vdk.internal.core.context import CoreContext
+from vdk.internal.core.statestore import CommonStoreKeys
 from vdk.plugin.structlog.constants import JSON_STRUCTLOG_LOGGING_METADATA_DEFAULT
+from vdk.plugin.structlog.constants import parse_log_level_module
 from vdk.plugin.structlog.constants import STRUCTLOG_LOGGING_FORMAT_DEFAULT
 from vdk.plugin.structlog.constants import STRUCTLOG_LOGGING_FORMAT_KEY
 from vdk.plugin.structlog.constants import STRUCTLOG_LOGGING_FORMAT_POSSIBLE_VALUES
 from vdk.plugin.structlog.constants import STRUCTLOG_LOGGING_METADATA_ALL_KEYS
 from vdk.plugin.structlog.constants import STRUCTLOG_LOGGING_METADATA_KEY
+from vdk.plugin.structlog.constants import SYSLOG_ENABLED
+from vdk.plugin.structlog.constants import SYSLOG_PORT
+from vdk.plugin.structlog.constants import SYSLOG_SOCK_TYPE
+from vdk.plugin.structlog.constants import SYSLOG_SOCK_TYPE_VALUES_DICT
+from vdk.plugin.structlog.constants import SYSLOG_URL
 from vdk.plugin.structlog.filters import AttributeAdder
 from vdk.plugin.structlog.formatters import create_formatter
+
+
+def configure_initial_logging():
+    log_level = (
+        os.environ.get("LOG_LEVEL_VDK")
+        or os.environ.get("VDK_LOG_LEVEL_VDK", "WARNING").upper()
+    )
+    logging.basicConfig(format="%(message)s", level=logging.getLevelName(log_level))
+
+
+def _set_already_configured() -> None:
+    setattr(sys.modules[__name__], "logging_already_configured", True)
+
+
+def _is_already_configured() -> bool:
+    res = hasattr(sys.modules[__name__], "logging_already_configured")
+    return res
+
+
+def configure_loggers(
+    job_name: str = "",
+    attempt_id: str = "no-id",
+    log_config_type: str = None,
+    vdk_logging_level: str = "DEBUG",
+    log_level_module: str = None,
+    syslog_args: (str, int, str, bool) = ("localhost", 514, "UDP", False),
+) -> None:
+    """
+    Configure logging for VDK and the user code.
+    :param job_name: The name of the job.
+    :param attempt_id: The id of the attempt.
+    :param log_config_type: The type of the logging configuration.
+    :param vdk_logging_level: The logging level for VDK.
+    :param log_level_module: The logging level for the user code.
+    :param syslog_args: The syslog arguments.
+    """
+
+    import logging.config
+
+    if _is_already_configured():
+        log = logging.getLogger(__name__)
+        msg = "Logging already configured. This seems like a bug. Fix me!."
+        # Plugins would override logging directly with logging library not through this method
+        # it is probably OK for tests to configure logging twice. VDK, however, shouldn't.
+        log.warning(msg)
+
+    # Likely most logging system (like Log Insight) show the hostname from where the syslog message arrived so no
+    # need to include it here.
+    DETAILED_FORMAT = (
+        f"%(asctime)s [VDK] {job_name} [%(levelname)-5.5s] %(name)-30.30s %(filename)20.20s:%("
+        f"lineno)-4.4s %(funcName)-16.16s[id:{attempt_id}]- %(message)s"
+    )
+
+    _LOGGERS = {
+        "requests_kerberos": {"level": "INFO"},
+        "requests_oauthlib": {"level": "INFO"},
+        "urllib3": {"level": "INFO"},
+        "vdk": {"level": vdk_logging_level},
+    }
+    _LOGGERS.update(parse_log_level_module(log_level_module))
+
+    _FORMATTERS = {"detailedFormatter": {"format": DETAILED_FORMAT}}
+
+    _CONSOLE_HANDLER = {
+        "class": "logging.StreamHandler",
+        "formatter": "detailedFormatter",
+        "stream": "ext://sys.stderr",
+    }
+
+    syslog_url, syslog_port, syslog_sock_type, syslog_enabled = syslog_args
+
+    if syslog_sock_type not in SYSLOG_SOCK_TYPE_VALUES_DICT:
+        errors.report_and_throw(
+            errors.VdkConfigurationError(
+                f"Provided configuration variable for {SYSLOG_SOCK_TYPE} has invalid value.",
+                f"VDK was run with {SYSLOG_SOCK_TYPE}={syslog_sock_type}, however {syslog_sock_type} is invalid value "
+                f"for this variable. Provide a valid value for {SYSLOG_SOCK_TYPE}."
+                f"Currently possible values are {list(SYSLOG_SOCK_TYPE_VALUES_DICT.keys())}",
+            )
+        )
+
+    _SYSLOG_HANDLER = {
+        "level": "DEBUG",
+        "class": "logging.handlers.SysLogHandler",
+        "formatter": "detailedFormatter",
+        "address": (syslog_url, syslog_port),
+        "socktype": SYSLOG_SOCK_TYPE_VALUES_DICT[syslog_sock_type],
+        "facility": "user",
+    }
+
+    handlers = ["consoleHandler"]
+    if syslog_enabled:
+        handlers.append("SysLog")
+
+    if "CLOUD" == log_config_type:
+        CLOUD = {  # @UnusedVariable
+            "version": 1,
+            "handlers": {"consoleHandler": _CONSOLE_HANDLER, "SysLog": _SYSLOG_HANDLER},
+            "formatters": _FORMATTERS,
+            "root": {"handlers": handlers},
+            "loggers": _LOGGERS,
+            "disable_existing_loggers": False,
+        }
+        logging.config.dictConfig(CLOUD)
+    elif "NONE" == log_config_type:
+        pass
+    else:
+        LOCAL = {  # @UnusedVariable
+            "version": 1,
+            "handlers": {"consoleHandler": _CONSOLE_HANDLER, "SysLog": _SYSLOG_HANDLER},
+            "formatters": _FORMATTERS,
+            "root": {"handlers": handlers},
+            "loggers": _LOGGERS,
+            "disable_existing_loggers": False,
+        }
+        logging.config.dictConfig(LOCAL)
+    _set_already_configured()
+
 
 """
 Handlers
@@ -48,7 +175,7 @@ Example:
 
 class BoundLogger(logging.LoggerAdapter):
     def process(self, msg, kwargs):
-        # merge bound extra dict with existing exra dict if any
+        # merge bound extra dict with existing extra dict if any
         if "extra" in kwargs:
             kwargs["extra"] = {**self.extra, **kwargs["extra"]}
         else:
@@ -74,8 +201,10 @@ class StructlogPlugin:
             ),
             description=(
                 f"Possible values: {STRUCTLOG_LOGGING_METADATA_ALL_KEYS}"
-                "User-defined key-value pairs added to the logger's context will be displayed after the metadata, but before the message"
-                "Keys for user-defined key-value pairs have to be added in this config option for the values to be displayed in the metadata"
+                "User-defined key-value pairs added to the logger's context will be displayed after the metadata, "
+                "but before the message"
+                "Keys for user-defined key-value pairs have to be added in this config option for the values to be "
+                "displayed in the metadata"
             ),
         )
 
@@ -87,8 +216,16 @@ class StructlogPlugin:
             ),
         )
 
+        config_builder.add(
+            key=SYSLOG_URL,
+            default_value="localhost",
+            description="The hostname of the endpoint to which VDK logs will be sent through SysLog.",
+        )
+
     @hookimpl
     def vdk_initialize(self, context: CoreContext):
+        os.environ["VDK_USE_STRUCTLOG"] = "1"
+        configure_initial_logging()
         metadata_keys = context.configuration.get_value(STRUCTLOG_LOGGING_METADATA_KEY)
         logging_formatter = context.configuration.get_value(
             STRUCTLOG_LOGGING_FORMAT_KEY
@@ -107,6 +244,33 @@ class StructlogPlugin:
 
     @hookimpl(hookwrapper=True)
     def initialize_job(self, context: JobContext) -> None:
+        attempt_id = context.core_context.state.get(CommonStoreKeys.ATTEMPT_ID)
+        job_name = context.name
+        log_config_type = context.core_context.configuration.get_value(
+            vdk_config.LOG_CONFIG
+        )
+        vdk_log_level = context.core_context.configuration.get_value(
+            vdk_config.LOG_LEVEL_VDK
+        )
+        log_level_module = context.core_context.configuration.get_value(
+            vdk_config.LOG_LEVEL_MODULE
+        )
+
+        syslog_args = (
+            context.core_context.configuration.get_value(SYSLOG_URL),
+            context.core_context.configuration.get_value(SYSLOG_PORT),
+            context.core_context.configuration.get_value(SYSLOG_SOCK_TYPE),
+            context.core_context.configuration.get_value(SYSLOG_ENABLED),
+        )
+        configure_loggers(
+            job_name,
+            attempt_id,
+            log_config_type,
+            vdk_log_level,
+            log_level_module,
+            syslog_args,
+        )
+        parse_log_level_module(log_level_module)
         logging_formatter = context.core_context.configuration.get_value(
             STRUCTLOG_LOGGING_FORMAT_KEY
         )
@@ -115,7 +279,7 @@ class StructlogPlugin:
         )
 
         formatter, metadata_filter = create_formatter(logging_formatter, metadata_keys)
-        job_name_adder = AttributeAdder("vdk_job_name", context.name)
+        job_name_adder = AttributeAdder("vdk_job_name", job_name)
 
         root_logger = logging.getLogger()
         root_logger.removeHandler(root_logger.handlers[0])

--- a/projects/vdk-plugins/vdk-structlog/src/vdk/plugin/structlog/structlog_plugin.py
+++ b/projects/vdk-plugins/vdk-structlog/src/vdk/plugin/structlog/structlog_plugin.py
@@ -221,9 +221,26 @@ class StructlogPlugin:
             default_value="localhost",
             description="The hostname of the endpoint to which VDK logs will be sent through SysLog.",
         )
+        config_builder.add(
+            key=SYSLOG_PORT,
+            default_value=514,
+            description="The port of the endpoint to which VDK logs will be sent through SysLog.",
+        )
+        config_builder.add(
+            key=SYSLOG_ENABLED,
+            default_value=False,
+            description="If set to True, SysLog log forwarding is enabled.",
+        )
+        config_builder.add(
+            key=SYSLOG_SOCK_TYPE,
+            default_value="UDP",
+            description=f"Socket type for SysLog log forwarding connection. Currently possible values are "
+            f"{list(SYSLOG_SOCK_TYPE_VALUES_DICT.keys())}",
+        )
 
     @hookimpl
     def vdk_initialize(self, context: CoreContext):
+        # Use this plugin for logging config and warn the user about the vdk-core logging deprecation
         os.environ["VDK_USE_STRUCTLOG"] = "1"
         configure_initial_logging()
         metadata_keys = context.configuration.get_value(STRUCTLOG_LOGGING_METADATA_KEY)


### PR DESCRIPTION
What:
Incorporate vdk-core built-in logging plugin into vdk-structlog by moving the logging configuration and relevant tests, adding deprecation warning and keeping the vdk-core functionality behind a flag which is activated upon vdk-structlog installation.

Why: To avoid reconfiguring the logging config, thus losing information, by vdk-structlog but instead just configure it once.

Testing Done: Existing tests pass and the vdk-core logging tests are added to vdk-structlog and are passing (except test_log_config()).

Signed-off-by: Yoan Salambashev <ysalambashev@vmware.com>