### PR TITLE
vdk-core: remove verbose logs

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_router.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_router.py
@@ -61,7 +61,7 @@ class IngesterRouter(IIngesterRegistry, IIngester):
         collection_id: Optional[str] = None,
     ):
         method, target = self.__get_correct_method_and_target(method, target)
-        self._log.info(
+        self._log.debug(
             "Sending object for ingestion with "
             f"method: {method} and target: {target}"
         )
@@ -102,7 +102,7 @@ class IngesterRouter(IIngesterRegistry, IIngester):
         collection_id: Optional[str] = None,
     ):
         method, target = self.__get_correct_method_and_target(method, target)
-        self._log.info(
+        self._log.debug(
             "Sending tabular data for ingestion with "
             f"method: {method} and target: {target}"
         )


### PR DESCRIPTION
Those looks can be extremely spammy if you try to ingest many records (millions) , as it's called for every record.
We can add some kind of stats logging which is done every minute or so to track progress.

This can cause significant slow down of the ingestion and the data job. 

Looking at the logs send by 500 jobs in one deployment of VDK. Logs from `ingester_router` represent more than 80% of hte logs sent.

