### PR TITLE
documentation: fix monthly download badges closing HTML tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <a href="https://github.com/vmware/versatile-data-kit/contributors" alt="Last Activity">
         <img src="https://img.shields.io/github/last-commit/vmware/versatile-data-kit" alt="Last Activity"></a>
     <a href="https://pypistats.org/packages/vdk-core" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-core.svg" alt="monthly download count for vdk-core">
+        <img src="https://img.shields.io/pypi/dm/vdk-core.svg" alt="monthly download count for vdk-core"></a>
     <a href="https://github.com/vmware/versatile-data-kit/blob/main/LICENSE" alt="License">
         <img src="https://img.shields.io/github/license/vmware/versatile-data-kit" alt="license"></a>
     <a href="https://github.com/pre-commit/pre-commit">

--- a/projects/vdk-control-cli/README.md
+++ b/projects/vdk-control-cli/README.md
@@ -1,7 +1,7 @@
 # Versatile Data Kit Control CLI
 
 <a href="https://pypistats.org/packages/vdk-control-cli" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-control-cli.svg" alt="monthly download count for vdk-control-cli">
+        <img src="https://img.shields.io/pypi/dm/vdk-control-cli.svg" alt="monthly download count for vdk-control-cli"></a>
 
 VDK Control CLI is meant for Data Engineers to use to manage the lifecycle of jobs - create, delete, deploy, configure Data Jobs.
 

--- a/projects/vdk-core/README.md
+++ b/projects/vdk-core/README.md
@@ -1,7 +1,7 @@
 # Versatile Data Kit SDK Core
 
 <a href="https://pypistats.org/packages/vdk-core" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-core.svg" alt="monthly download count for vdk-core">
+        <img src="https://img.shields.io/pypi/dm/vdk-core.svg" alt="monthly download count for vdk-core"></a>
 
 To build or contribute, see [CONTRIBUTING.md](./CONTRIBUTING.md).
 

--- a/projects/vdk-heartbeat/README.md
+++ b/projects/vdk-heartbeat/README.md
@@ -1,7 +1,7 @@
 # Versatile Data Kit Heartbeat tool
 
 <a href="https://pypistats.org/packages/vdk-heartbeat" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-heartbeat.svg" alt="monthly download count for vdk-heartbeat">
+        <img src="https://img.shields.io/pypi/dm/vdk-heartbeat.svg" alt="monthly download count for vdk-heartbeat"></a>
 
 Heartbeat tool for verifying deployed SDK and Control Service are functional and working correctly.<br>
 It  checks that a job can be created, deployed, run and deleted.

--- a/projects/vdk-plugins/airflow-provider-vdk/README.md
+++ b/projects/vdk-plugins/airflow-provider-vdk/README.md
@@ -1,7 +1,7 @@
 # Versatile Data Kit Airflow provider
 
 <a href="https://pypistats.org/packages/airflow-provider-vdk" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/airflow-provider-vdk.svg" alt="monthly download count for airflow-provider-vdk">
+        <img src="https://img.shields.io/pypi/dm/airflow-provider-vdk.svg" alt="monthly download count for airflow-provider-vdk"></a>
 
 A set of Airflow operators, sensors and a connection hook intended to help schedule Versatile Data Kit jobs using Apache Airflow.
 

--- a/projects/vdk-plugins/quickstart-vdk/README.md
+++ b/projects/vdk-plugins/quickstart-vdk/README.md
@@ -1,7 +1,7 @@
 # Quickstart-VDK
 
 <a href="https://pypistats.org/packages/quickstart-vdk" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/quickstart-vdk.svg" alt="monthly download count for quickstart-vdk">
+        <img src="https://img.shields.io/pypi/dm/quickstart-vdk.svg" alt="monthly download count for quickstart-vdk"></a>
 
 This is the first VDK packaging that users would install to play around with.
 

--- a/projects/vdk-plugins/vdk-audit/README.md
+++ b/projects/vdk-plugins/vdk-audit/README.md
@@ -1,7 +1,7 @@
 ## Versatile Data Kit Audit Plugin
 
 <a href="https://pypistats.org/packages/vdk-audit" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-audit.svg" alt="monthly download count for vdk-audit">
