### PR TITLE
vdk-core: replace deprecated imp module with importlib

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/file_based_step.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/file_based_step.py
@@ -1,6 +1,6 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
-import imp
+import importlib.util
 import inspect
 import logging
 import pathlib
@@ -79,7 +79,11 @@ class StepFuncFactory:
 
             try:
                 log.debug("Loading %s ..." % filename)
-                python_module = imp.load_source(namespace, str(step.file_path))
+                spec = importlib.util.spec_from_file_location(
+                    namespace, str(step.file_path)
+                )
+                python_module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(python_module)
                 log.debug("Loading %s SUCCESS" % filename)
             except BaseException as e:
                 log.info("Loading %s FAILURE" % filename)


### PR DESCRIPTION
What: Replace deprecated imp module with importlib.

Why: To fix an error with the VDK command faced by a user.

Testing Done: existing tests pass

Signed-off-by: Yoan Salambashev <yoan.salambashev@broadcom.com>