### PR TITLE
frontend: [SC-2632] Save Executions grid state

### DIFF
--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/data-job-executions-grid/data-job-executions-grid.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/data-job-executions-grid/data-job-executions-grid.component.ts
@@ -126,6 +126,7 @@ export class DataJobExecutionsGridComponent implements OnChanges, OnInit, OnDest
     jobDeploymentModalData: DataJobDeployment;
 
     paginatedJobExecutions: GridDataJobExecution[] = [];
+    gridState: ClrDatagridStateInterface;
 
     paginationPageNumber: number;
     paginationPageSize: number;
@@ -183,6 +184,7 @@ export class DataJobExecutionsGridComponent implements OnChanges, OnInit, OnDest
         }
 
         let skipCriteriaAndComparatorEmitterDebouncing = false;
+        this.gridState = state;
 
         if (this.isInitialCriteriasEmit) {
             this.isInitialCriteriasEmit = false;
@@ -208,7 +210,7 @@ export class DataJobExecutionsGridComponent implements OnChanges, OnInit, OnDest
             !CollectionsUtil.isEqual(changes['jobExecutions'].previousValue, changes['jobExecutions'].currentValue)
         ) {
             this.paginationTotalItems = this.jobExecutions.length;
-            this._paginateExecutions(null);
+            this._paginateExecutions(this.gridState);
         }
     }
 


### PR DESCRIPTION
Why
Data Job Executions list (in Data Job Executions page) pagination behaviour is unpredictable whenever the job is running.

What
Save and reuse executions grid state

How was this tested
Ran e2e tests locally

What type of change is this
Bug fix