### PR TITLE
versatile-data-kit: Support for Py3.12

### DIFF
--- a/projects/vdk-control-cli/.gitlab-ci.yml
+++ b/projects/vdk-control-cli/.gitlab-ci.yml
@@ -32,6 +32,10 @@ vdk-control-cli-build-with-py311:
     image: "python:3.11"
     extends: .vdk-control-cli-build
 
+vdk-control-cli-build-with-py312:
+  image: "python:3.12"
+  extends: .vdk-control-cli-build
+
 vdk-control-cli-release-acceptance-test:
   stage: pre_release
   before_script:

--- a/projects/vdk-core/.gitlab-ci.yml
+++ b/projects/vdk-core/.gitlab-ci.yml
@@ -52,6 +52,10 @@ vdk-core-build_with_py311:
     image: "python:3.11"
     extends: .vdk-core-build
 
+vdk-core-build_with_py312:
+  image: "python:3.12"
+  extends: .vdk-core-build
+
 .vdk-core-simple_func_test:
   services:
     - name: trinodb/trino
@@ -96,6 +100,9 @@ vdk-core-simple_func_test_with_py311:
   image: "python:3.11"
   extends: .vdk-core-simple_func_test
 
+vdk-core-simple_func_test_with_py312:
+  image: "python:3.12"
+  extends: .vdk-core-simple_func_test
 
 vdk-core-release:
   stage: release

--- a/projects/vdk-plugins/quickstart-vdk/.plugin-ci.yml
+++ b/projects/vdk-plugins/quickstart-vdk/.plugin-ci.yml
@@ -35,6 +35,10 @@ build-py311-quickstart-vdk:
   extends: .build-quickstart-vdk
   image: "python:3.11"
 
+build-py312-quickstart-vdk:
+  extends: .build-quickstart-vdk
+  image: "python:3.12"
+
 quickstart-vdk-release-candidate:
   stage: pre_release
   variables:

--- a/projects/vdk-plugins/vdk-audit/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-audit/.plugin-ci.yml
@@ -14,6 +14,10 @@ build-py311-vdk-audit:
   extends: .build-vdk-audit
   image: "python:3.11"
 
+build-py312-vdk-audit:
+  extends: .build-vdk-audit
+  image: "python:3.12"
+
 release-vdk-audit:
   variables:
     PLUGIN_NAME: vdk-audit

--- a/projects/vdk-plugins/vdk-confluence-data-source/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-confluence-data-source/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-confluence-data-source:
   extends: .build-vdk-confluence-data-source
   image: "python:3.11"
 
+build-py312-vdk-confluence-data-source:
+  extends: .build-vdk-confluence-data-source
+  image: "python:3.12"
+
 release-vdk-confluence-data-source:
   variables:
     PLUGIN_NAME: vdk-confluence-data-source

--- a/projects/vdk-plugins/vdk-control-api-auth/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-control-api-auth/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-control-api-auth:
   extends: .build-vdk-control-api-auth
   image: "python:3.11"
 
+build-py312-vdk-control-api-auth:
+  extends: .build-vdk-control-api-auth
+  image: "python:3.12"
+
 build-vdk-control-api-auth-on-vdk-core-release:
   variables:
     PLUGIN_NAME: vdk-control-api-auth

--- a/projects/vdk-plugins/vdk-csv/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-csv/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-csv:
   extends: .build-vdk-csv
   image: "python:3.11"
 
+build-py312-vdk-csv:
+  extends: .build-vdk-csv
+  image: "python:3.12"
+
 build-vdk-csv-on-vdk-core-release:
   variables:
     PLUGIN_NAME: vdk-csv

--- a/projects/vdk-plugins/vdk-dag/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-dag/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-dag:
   extends: .build-vdk-dag
   image: "python:3.11"
 
+build-py312-vdk-dag:
+  extends: .build-vdk-dag
+  image: "python:3.12"
+
 release-vdk-dag:
   variables:
     PLUGIN_NAME: vdk-dag

