### PR TITLE
control-service: optimize job builder pip install

### DIFF
--- a/projects/control-service/projects/job-builder-rootless/Dockerfile.python.vdk
+++ b/projects/control-service/projects/job-builder-rootless/Dockerfile.python.vdk
@@ -21,7 +21,7 @@ COPY --chown=$UID:$GID $job_name $job_name/
 # TODO: this would trigger for any change in job even if requirements.txt does not change
 # but there's no COPY_IF_EXISTS command in docker to try copy it.
 ARG requirements_file=requirements.txt
-RUN if [ -f "$job_name/$requirements_file" ]; then pip3 install --disable-pip-version-check -q -r "$job_name/$requirements_file" || ( echo ">requirements_failed<" && exit 1 ) ; fi
+RUN if [ -f "$job_name/$requirements_file" ]; then pip3 install --no-cache-dir --disable-pip-version-check -q -r "$job_name/$requirements_file" || ( echo ">requirements_failed<" && exit 1 ) ; fi
 
 ARG job_githash
 ENV JOB_NAME $job_name

--- a/projects/control-service/projects/job-builder-secure/Dockerfile.python.vdk
+++ b/projects/control-service/projects/job-builder-secure/Dockerfile.python.vdk
@@ -49,7 +49,7 @@ RUN : \
           echo "Installing native dependencies ..." \
           && yum install build-essential gcc glibc-devel git freetype2-devel libpng-devel -y \
           && echo "Installing requirements.txt ..." \
-          && pip install --disable-pip-version-check -q -r "$job_name/$requirements_file"  \
+          && pip install --no-cache-dir --disable-pip-version-check -q -r "$job_name/$requirements_file"  \
           || ( echo ">requirements_failed<" && exit 1 ) \
           && echo "Removing native dependencies ..." \
           && yum autoremove build-essential gcc glibc-devel git unzip -y \

--- a/projects/control-service/projects/job-builder/Dockerfile.python.vdk
+++ b/projects/control-service/projects/job-builder/Dockerfile.python.vdk
@@ -21,7 +21,7 @@ COPY --chown=$UID:$GID $job_name $job_name/
 # TODO: this would trigger for any change in job even if requirements.txt does not change
 # but there's no COPY_IF_EXISTS command in docker to try copy it.
 ARG requirements_file=requirements.txt
-RUN if [ -f "$job_name/$requirements_file" ]; then pip3 install --disable-pip-version-check -q -r "$job_name/$requirements_file" || ( echo ">requirements_failed<" && exit 1 ) ; fi
+RUN if [ -f "$job_name/$requirements_file" ]; then pip3 install --no-cache-dir --disable-pip-version-check -q -r "$job_name/$requirements_file" || ( echo ">requirements_failed<" && exit 1 ) ; fi
 
 ARG job_githash
 ENV JOB_NAME $job_name


### PR DESCRIPTION
Pip caching is never useful for Docker builds, and it makes the image bigger and cause the process to consume more memory which can lead to OOM errors.