### PR TITLE
vdk-frontend: Show Python Version of the Data Jobs Deployment

### DIFF
--- a/projects/frontend/data-pipelines/gui/e2e/integration/frontend-tests/explore/data-jobs/data-jobs.spec.js
+++ b/projects/frontend/data-pipelines/gui/e2e/integration/frontend-tests/explore/data-jobs/data-jobs.spec.js
@@ -294,7 +294,7 @@ describe('Data Jobs Explore Page', { tags: ['@dataPipelines', '@exploreDataJobs'
             dataJobsExplorePage.toggleColumnShowHidePanel();
 
             // verify correct options are rendered
-            dataJobsExplorePage.getDataGridColumnShowHideOptionsValues().should('have.length', 9).invoke('join', ',').should('eq', 'Description,Deployment Status,Last Execution Duration,Success rate,Next run (UTC),Last Deployed (UTC),Last Deployed By,Source,Logs');
+            dataJobsExplorePage.getDataGridColumnShowHideOptionsValues().should('have.length', 10).invoke('join', ',').should('eq', 'Description,Deployment Status,Python Version,Last Execution Duration,Success rate,Next run (UTC),Last Deployed (UTC),Last Deployed By,Source,Logs');
 
             // verify column is not checked in toggling menu
             dataJobsExplorePage.getDataGridColumnShowHideOption('Last Execution Duration').should('exist').should('not.be.checked');

--- a/projects/frontend/data-pipelines/gui/e2e/integration/frontend-tests/manage/data-jobs/data-jobs.spec.js
+++ b/projects/frontend/data-pipelines/gui/e2e/integration/frontend-tests/manage/data-jobs/data-jobs.spec.js
@@ -403,7 +403,7 @@ describe('Data Jobs Manage Page', { tags: ['@dataPipelines', '@manageDataJobs', 
             dataJobsManagePage.toggleColumnShowHidePanel();
 
             // verify correct options are rendered
-            dataJobsManagePage.getDataGridColumnShowHideOptionsValues().should('have.length', 10).invoke('join', ',').should('eq', 'Description,Deployment Status,Last Execution Duration,Success rate,Next run (UTC),Last Deployed (UTC),Last Deployed By,Notifications,Source,Logs');
+            dataJobsManagePage.getDataGridColumnShowHideOptionsValues().should('have.length', 11).invoke('join', ',').should('eq', 'Description,Deployment Status,Python Version,Last Execution Duration,Success rate,Next run (UTC),Last Deployed (UTC),Last Deployed By,Notifications,Source,Logs');
 
             // verify column is not checked in toggling menu
             dataJobsManagePage.getDataGridColumnShowHideOption('Notifications').should('exist').should('not.be.checked');

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/base-grid/data-jobs-base-grid.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/base-grid/data-jobs-base-grid.component.ts
@@ -683,7 +683,7 @@ export abstract class DataJobsBaseGridComponent
         ) {
             return false;
         }
-        
+
         return (
             this.clrGridUIState.filter.deploymentLastExecutionStatus ===
             this._decodeFilterFromQueryParam('deploymentLastExecutionStatus', routeState.getQueryParam('deploymentLastExecutionStatus'))

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/base-grid/data-jobs-base-grid.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/base-grid/data-jobs-base-grid.component.ts
@@ -683,7 +683,7 @@ export abstract class DataJobsBaseGridComponent
         ) {
             return false;
         }
-
+        
         return (
             this.clrGridUIState.filter.deploymentLastExecutionStatus ===
             this._decodeFilterFromQueryParam('deploymentLastExecutionStatus', routeState.getQueryParam('deploymentLastExecutionStatus'))

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/data-job-page.component.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/data-job-page.component.spec.ts
@@ -87,6 +87,7 @@ describe('DataJobsDetailsComponent', () => {
         mode: 'test_mode',
         /* eslint-disable-next-line @typescript-eslint/naming-convention */
         vdk_version: '002',
+        python_version: '3.9-secure',
         endTime: new Date(),
         opId: 'op002',
         message: 'message002',

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/details/data-job-details-page.component.html
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/details/data-job-details-page.component.html
@@ -143,6 +143,21 @@
                         </vdk-form-section-container>
 
                         <vdk-form-section-container
+                            data-cy="data-pipelines-data-job-details-python-version"
+                            class="p-header-section"
+                            sectionName="jobPythonVersion"
+                            [formState]="readFormState"
+                        >
+                            <div class="section-title" style="width: 7rem">
+                                Python version
+                            </div>
+
+                            <div class="form-section-readonly">
+                                <span>{{ jobPythonVersion.value }} </span>
+                            </div>
+                        </vdk-form-section-container>
+
+                        <vdk-form-section-container
                             *ngIf="shouldShowTeamsSection"
                             data-cy="team-form-field"
                             class="p-header-section"

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/details/data-job-details-page.component.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/details/data-job-details-page.component.spec.ts
@@ -65,6 +65,7 @@ const TEST_JOB_EXECUTION = {
         jobVersion: '002',
         mode: 'test_mode',
         vdkVersion: '002',
+        jobPythonVersion: '3.9-secure',
         resources: {
             memoryLimit: 1000,
             memoryRequest: 1000,
@@ -85,7 +86,8 @@ const TEST_JOB_DEPLOYMENT = {
     job_version: '001',
     mode: 'test_mode',
     /* eslint-disable-next-line @typescript-eslint/naming-convention */
-    vdk_version: '001'
+    vdk_version: '001',
+    python_version: '3.7-secure'
 } as DataJobDeploymentDetails;
 
 const TEST_JOB_DETAILS = {

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/details/data-job-details-page.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/details/data-job-details-page.component.ts
@@ -140,6 +140,10 @@ export class DataJobDetailsPageComponent
         return this.tmForm.get('description');
     }
 
+    get jobPythonVersion() {
+        return this.tmForm.get('jobPythonVersion');
+    }
+
     /**
      * ** Array of error code patterns that component should listen for in errors store.
      */
@@ -467,7 +471,8 @@ export class DataJobDetailsPageComponent
             name: '',
             team: '',
             status: '',
-            description: ''
+            description: '',
+            jobPythonVersion: ''
         });
     }
 
@@ -476,7 +481,8 @@ export class DataJobDetailsPageComponent
             name: this.jobDetails.job_name,
             team: this.jobDetails.team,
             status: ExtractJobStatusPipe.transform(this.jobState?.deployments),
-            description: this.jobDetails.description
+            description: this.jobDetails.description,
+            jobPythonVersion: this.jobState?.deployments && this.jobState?.deployments[0] ? this.jobState?.deployments[0]?.jobPythonVersion : ''
         });
     }
 

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/details/data-job-details-page.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/details/data-job-details-page.component.ts
@@ -482,7 +482,8 @@ export class DataJobDetailsPageComponent
             team: this.jobDetails.team,
             status: ExtractJobStatusPipe.transform(this.jobState?.deployments),
             description: this.jobDetails.description,
-            jobPythonVersion: this.jobState?.deployments && this.jobState?.deployments[0] ? this.jobState?.deployments[0]?.jobPythonVersion : ''
+            jobPythonVersion:
+                this.jobState?.deployments && this.jobState?.deployments[0] ? this.jobState?.deployments[0]?.jobPythonVersion : ''
         });
     }
 

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/data-job-deployment-details-modal/data-job-deployment-details-modal.component.html
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-job/pages/executions/data-job-deployment-details-modal/data-job-deployment-details-modal.component.html
@@ -33,6 +33,10 @@
                 <h6>VDK version</h6>
                 <p>{{ dataJobDeployment.vdkVersion }}</p>
             </div>
+            <div class="clr-col-4">
+                <h6>Python Version</h6>
+                <p>{{ dataJobDeployment.jobPythonVersion }}</p>
+            </div>
         </div>
 
         <h4>

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-explore/components/grid/data-jobs-explore-grid.component.html
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-explore/components/grid/data-jobs-explore-grid.component.html
@@ -109,6 +109,21 @@
                 </clr-dg-filter>
             </clr-dg-column>
 
+            <clr-dg-column class="column__min-width--l">
+                <ng-template
+                    [clrDgHideableColumn]="{
+                        hidden: localStorageUserConfig.hiddenColumns[
+                            'jobPythonVersion'
+                        ]
+                    }"
+                    (clrDgHiddenChange)="
+                        showOrHideColumnChange('jobPythonVersion', $event)
+                    "
+                >
+                    Python Version
+                </ng-template>
+            </clr-dg-column>
+
             <clr-dg-column
                 class="column__min-width--l"
                 [clrDgSortBy]="'deployments.lastExecutionTime'"
