### PR TITLE
vdk-kerberos-auth: fix dependency issue

### DIFF
--- a/projects/vdk-plugins/vdk-kerberos-auth/requirements.txt
+++ b/projects/vdk-plugins/vdk-kerberos-auth/requirements.txt
@@ -1,5 +1,5 @@
-docker-compose
 docker<7
+docker-compose
 # Pinned minikerberos because the current implementation is not compatible with 0.3.0+
 # https://github.com/vmware/versatile-data-kit/issues/1169
 pytest

--- a/projects/vdk-plugins/vdk-kerberos-auth/requirements.txt
+++ b/projects/vdk-plugins/vdk-kerberos-auth/requirements.txt
@@ -1,5 +1,5 @@
 docker-compose
-
+docker<7
 # Pinned minikerberos because the current implementation is not compatible with 0.3.0+
 # https://github.com/vmware/versatile-data-kit/issues/1169
 pytest


### PR DESCRIPTION
# Why
The latest release of docker doesn't work with our version of pytest-docker. 
I am fixing the docker version. 