### PR TITLE
vdk-core: Update IngesterRouter to ignore pre-processors

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_configuration_plugin.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_configuration_plugin.py
@@ -60,6 +60,18 @@ class IngesterConfigurationPlugin:
             """,
         )
         config_builder.add(
+            key="INGEST_IGNORE_PAYLOAD_PREPROCESS_SEQUENCE_FOR_METHOD",
+            default_value=None,
+            description="""A string of coma-separated ingestion methods, for
+            which the payload preprocess sequence is not to be applied.
+            Example:
+                   INGEST_IGNORE_PAYLOAD_PREPROCESS_SEQUENCE_FOR_METHOD="file, http"
+            This configuration can be used in cases, where a data job ingests
+            payloads through multiple methods and the preprocessors need to be
+            used only for some payloads.
+            """,
+        )
+        config_builder.add(
             key="INGEST_PAYLOAD_POSTPROCESS_SEQUENCE",
             default_value=None,
             description="""A string of coma-separated ingestion post-

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_router.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/ingestion/ingester_router.py
@@ -189,6 +189,26 @@ class IngesterRouter(IIngesterRegistry, IIngester):
                 "INGEST_PAYLOAD_POSTPROCESS_SEQUENCE"
             )
 
+            if self._cfg.get_value(
+                "INGEST_IGNORE_PAYLOAD_PREPROCESS_SEQUENCE_FOR_METHOD"
+            ):
+                ignore_seq = [
+                    i.strip()
+                    for i in self._cfg.get_value(
+                        "INGEST_IGNORE_PAYLOAD_PREPROCESS_SEQUENCE_FOR_METHOD"
+                    ).split(",")
+                ]
+                if method in ignore_seq:
+                    self._cached_ingesters[method] = IngesterBase(
+                        self._state.get(ExecutionStateStoreKeys.JOB_NAME),
+                        self._state.get(CommonStoreKeys.OP_ID),
+                        ingester_plugin,
+                        IngesterConfiguration(config=self._cfg),
+                        pre_processors=[],
+                        post_processors=initialized_post_processors,
+                    )
+                    return self._cached_ingesters[method]
+
             self._cached_ingesters[method] = IngesterBase(
                 self._state.get(ExecutionStateStoreKeys.JOB_NAME),
                 self._state.get(CommonStoreKeys.OP_ID),


### PR DESCRIPTION
Currently, the IntesterRouter applies all available pre-processors, irrespective if the ingested payload actually needs to go through them.

This change introduces a new configuration variable, `INGEST_IGNORE_PAYLOAD_PREPROCESS_SEQUENCE_FOR_METHOD`, that allows a user to specify for which ingestion methods should the pre-processors be ignored. The new configuration accepts a comma-separated string of the form "<ingest-method1>, <ingest-method2>". This way, a data job can have the following logic:
```python
job_input.send_object_for_ingestion(payload, destination_table="test_table", method="file")

job_input.send_object_for_ingestion(payload2, destination_table="test_table", method="http")
```
and based on the value in "INGEST_IGNORE_PAYLOAD_PREPROCESS_SEQUENCE_FOR_METHOD", the available pre- processors could be applied, for example, to only the payload whose `method` is **http**.

Testing Done: Added test