+        <img src="https://img.shields.io/pypi/dm/vdk-audit.svg" alt="monthly download count for vdk-audit"></a>
 
 Visibility into the actions provides opportunities for test frameworks, logging
 frameworks, and security tools to monitor and optionally limit actions taken by the

--- a/projects/vdk-plugins/vdk-control-api-auth/README.md
+++ b/projects/vdk-plugins/vdk-control-api-auth/README.md
@@ -1,7 +1,7 @@
 # vdk-control-api-auth
 
 <a href="https://pypistats.org/packages/vdk-control-api-auth" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-control-api-auth.svg" alt="monthly download count for vdk-control-api-auth">
+        <img src="https://img.shields.io/pypi/dm/vdk-control-api-auth.svg" alt="monthly download count for vdk-control-api-auth"></a>
 
 vdk-control-api-auth is a plugin library that implements authentication
 utilities used by vdk-control-cli and other plugins.

--- a/projects/vdk-plugins/vdk-csv/README.md
+++ b/projects/vdk-plugins/vdk-csv/README.md
@@ -1,7 +1,7 @@
 ## Versatile Data Kit CSV Plugin
 
 <a href="https://pypistats.org/packages/vdk-csv" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-csv.svg" alt="monthly download count for vdk-csv">
+        <img src="https://img.shields.io/pypi/dm/vdk-csv.svg" alt="monthly download count for vdk-csv"></a>
 
 This plugin provides functionality to ingest and export CSV files.
 

--- a/projects/vdk-plugins/vdk-dag/README.md
+++ b/projects/vdk-plugins/vdk-dag/README.md
@@ -1,7 +1,7 @@
 # VDK DAGs
 
 <a href="https://pypistats.org/packages/vdk-dag" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-dag.svg" alt="monthly download count for vdk-dag">
+        <img src="https://img.shields.io/pypi/dm/vdk-dag.svg" alt="monthly download count for vdk-dag"></a>
 
 Express dependencies between data jobs.
 

--- a/projects/vdk-plugins/vdk-data-source-git/README.md
+++ b/projects/vdk-plugins/vdk-data-source-git/README.md
@@ -1,7 +1,7 @@
 # data-source-git
 
 <a href="https://pypistats.org/packages/vdk-data-source-git" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-data-source-git.svg" alt="monthly download count for vdk-data-source-git">
+        <img src="https://img.shields.io/pypi/dm/vdk-data-source-git.svg" alt="monthly download count for vdk-data-source-git"></a>
 
 Extracts content from Git repositories along with associated file metadata.
 

--- a/projects/vdk-plugins/vdk-data-sources/README.md
+++ b/projects/vdk-plugins/vdk-data-sources/README.md
@@ -1,7 +1,7 @@
 # data-sources
 
 <a href="https://pypistats.org/packages/vdk-data-sources" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-data-sources.svg" alt="monthly download count for vdk-data-sources">
+        <img src="https://img.shields.io/pypi/dm/vdk-data-sources.svg" alt="monthly download count for vdk-data-sources"></a>
 
 Enables Versatile Data Kit (VDK) to integrate with various data sources by providing a unified interface for data ingestion and management.
 

--- a/projects/vdk-plugins/vdk-duckdb/README.md
+++ b/projects/vdk-plugins/vdk-duckdb/README.md
@@ -1,7 +1,7 @@
 # duckdb
 
 <a href="https://pypistats.org/packages/vdk-duckdb" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-duckdb.svg" alt="monthly download count for vdk-duckdb">
+        <img src="https://img.shields.io/pypi/dm/vdk-duckdb.svg" alt="monthly download count for vdk-duckdb"></a>
 
 DuckDB plugin for the Versatile Data Kit (VDK), which enables users to connect to and interact with DuckDB databases.
 The purpose is to simplify data extraction, transformation, and loading tasks when working with DuckDB as a data source or destination

--- a/projects/vdk-plugins/vdk-gdp-execution-id/README.md
+++ b/projects/vdk-plugins/vdk-gdp-execution-id/README.md
@@ -1,5 +1,5 @@
 <a href="https://pypistats.org/packages/vdk-gdp-execution-id" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-gdp-execution-id.svg" alt="monthly download count for vdk-gdp-execution-id">
