### PR TITLE
vdk-plugins: replace report_and_rethrow

### DIFF
--- a/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/template_arguments_validator.py
+++ b/projects/vdk-plugins/vdk-impala/src/vdk/plugin/impala/templates/template_arguments_validator.py
@@ -58,4 +58,5 @@ class TemplateArgumentsValidator:
         try:
             return self.TemplateParams(**args).dict()
         except ValidationError as error:
-            errors.report_and_rethrow(ResolvableBy.USER_ERROR, error)
+            errors.report(ResolvableBy.USER_ERROR, error)
+            raise error

--- a/projects/vdk-plugins/vdk-ingest-http/src/vdk/plugin/ingest_http/ingest_over_http.py
+++ b/projects/vdk-plugins/vdk-ingest-http/src/vdk/plugin/ingest_http/ingest_over_http.py
@@ -228,4 +228,5 @@ class IngestOverHttp(IIngesterPlugin):
                 }
             )
         except Exception as e:
-            errors.report_and_rethrow(ResolvableBy.PLATFORM_ERROR, e)
+            errors.report(ResolvableBy.PLATFORM_ERROR, e)
+            raise e

--- a/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/minikerberos_authenticator.py
+++ b/projects/vdk-plugins/vdk-kerberos-auth/src/vdk/plugin/kerberos/minikerberos_authenticator.py
@@ -138,4 +138,5 @@ class MinikerberosGSSAPIAuthenticator(BaseAuthenticator):
             )
         except Exception as e:
             log.warning("Could not retrieve Kerberos TGT")
-            errors.report_and_rethrow(ResolvableBy.CONFIG_ERROR, e)
+            errors.report(ResolvableBy.CONFIG_ERROR, e)
+            raise e

--- a/projects/vdk-plugins/vdk-postgres/src/vdk/plugin/postgres/ingest_to_postgres.py
+++ b/projects/vdk-plugins/vdk-postgres/src/vdk/plugin/postgres/ingest_to_postgres.py
@@ -51,9 +51,8 @@ class IngestToPostgres(IIngesterPlugin):
                 connection.commit()
                 log.debug("Payload was ingested.")
             except Exception as e:
-                errors.report_and_rethrow(
-                    errors.find_whom_to_blame_from_exception(e), e
-                )
+                errors.report(errors.find_whom_to_blame_from_exception(e), e)
+                raise e
 
     @staticmethod
     def _populate_query_parameters_tuple(

--- a/projects/vdk-plugins/vdk-snowflake/src/vdk/plugin/snowflake/snowflake_connection.py
+++ b/projects/vdk-plugins/vdk-snowflake/src/vdk/plugin/snowflake/snowflake_connection.py
@@ -78,7 +78,8 @@ class SnowflakeConnection(ManagedConnectionBase):
         except (errors.BaseVdkError, ProgrammingError, Exception) as e:
             blamee = ResolvableBy.CONFIG_ERROR
             log.warning("Connecting to Snowflake FAILED.")
-            errors.report_and_rethrow(blamee, e)
+            errors.report(blamee, e)
+            raise e
 
     def execute_query(self, query) -> List[List[Any]]:
         try:

--- a/projects/vdk-plugins/vdk-sqlite/src/vdk/plugin/sqlite/ingest_to_sqlite.py
+++ b/projects/vdk-plugins/vdk-sqlite/src/vdk/plugin/sqlite/ingest_to_sqlite.py
@@ -99,9 +99,10 @@ class IngestToSQLite(IIngesterPlugin):
                     log.warning(
                         "Failed to sent payload. An issue with the SQL query occurred."
                     )
-                    errors.report_and_rethrow(ResolvableBy.USER_ERROR, e)
+                    errors.report(ResolvableBy.USER_ERROR, e)
                 else:
-                    errors.report_and_rethrow(errors.ResolvableBy.PLATFORM_ERROR, e)
+                    errors.report(errors.ResolvableBy.PLATFORM_ERROR, e)
+                raise e
 
     def __check_destination_table_exists(
         self, destination_table: str, cur: Cursor

--- a/projects/vdk-plugins/vdk-trino/src/vdk/plugin/trino/ingest_to_trino.py
+++ b/projects/vdk-plugins/vdk-trino/src/vdk/plugin/trino/ingest_to_trino.py
@@ -78,7 +78,8 @@ class IngestToTrino(IIngesterPlugin):
             cur.fetchall()
             log.debug("Payload was ingested.")
         except Exception as e:
-            errors.report_and_rethrow(errors.find_whom_to_blame_from_exception(e), e)
+            errors.report(errors.find_whom_to_blame_from_exception(e), e)
+            raise e
 
     @staticmethod
     def __to_bool(value: Any) -> bool:


### PR DESCRIPTION
## Why?

Calling report_and_rethrow causes confusing stack traces, because of adding an extra frame from the extra function call

## What?

Replace report_and_rethrow with just calling report and raising the exception after

## How was this tested?

CI

## What kind of change is this?

Feature/non-breaking