### PR TITLE
vdk-core: do not count memory properties toward the count

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/job_properties/properties_router.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/job_properties/properties_router.py
@@ -111,6 +111,14 @@ class PropertiesRouter(IPropertiesRegistry, IProperties):
                 factory_method = self.__properties_builders[
                     list(self.__properties_builders.keys())[0]
                 ]
+            elif (
+                len(self.__properties_builders) == 2
+                and "memory" in self.__properties_builders.keys()
+            ):
+                properties_type = list(self.__properties_builders.keys())[0]
+                if properties_type == "memory":
+                    properties_type = list(self.__properties_builders.keys())[1]
+                factory_method = self.__choose_from_default_type(properties_type)
             else:
                 errors.report_and_throw(
                     errors.VdkConfigurationError(


### PR DESCRIPTION
Property type "memory" comes with vdk-core. If another one like fs-client proeprty comes it will call ambiguity order but that's unecesary since memory is only useful for unit testing. Otherwise it's not and we should defualt to the other one if only two are available.