### PR TITLE
vdk-oracle: set thik mode default to true

### DIFF
--- a/projects/vdk-plugins/vdk-oracle/src/vdk/plugin/oracle/oracle_configuration.py
+++ b/projects/vdk-plugins/vdk-oracle/src/vdk/plugin/oracle/oracle_configuration.py
@@ -107,7 +107,7 @@ class OracleConfiguration:
         )
         config_builder.add(
             key=ORACLE_THICK_MODE,
-            default_value=False,
+            default_value=True,
             description="Use oracle thick mode. Set to False to disable oracle thick mode."
             "If set to true you may need to manually install client library. "
             "Refer to "


### PR DESCRIPTION
The tick mode = true is more frequently used for now

So it makes more sense to be default