--- a/projects/vdk-plugins/vdk-data-source-git/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-data-source-git/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-data-source-git:
   extends: .build-vdk-data-source-git
   image: "python:3.11"
 
+build-py312-vdk-data-source-git:
+  extends: .build-vdk-data-source-git
+  image: "python:3.12"
+
 release-vdk-data-source-git:
   variables:
     PLUGIN_NAME: vdk-data-source-git

--- a/projects/vdk-plugins/vdk-data-sources/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-data-sources/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-data-sources:
   extends: .build-vdk-data-sources
   image: "python:3.11"
 
+build-py312-vdk-data-sources:
+  extends: .build-vdk-data-sources
+  image: "python:3.12"
+
 release-vdk-data-sources:
   variables:
     PLUGIN_NAME: vdk-data-sources

--- a/projects/vdk-plugins/vdk-duckdb/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-duckdb/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-duckdb:
   extends: .build-vdk-duckdb
   image: "python:3.11"
 
+build-py312-vdk-duckdb:
+  extends: .build-vdk-duckdb
+  image: "python:3.12"
+
 release-vdk-duckdb:
   variables:
     PLUGIN_NAME: vdk-duckdb

--- a/projects/vdk-plugins/vdk-gdp-execution-id/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-gdp-execution-id/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-gdp-execution-id:
   extends: .build-vdk-gdp-execution-id
   image: "python:3.11"
 
+build-py312-vdk-gdp-execution-id:
+  extends: .build-vdk-gdp-execution-id
+  image: "python:3.12"
+
 build-vdk-gdp-execution-id-on-vdk-core-release:
   variables:
     PLUGIN_NAME: vdk-gdp-execution-id

--- a/projects/vdk-plugins/vdk-greenplum/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-greenplum/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-greenplum:
   extends: .build-vdk-greenplum
   image: "python:3.11"
 
+build-py312-vdk-greenplum:
+  extends: .build-vdk-greenplum
+  image: "python:3.12"
+
 release-vdk-greenplum:
   variables:
     PLUGIN_NAME: vdk-greenplum

--- a/projects/vdk-plugins/vdk-huggingface/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-huggingface/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-huggingface:
   extends: .build-vdk-huggingface
   image: "python:3.11"
 
+build-py312-vdk-huggingface:
+  extends: .build-vdk-huggingface
+  image: "python:3.12"
+
 release-vdk-huggingface:
   variables:
     PLUGIN_NAME: vdk-huggingface

--- a/projects/vdk-plugins/vdk-impala/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-impala/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-impala:
   extends: .build-vdk-impala
   image: "python:3.11"
 
+build-py312-vdk-impala:
+  extends: .build-vdk-impala
+  image: "python:3.12"
+
 build-vdk-impala-on-vdk-core-release:
   variables:
     PLUGIN_NAME: vdk-impala

--- a/projects/vdk-plugins/vdk-ingest-file/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-ingest-file/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-ingest-file:
   extends: .build-vdk-ingest-file
   image: "python:3.11"
 
+build-py312-vdk-ingest-file:
+  extends: .build-vdk-ingest-file
+  image: "python:3.12"
+
 release-vdk-ingest-file:
   variables:
     PLUGIN_NAME: vdk-ingest-file

--- a/projects/vdk-plugins/vdk-ingest-http/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-ingest-http/.plugin-ci.yml
@@ -16,6 +16,11 @@ build-py311-vdk-ingest-http:
   extends: .build-vdk-ingest-http
   image: "python:3.11"
 
+build-py312-vdk-ingest-http:
+  extends: .build-vdk-ingest-http
+  image: "python:3.12"
+
+
 build-vdk-ingest-http-on-vdk-core-release:
   variables:
     PLUGIN_NAME: vdk-ingest-http

--- a/projects/vdk-plugins/vdk-ipython/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-ipython/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-ipython:
   extends: .build-vdk-ipython
   image: "python:3.11"
 
