### PR TITLE
vdk-core: relevant info in step result

### DIFF
--- a/projects/vdk-core/tests/functional/run/test_run_errors.py
+++ b/projects/vdk-core/tests/functional/run/test_run_errors.py
@@ -229,3 +229,18 @@ def test_error_from_pandas_user_error(tmp_termination_msg_file):
         assert _get_job_status(tmp_termination_msg_file) == "User error"
         assert '"blamee": "User Error"' in result.output
         assert '"exception_name": "KeyError"' in result.output
+
+
+def test_run_simple_job_summary(tmp_termination_msg_file):
+    runner = CliEntryBasedTestRunner()
+
+    result: Result = runner.invoke(["run", util.job_path("fail-job")])
+    cli_assert_equal(1, result)
+    expected = f"""
+Step results:
+1_step.py - ERROR
+  File "{os.getcwd()}/tests/functional/run/jobs/fail-job/1_step.py", line 7, in run
+    raise ArithmeticError("cannot do math :(")
+ArithmeticError: cannot do math :(
+"""
+    assert expected in result.output


### PR DESCRIPTION
## Why?

Sometimes the exact errors in user code are hard to find in the stack trace

## What?

Print relevant information from stack trace in step results

Example:

On error in step 20_python_step.py, the short result summary looks like this

```
2024-01-29 15:14:14,736 [VDK] hello-world [INFO ] vdk.internal.builtin_plugins.r           cli_run.py:166  __log_short_exec[id:3a22ec2e-d6e6-4f94-96c0-122955930cbb-1706534052-abffd]- Job execution result: ERROR
Step results:
10_sql_step.sql - SUCCESS
20_python_step.py - ERROR
  File "/Users/mdilyan/Projects/vdk-playground/hello-world/20_python_step.py", line 27, in run
    raise ValueError("No value in this")
ValueError: No value in this
```

## How was this tested?

Ran locally
Functional test

## What kind of change is this?

Feature/non-breaking