### PR TITLE
vdk-oracle: support secrets to connect to database

### DIFF
--- a/projects/vdk-plugins/vdk-oracle/README.md
+++ b/projects/vdk-plugins/vdk-oracle/README.md
@@ -15,13 +15,27 @@ pip install vdk-oracle
 
 (`vdk config-help` is useful command to browse all config options of your installation of vdk)
 
-| Name                     | Description                                      | (example)  Value     |
-|--------------------------|--------------------------------------------------|----------------------|
-| oracle_user              | Username used when connecting to Oracle database | "my_user"            |
-| oracle_password          | Password used when connecting to Oracle database | "super_secret_shhhh" |
-| oracle_connection_string | The Oracle connection string                     | "localhost/free"     |
+| Name                     | Description                                                    | (example)  Value      |
+| ------------------------ | -------------------------------------------------------------- | --------------------- |
+| oracle_user              | Username used when connecting to Oracle database               | "my_user"             |
+| oracle_password          | Password used when connecting to Oracle database               | "super_secret_shhhh"  |
+| oracle_user_secret       | The user name secret key if using secrets to connect to Oracle | "user_secret_key"     |
+| oracle_password_secret   | The password secret key if using secrets to connect to Oracle  | "password_secret_key" |
+| oracle_use_secrets       | Set to True to use secrets to connect to Oracle                | "True"                |
+| oracle_connection_string | The Oracle connection string                                   | "localhost:1521/free" |
 
 ### Example
+
+#### CLI Queries
+
+```sh
+export VDK_ORACLE_USER=my_username
+export VDK_ORACLE_PASSWORD=my_password
+export VDK_ORACLE_CONNECTION_STRING=localhost:1521/free
+vdk oracle-query -q "SELECT * FROM TEST_TABLE"
+```
+
+**Note:** Running CLI queries does not support secrets
 
 #### Ingestion
 
@@ -88,6 +102,38 @@ def run(job_input):
     job_input.send_tabular_data_for_ingestion(
         rows=row_data, column_names=col_names, destination_table="test_table"
     )
