### PR TITLE
control-service: fix deployment resources

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
@@ -267,19 +267,42 @@ public class DeploymentModelConverter {
 
     if (newDeployment.getResources() == null && oldDeployment.getResources() != null) {
       DataJobDeploymentResources resources = oldDeployment.getResources();
-      setDeploymentResources(mergedDeployment, resources.getCpuRequestCores(), resources.getCpuLimitCores(), resources.getMemoryRequestMi(), resources.getMemoryLimitMi());
+      setDeploymentResources(
+          mergedDeployment,
+          resources.getCpuRequestCores(),
+          resources.getCpuLimitCores(),
+          resources.getMemoryRequestMi(),
+          resources.getMemoryLimitMi());
     } else if (newDeployment.getResources() != null && oldDeployment.getResources() == null) {
       DataJobResources resources = newDeployment.getResources();
-      setDeploymentResources(mergedDeployment, resources.getCpuRequest(), resources.getCpuLimit(), resources.getMemoryRequest(), resources.getMemoryLimit());
+      setDeploymentResources(
+          mergedDeployment,
+          resources.getCpuRequest(),
+          resources.getCpuLimit(),
+          resources.getMemoryRequest(),
+          resources.getMemoryLimit());
     } else if (newDeployment.getResources() != null && oldDeployment.getResources() != null) {
       DataJobResources newResources = newDeployment.getResources();
       DataJobDeploymentResources oldResources = oldDeployment.getResources();
-      Float cpuRequestCores = newResources.getCpuRequest() != null ? newResources.getCpuRequest() : oldResources.getCpuRequestCores();
-      Float cpuLimitCores = newResources.getCpuLimit() != null ? newResources.getCpuLimit() : oldResources.getCpuLimitCores();
-      Integer memoryRequestMi = newResources.getMemoryRequest() != null ? newResources.getMemoryRequest() : oldResources.getMemoryRequestMi();
-      Integer memoryLimitMi = newResources.getMemoryLimit() != null ? newResources.getMemoryLimit() : oldResources.getMemoryLimitMi();
+      Float cpuRequestCores =
+          newResources.getCpuRequest() != null
+              ? newResources.getCpuRequest()
+              : oldResources.getCpuRequestCores();
+      Float cpuLimitCores =
+          newResources.getCpuLimit() != null
+              ? newResources.getCpuLimit()
+              : oldResources.getCpuLimitCores();
+      Integer memoryRequestMi =
+          newResources.getMemoryRequest() != null
+              ? newResources.getMemoryRequest()
+              : oldResources.getMemoryRequestMi();
+      Integer memoryLimitMi =
+          newResources.getMemoryLimit() != null
+              ? newResources.getMemoryLimit()
+              : oldResources.getMemoryLimitMi();
 
-      setDeploymentResources(mergedDeployment, cpuRequestCores, cpuLimitCores, memoryRequestMi, memoryLimitMi);
+      setDeploymentResources(
+          mergedDeployment, cpuRequestCores, cpuLimitCores, memoryRequestMi, memoryLimitMi);
     }
   }
 
@@ -349,7 +372,12 @@ public class DeploymentModelConverter {
     return resources;
   }
 