+        <img src="https://img.shields.io/pypi/dm/vdk-gdp-execution-id.svg" alt="monthly download count for vdk-gdp-execution-id"></a>
 
 An installed Generative Data Pack plugin automatically expands the data sent for ingestion.
 

--- a/projects/vdk-plugins/vdk-greenplum/README.md
+++ b/projects/vdk-plugins/vdk-greenplum/README.md
@@ -1,5 +1,5 @@
 <a href="https://pypistats.org/packages/vdk-greenplum" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-greenplum.svg" alt="monthly download count for vdk-greenplum">
+        <img src="https://img.shields.io/pypi/dm/vdk-greenplum.svg" alt="monthly download count for vdk-greenplum"></a>
 
 This plugin allows vdk-core to interface with and execute queries against a Greenplum database.
 

--- a/projects/vdk-plugins/vdk-huggingface/README.md
+++ b/projects/vdk-plugins/vdk-huggingface/README.md
@@ -1,7 +1,7 @@
 # Huggingface
 
 <a href="https://pypistats.org/packages/vdk-huggingface" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-huggingface.svg" alt="monthly download count for vdk-huggingface">
+        <img src="https://img.shields.io/pypi/dm/vdk-huggingface.svg" alt="monthly download count for vdk-huggingface"></a>
 
 Versatile Data Kit (VDK) plugin for integrating with Huggingface as both a data source and a target.
 This plugin allows you to ingest data payloads into a Huggingface repository and makes it easier to work with datasets stored in Huggingface.

--- a/projects/vdk-plugins/vdk-impala/README.md
+++ b/projects/vdk-plugins/vdk-impala/README.md
@@ -1,7 +1,7 @@
 This plugin allows vdk-core to interface with and execute queries against an Impala database.
 
 <a href="https://pypistats.org/packages/vdk-impala" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-impala.svg" alt="monthly download count for vdk-impala">
+        <img src="https://img.shields.io/pypi/dm/vdk-impala.svg" alt="monthly download count for vdk-impala"></a>
 
 # Features
 

--- a/projects/vdk-plugins/vdk-ingest-file/README.md
+++ b/projects/vdk-plugins/vdk-ingest-file/README.md
@@ -1,7 +1,7 @@
 ## VDK-INGEST-FILE Plugin
 
 <a href="https://pypistats.org/packages/vdk-ingest-file" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-ingest-file.svg" alt="monthly download count for vdk-ingest-file">
+        <img src="https://img.shields.io/pypi/dm/vdk-ingest-file.svg" alt="monthly download count for vdk-ingest-file"></a>
 
 This plugin provides functionality to ingest data into a file. It is intended for local testing.
 

--- a/projects/vdk-plugins/vdk-ingest-http/README.md
+++ b/projects/vdk-plugins/vdk-ingest-http/README.md
@@ -1,7 +1,7 @@
 ### VDK-INGEST-HTTP Plugin
 
 <a href="https://pypistats.org/packages/vdk-ingest-http" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-ingest-http.svg" alt="monthly download count for vdk-ingest-http">
+        <img src="https://img.shields.io/pypi/dm/vdk-ingest-http.svg" alt="monthly download count for vdk-ingest-http"></a>
 
 This plugin provides functionality to ingest data over http.
 

--- a/projects/vdk-plugins/vdk-ipython/README.md
+++ b/projects/vdk-plugins/vdk-ipython/README.md
@@ -1,7 +1,7 @@
 # vdk-ipython
 
 <a href="https://pypistats.org/packages/vdk-ipython" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-ipython.svg" alt="monthly download count for vdk-ipython">
+        <img src="https://img.shields.io/pypi/dm/vdk-ipython.svg" alt="monthly download count for vdk-ipython"></a>
 
 Ipython extension for VDK
 

--- a/projects/vdk-plugins/vdk-jobs-troubleshooting/README.md
+++ b/projects/vdk-plugins/vdk-jobs-troubleshooting/README.md
@@ -1,7 +1,7 @@
 ## VDK-JOBS-TROUBLESHOOTING Plugin
 
 <a href="https://pypistats.org/packages/vdk-jobs-troubleshooting" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-jobs-troubleshooting.svg" alt="monthly download count for vdk-jobs-troubleshooting">
