### PR TITLE
vdk-core: add test for different db connection and ingest target 

### DIFF
--- a/projects/vdk-core/requirements.txt
+++ b/projects/vdk-core/requirements.txt
@@ -3,6 +3,7 @@
 
 -e ../vdk-plugins/vdk-test-utils
 black
+duckdb
 mypy
 pandas
 
@@ -22,4 +23,3 @@ reorder-python-imports
 smtpdfix
 vdk-duckdb
 vdk-sqlite
-duckdb

--- a/projects/vdk-core/requirements.txt
+++ b/projects/vdk-core/requirements.txt
@@ -21,3 +21,4 @@ pytest-sugar
 reorder-python-imports
 smtpdfix
 vdk-sqlite
+vdk-duckdb

--- a/projects/vdk-core/requirements.txt
+++ b/projects/vdk-core/requirements.txt
@@ -20,5 +20,5 @@ pytest-randomly
 pytest-sugar
 reorder-python-imports
 smtpdfix
-vdk-sqlite
 vdk-duckdb
+vdk-sqlite

--- a/projects/vdk-core/requirements.txt
+++ b/projects/vdk-core/requirements.txt
@@ -22,3 +22,4 @@ reorder-python-imports
 smtpdfix
 vdk-duckdb
 vdk-sqlite
+duckdb

--- a/projects/vdk-core/tests/functional/run/jobs/different-db-conn-and-ingest-target/1_step.py
+++ b/projects/vdk-core/tests/functional/run/jobs/different-db-conn-and-ingest-target/1_step.py
@@ -1,0 +1,21 @@
+# Copyright 2023-2024 Broadcom
+# SPDX-License-Identifier: Apache-2.0
+import decimal
+
+from vdk.api.job_input import IJobInput
+
+
+def run(job_input: IJobInput):
+    job_input.execute_query("CREATE TABLE stocks (date text, symbol text, price real)")
+    job_input.execute_query("INSERT INTO stocks VALUES ('2020-01-01', 'GOOG', 123.0), ('2020-01-01', 'GOOG', 123.0)")
+    payload = {
+        "str_col": "str",
+        "int_col": 2,
+        "bool_col": False,
+        "dec_col": decimal.Decimal(1.234),
+    }
+
+    job_input.send_object_for_ingestion(
+        payload=payload, destination_table="test_duckdb_table", method="duckdb"
+    )
+

--- a/projects/vdk-core/tests/functional/run/jobs/different-db-conn-and-ingest-target/1_step.py
+++ b/projects/vdk-core/tests/functional/run/jobs/different-db-conn-and-ingest-target/1_step.py
@@ -7,7 +7,9 @@ from vdk.api.job_input import IJobInput
 
 def run(job_input: IJobInput):
     job_input.execute_query("CREATE TABLE stocks (date text, symbol text, price real)")
