### PR TITLE
vdk-core: replace report_and_rethrow

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
@@ -156,10 +156,8 @@ class ManagedConnectionBase(PEP249Connection, IManagedConnection):
                             ]
                         )
                     )
-                    errors.report_and_rethrow(
-                        blamee,
-                        e,
-                    )
+                    errors.report(blamee, e)
+                    raise e
             return cast(
                 List[List[Any]], res
             )  # we return None in case of DML. This is not PEP249 compliant, but is more convenient

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
@@ -119,10 +119,11 @@ class ManagedCursor(ProxyCursor):
                         ]
                     )
                 )
-                errors.report_and_rethrow(
+                errors.report(
                     blamee,
                     e,
                 )
+                raise e
 
     def _decorate_operation(self, managed_operation: ManagedOperation, operation: str):
         if self.__connection_hook_spec.db_connection_decorate_operation.get_hookimpls():
@@ -143,7 +144,8 @@ class ManagedCursor(ProxyCursor):
                         ]
                     )
                 )
-                errors.report_and_rethrow(errors.ResolvableBy.PLATFORM_ERROR, e)
+                errors.report(errors.ResolvableBy.PLATFORM_ERROR, e)
+                raise e
 
     def _validate_operation(self, operation: str, parameters: Optional[Container]):
         if self.__connection_hook_spec.db_connection_validate_operation.get_hookimpls():
@@ -161,10 +163,11 @@ class ManagedCursor(ProxyCursor):
                         ]
                     )
                 )
-                errors.report_and_rethrow(
+                errors.report(
                     errors.ResolvableBy.USER_ERROR,
                     exception=e,
                 )
+                raise e
 
     def _execute_operation(self, managed_operation: ManagedOperation):
         self._log.info("Executing query:\n%s" % managed_operation.get_operation())

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/cli_run.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/cli_run.py
@@ -49,7 +49,8 @@ class CliRunImpl:
                     ]
                 )
             )
-            errors.report_and_rethrow(errors.ResolvableBy.USER_ERROR, e)
+            errors.report(errors.ResolvableBy.USER_ERROR, e)
+            raise e
 
     @staticmethod
     def __split_into_chunks(exec_steps: List, chunks: int) -> List:
@@ -193,12 +194,13 @@ class CliRunImpl:
                     ]
                 )
             )
-            errors.report_and_rethrow(
+            errors.report(
                 job_input_error_classifier.whom_to_blame(
                     e, __file__, data_job_directory
                 ),
                 e,
             )
+            raise e
         if execution_result.is_failed() and execution_result.get_exception_to_raise():
             raise execution_result.get_exception_to_raise()
 

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/run/file_based_step.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/run/file_based_step.py
@@ -97,7 +97,8 @@ class StepFuncFactory:
                         ]
                     )
                 )
-                errors.report_and_rethrow(errors.ResolvableBy.USER_ERROR, e)
+                errors.report(errors.ResolvableBy.USER_ERROR, e)
+                raise e
 
             for _, func in inspect.getmembers(python_module, inspect.isfunction):
                 if func.__name__ == "run":
@@ -153,7 +154,8 @@ class StepFuncFactory:
                 )
 
                 to_be_fixed_by = whom_to_blame(e, __file__, None)
-                errors.report_and_rethrow(to_be_fixed_by, e)
+                errors.report(to_be_fixed_by, e)
+                raise e
         else:
             errors.report_and_throw(
                 errors.UserCodeError(

--- a/projects/vdk-core/src/vdk/internal/core/errors.py
+++ b/projects/vdk-core/src/vdk/internal/core/errors.py
@@ -259,7 +259,8 @@ def log_and_rethrow(
         # wrap
     message = [what_happened, why_it_happened, consequences, countermeasures]
     log.error("\n".join(message))
-    report_and_rethrow(to_be_fixed_by, exception)
+    report(to_be_fixed_by, exception)
+    raise exception
 
 
 class ErrorMessage:

--- a/projects/vdk-core/tests/vdk/internal/core/test_errors.py
+++ b/projects/vdk-core/tests/vdk/internal/core/test_errors.py
@@ -168,6 +168,18 @@ class ErrorsTest(unittest.TestCase):
             is 1
         )
 
+    def test_report(self):
+        ex = IndexError("foo")
+        errors.report(
+            errors.ResolvableBy.USER_ERROR,
+            exception=ex,
+        )
+        assert errors.ResolvableByActual.USER in errors.resolvable_context().resolvables
+        assert (
+            len(errors.resolvable_context().resolvables[errors.ResolvableByActual.USER])
+            is 1
+        )
+
     def test_report_and_throw(self):
         with pytest.raises(errors.PlatformServiceError):
             errors.report_and_throw(PlatformServiceError("My super awesome message"))


### PR DESCRIPTION
## Why?

Calling report_and_rethrow causes confusing stack traces, because of adding an extra frame from the extra function call

## What?

Replace report_and_rethrow with just calling report and raising the exception after

## How was this tested?

CI

## What kind of change is this?

Feature/non-breaking