+        <img src="https://img.shields.io/pypi/dm/vdk-jobs-troubleshooting.svg" alt="monthly download count for vdk-jobs-troubleshooting"></a>
 
 The VDK JOB Troubleshooting plugin provides the ability to add various troubleshooting utilities which can be accessed
 during the data job runtime.

--- a/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/README.md
+++ b/projects/vdk-plugins/vdk-jupyter/vdk-jupyterlab-extension/README.md
@@ -1,7 +1,7 @@
 # vdk-jupyterlab-extension
 
 <a href="https://pypistats.org/packages/vdk-jupyterlab-extension" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-jupyterlab-extension.svg" alt="monthly download count for vdk-jupyterlab-extension">
+        <img src="https://img.shields.io/pypi/dm/vdk-jupyterlab-extension.svg" alt="monthly download count for vdk-jupyterlab-extension"></a>
 
 A Jupyterlab extension for using VDK
 For more information see: https://github.com/vmware/versatile-data-kit/tree/main/specs/vep-994-jupyter-notebook-integration

--- a/projects/vdk-plugins/vdk-kerberos-auth/README.md
+++ b/projects/vdk-plugins/vdk-kerberos-auth/README.md
@@ -1,5 +1,5 @@
 <a href="https://pypistats.org/packages/vdk-kerberos-auth" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-kerberos-auth.svg" alt="monthly download count for vdk-kerberos-auth">
+        <img src="https://img.shields.io/pypi/dm/vdk-kerberos-auth.svg" alt="monthly download count for vdk-kerberos-auth"></a>
 
 The plugin provides GSSAPI Kerberos authentication on data job startup. The plugin also adds Kerberos/GSSAPI support for HTTP requests.
 

--- a/projects/vdk-plugins/vdk-lineage-model/README.md
+++ b/projects/vdk-plugins/vdk-lineage-model/README.md
@@ -1,7 +1,7 @@
 # VDK Lineage Model
 
 <a href="https://pypistats.org/packages/vdk-lineage-model" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-lineage-model.svg" alt="monthly download count for vdk-lineage-model">
+        <img src="https://img.shields.io/pypi/dm/vdk-lineage-model.svg" alt="monthly download count for vdk-lineage-model"></a>
 
 VDK Lineage Model plugin aims to abstract emitting lineage data from VDK data jobs, so that different lineage loggers
 can be configured at run time in any plugin that supports emitting lineage data.

--- a/projects/vdk-plugins/vdk-lineage/README.md
+++ b/projects/vdk-plugins/vdk-lineage/README.md
@@ -1,7 +1,7 @@
 # VDK Lineage
 
 <a href="https://pypistats.org/packages/vdk-lineage" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-lineage.svg" alt="monthly download count for vdk-lineage">