@@ -315,6 +330,11 @@
                     class="column__min-width--l column__max-width--l text-center"
                 >
                     <lib-status-cell [dataJob]="job"></lib-status-cell>
+                </clr-dg-cell>
+
+                <clr-dg-cell class="column__min-width--l">
+                    {{ job.deployments ? job.deployments[0]?.jobPythonVersion :
+                    null }}
                 </clr-dg-cell>
 
                 <clr-dg-cell class="column__min-width--l">

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-explore/components/grid/data-jobs-explore-grid.component.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-explore/components/grid/data-jobs-explore-grid.component.ts
@@ -76,7 +76,8 @@ export class DataJobsExploreGridComponent extends DataJobsBaseGridComponent impl
                     lastDeployedDate: true,
                     lastDeployedBy: true,
                     source: true,
-                    logsUrl: true
+                    logsUrl: true,
+                    jobPythonVersion: true
                 }
             },
             DataJobsExploreGridComponent.CLASS_NAME

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-manage/components/grid/data-jobs-manage-grid.component.html
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-manage/components/grid/data-jobs-manage-grid.component.html
@@ -169,6 +169,21 @@
                 </clr-dg-filter>
             </clr-dg-column>
 
+            <clr-dg-column class="column__min-width--l">
+                <ng-template
+                    [clrDgHideableColumn]="{
+                        hidden: localStorageUserConfig.hiddenColumns[
+                            'jobPythonVersion'
+                        ]
+                    }"
+                    (clrDgHiddenChange)="
+                        showOrHideColumnChange('jobPythonVersion', $event)
+                    "
+                >
+                    Python Version
+                </ng-template>
+            </clr-dg-column>
+
             <clr-dg-column
                 class="column__min-width--l"
                 [clrDgSortBy]="'deployments.lastExecutionTime'"
