### PR TITLE
Included data job version in job_input.get_execution_properties() #1246

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/job_input.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/job_input.py
@@ -28,6 +28,7 @@ from vdk.internal.core.context import CoreContext
 from vdk.internal.core.errors import SkipRemainingStepsException
 from vdk.internal.core.errors import UserCodeError
 from vdk.internal.core.statestore import CommonStoreKeys
+from vdk.internal.core.statestore import ExecutionStateStoreKeys
 
 
 # TODO make this extensible so new job inputs can be added by plugins
@@ -182,6 +183,7 @@ class JobInput(IJobInput):
             "pa__job_start_unixtime": str(int(start_time.timestamp())),
             "pa__job_start_ts_expr": f"cast ({start_time.timestamp()} as timestamp)",
             "pa__op_id": self.__statestore.get(CommonStoreKeys.OP_ID),
+            "pa__job_version": self.__statestore.get(ExecutionStateStoreKeys.JOB_GIT_HASH),
         }
 
     def skip_remaining_steps(self) -> None:


### PR DESCRIPTION
As part of job_input.get_execution_properties(), I added a way to get the data job version.

Now you can see the data job version too.