+        <img src="https://img.shields.io/pypi/dm/vdk-lineage.svg" alt="monthly download count for vdk-lineage"></a>
 
 VDK Lineage plugin provides lineage data (input data -> job -> output data) information and send it to a pre-configured
 destination. The lineage data is send using [OpenLineage standard](https://openlineage.io)

--- a/projects/vdk-plugins/vdk-logging-format/README.md
+++ b/projects/vdk-plugins/vdk-logging-format/README.md
@@ -1,7 +1,7 @@
 # This plugin has been deprecated; please use vdk-structlog instead.
 
 <a href="https://pypistats.org/packages/vdk-logging-format" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-logging-format.svg" alt="monthly download count for vdk-logging-format">
+        <img src="https://img.shields.io/pypi/dm/vdk-logging-format.svg" alt="monthly download count for vdk-logging-format"></a>
 
 This plugins allows for the configuration of the format of VDK logs.
 

--- a/projects/vdk-plugins/vdk-meta-jobs/README.md
+++ b/projects/vdk-plugins/vdk-meta-jobs/README.md
@@ -1,7 +1,7 @@
 # Meta Jobs
 
 <a href="https://pypistats.org/packages/vdk-meta-jobs" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-meta-jobs.svg" alt="monthly download count for vdk-meta-jobs">
+        <img src="https://img.shields.io/pypi/dm/vdk-meta-jobs.svg" alt="monthly download count for vdk-meta-jobs"></a>
 
 Express dependencies between data jobs.
 

--- a/projects/vdk-plugins/vdk-notebook/README.md
+++ b/projects/vdk-plugins/vdk-notebook/README.md
@@ -1,7 +1,7 @@
 # vdk-notebook
 
 <a href="https://pypistats.org/packages/vdk-notebook" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-notebook.svg" alt="monthly download count for vdk-notebook">
+        <img src="https://img.shields.io/pypi/dm/vdk-notebook.svg" alt="monthly download count for vdk-notebook"></a>
 
 A new VDK plugin which supports running data jobs which consists of .ipynb files.
 You can see [VDK Jupyter Integration VEP](https://github.com/vmware/versatile-data-kit/blob/main/specs/vep-994-jupyter-notebook-integration/README.md) for more information.

--- a/projects/vdk-plugins/vdk-oracle/README.md
+++ b/projects/vdk-plugins/vdk-oracle/README.md
@@ -1,7 +1,7 @@
 # oracle
 
 <a href="https://pypistats.org/packages/vdk-oracle" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-oracle.svg" alt="monthly download count for vdk-oracle">
+        <img src="https://img.shields.io/pypi/dm/vdk-oracle.svg" alt="monthly download count for vdk-oracle"></a>
 
 Support for VDK Managed Oracle connection
 

--- a/projects/vdk-plugins/vdk-plugin-control-cli/README.md
+++ b/projects/vdk-plugins/vdk-plugin-control-cli/README.md
@@ -1,5 +1,5 @@
 <a href="https://pypistats.org/packages/vdk-plugin-control-cli" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-plugin-control-cli.svg" alt="monthly download count for vdk-plugin-control-cli">
+        <img src="https://img.shields.io/pypi/dm/vdk-plugin-control-cli.svg" alt="monthly download count for vdk-plugin-control-cli"></a>
 
 This plugin allows vdk-core to access vdk-control-cli functionality.
 

--- a/projects/vdk-plugins/vdk-postgres/README.md
+++ b/projects/vdk-plugins/vdk-postgres/README.md
@@ -1,5 +1,5 @@
 <a href="https://pypistats.org/packages/vdk-postgres" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-postgres.svg" alt="monthly download count for vdk-postgres">
+        <img src="https://img.shields.io/pypi/dm/vdk-postgres.svg" alt="monthly download count for vdk-postgres"></a>
 
 This plugin allows vdk-core to interface with and execute queries against a PostgreSQL database.
 

--- a/projects/vdk-plugins/vdk-properties-fs/README.md
+++ b/projects/vdk-plugins/vdk-properties-fs/README.md
@@ -1,5 +1,5 @@
 <a href="https://pypistats.org/packages/vdk-properties-fs" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-properties-fs.svg" alt="monthly download count for vdk-properties-fs">
+        <img src="https://img.shields.io/pypi/dm/vdk-properties-fs.svg" alt="monthly download count for vdk-properties-fs"></a>
 
 This plugin allows vdk-core to read/write properties on the local FS. Mainly for development purposes,
 to simplify a use-case with local Properties API usage, that would otherwise require a Control Service instance prerequisite.

--- a/projects/vdk-plugins/vdk-server/README.md
+++ b/projects/vdk-plugins/vdk-server/README.md
@@ -1,7 +1,7 @@
 ## Versatile Data Kit Server Plugin
 
 <a href="https://pypistats.org/packages/vdk-server" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-server.svg" alt="monthly download count for vdk-server">
+        <img src="https://img.shields.io/pypi/dm/vdk-server.svg" alt="monthly download count for vdk-server"></a>
 
 This plugin facilitates installation of the Control Service in a local [Kind](https://kind.sigs.k8s.io/) cluster.
 

--- a/projects/vdk-plugins/vdk-singer/README.md
+++ b/projects/vdk-plugins/vdk-singer/README.md
@@ -1,7 +1,7 @@
 # singer
 
 <a href="https://pypistats.org/packages/vdk-singer" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-singer.svg" alt="monthly download count for vdk-singer">
+        <img src="https://img.shields.io/pypi/dm/vdk-singer.svg" alt="monthly download count for vdk-singer"></a>
 
 The vdk-singer plugin provides an easy way to integrate Singer Taps as data sources within the Versatile Data Kit (VDK).
 This allows you to pull data from various external systems that have Singer Taps available and use them seamlessly

--- a/projects/vdk-plugins/vdk-smarter/README.md
+++ b/projects/vdk-plugins/vdk-smarter/README.md
@@ -1,7 +1,7 @@
 # VDK Smarter
 
 <a href="https://pypistats.org/packages/vdk-smarter" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-smarter.svg" alt="monthly download count for vdk-smarter">
+        <img src="https://img.shields.io/pypi/dm/vdk-smarter.svg" alt="monthly download count for vdk-smarter"></a>
 
 Making VDK smarter by employing ML/AI.
 

--- a/projects/vdk-plugins/vdk-snowflake/README.md
+++ b/projects/vdk-plugins/vdk-snowflake/README.md
@@ -1,7 +1,7 @@
 # Versatile Data Kit Plugin for Snowflake Support
 
 <a href="https://pypistats.org/packages/vdk-snowflake" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-snowflake.svg" alt="monthly download count for vdk-snowflake">
+        <img src="https://img.shields.io/pypi/dm/vdk-snowflake.svg" alt="monthly download count for vdk-snowflake"></a>
 
 This plugin provides functionality, used by the Versatile Data Kit
 to interact with a Snowflake instance. Users of the plugin can connect to

--- a/projects/vdk-plugins/vdk-sqlite/README.md
+++ b/projects/vdk-plugins/vdk-sqlite/README.md
@@ -1,5 +1,5 @@
 <a href="https://pypistats.org/packages/vdk-sqlite" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-sqlite.svg" alt="monthly download count for vdk-sqlite">
+        <img src="https://img.shields.io/pypi/dm/vdk-sqlite.svg" alt="monthly download count for vdk-sqlite"></a>
 
 This plugin allows vdk-core to interface with, execute queries against, and ingest data to a SQLite database.
 

--- a/projects/vdk-plugins/vdk-structlog/README.md
+++ b/projects/vdk-plugins/vdk-structlog/README.md
@@ -1,7 +1,7 @@
 # Structured Logging For VDK
 
 <a href="https://pypistats.org/packages/vdk-structlog" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-structlog.svg" alt="monthly download count for vdk-structlog">
+        <img src="https://img.shields.io/pypi/dm/vdk-structlog.svg" alt="monthly download count for vdk-structlog"></a>
 
 This plugin allows users to:
 - select the log output format

--- a/projects/vdk-plugins/vdk-test-utils/README.md
+++ b/projects/vdk-plugins/vdk-test-utils/README.md
@@ -1,5 +1,5 @@
 <a href="https://pypistats.org/packages/vdk-test-utils" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-test-utils.svg" alt="monthly download count for vdk-test-utils">
+        <img src="https://img.shields.io/pypi/dm/vdk-test-utils.svg" alt="monthly download count for vdk-test-utils"></a>
 
 This plugin provides utility tools used for the testing of vdk-core and vdk-core plugins.
 

--- a/projects/vdk-plugins/vdk-trino/README.md
+++ b/projects/vdk-plugins/vdk-trino/README.md
@@ -1,5 +1,5 @@
 <a href="https://pypistats.org/packages/vdk-trino" alt="Monthly Downloads">
-        <img src="https://img.shields.io/pypi/dm/vdk-trino.svg" alt="monthly download count for vdk-trino">
+        <img src="https://img.shields.io/pypi/dm/vdk-trino.svg" alt="monthly download count for vdk-trino"></a>
 
 This plugin allows vdk-core to interface with and execute queries against a Trino database. Additionally, it can collect lineage data, assuming a lineage logger has been provided through the vdk-core configuration.
 


### PR DESCRIPTION
What: Add the missing closing tags for the monthly download badges.

Why: To fix the links in the READMEs.

Addresses this [comment](https://github.com/vmware/versatile-data-kit/pull/2983/files#r1467570214).

Before:
<img width="1011" alt="Without closing tag" src="https://github.com/vmware/versatile-data-kit/assets/36246462/6717ca4d-0509-417a-a052-07864272a237">

After:
<img width="1011" alt="With closing tag" src="https://github.com/vmware/versatile-data-kit/assets/36246462/fb6f7d99-f3b7-4b8b-bbc0-6b0adedc7b03">


Signed-off by: Yoan Salambashev <yoan.salambashev@broadcom.com>