### PR TITLE
vdk-control-cli: Modify how data is written to job config.ini

### DIFF
--- a/projects/vdk-control-cli/src/vdk/internal/control/job/job_config.py
+++ b/projects/vdk-control-cli/src/vdk/internal/control/job/job_config.py
@@ -104,11 +104,15 @@ class JobConfig:
     def _set_value(self, section, key, value) -> bool:
         success = False
         if self._config_ini.has_option(section, key):
-            for line in fileinput.input(self._config_file, inplace=1):
-                if line.replace(" ", "").startswith(f"{key}="):
-                    success = True
-                    line = f"{key} = {value}\n"
-                sys.stdout.write(line)
+            with open(self._config_file) as config_file:
+                conf_lines = config_file.readlines()
+
+            with open(self._config_file, "w") as f:
+                for line in conf_lines:
+                    if line.replace(" ", "").startswith(f"{key}="):
+                        success = True
+                        line = f"{key} = {value}\n"
+                    f.write(line)
         return success
 
     def _get_contacts(self, key) -> List[str]:

--- a/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_create.py
+++ b/projects/vdk-control-cli/tests/vdk/internal/control/command_groups/job/test_create.py
@@ -288,8 +288,44 @@ def test_create_only_local_flag(httpserver: PluginHTTPServer, tmpdir: LocalPath)
         ],
     )
 
-    # created only locally would not try to contact REST API so it should succeeds.
+    # created only locally would not try to contact REST API, so it should succeed.
     assert_click_status(result, 0)
+
+
+def test_create_local_flag_check_generated_config_file(
+    httpserver: PluginHTTPServer, tmpdir: LocalPath
+):
+    team_name = "test-team"
+    job_name = "test-job"
+    jobs_dir, rest_api_url = setup_create(
+        httpserver, tmpdir, 500, 500, job_name, team_name
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        create,
+        [
+            "-n",
+            "test-job",
+            "-t",
+            "team_name",
+            "-p",
+            jobs_dir,
+            "-u",
+            rest_api_url,
+            "--local",
+        ],
+    )
+
+    # created only locally would not try to contact REST API, so it should succeed.
+    job_dir = os.path.join(jobs_dir, job_name)
+    assert_click_status(result, 0)
+    assert os.path.isdir(job_dir)
+    assert os.path.isfile(os.path.join(job_dir, "config.ini"))
+
+    # Verify that config.ini is not empty
+    with open(os.path.join(job_dir, "config.ini"), "rb") as f:
+        assert f.seek(0, 2) > 0
 
 
 def test_create_with_empty_url(httpserver: PluginHTTPServer, tmpdir: LocalPath):


### PR DESCRIPTION
Currently, the `_set_value()` logic in **JobConfig** uses `fileinput.input()` to traverse the contents of the job config file, and update the keys passed. This works as expected on python versions up to 3.11. It, however breaks on python3.11 on some platforms. For example, it works fine on Ubuntu, but the config file gets truncated on photonOS (the operating system used for the secure base images), which causes job creation failures.

This change modifies the `_set_value()` logic to directly read and write the config file's contents, and drops the use of *fileinput*.

Testing Done: Added test, and did some local testing using docker containers with different host OSs.