+build-py312-vdk-ipython:
+  extends: .build-vdk-ipython
+  image: "python:3.12"
+
 release-vdk-ipython:
   variables:
     PLUGIN_NAME: vdk-ipython

--- a/projects/vdk-plugins/vdk-jobs-troubleshooting/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-jobs-troubleshooting/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-jobs-troubleshooting:
   extends: .build-vdk-jobs-troubleshooting
   image: "python:3.11"
 
+build-py312-vdk-jobs-troubleshooting:
+  extends: .build-vdk-jobs-troubleshooting
+  image: "python:3.12"
+
 build-vdk-jobs-troubleshooting-on-vdk-core-release:
  variables:
    PLUGIN_NAME: vdk-jobs-troubleshooting

--- a/projects/vdk-plugins/vdk-kerberos-auth/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-kerberos-auth/.plugin-ci.yml
@@ -24,6 +24,10 @@ build-py311-vdk-kerberos-auth:
   extends: .build-vdk-kerberos-auth
   image: "python:3.11"
 
+build-py312-vdk-kerberos-auth:
+  extends: .build-vdk-kerberos-auth
+  image: "python:3.12"
+
 #build-vdk-kerberos-auth-on-vdk-core-release:
 #  variables:
 #    PLUGIN_NAME: vdk-kerberos-auth

--- a/projects/vdk-plugins/vdk-lineage-model/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-lineage-model/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-lineage-model:
   extends: .build-vdk-lineage-model
   image: "python:3.11"
 
+build-py312-vdk-lineage-model:
+  extends: .build-vdk-lineage-model
+  image: "python:3.12"
+
 release-vdk-lineage-model:
   variables:
     PLUGIN_NAME: vdk-lineage-model

--- a/projects/vdk-plugins/vdk-lineage/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-lineage/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-lineage:
   extends: .build-vdk-lineage
   image: "python:3.11"
 
+build-py312-vdk-lineage:
+  extends: .build-vdk-lineage
+  image: "python:3.12"
+
 release-vdk-lineage:
   variables:
     PLUGIN_NAME: vdk-lineage

--- a/projects/vdk-plugins/vdk-meta-jobs/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-meta-jobs/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-meta-jobs:
   extends: .build-vdk-meta-jobs
   image: "python:3.11"
 
+build-py312-vdk-meta-jobs:
+  extends: .build-vdk-meta-jobs
+  image: "python:3.12"
+
 release-vdk-meta-jobs:
   variables:
     PLUGIN_NAME: vdk-meta-jobs

--- a/projects/vdk-plugins/vdk-notebook/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-notebook/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-notebook:
   extends: .build-vdk-notebook
   image: "python:3.11"
 
+build-py312-vdk-notebook:
+  extends: .build-vdk-notebook
+  image: "python:3.12"
+
 release-vdk-notebook:
   variables:
     PLUGIN_NAME: vdk-notebook

--- a/projects/vdk-plugins/vdk-oracle/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-oracle/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-oracle:
   extends: .build-vdk-oracle
   image: "python:3.11"
 
+build-py312-vdk-oracle:
+  extends: .build-vdk-oracle
+  image: "python:3.12"
+
 release-vdk-oracle:
   variables:
     PLUGIN_NAME: vdk-oracle

--- a/projects/vdk-plugins/vdk-plugin-control-cli/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-plugin-control-cli/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-plugin-control-cli:
   extends: .build-vdk-plugin-control-cli
   image: "python:3.11"
 
+build-py312-vdk-plugin-control-cli:
+  extends: .build-vdk-plugin-control-cli
+  image: "python:3.12"
+
 build-vdk-plugin-control-cli-on-vdk-core-release:
   variables:
     PLUGIN_NAME: vdk-plugin-control-cli

--- a/projects/vdk-plugins/vdk-postgres/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-postgres/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-postgres:
   extends: .build-vdk-postgres
   image: "python:3.11"
 
