### PR TITLE
vdk-core: enable/disable structlog based on config

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/log_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/log_config.py
@@ -288,7 +288,7 @@ class LoggingPlugin:
         )
         syslog_enabled = context.core_context.configuration.get_value(SYSLOG_ENABLED)
         try:  # If logging initialization fails we want to attempt sending telemetry before exiting VDK
-            if not os.environ.get("VDK_USE_STRUCTLOG"):
+            if not context.core_context.configuration.get_value("use_structlog"):
                 configure_loggers(
                     job_name,
                     attempt_id,


### PR DESCRIPTION
## Why?

vdk-structlog has a default config flag set to True when installed. It relegates all logging configuration to the plugin and is checked in core, i.e. if structlog is installed, vdk will use structlog. If it's not installed, it will use the configuration available in core. The flag is currently checked using an env variable, which makes it not work.

## What?

Check the flag using the config object

## How was this tested?

Manually

## What kind of change is this?

Bugfix