+```
+
+#### Ingestion with type inference
+
+Ingestion works with an already created table even if you pass strings in the
+payload. `vdk-oracle` infers the correct type based on the existing table.
+
+```sql
+create table test_table (
+    id number,
+    str_data varchar2(255),
+    int_data number,
+    float_data float,
+    bool_data number(1),
+    timestamp_data timestamp,
+    decimal_data decimal(14,8),
+    primary key(id))
+```
+
+```python
+def run(job_input):
+    payload = {
+        "id": "5",
+        "str_data": "string",
+        "int_data": "12",
+        "float_data": "1.2",
+        "bool_data": "False",
+        "timestamp_data": "2023-11-21T08:12:53",
+        "decimal_data": "0.1",
+    }
+
+    job_input.send_object_for_ingestion(payload=payload, destination_table="test_table")
 ```
 ### Build and testing
 

--- a/projects/vdk-plugins/vdk-oracle/requirements.txt
+++ b/projects/vdk-plugins/vdk-oracle/requirements.txt
@@ -3,6 +3,9 @@
 
 
 pytest
+pytest-httpserver
 testcontainers
 vdk-core
+vdk-plugin-control-cli
 vdk-test-utils
+werkzeug

--- a/projects/vdk-plugins/vdk-oracle/setup.py
+++ b/projects/vdk-plugins/vdk-oracle/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     # Define entry point called "vdk.plugin.run" with name of plugin and module to act as entry point.
     entry_points={"vdk.plugin.run": ["vdk-oracle = vdk.plugin.oracle.oracle_plugin"]},
     classifiers=[
-        "Development Status :: 2 - Pre-Alpha",
+        "Development Status :: 4 - Beta",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/projects/vdk-plugins/vdk-oracle/src/vdk/plugin/oracle/oracle_configuration.py
+++ b/projects/vdk-plugins/vdk-oracle/src/vdk/plugin/oracle/oracle_configuration.py
@@ -11,6 +11,9 @@ from vdk.internal.core.config import ConfigurationBuilder
 
 ORACLE_USER = "ORACLE_USER"
 ORACLE_PASSWORD = "ORACLE_PASSWORD"
+ORACLE_USE_SECRETS = "ORACLE_USE_SECRETS"
+ORACLE_USER_SECRET = "ORACLE_USER_SECRET"
+ORACLE_PASSWORD_SECRET = "ORACLE_PASSWORD_SECRET"
 ORACLE_CONNECTION_STRING = "ORACLE_CONNECTION_STRING"
 
 
@@ -24,8 +27,17 @@ class OracleConfiguration:
     def get_oracle_password(self) -> str:
         return self.__config.get_value(ORACLE_PASSWORD)
 
-    def get_oracle_connection_string(self) -> Optional[Dict[str, str]]:
+    def get_oracle_user_secret(self) -> str:
+        return self.__config.get_value(ORACLE_USER_SECRET)
+
+    def get_oracle_password_secret(self) -> str:
+        return self.__config.get_value(ORACLE_PASSWORD_SECRET)
+
+    def get_oracle_connection_string(self) -> str:
         return self.__config.get_value(ORACLE_CONNECTION_STRING)
+
+    def oracle_use_secrets(self) -> bool:
+        return self.__config.get_value(ORACLE_USE_SECRETS)
 
     @staticmethod
     def add_definitions(config_builder: ConfigurationBuilder):
@@ -39,11 +51,26 @@ class OracleConfiguration:
             key=ORACLE_PASSWORD,
             default_value=None,
             is_sensitive=True,
-            description="The oracle password for the database connection",
+            description="The Oracle password for the database connection",
         )
         config_builder.add(
             key=ORACLE_CONNECTION_STRING,
             default_value=None,
             is_sensitive=True,
             description="The Oracle database connection string",
+        )
+        config_builder.add(
+            key=ORACLE_USE_SECRETS,
+            default_value=False,
+            description="Set this flag to use secrets to connect to Oracle",
+        )
+        config_builder.add(
+            key=ORACLE_USER_SECRET,
+            default_value=None,
+            description="The user secret key if using secrets to connect to Oracle",
+        )
+        config_builder.add(
+            key=ORACLE_PASSWORD_SECRET,
+            default_value=None,
+            description="The password secret key if using secrets to connect to Oracle",
         )

--- a/projects/vdk-plugins/vdk-oracle/src/vdk/plugin/oracle/oracle_plugin.py
+++ b/projects/vdk-plugins/vdk-oracle/src/vdk/plugin/oracle/oracle_plugin.py
@@ -7,6 +7,7 @@ import click
 import oracledb
 from tabulate import tabulate
 from vdk.api.plugin.hook_markers import hookimpl
+from vdk.api.plugin.plugin_registry import HookCallResult
 from vdk.api.plugin.plugin_registry import IPluginRegistry
 from vdk.internal.builtin_plugins.run.job_context import JobContext
 from vdk.internal.core.config import ConfigurationBuilder
@@ -30,14 +31,19 @@ class OraclePlugin:
     def vdk_configure(self, config_builder: ConfigurationBuilder):
         OracleConfiguration.add_definitions(config_builder)
 
-    @hookimpl
+    @hookimpl(trylast=True)
     def initialize_job(self, context: JobContext):
         conf = OracleConfiguration(context.core_context.configuration)
+        oracle_user, oracle_pass = conf.get_oracle_user(), conf.get_oracle_password()
+        if conf.oracle_use_secrets():
+            job_secrets = context.job_input.get_all_secrets()
+            oracle_user = job_secrets[conf.get_oracle_user_secret()]
+            oracle_pass = job_secrets[conf.get_oracle_password_secret()]
         context.connections.add_open_connection_factory_method(
             "ORACLE",
             lambda: OracleConnection(
-                conf.get_oracle_user(),
-                conf.get_oracle_password(),
+                oracle_user,
+                oracle_pass,
                 conf.get_oracle_connection_string(),
             ),
         )

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-connect-execute-job/config.ini
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-connect-execute-job/config.ini
@@ -1,0 +1,2 @@
+[owner]
+team = test-team

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-type-inference/20_ingest.py
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-type-inference/20_ingest.py
@@ -1,8 +1,6 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
-import datetime
 import math
-from decimal import Decimal
 
 
 def run(job_input):

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job/config.ini
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job/config.ini
@@ -1,0 +1,2 @@
+[owner]
+team = test-team

--- a/projects/vdk-plugins/vdk-oracle/tests/test_secrets_config.py
+++ b/projects/vdk-plugins/vdk-oracle/tests/test_secrets_config.py
@@ -1,0 +1,135 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import json
+import os
+from unittest import mock
+
+import pytest
+from click.testing import Result
+from pytest_httpserver.pytest_plugin import PluginHTTPServer
+from vdk.plugin.control_cli_plugin import secrets_plugin
+from vdk.plugin.control_cli_plugin import vdk_plugin_control_cli
+from vdk.plugin.oracle import oracle_plugin
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_funcs import jobs_path_from_caller_directory
+from werkzeug import Response
+
+
+@pytest.fixture(scope="session")
+def test_oracle_secrets_sql_only(httpserver: PluginHTTPServer):
+    api_url = httpserver.url_for("")
+    secrets_data = {"vdk_user": "SYSTEM", "vdk_pass": "Gr0mh3llscr3am"}
+
+    httpserver.expect_request(
+        method="GET",
+        uri=f"/data-jobs/for-team/test-team/jobs/oracle-connect-execute-job/deployments/TODO/secrets",
+    ).respond_with_handler(
+        lambda r: Response(status=200, response=json.dumps(secrets_data, indent=4))
+    )
+    with mock.patch.dict(
+        os.environ,
+        {
+            "VDK_CONTROL_SERVICE_REST_API_URL": api_url,
+            "VDK_secrets_DEFAULT_TYPE": "control-service",
+            "VDK_ORACLE_USER_SECRET": "vdk_user",
+            "VDK_ORACLE_PASSWORD_SECRET": "vdk_pass",
+            "VDK_ORACLE_USE_SECRETS": "True",
+            "VDK_ORACLE_CONNECTION_STRING": "localhost:1521/FREE",
+            "VDK_LOG_EXECUTION_RESULT": "True",
+            "VDK_INGEST_METHOD_DEFAULT": "ORACLE",
+            "DB_DEFAULT_TYPE": "oracle",
+        },
+    ):
+        runner = CliEntryBasedTestRunner(
+            vdk_plugin_control_cli, secrets_plugin, oracle_plugin
+        )
+        result: Result = runner.invoke(
+            ["run", jobs_path_from_caller_directory("oracle-connect-execute-job")]
+        )
+        cli_assert_equal(0, result)
+    with mock.patch.dict(
+        os.environ,
+        {
+            "VDK_ORACLE_USER": "SYSTEM",
+            "VDK_ORACLE_PASSWORD": "Gr0mh3llscr3am",
+            "VDK_ORACLE_USE_SECRETS": "False",
+            "VDK_ORACLE_CONNECTION_STRING": "localhost:1521/FREE",
+            "VDK_LOG_EXECUTION_RESULT": "True",
+            "VDK_INGEST_METHOD_DEFAULT": "ORACLE",
+            "DB_DEFAULT_TYPE": "oracle",
+        },
+    ):
+        _verify_query_execution(runner)
+
+
+@pytest.fixture(scope="session")
+def test_oracle_secrets_ingest_job(httpserver: PluginHTTPServer):
+    api_url = httpserver.url_for("")
+    secrets_data = {"vdk_user": "SYSTEM", "vdk_pass": "Gr0mh3llscr3am"}
+
+    httpserver.expect_request(
+        method="GET",
+        uri=f"/data-jobs/for-team/test-team/jobs/oracle-ingest-job/deployments/TODO/secrets",
+    ).respond_with_handler(
+        lambda r: Response(status=200, response=json.dumps(secrets_data, indent=4))
+    )
+    with mock.patch.dict(
+        os.environ,
+        {
+            "VDK_CONTROL_SERVICE_REST_API_URL": api_url,
+            "VDK_secrets_DEFAULT_TYPE": "control-service",
+            "VDK_ORACLE_USER_SECRET": "vdk_user",
+            "VDK_ORACLE_PASSWORD_SECRET": "vdk_pass",
+            "VDK_ORACLE_USE_SECRETS": "True",
+            "VDK_ORACLE_CONNECTION_STRING": "localhost:1521/FREE",
+            "VDK_LOG_EXECUTION_RESULT": "True",
+            "VDK_INGEST_METHOD_DEFAULT": "ORACLE",
+            "DB_DEFAULT_TYPE": "oracle",
+        },
+    ):
+        runner = CliEntryBasedTestRunner(
+            vdk_plugin_control_cli, secrets_plugin, oracle_plugin
+        )
+        result: Result = runner.invoke(
+            ["run", jobs_path_from_caller_directory("oracle-ingest-job")]
+        )
+        cli_assert_equal(0, result)
+    with mock.patch.dict(
+        os.environ,
+        {
+            "VDK_ORACLE_USER": "SYSTEM",
+            "VDK_ORACLE_PASSWORD": "Gr0mh3llscr3am",
+            "VDK_ORACLE_USE_SECRETS": "False",
+            "VDK_ORACLE_CONNECTION_STRING": "localhost:1521/FREE",
+            "VDK_LOG_EXECUTION_RESULT": "True",
+            "VDK_INGEST_METHOD_DEFAULT": "ORACLE",
+            "DB_DEFAULT_TYPE": "oracle",
+        },
+    ):
+        _verify_ingest_execution(runner)
+
+
+def _verify_query_execution(runner):
+    check_result = runner.invoke(["oracle-query", "--query", "SELECT * FROM todoitem"])
+    expected = (
+        "  ID  DESCRIPTION      DONE\n"
+        "----  -------------  ------\n"
+        "   1  Task 1              1\n"
+    )
+    assert check_result.output == expected
+
+
+def _verify_ingest_execution(runner):
+    check_result = runner.invoke(
+        ["oracle-query", "--query", "SELECT * FROM test_table"]
+    )
+    expected = (
+        "  ID  STR_DATA      INT_DATA    FLOAT_DATA    BOOL_DATA  "
+        "TIMESTAMP_DATA         DECIMAL_DATA\n"
+        "----  ----------  ----------  ------------  -----------  "
+        "-------------------  --------------\n"
+        "   5  string              12           1.2            1  2023-11-21 "
+        "08:12:53             0.1\n"
+    )
+    assert check_result.output == expected


### PR DESCRIPTION
## Why?

Secrets should be supported to avoid storing credentials in plaintext for cloud deployments

## What?

Add support for secrets
Update README.md
Change development status to beta

## How was this tested?

Ran funcational tests locally
CI/CD

## What kind of change is this?

Feature/non-breaking