@@ -364,6 +379,10 @@
                     data-cy="data-pipelines-manage-grid-status-cell"
                 >
                     <lib-status-cell [dataJob]="job"></lib-status-cell>
+                </clr-dg-cell>
+
+                <clr-dg-cell class="column__min-width--l">
+                    {{ job.deployments ? job.deployments[0]?.jobPythonVersion : null }}
                 </clr-dg-cell>
 
                 <clr-dg-cell class="column__min-width--l">

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-manage/components/grid/data-jobs-manage-grid.component.html
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/components/data-jobs-manage/components/grid/data-jobs-manage-grid.component.html
@@ -382,7 +382,8 @@
                 </clr-dg-cell>
 
                 <clr-dg-cell class="column__min-width--l">
-                    {{ job.deployments ? job.deployments[0]?.jobPythonVersion : null }}
+                    {{ job.deployments ? job.deployments[0]?.jobPythonVersion :
+                    null }}
                 </clr-dg-cell>
 
                 <clr-dg-cell class="column__min-width--l">

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/data-job-base.model.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/data-job-base.model.ts
@@ -27,6 +27,7 @@ export interface BaseDataJobDeployment<E extends DataJobExecution = DataJobExecu
     resources?: DataJobResources;
     schedule?: DataJobSchedule;
     vdkVersion?: string;
+    jobPythonVersion?: string;
     status?: DataJobDeploymentStatus;
     executions?: E[];
 }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/data-job-details.model.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/data-job-details.model.ts
@@ -70,6 +70,7 @@ export interface DataJobDeploymentDetails extends StatusDetails {
     };
     contacts?: DataJobContactsDetails;
     schedule?: DataJobScheduleDetails;
