### PR TITLE
vdk-core: add is_default() function to config

### DIFF
--- a/examples/confluence-reader/confluence_document.py
+++ b/examples/confluence-reader/confluence_document.py
@@ -1,6 +1,7 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+
 class ConfluenceDocument:
     def __init__(self, metadata, data, deleted=False):
         """

--- a/projects/vdk-core/src/vdk/internal/core/config.py
+++ b/projects/vdk-core/src/vdk/internal/core/config.py
@@ -124,6 +124,17 @@ class Configuration:
         """
         return self.__config_key_to_sensitive.get(key)
 
+    def is_default(self, key: ConfigKey) -> bool:
+        """
+        Return True if the configuration value for a given key uses the default value.
+        If set_value is called for a specific key, this will return False, even if
+        value == default_value
+
+        :param key: the configuration key (e.g db_host, service_uri, etc.)
+        :return: the value corresponding to the configuration key
+        """
+        return key not in self.__config_key_to_value
+
     def list_config_keys(self) -> list[ConfigKey]:
         """
         List all added (defined) config keys

--- a/projects/vdk-core/tests/vdk/internal/core/test_config.py
+++ b/projects/vdk-core/tests/vdk/internal/core/test_config.py
@@ -22,6 +22,7 @@ def test_add(key, default_value, show_default_value, description):
     assert description is None or description in cfg.get_description(key)
     assert default_value == cfg.get_value(key)
     assert default_value == cfg[key]
+    assert cfg.is_default(key)
 
 
 def test_unknown_key():
@@ -81,6 +82,16 @@ def test_set_value_overrides_default():
     builder.add("key", "default_value", False, "key description")
     cfg = builder.build()
     assert cfg.get_value("key") == "value"
+    assert not cfg.is_default("key")
+
+
+def test_set_value_eq_default_is_not_default():
+    builder = ConfigurationBuilder()
+    builder.add("key", "value", False, "key description")
+    builder.set_value("key", "value")
+    cfg = builder.build()
+    assert cfg.get_value("key") == "value"
+    assert not cfg.is_default("key")
 
 
 def test_set_value_overrides_default_preserve_types():


### PR DESCRIPTION
## Why?

There are cases where we want to know we're using the default value for a config option. One such case is configuration presets

https://github.com/vmware/versatile-data-kit/pull/3055

## What?

Add is_default() to the config object.

## How was this tested?

Unit tests

## What kind of change is this?

Feature/non-breaking