### PR TITLE
vdk-dag: fix unnecessary authorization failure

### DIFF
--- a/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/remote_data_job.py
+++ b/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/remote_data_job.py
@@ -245,8 +245,15 @@ class RemoteDataJob:
         if self.auth:
             return self.auth.read_access_token()
         else:
-            self._login()
-            return self.auth.read_access_token()
+            try:
+                self._login()
+                return self.auth.read_access_token()
+            except Exception as e:
+                log.warning(
+                    f"Failed to get access token. If authorization is required later it, it won't work."
+                    f"Authentication error is {e}"
+                )
+                return None
 
     def _login(self) -> None:
         self.auth = Authentication()


### PR DESCRIPTION
If you have locally configured authorizaton settings (e.g client id, refresh token and so on) which might be expired or wrong, VDK dag still tries to authenticate and generate access token even if no authentication may be required by the Control Service API. This casues the DAG jobs to fail with authentication error which is unnecssary if the API didn't require auth.

Instead we now just post a warning about the failure to get acess token. We fail later if and only if the API requires authentication . If not everything suceeeds.

Testing Done: local tests pass (they failed before for above reason)