### PR TITLE
vdk-core: fix exception cause swallowing

### DIFF
--- a/projects/vdk-core/src/vdk/internal/core/errors.py
+++ b/projects/vdk-core/src/vdk/internal/core/errors.py
@@ -187,9 +187,7 @@ def report(error_type: ResolvableBy, exception: BaseException):
 
 
 def report_and_throw(
-    exception: BaseVdkError,
-    resolvable_by: ResolvableBy = None,
-    cause: BaseException = None,
+    exception: BaseVdkError, resolvable_by: ResolvableBy = None
 ) -> None:
     """
     Add exception to resolvable context and then throw it to be handled up the stack.
@@ -205,7 +203,7 @@ def report_and_throw(
             exception,
         )
     )
-    raise exception from cause
+    raise exception
 
 
 def report_and_rethrow(error_type: ResolvableBy, exception: BaseException) -> None:


### PR DESCRIPTION
## Why?

report_and_throw swallows the actual exception cause if we don't pass a cause

## What?

Remove the cause parameter (it's not used)

## How was this tested?

CI

## What kind of change is this?

Bugfix