### PR TITLE
control-service: deployment cannot be suspended

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/BaseDataJobDeploymentCrudIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/BaseDataJobDeploymentCrudIT.java
@@ -121,7 +121,7 @@ public abstract class BaseDataJobDeploymentCrudIT extends BaseIT {
 
     executeDisableDeploymentWrongTeam();
 
-    verifyDeploymentDisabled(jobDeploymentName);
+    verifyDeploymentDisabled();
 
     verifyDeploymentFieldsAfterDisable(testJobVersionSha);
 
@@ -319,14 +319,13 @@ public abstract class BaseDataJobDeploymentCrudIT extends BaseIT {
         .andExpect(status().isNotFound());
   }
 
-  private void verifyDeploymentDisabled(String jobDeploymentName) {
+  private void verifyDeploymentDisabled() {
     waitUntil(
         () -> {
-          Optional<JobDeploymentStatus> deploymentOptional =
-              dataJobsKubernetesService.readCronJob(jobDeploymentName);
-          Assertions.assertTrue(deploymentOptional.isPresent());
-          JobDeploymentStatus deployment = deploymentOptional.get();
-          return !deployment.getEnabled();
+          var result = getJobDeployment();
+          DataJobDeploymentStatus jobDeployment =
+                  mapper.readValue(result.getResponse().getContentAsString(), DataJobDeploymentStatus.class);
+          return !jobDeployment.getEnabled();
         });
   }
 

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/BaseDataJobDeploymentCrudIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/BaseDataJobDeploymentCrudIT.java
@@ -324,7 +324,8 @@ public abstract class BaseDataJobDeploymentCrudIT extends BaseIT {
         () -> {
           var result = getJobDeployment();
           DataJobDeploymentStatus jobDeployment =
-                  mapper.readValue(result.getResponse().getContentAsString(), DataJobDeploymentStatus.class);
+              mapper.readValue(
+                  result.getResponse().getContentAsString(), DataJobDeploymentStatus.class);
           return !jobDeployment.getEnabled();
         });
   }

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/service/deploy/DataJobDeploymentCrudITV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/service/deploy/DataJobDeploymentCrudITV2.java
@@ -118,7 +118,7 @@ public class DataJobDeploymentCrudITV2 extends BaseIT {
     String testJobVersionSha = testDataJobVersion.getVersionSha();
     Assertions.assertFalse(StringUtils.isBlank(testJobVersionSha));
 
-    boolean jobEnabled = false;
+    boolean jobEnabled = true;
     DesiredDataJobDeployment desiredDataJobDeployment =
         createDesiredDataJobDeployment(testJobVersionSha, jobEnabled);
 
@@ -149,7 +149,7 @@ public class DataJobDeploymentCrudITV2 extends BaseIT {
     Assertions.assertEquals(lastDeployedDateInitial, lastDeployedDateShouldNotBeChanged);
 
     // Tries to redeploy job with changes
-    jobEnabled = true;
+    jobEnabled = false;
     desiredDataJobDeployment = updateDataJobDeployment(jobEnabled);
     dataJobsSynchronizer.synchronizeDataJob(
         dataJob, desiredDataJobDeployment, actualDataJobDeployment, true);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentServiceV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentServiceV2.java
@@ -160,8 +160,9 @@ public class DeploymentServiceV2 {
           dockerRegistryService.dataJobImage(
               desiredJobDeployment.getDataJobName(), desiredJobDeployment.getGitCommitSha());
 
-      if (jobImageBuilder.buildImage(
-          imageName, dataJob, desiredJobDeployment, actualJobDeployment, sendNotification)) {
+      // If the job suspension operation is performed, we don't want to build the image.
+      if (Boolean.FALSE.equals(desiredJobDeployment.getEnabled()) ||
+              jobImageBuilder.buildImage(imageName, dataJob, desiredJobDeployment, actualJobDeployment, sendNotification)) {
         ActualDataJobDeployment actualJobDeploymentResult =
             jobImageDeployer.scheduleJob(
                 dataJob,

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentServiceV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentServiceV2.java
@@ -161,8 +161,9 @@ public class DeploymentServiceV2 {
               desiredJobDeployment.getDataJobName(), desiredJobDeployment.getGitCommitSha());
 
       // If the job suspension operation is performed, we don't want to build the image.
-      if (Boolean.FALSE.equals(desiredJobDeployment.getEnabled()) ||
-              jobImageBuilder.buildImage(imageName, dataJob, desiredJobDeployment, actualJobDeployment, sendNotification)) {
+      if (Boolean.FALSE.equals(desiredJobDeployment.getEnabled())
+          || jobImageBuilder.buildImage(
+              imageName, dataJob, desiredJobDeployment, actualJobDeployment, sendNotification)) {
         ActualDataJobDeployment actualJobDeploymentResult =
             jobImageDeployer.scheduleJob(
                 dataJob,

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
@@ -222,7 +222,7 @@ public class DataJobsKubernetesService extends KubernetesService {
           v1CronJobs.getItems().stream()
               .map(j -> j.getMetadata().getName())
               .collect(Collectors.toSet());
-      log.debug("K8s V1 cron jobs: {}", v1CronJobNames);
+      log.trace("K8s V1 cron jobs: {}", v1CronJobNames);
     } catch (ApiException e) {
       if (e.getCode()
           == 404) { // as soon as the minimum supported k8s version is >=1.21 then we should remove

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceV2TestIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceV2TestIT.java
@@ -73,28 +73,28 @@ public class DeploymentServiceV2TestIT {
 
   @Test
   public void
-  updateDeployment_withDesiredDeploymentEnabledFalseAndActualDeploymentEnabledTrueAndBuildImageSucceededFalse_shouldUpdateDeployment()
+      updateDeployment_withDesiredDeploymentEnabledFalseAndActualDeploymentEnabledTrueAndBuildImageSucceededFalse_shouldUpdateDeployment()
           throws IOException, InterruptedException, ApiException {
     updateDeployment(false, true, false, 1);
   }
 
   @Test
   public void
-  updateDeployment_withDesiredDeploymentEnabledFalseAndActualDeploymentEnabledFalseAndBuildImageSucceededFalse_shouldUpdateDeployment()
+      updateDeployment_withDesiredDeploymentEnabledFalseAndActualDeploymentEnabledFalseAndBuildImageSucceededFalse_shouldUpdateDeployment()
           throws IOException, InterruptedException, ApiException {
     updateDeployment(false, false, false, 1);
   }
 
   @Test
   public void
-  updateDeployment_withDesiredDeploymentEnabledTrueAndActualDeploymentEnabledFalseAndBuildImageSucceededTrue_shouldUpdateDeployment()
+      updateDeployment_withDesiredDeploymentEnabledTrueAndActualDeploymentEnabledFalseAndBuildImageSucceededTrue_shouldUpdateDeployment()
           throws IOException, InterruptedException, ApiException {
     updateDeployment(true, false, true, 1);
   }
 
   @Test
   public void
-  updateDeployment_withDesiredDeploymentEnabledTrueAndActualDeploymentEnabledFalseAndBuildImageSucceededFalse_shouldUpdateDeployment()
+      updateDeployment_withDesiredDeploymentEnabledTrueAndActualDeploymentEnabledFalseAndBuildImageSucceededFalse_shouldUpdateDeployment()
           throws IOException, InterruptedException, ApiException {
     updateDeployment(true, false, false, 0);
   }
@@ -128,11 +128,11 @@ public class DeploymentServiceV2TestIT {
   }
 
   private void updateDeployment(
-          boolean desiredDeploymentEnabled,
-          boolean actualDeploymentEnabled,
-          boolean buildImageSucceeded,
-          int deploymentProgressStartedInvocations)
-          throws IOException, InterruptedException, ApiException {
+      boolean desiredDeploymentEnabled,
+      boolean actualDeploymentEnabled,
+      boolean buildImageSucceeded,
+      int deploymentProgressStartedInvocations)
+      throws IOException, InterruptedException, ApiException {
     DesiredDataJobDeployment desiredDataJobDeployment = new DesiredDataJobDeployment();
     desiredDataJobDeployment.setEnabled(desiredDeploymentEnabled);
     desiredDataJobDeployment.setStatus(DeploymentStatus.NONE);
@@ -144,13 +144,19 @@ public class DeploymentServiceV2TestIT {
     dataJob.setJobConfig(new JobConfig());
 
     Mockito.when(
-                    jobImageBuilder.buildImage(
-                            Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
-            .thenReturn(buildImageSucceeded);
+            jobImageBuilder.buildImage(
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+        .thenReturn(buildImageSucceeded);
 
-    deploymentService.updateDeployment(
-            dataJob, desiredDataJobDeployment, actualDeployment, true);
+    deploymentService.updateDeployment(dataJob, desiredDataJobDeployment, actualDeployment, true);
 
-    Mockito.verify(jobImageDeployer, Mockito.times(deploymentProgressStartedInvocations)).scheduleJob(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyString());
+    Mockito.verify(jobImageDeployer, Mockito.times(deploymentProgressStartedInvocations))
+        .scheduleJob(
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.anyBoolean(),
+            Mockito.anyBoolean(),
+            Mockito.anyString());
   }
 }


### PR DESCRIPTION
Why:
The deployment cannot be suspended in the case of a previously failed one.

What:
Added additional logic to the DeploymentServiceV2 to handle this particular case.

Testing done:
IT and unit tests.

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com