### PR TITLE
vdk-structlog: filter vdk_step_name and vdk_step_type correctly

### DIFF
--- a/projects/vdk-plugins/vdk-structlog/src/vdk/plugin/structlog/formatters.py
+++ b/projects/vdk-plugins/vdk-structlog/src/vdk/plugin/structlog/formatters.py
@@ -162,5 +162,5 @@ def create_formatter(
         )
         formatter = ConsoleFormatter(fmt=format_string)
         custom_key_filter = ConsoleMetadataFilter(key_set)
-
+    custom_key_filter.name = "metadata_filter"
     return formatter, custom_key_filter

--- a/projects/vdk-plugins/vdk-structlog/tests/test_structlog.py
+++ b/projects/vdk-plugins/vdk-structlog/tests/test_structlog.py
@@ -87,8 +87,7 @@ def test_structlog(log_format):
         # due to the log_level_module config specified in the config.ini of the test job
         # the 'This log statement should not appear' log should not appear in the output logs
         assert (
-            _get_log_containing_s(
-                logs, "This log statement should not appear") is None
+            _get_log_containing_s(logs, "This log statement should not appear") is None
         )
 
         _assert_cases(
@@ -103,10 +102,8 @@ def test_stock_fields_removal(log_format):
     stock_field_reps = STOCK_FIELD_REPRESENTATIONS[log_format]
 
     for removed_field in STOCK_FIELDS:
-        shown_fields = [
-            field for field in STOCK_FIELDS if field != removed_field]
-        vdk_logging_metadata = ",".join(
-            shown_fields) + ",bound_test_key,extra_test_key"
+        shown_fields = [field for field in STOCK_FIELDS if field != removed_field]
+        vdk_logging_metadata = ",".join(shown_fields) + ",bound_test_key,extra_test_key"
 
         with mock.patch.dict(
             os.environ,
@@ -126,8 +123,7 @@ def test_stock_fields_removal(log_format):
 
             # check the rest are shown
             for shown_field in shown_fields:
-                assert re.search(
-                    stock_field_reps[shown_field], test_log) is not None
+                assert re.search(stock_field_reps[shown_field], test_log) is not None
 
 
 @pytest.mark.parametrize("log_format", ["console"])
@@ -148,8 +144,7 @@ def test_custom_format_applied(log_format):
                 assert _matches_custom_format(log)
                 break
         else:
-            pytest.fail(
-                "Log statement with no bound context not found in logs")
+            pytest.fail("Log statement with no bound context not found in logs")
 
 
 @pytest.mark.parametrize("log_format", ["json", "ltsv"])
@@ -173,8 +168,7 @@ def test_custom_format_not_applied_for_non_console_formats(log_format):
                 ), f"Custom format was incorrectly applied for {log_format} format. Log: {log}"
                 break
         else:
-            pytest.fail(
-                "Log statement with no bound context not found in logs")
+            pytest.fail("Log statement with no bound context not found in logs")
 
 
 @pytest.mark.parametrize("log_format", ["console", "json", "ltsv"])
@@ -188,12 +182,9 @@ def test_step_name_step_type(log_format):
         },
     ):
         logs = _run_job_and_get_logs()
-        test_log = _get_log_containing_s(
-            logs, "Log statement with no bound context")
-        assert re.search(
-            stock_field_reps["vdk_step_name"], test_log) is not None
-        assert re.search(
-            stock_field_reps["vdk_step_type"], test_log) is not None
+        test_log = _get_log_containing_s(logs, "Log statement with no bound context")
+        assert re.search(stock_field_reps["vdk_step_name"], test_log) is not None
+        assert re.search(stock_field_reps["vdk_step_type"], test_log) is not None
 
     with mock.patch.dict(
         os.environ,
@@ -203,10 +194,8 @@ def test_step_name_step_type(log_format):
         },
     ):
         logs = _run_job_and_get_logs()
-        test_log = _get_log_containing_s(
-            logs, "Log statement with no bound context")
-        assert re.search(
-            stock_field_reps["vdk_step_name"], test_log) is not None
+        test_log = _get_log_containing_s(logs, "Log statement with no bound context")
+        assert re.search(stock_field_reps["vdk_step_name"], test_log) is not None
         assert re.search(stock_field_reps["vdk_step_type"], test_log) is None
 
     with mock.patch.dict(
@@ -217,11 +206,9 @@ def test_step_name_step_type(log_format):
         },
     ):
         logs = _run_job_and_get_logs()
-        test_log = _get_log_containing_s(
-            logs, "Log statement with no bound context")
+        test_log = _get_log_containing_s(logs, "Log statement with no bound context")
         assert re.search(stock_field_reps["vdk_step_name"], test_log) is None
-        assert re.search(
-            stock_field_reps["vdk_step_type"], test_log) is not None
+        assert re.search(stock_field_reps["vdk_step_type"], test_log) is not None
 
 
 def _matches_custom_format(log):


### PR DESCRIPTION
## Why?

vdk_step_name and vdk_step_type were not filtered correctly when using json format

## What?

Make sure the metadata filter alwats executes last, even when vdk_step_name and vdk_step_type are involved

Add separate functional test for vdk_step_name and vdk_step_type to avoid conflict with file_name in other tests

## How was this tested?

Functional tests

## What kind of change is this?

Feature/non-breaking