### PR TITLE
vdk-postgres: batch inserts during ingestion

### DIFF
--- a/projects/vdk-plugins/vdk-postgres/src/vdk/plugin/postgres/ingest_to_postgres.py
+++ b/projects/vdk-plugins/vdk-postgres/src/vdk/plugin/postgres/ingest_to_postgres.py
@@ -61,7 +61,7 @@ class IngestToPostgres(IIngesterPlugin):
     ) -> (str, list):
         """
         Prepare the SQL query and parameters for bulk insertion.
-        
+
         Returns insert into destination table tuple of query and parameters;
         E.g. for a table dest_table with columns val1, val2 and payload size 2, this method will return:
         'INSERT INTO dest_table (val1, val2) VALUES (%s, %s)',

--- a/projects/vdk-plugins/vdk-postgres/src/vdk/plugin/postgres/ingest_to_postgres.py
+++ b/projects/vdk-plugins/vdk-postgres/src/vdk/plugin/postgres/ingest_to_postgres.py
@@ -61,6 +61,11 @@ class IngestToPostgres(IIngesterPlugin):
     ) -> (str, list):
         """
         Prepare the SQL query and parameters for bulk insertion.
+        
+        Returns insert into destination table tuple of query and parameters;
+        E.g. for a table dest_table with columns val1, val2 and payload size 2, this method will return:
+        'INSERT INTO dest_table (val1, val2) VALUES (%s, %s)',
+        [('val1', 'val2'), ('val1', 'val2')]
         """
         cursor.execute(f"SELECT * FROM {destination_table} WHERE false")
         columns = [desc[0] for desc in cursor.description]

--- a/projects/vdk-plugins/vdk-postgres/tests/conftest.py
+++ b/projects/vdk-plugins/vdk-postgres/tests/conftest.py
@@ -1,14 +1,13 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import logging
 import os
 import time
-from functools import partial
 from unittest import mock
 
 import pytest
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_container_is_ready
-from testcontainers.core.waiting_utils import wait_for
 from vdk.plugin.postgres import postgres_plugin
 from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
 
@@ -18,6 +17,8 @@ VDK_POSTGRES_USER = "VDK_POSTGRES_USER"
 VDK_POSTGRES_PASSWORD = "VDK_POSTGRES_PASSWORD"
 VDK_POSTGRES_HOST = "VDK_POSTGRES_HOST"
 VDK_POSTGRES_PORT = "VDK_POSTGRES_PORT"
+
+log = logging.getLogger(__name__)
 
 
 @wait_container_is_ready(Exception)
@@ -59,7 +60,7 @@ def postgres_service(request):
         # wait 2 seconds to make sure the service is up and responsive
         # might be unnecessary but it's out of abundance of caution
         time.sleep(2)
-        print(
+        log.info(
             f"Postgres service started on port {container.get_exposed_port(port)} and host {container.get_container_host_ip()}"
         )
     except Exception as e:
@@ -70,7 +71,7 @@ def postgres_service(request):
 
     def stop_container():
         container.stop()
-        print("Postgres service stopped")
+        log.info("Postgres service stopped")
 
     request.addfinalizer(stop_container)
 


### PR DESCRIPTION
Insert data is painfully slow even small amounts making even testing and pocs hard. So this is a quick and slight optimization Before insert 300 rows took 15 minutes. Now it's about 1 minute

Testing Done: made sure existing test pass. Tested with a job sending 300 rows in 2 tables.