+build-py312-vdk-postgres:
+  extends: .build-vdk-postgres
+  image: "python:3.12"
+
 release-vdk-postgres:
   variables:
     PLUGIN_NAME: vdk-postgres

--- a/projects/vdk-plugins/vdk-properties-fs/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-properties-fs/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-properties-fs:
   extends: .build-vdk-properties-fs
   image: "python:3.11"
 
+build-py312-vdk-properties-fs:
+  extends: .build-vdk-properties-fs
+  image: "python:3.12"
+
 release-vdk-properties-fs:
   variables:
     PLUGIN_NAME: vdk-properties-fs

--- a/projects/vdk-plugins/vdk-server/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-server/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-server:
   extends: .build-vdk-server
   image: "python:3.11"
 
+build-py312-vdk-server:
+  extends: .build-vdk-server
+  image: "python:3.12"
+
 release-vdk-server:
   variables:
     PLUGIN_NAME: vdk-server

--- a/projects/vdk-plugins/vdk-singer/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-singer/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-singer:
   extends: .build-vdk-singer
   image: "python:3.11"
 
+build-py312-vdk-singer:
+  extends: .build-vdk-singer
+  image: "python:3.12"
+
 release-vdk-singer:
   variables:
     PLUGIN_NAME: vdk-singer

--- a/projects/vdk-plugins/vdk-smarter/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-smarter/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-smarter:
   extends: .build-vdk-smarter
   image: "python:3.11"
 
+build-py312-vdk-smarter:
+  extends: .build-vdk-smarter
+  image: "python:3.12"
+
 release-vdk-smarter:
   variables:
     PLUGIN_NAME: vdk-smarter

--- a/projects/vdk-plugins/vdk-snowflake/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-snowflake/.plugin-ci.yml
@@ -15,6 +15,10 @@ build-py311-vdk-snowflake:
   extends: .build-vdk-snowflake
   image: "python:3.11"
 
+build-py312-vdk-snowflake:
+  extends: .build-vdk-snowflake
+  image: "python:3.12"
+
 release-vdk-snowflake:
   variables:
     PLUGIN_NAME: vdk-snowflake

--- a/projects/vdk-plugins/vdk-sqlite/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-sqlite/.plugin-ci.yml
@@ -17,6 +17,10 @@ build-py311-vdk-sqlite:
   extends: .build-vdk-sqlite
   image: "python:3.11"
 
+build-py312-vdk-sqlite:
+  extends: .build-vdk-sqlite
+  image: "python:3.12"
+
 release-vdk-sqlite:
   variables:
     PLUGIN_NAME: vdk-sqlite

--- a/projects/vdk-plugins/vdk-structlog/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-structlog/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-structlog:
   extends: .build-vdk-structlog
   image: "python:3.11"
 
+build-py312-vdk-structlog:
+  extends: .build-vdk-structlog
+  image: "python:3.12"
+
 release-vdk-structlog:
   variables:
     PLUGIN_NAME: vdk-structlog

--- a/projects/vdk-plugins/vdk-test-utils/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-test-utils/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-test-utils:
   extends: .build-vdk-test-utils
   image: "python:3.11"
 
+build-py312-vdk-test-utils:
+  extends: .build-vdk-test-utils
+  image: "python:3.12"
+
 release-vdk-test-utils:
   variables:
     PLUGIN_NAME: vdk-test-utils

--- a/projects/vdk-plugins/vdk-trino/.plugin-ci.yml
+++ b/projects/vdk-plugins/vdk-trino/.plugin-ci.yml
@@ -16,6 +16,10 @@ build-py311-vdk-trino:
   extends: .build-vdk-trino
   image: "python:3.11"
 
+build-py312-vdk-trino:
+  extends: .build-vdk-trino
+  image: "python:3.12"
+
 build-vdk-trino-on-vdk-core-release:
   variables:
     PLUGIN_NAME: vdk-trino


### PR DESCRIPTION
This PR adds a CICD job checking that components and plugins can be built and tested in a Py3.12 environment.

Testing done: cicd