### PR TITLE
vdk-core: remove structlog logging override

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/log_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/log_config.py
@@ -86,14 +86,13 @@ def configure_initial_logging_before_anything():
     # warnings.warn(
     #     "The vdk-core logging configuration is not suitable for production. Please use vdk-structlog instead."
     # )
-    if not os.environ.get("VDK_USE_STRUCTLOG"):
-        log_level = "WARNING"
-        if os.environ.get(LOG_LEVEL_VDK, None):
-            log_level = os.environ.get(LOG_LEVEL_VDK)
-        elif os.environ.get("VDK_LOG_LEVEL_VDK", None):
-            log_level = os.environ.get("VDK_LOG_LEVEL_VDK")
+    log_level = "WARNING"
+    if os.environ.get(LOG_LEVEL_VDK, None):
+        log_level = os.environ.get(LOG_LEVEL_VDK)
+    elif os.environ.get("VDK_LOG_LEVEL_VDK", None):
+        log_level = os.environ.get("VDK_LOG_LEVEL_VDK")
 
-        logging.basicConfig(format="%(message)s", level=logging.getLevelName(log_level))
+    logging.basicConfig(format="%(message)s", level=logging.getLevelName(log_level))
 
 
 def configure_loggers(


### PR DESCRIPTION
## Why?

Structlog should not override the initial logging config. It applies to logging before vdk is initialized and before any plugins are loaded. If an error happens in vdk_main, the logging config will apply. It should remain in core.

It's also not a problem for structlog, because it ejects all logging config just in case.

## What?

Remove the structlog override in core

## How was this tested?

Locally
CI

## What kind of change is this?

Bugfix