+    python_version: string;
 }
 
 /**

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/grid-config.model.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/model/grid-config.model.ts
@@ -16,4 +16,5 @@ export interface GridFilters {
     description?: string;
     deploymentStatus?: string;
     deploymentLastExecutionStatus?: string;
+    jobPythonVersion?: string;
 }

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/services/data-jobs.api.service.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/services/data-jobs.api.service.spec.ts
@@ -115,8 +115,9 @@ describe('DataJobsApiService', () => {
                       lastExecutionDuration
                       successfulExecutions
                       failedExecutions
+                      jobPythonVersion
                       executions(pageNumber: 1, pageSize: 10, order: { property: "startTime", direction: DESC }) {
-						id
+						            id
                         status
                         logsUrl
                         message
@@ -180,6 +181,7 @@ describe('DataJobsApiService', () => {
                     deployments {
                       id
                       enabled
+                      jobPythonVersion
                       executions(pageNumber: 1, pageSize: 10, order: { property: "startTime", direction: DESC }) {
                         id
                         status

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/services/data-jobs.api.service.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/services/data-jobs.api.service.ts
@@ -107,8 +107,9 @@ export class DataJobsApiService extends TaurusBaseApiService<DataJobsApiService>
                       lastExecutionDuration
                       successfulExecutions
                       failedExecutions
+                      jobPythonVersion
                       executions(pageNumber: 1, pageSize: 10, order: { property: "startTime", direction: DESC }) {
-						id
+						            id
                         status
                         logsUrl
                         message
@@ -155,6 +156,7 @@ export class DataJobsApiService extends TaurusBaseApiService<DataJobsApiService>
                     deployments {
                       id
                       enabled
+                      jobPythonVersion
                       executions(pageNumber: 1, pageSize: 10, order: { property: "startTime", direction: DESC }) {
                         id
                         status
@@ -268,6 +270,7 @@ export class DataJobsApiService extends TaurusBaseApiService<DataJobsApiService>
                       }
                       vdkVersion
                       status
+                      jobPythonVersion
                     }
                   }
                   totalPages

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/extract-job-status.pipe.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/pipes/extract-job-status.pipe.spec.ts
@@ -15,6 +15,7 @@ const TEST_JOB_DEPLOYMENT_DETAILS: DataJobDeploymentDetails = {
     mode: 'special',
     /* eslint-disable-next-line @typescript-eslint/naming-convention */
     vdk_version: 'v002',
+    python_version: '3.9-secure',
     contacts: null,
     /* eslint-disable @typescript-eslint/naming-convention */
     deployed_date: '2020-11-11T10:10:10Z',

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/utils/data-job.util.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/utils/data-job.util.spec.ts
@@ -152,6 +152,7 @@ describe('DataJobUtil', () => {
                     job_version: '002',
                     mode: 'test_mode',
                     vdk_version: '002',
+                    python_version: '3.9-secure',
                     resources: {
                         memory_limit: 1000,
                         memory_request: 1000,
@@ -182,6 +183,7 @@ describe('DataJobUtil', () => {
                     jobVersion: '002',
                     mode: 'test_mode',
                     vdkVersion: '002',
+                    jobPythonVersion:'3.9-secure',
                     resources: {
                         memoryLimit: 1000,
                         memoryRequest: 1000,

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/utils/data-job.util.spec.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/utils/data-job.util.spec.ts
@@ -183,7 +183,7 @@ describe('DataJobUtil', () => {
                     jobVersion: '002',
                     mode: 'test_mode',
                     vdkVersion: '002',
-                    jobPythonVersion:'3.9-secure',
+                    jobPythonVersion: '3.9-secure',
                     resources: {
                         memoryLimit: 1000,
                         memoryRequest: 1000,

--- a/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/utils/data-job.util.ts
+++ b/projects/frontend/data-pipelines/gui/projects/data-pipelines/src/lib/shared/utils/data-job.util.ts
@@ -70,6 +70,7 @@ export class DataJobUtil {
             execution.deployment.mode = jobExecutionDetails.deployment.mode;
             execution.deployment.deployedDate = jobExecutionDetails.deployment.deployed_date;
             execution.deployment.deployedBy = jobExecutionDetails.deployment.deployed_by;
+            execution.deployment.jobPythonVersion = jobExecutionDetails.deployment.python_version;
 
             if (CollectionsUtil.isLiteralObject(jobExecutionDetails.deployment.schedule)) {
                 execution.deployment.schedule.scheduleCron = jobExecutionDetails.deployment.schedule.schedule_cron;


### PR DESCRIPTION
 - Manage Data Jobs page - Python version column
   - make column to be able to be hide, shown by default
   - disable filter and sort on the column
 - Explore Data Jobs page - Python version column
   - render column, hidden by default
   - make column to be able to be shown, hidden by default
   - disable filter and sort on the column
 - Manage Data Job page - Python version section
   - render readonly section on the left details part of the page
 - Explore Data Job page - Python version section
   - render readonly section on the left details part of the page
   
Local tests passed

Feature/ Non-breaking