-    job_input.execute_query("INSERT INTO stocks VALUES ('2020-01-01', 'GOOG', 123.0), ('2020-01-01', 'GOOG', 123.0)")
+    job_input.execute_query(
+        "INSERT INTO stocks VALUES ('2020-01-01', 'GOOG', 123.0), ('2020-01-01', 'GOOG', 123.0)"
+    )
     payload = {
         "str_col": "str",
         "int_col": 2,
@@ -18,4 +20,3 @@ def run(job_input: IJobInput):
     job_input.send_object_for_ingestion(
         payload=payload, destination_table="test_duckdb_table", method="duckdb"
     )
-

--- a/projects/vdk-core/tests/functional/run/jobs/different-source-and-ingest-target/1_step.py
+++ b/projects/vdk-core/tests/functional/run/jobs/different-source-and-ingest-target/1_step.py
@@ -7,9 +7,7 @@ from vdk.api.job_input import IJobInput
 
 def run(job_input: IJobInput):
     job_input.execute_query("CREATE TABLE stocks (date text, symbol text, price real)")
-    job_input.execute_query(
-        "INSERT INTO stocks VALUES ('2020-01-01', 'GOOG', 122.0)"
-    )
+    job_input.execute_query("INSERT INTO stocks VALUES ('2020-01-01', 'GOOG', 122.0)")
     result = job_input.execute_query("SELECT * FROM stocks")
     payload = {
         "date": result[0][0],

--- a/projects/vdk-core/tests/functional/run/jobs/different-source-and-ingest-target/1_step.py
+++ b/projects/vdk-core/tests/functional/run/jobs/different-source-and-ingest-target/1_step.py
@@ -8,13 +8,13 @@ from vdk.api.job_input import IJobInput
 def run(job_input: IJobInput):
     job_input.execute_query("CREATE TABLE stocks (date text, symbol text, price real)")
     job_input.execute_query(
-        "INSERT INTO stocks VALUES ('2020-01-01', 'GOOG', 123.0), ('2020-01-01', 'GOOG', 123.0)"
+        "INSERT INTO stocks VALUES ('2020-01-01', 'GOOG', 122.0)"
     )
+    result = job_input.execute_query("SELECT * FROM stocks")
     payload = {
-        "str_col": "str",
-        "int_col": 2,
-        "bool_col": False,
-        "dec_col": decimal.Decimal(1.234),
+        "date": result[0][0],
+        "symbol": result[0][1],
+        "price": 500,
     }
 
     job_input.send_object_for_ingestion(

--- a/projects/vdk-core/tests/functional/run/jobs/different-source-and-ingest-target/1_step.py
+++ b/projects/vdk-core/tests/functional/run/jobs/different-source-and-ingest-target/1_step.py
@@ -1,6 +1,5 @@
 # Copyright 2023-2024 Broadcom
 # SPDX-License-Identifier: Apache-2.0
-import decimal
 
 from vdk.api.job_input import IJobInput
 

--- a/projects/vdk-core/tests/functional/run/jobs/different-source-and-ingest-target/1_step.py
+++ b/projects/vdk-core/tests/functional/run/jobs/different-source-and-ingest-target/1_step.py
@@ -1,6 +1,5 @@
 # Copyright 2023-2024 Broadcom
 # SPDX-License-Identifier: Apache-2.0
-
 from vdk.api.job_input import IJobInput
 
 

--- a/projects/vdk-core/tests/functional/run/test_run_different_source_and_destination.py
+++ b/projects/vdk-core/tests/functional/run/test_run_different_source_and_destination.py
@@ -1,0 +1,106 @@
+import json
+import os
+import re
+from unittest import mock
+
+import duckdb
+import pytest
+from click.testing import CliRunner
+from click.testing import Result
+from vdk.plugin.duckdb import duckdb_plugin
+from vdk.plugin.sqlite import sqlite_plugin
+from vdk.plugin.test_utils.util_funcs import cli_assert_equal
+from vdk.plugin.test_utils.util_funcs import CliEntryBasedTestRunner
+from vdk.plugin.test_utils.util_funcs import jobs_path_from_caller_directory
+
+
+@pytest.fixture(scope="function")
+def setup(tmpdir):
+    temp_db_file = os.path.join(str(tmpdir), "test_db.duckdb")
+    connection = duckdb.connect(temp_db_file)
+
+    with mock.patch.dict(
+        os.environ,
+        {
+            "VDK_DB_DEFAULT_TYPE": "SQLITE",
+            "VDK_SQLITE_FILE": str(tmpdir) + "vdk-sqlite.db",
+            "VDK_INGEST_TARGET_DEFAULT": "DUCKDB",
+            "DUCKDB_DATABASE": temp_db_file,
+            "DUCKDB_INGEST_AUTO_CREATE_TABLE_ENABLED": "true",
+        },
+    ):
+        yield
+
+        connection.close()
+        os.remove(temp_db_file)
+
+
+def test(setup):
+    runner = CliEntryBasedTestRunner(duckdb_plugin, sqlite_plugin)
+
+    result: Result = runner.invoke(
+        ["run", jobs_path_from_caller_directory("different-db-conn-and-ingest-target")]
+    )
+
+    cli_assert_equal(0, result)
+
+    _verify_sql_steps(runner)
+    _verify_ingest_step()
+
+
+def _verify_sql_steps(runner):
+    actual_rs = _sql_query(runner, "SELECT * FROM stocks")
+    cli_assert_equal(0, actual_rs)
+    expected_data = [
+        {"date": "2020-01-01", "symbol": "GOOG", "price": 123.0},
+        {"date": "2020-01-01", "symbol": "GOOG", "price": 123.0},
+    ]
+    assert json.loads(actual_rs.output) == expected_data
+
+
+def _verify_ingest_step():
+    # TODO: why should we use duckdb connection here instead of vdk, usability gap
+    connection = duckdb.connect(os.environ["DUCKDB_DATABASE"])
+    actual_rs = connection.query("SELECT * FROM test_duckdb_table")
+    """
+    This is the expected actual_rs:
+    ┌─────────┬─────────┬──────────┬─────────┐
+    │ str_col │ int_col │ bool_col │ dec_col │
+    │ varchar │  int32  │  int32   │ varchar │
+    ├─────────┼─────────┼──────────┼─────────┤
+    │ str     │       2 │        0 │ 1.234   │
+    └─────────┴─────────┴──────────┴─────────┘
+    """
+
+    pattern = r"│\s*(\w+)\s*│\s*(\d+)\s*│\s*(\d+)\s*│\s*([\d.]+)\s*│"
+
+    match = re.search(pattern, actual_rs.__str__())
+
+    if match:
+        str_col, int_col, bool_col, dec_col = match.groups()
+
+        expected_values = {
+            "str_col": "str",
+            "int_col": "2",
+            "bool_col": "0",
+            "dec_col": "1.234"
+        }
+
+        actual_values = {
+            "str_col": str_col,
+            "int_col": int_col,
+            "bool_col": bool_col,
+            "dec_col": dec_col
+        }
+
+        assert actual_values == expected_values
+
+
+def _sql_query(runner, query):
+    actual_rs: Result = runner.invoke(
+        ["sql-query", "-o", "json", "--query", query],
+        runner=CliRunner(
+            mix_stderr=False
+        ),
+    )
+    return actual_rs

--- a/projects/vdk-core/tests/functional/run/test_run_different_source_and_destination.py
+++ b/projects/vdk-core/tests/functional/run/test_run_different_source_and_destination.py
@@ -1,6 +1,5 @@
 # Copyright 2023-2024 Broadcom
 # SPDX-License-Identifier: Apache-2.0
-
 import json
 import os
 import re
@@ -54,9 +53,7 @@ def test_different_db_conn_and_ingest_target(setup):
 def _verify_sql_steps(runner):
     actual_rs = _sql_query(runner, "SELECT * FROM stocks")
     cli_assert_equal(0, actual_rs)
-    expected_data = [
-        {"date": "2020-01-01", "symbol": "GOOG", "price": 122.0}
-    ]
+    expected_data = [{"date": "2020-01-01", "symbol": "GOOG", "price": 122.0}]
     assert json.loads(actual_rs.output) == expected_data
 
 
@@ -74,9 +71,9 @@ def _verify_ingest_step():
     └────────────┴─────────┴───────┘
     """
     result_string = actual_rs.__str__()
-    assert result_string.count('2020-01-01') == 1
-    assert result_string.count('GOOG') == 1
-    assert result_string.count('500') == 1
+    assert result_string.count("2020-01-01") == 1
+    assert result_string.count("GOOG") == 1
+    assert result_string.count("500") == 1
 
 
 def _sql_query(runner, query):

--- a/projects/vdk-core/tests/functional/run/test_run_different_source_and_destination.py
+++ b/projects/vdk-core/tests/functional/run/test_run_different_source_and_destination.py
@@ -1,3 +1,6 @@
+# Copyright 2023-2024 Broadcom
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import os
 import re
@@ -83,14 +86,14 @@ def _verify_ingest_step():
             "str_col": "str",
             "int_col": "2",
             "bool_col": "0",
-            "dec_col": "1.234"
+            "dec_col": "1.234",
         }
 
         actual_values = {
             "str_col": str_col,
             "int_col": int_col,
             "bool_col": bool_col,
-            "dec_col": dec_col
+            "dec_col": dec_col,
         }
 
         assert actual_values == expected_values
@@ -99,8 +102,6 @@ def _verify_ingest_step():
 def _sql_query(runner, query):
     actual_rs: Result = runner.invoke(
         ["sql-query", "-o", "json", "--query", query],
-        runner=CliRunner(
-            mix_stderr=False
-        ),
+        runner=CliRunner(mix_stderr=False),
     )
     return actual_rs

--- a/projects/vdk-core/tests/functional/run/test_run_different_source_and_destination.py
+++ b/projects/vdk-core/tests/functional/run/test_run_different_source_and_destination.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import json
 import os
-import re
 from unittest import mock
 
 import duckdb

--- a/projects/vdk-core/tests/functional/run/test_run_different_source_and_destination.py
+++ b/projects/vdk-core/tests/functional/run/test_run_different_source_and_destination.py
@@ -60,15 +60,13 @@ def _verify_ingest_step():
     # TODO: why should we use duckdb connection here instead of vdk, usability gap
     connection = duckdb.connect(os.environ["DUCKDB_DATABASE"])
     actual_rs = connection.query("SELECT * FROM test_duckdb_table")
-    """
-    This is the expected actual_rs:
-    ┌────────────┬─────────┬───────┐
-    │    date    │ symbol  │ price │
-    │  varchar   │ varchar │ float │
-    ├────────────┼─────────┼───────┤
-    │ 2020-01-01 │ GOOG    │ 500   │
-    └────────────┴─────────┴───────┘
-    """
+    # This is the expected actual_rs:
+    # ┌────────────┬─────────┬───────┐
+    # │    date    │ symbol  │ price │
+    # │  varchar   │ varchar │ float │
+    # ├────────────┼─────────┼───────┤
+    # │ 2020-01-01 │ GOOG    │ 500   │
+    # └────────────┴─────────┴───────┘
     result_string = actual_rs.__str__()
     assert result_string.count("2020-01-01") == 1
     assert result_string.count("GOOG") == 1


### PR DESCRIPTION
What: added a test that shows we can have different db connection and ingest target in a data job 
Linked to: https://github.com/vmware/versatile-data-kit/issues/3128

Follows the scenario: 
- write and read data from sqlite
- change the data a little
- send changed data to another database (duckdb)