### PR TITLE
control-service: getting all jobs should now be consistent

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLDataFetchers.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLDataFetchers.java
@@ -182,11 +182,13 @@ public class GraphQLDataFetchers {
                     f -> f,
                     filter ->
                         strategyFactory.findStrategy(
-                            JobFieldStrategyBy.field(filter.getProperty())), (v1, v2) -> {
+                            JobFieldStrategyBy.field(filter.getProperty())),
+                    (v1, v2) -> {
                       throw new IllegalArgumentException(
                           "No duplicate keys allowed in Filter Strategy Map. Duplicate was: "
                               + v1.getStrategyName());
-                    }, LinkedHashMap::new));
+                    },
+                    LinkedHashMap::new));
 
     // compute criteria
     filterStrategyMap.forEach(

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLDataFetchers.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/graphql/GraphQLDataFetchers.java
@@ -7,11 +7,10 @@ package com.vmware.taurus.service.graphql;
 
 import com.vmware.taurus.datajobs.DeploymentModelConverter;
 import com.vmware.taurus.datajobs.ToApiModelConverter;
-import com.vmware.taurus.service.deploy.DeploymentServiceV2;
-import com.vmware.taurus.service.repository.JobsRepository;
 import com.vmware.taurus.service.deploy.DataJobDeploymentPropertiesConfig;
 import com.vmware.taurus.service.deploy.DataJobDeploymentPropertiesConfig.ReadFrom;
 import com.vmware.taurus.service.deploy.DeploymentService;
+import com.vmware.taurus.service.deploy.DeploymentServiceV2;
 import com.vmware.taurus.service.graphql.model.Criteria;
 import com.vmware.taurus.service.graphql.model.DataJobPage;
 import com.vmware.taurus.service.graphql.model.DataJobQueryVariables;
@@ -22,19 +21,26 @@ import com.vmware.taurus.service.graphql.strategy.JobFieldStrategyFactory;
 import com.vmware.taurus.service.graphql.strategy.datajob.JobFieldStrategyBy;
 import com.vmware.taurus.service.model.DataJob;
 import com.vmware.taurus.service.model.JobDeploymentStatus;
+import com.vmware.taurus.service.repository.JobsRepository;
 import graphql.GraphqlErrorException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingFieldSelectionSet;
-import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
@@ -176,7 +182,11 @@ public class GraphQLDataFetchers {
                     f -> f,
                     filter ->
                         strategyFactory.findStrategy(
-                            JobFieldStrategyBy.field(filter.getProperty()))));
+                            JobFieldStrategyBy.field(filter.getProperty())), (v1, v2) -> {
+                      throw new IllegalArgumentException(
+                          "No duplicate keys allowed in Filter Strategy Map. Duplicate was: "
+                              + v1.getStrategyName());
+                    }, LinkedHashMap::new));
 
     // compute criteria
     filterStrategyMap.forEach(

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/FindAllDataJobsTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/FindAllDataJobsTest.java
@@ -37,17 +37,13 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @AutoConfigureMockMvc(addFilters = false)
 public class FindAllDataJobsTest {
 
-  @Autowired
-  JobsRepository jobsRepository;
+  @Autowired JobsRepository jobsRepository;
 
-  @Autowired
-  ActualJobDeploymentRepository actualJobDeploymentRepository;
+  @Autowired ActualJobDeploymentRepository actualJobDeploymentRepository;
 
-  @Autowired
-  JobExecutionRepository jobExecutionRepository;
+  @Autowired JobExecutionRepository jobExecutionRepository;
 
-  @Autowired
-  private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
   @AfterEach
   public void cleanup() {
@@ -61,7 +57,8 @@ public class FindAllDataJobsTest {
   }
 
   private static String getQuery(int pageNumber) {
-    return "{ jobs(pageNumber: " + pageNumber
+    return "{ jobs(pageNumber: "
+        + pageNumber
         + ", pageSize: 100, filter: [{ property: \"config.team\", sort: ASC },"
         + " { property: \"jobName\", sort: ASC }]) { content { jobName config { team description "
         + "schedule { scheduleCron }  }  deployments { enabled status }  }  }  }";
@@ -84,7 +81,6 @@ public class FindAllDataJobsTest {
       Assertions.assertEquals(firstPage, firstPageInALoop);
       Assertions.assertEquals(secondPage, secondPageInALoop);
       Assertions.assertEquals(thirdPage, thirdPageInALoop);
-
     }
   }
 
@@ -105,13 +101,14 @@ public class FindAllDataJobsTest {
   private String getResponseAsString(String team, int pageNumber) throws Exception {
     return getAllJobs(team, pageNumber)
         .andExpect(status().is(200))
-        .andReturn().getResponse()
+        .andReturn()
+        .getResponse()
         .getContentAsString();
   }
 
   private ResultActions getAllJobs(String jobTeam, int pageNumber) throws Exception {
-    var response = mockMvc
-        .perform(
+    var response =
+        mockMvc.perform(
             MockMvcRequestBuilders.get(getJobsUri(jobTeam))
                 .queryParam("query", getQuery(pageNumber))
                 .with(user("test")));
@@ -120,7 +117,7 @@ public class FindAllDataJobsTest {
   }
 
   private void populateThreePagesOfDummyJobs() {
-    //create 202 jobs to have 3 pages of results
+    // create 202 jobs to have 3 pages of results
     for (int i = 0; i < 101; i++) {
       saveTestJob(i + "bar", "AAAA");
       saveTestJob(i + "foo", "BBBB");

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/FindAllDataJobsTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/graphql/FindAllDataJobsTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2021-2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.graphql;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.vmware.taurus.ControlplaneApplication;
+import com.vmware.taurus.service.model.ActualDataJobDeployment;
+import com.vmware.taurus.service.model.DataJob;
+import com.vmware.taurus.service.model.DataJobExecution;
+import com.vmware.taurus.service.model.ExecutionStatus;
+import com.vmware.taurus.service.model.ExecutionType;
+import com.vmware.taurus.service.model.JobConfig;
+import com.vmware.taurus.service.repository.ActualJobDeploymentRepository;
+import com.vmware.taurus.service.repository.JobExecutionRepository;
+import com.vmware.taurus.service.repository.JobsRepository;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = ControlplaneApplication.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class FindAllDataJobsTest {
+
+  @Autowired
+  JobsRepository jobsRepository;
+
+  @Autowired
+  ActualJobDeploymentRepository actualJobDeploymentRepository;
+
+  @Autowired
+  JobExecutionRepository jobExecutionRepository;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @AfterEach
+  public void cleanup() {
+    jobsRepository.deleteAll();
+    actualJobDeploymentRepository.deleteAll();
+    jobExecutionRepository.deleteAll();
+  }
+
+  private static String getJobsUri(String teamName) {
+    return "/data-jobs/for-team/" + teamName + "/jobs";
+  }
+
+  private static String getQuery(int pageNumber) {
+    return "{ jobs(pageNumber: " + pageNumber
+        + ", pageSize: 100, filter: [{ property: \"config.team\", sort: ASC },"
+        + " { property: \"jobName\", sort: ASC }]) { content { jobName config { team description "
+        + "schedule { scheduleCron }  }  deployments { enabled status }  }  }  }";
+  }
+
+  @Test
+  public void testJsonReturnOrder_expectNoChanges() throws Exception {
+    populateThreePagesOfDummyJobs();
+
+    var firstPage = getResponseAsString("unspecified", 1);
+    var secondPage = getResponseAsString("unspecified", 2);
+    var thirdPage = getResponseAsString("unspecified", 3);
+
+    for (int i = 0; i < 100; i++) {
+      // we test if the returned json has a changed sort order
+      var firstPageInALoop = getResponseAsString("unspecified", 1);
+      var secondPageInALoop = getResponseAsString("unspecified", 2);
+      var thirdPageInALoop = getResponseAsString("unspecified", 3);
+
+      Assertions.assertEquals(firstPage, firstPageInALoop);
+      Assertions.assertEquals(secondPage, secondPageInALoop);
+      Assertions.assertEquals(thirdPage, thirdPageInALoop);
+
+    }
+  }
+
+  @Test
+  public void testNumberOfReturnedJobs() throws Exception {
+    populateThreePagesOfDummyJobs();
+    getAllJobs("unspecified", 1)
+        .andExpect(jsonPath("$.data.content[99].jobName").exists())
+        .andExpect(jsonPath("$.data.content[101].jobName").doesNotExist());
+    getAllJobs("unspecified", 2)
+        .andExpect(jsonPath("$.data.content[99].jobName").exists())
+        .andExpect(jsonPath("$.data.content[101].jobName").doesNotExist());
+    getAllJobs("unspecified", 3)
+        .andExpect(jsonPath("$.data.content[1].jobName").exists())
+        .andExpect(jsonPath("$.data.content[2].jobName").doesNotExist());
+  }
+
+  private String getResponseAsString(String team, int pageNumber) throws Exception {
+    return getAllJobs(team, pageNumber)
+        .andExpect(status().is(200))
+        .andReturn().getResponse()
+        .getContentAsString();
+  }
+
+  private ResultActions getAllJobs(String jobTeam, int pageNumber) throws Exception {
+    var response = mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(getJobsUri(jobTeam))
+                .queryParam("query", getQuery(pageNumber))
+                .with(user("test")));
+
+    return response;
+  }
+
+  private void populateThreePagesOfDummyJobs() {
+    //create 202 jobs to have 3 pages of results
+    for (int i = 0; i < 101; i++) {
+      saveTestJob(i + "bar", "AAAA");
+      saveTestJob(i + "foo", "BBBB");
+    }
+  }
+
+  private void saveTestJob(String jobName, String jobTeam) {
+    var job = new DataJob();
+    var config = new JobConfig();
+    config.setTeam(jobTeam);
+    job.setJobConfig(config);
+    job.setName(jobName);
+    job.setEnabled(true);
+    jobsRepository.save(job);
+    var execution = new DataJobExecution();
+    execution.setStatus(ExecutionStatus.SUCCEEDED);
+    execution.setDataJob(job);
+    execution.setId(job.getName());
+    execution.setType(ExecutionType.MANUAL);
+    execution.setOpId(UUID.randomUUID().toString());
+    jobExecutionRepository.save(execution);
+    var deployment = new ActualDataJobDeployment();
+    deployment.setDataJobName(job.getName());
+    deployment.setEnabled(true);
+    deployment.setLastDeployedDate(OffsetDateTime.now());
+    actualJobDeploymentRepository.save(deployment);
+  }
+}


### PR DESCRIPTION
what: The control-service now uses LinkedHashMap when populating the graphQL filter and search criteria strategies.
Which ensures consistent filtering and sorting.

why: The previous usage of a HashMap would not guarantee any ordering of the key set which would lead to user issues when querying data from the API such as differently sorted lists of data jobs for the same query. This would cause more problems when we include pagination on a larger query - such as vdk list -a - users would see duplicated data, or missing data. Example of the same query with different ordering results can be seen below:

![image](https://github.com/vmware/versatile-data-kit/assets/30639485/ac004a19-38e3-4c53-b86b-e99cfaa85afa)

This was run on a local instance of the control-service with dummy data.

testing: Added unit test.