-  private static void setDeploymentResources(DesiredDataJobDeployment mergedDeployment, Float cpuRequestCores, Float cpuLimitCores, Integer memoryRequestMi, Integer memoryLimitMi) {
+  private static void setDeploymentResources(
+      DesiredDataJobDeployment mergedDeployment,
+      Float cpuRequestCores,
+      Float cpuLimitCores,
+      Integer memoryRequestMi,
+      Integer memoryLimitMi) {
     DataJobDeploymentResources resources = new DataJobDeploymentResources();
     resources.setCpuRequestCores(cpuRequestCores);
     resources.setCpuLimitCores(cpuLimitCores);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/datajobs/DeploymentModelConverter.java
@@ -264,27 +264,23 @@ public class DeploymentModelConverter {
       DesiredDataJobDeployment mergedDeployment,
       JobDeployment newDeployment,
       DesiredDataJobDeployment oldDeployment) {
-    if (newDeployment.getResources() == null) {
-      return;
+
+    if (newDeployment.getResources() == null && oldDeployment.getResources() != null) {
+      DataJobDeploymentResources resources = oldDeployment.getResources();
+      setDeploymentResources(mergedDeployment, resources.getCpuRequestCores(), resources.getCpuLimitCores(), resources.getMemoryRequestMi(), resources.getMemoryLimitMi());
+    } else if (newDeployment.getResources() != null && oldDeployment.getResources() == null) {
+      DataJobResources resources = newDeployment.getResources();
+      setDeploymentResources(mergedDeployment, resources.getCpuRequest(), resources.getCpuLimit(), resources.getMemoryRequest(), resources.getMemoryLimit());
+    } else if (newDeployment.getResources() != null && oldDeployment.getResources() != null) {
+      DataJobResources newResources = newDeployment.getResources();
+      DataJobDeploymentResources oldResources = oldDeployment.getResources();
+      Float cpuRequestCores = newResources.getCpuRequest() != null ? newResources.getCpuRequest() : oldResources.getCpuRequestCores();
+      Float cpuLimitCores = newResources.getCpuLimit() != null ? newResources.getCpuLimit() : oldResources.getCpuLimitCores();
+      Integer memoryRequestMi = newResources.getMemoryRequest() != null ? newResources.getMemoryRequest() : oldResources.getMemoryRequestMi();
+      Integer memoryLimitMi = newResources.getMemoryLimit() != null ? newResources.getMemoryLimit() : oldResources.getMemoryLimitMi();
+
+      setDeploymentResources(mergedDeployment, cpuRequestCores, cpuLimitCores, memoryRequestMi, memoryLimitMi);
     }
-    DataJobDeploymentResources resources = new DataJobDeploymentResources();
-    resources.setCpuRequestCores(
-        newDeployment.getResources().getCpuRequest() != null
-            ? newDeployment.getResources().getCpuRequest()
-            : oldDeployment.getResources().getCpuRequestCores());
-    resources.setCpuLimitCores(
-        newDeployment.getResources().getCpuLimit() != null
-            ? newDeployment.getResources().getCpuLimit()
-            : oldDeployment.getResources().getCpuLimitCores());
-    resources.setMemoryRequestMi(
-        newDeployment.getResources().getMemoryRequest() != null
-            ? newDeployment.getResources().getMemoryRequest()
-            : oldDeployment.getResources().getMemoryRequestMi());
-    resources.setMemoryLimitMi(
-        newDeployment.getResources().getMemoryLimit() != null
-            ? newDeployment.getResources().getMemoryLimit()
-            : oldDeployment.getResources().getMemoryLimitMi());
-    mergedDeployment.setResources(resources);
   }
 
   public static DataJobDeploymentStatus toJobDeploymentStatus(
@@ -351,5 +347,14 @@ public class DeploymentModelConverter {
       resources.setMemoryLimit(deploymentResources.getMemoryLimitMi());
     }
     return resources;
+  }
+
+  private static void setDeploymentResources(DesiredDataJobDeployment mergedDeployment, Float cpuRequestCores, Float cpuLimitCores, Integer memoryRequestMi, Integer memoryLimitMi) {
+    DataJobDeploymentResources resources = new DataJobDeploymentResources();
+    resources.setCpuRequestCores(cpuRequestCores);
+    resources.setCpuLimitCores(cpuLimitCores);
+    resources.setMemoryRequestMi(memoryRequestMi);
+    resources.setMemoryLimitMi(memoryLimitMi);
+    mergedDeployment.setResources(resources);
   }
 }


### PR DESCRIPTION
Why:
Currently, the redeployment of a data job resets previously changed resources, such as CPU and memory.

What:
I have improved the method for merging deployment resources.

Signed-off-by: Miroslav Ivanov miroslavi@vmware.com