### PR TITLE
control-plane: remove needless step in docker build.

### DIFF
--- a/projects/control-service/projects/job-builder-rootless/Dockerfile.python.vdk
+++ b/projects/control-service/projects/job-builder-rootless/Dockerfile.python.vdk
@@ -10,8 +10,6 @@ ARG GID=1000
 # Set the working directory
 WORKDIR /job
 
-# Validate base image is python based
-RUN python -V
 # Create necessary users and set home directory to /job
 RUN groupadd -r -g $GID vdkgroup && useradd -u $UID -g $GID -r vdkuser && chown -R $UID:$GID /job
 ENV HOME=/job

--- a/projects/control-service/projects/job-builder/Dockerfile.python.vdk
+++ b/projects/control-service/projects/job-builder/Dockerfile.python.vdk
@@ -10,8 +10,6 @@ ARG GID=1000
 # Set the working directory
 WORKDIR /job
 
-# Validate base image is python based
-RUN python -V
 # Create necessary users and set home directory to /job
 RUN groupadd -r -g $GID group && useradd -u $UID -g $GID -r user && chown -R $UID:$GID /job
 ENV HOME=/job


### PR DESCRIPTION
# Why

Between each step in a docker build it needs to save a snapshot of the system. 
Some operations actually require unpacking layers created before it. 

This python -V is a really expensive operation. 

Because it needs to unpack all the layers that came before it to run that command. 


from the logs we can see 
```
INFO[0001] Unpacking rootfs as cmd RUN python -V requires it.
```

# What
I removed the operation because it actually has no impact. 

# How was this tested? 

I will deploy in CICD env and test when I get approvals. 
I want it removed incase there is some context I am missing. 

