### PR TITLE
vdk-oracle: replace oracle-query with sql-query

### DIFF
--- a/projects/vdk-plugins/vdk-oracle/src/vdk/plugin/oracle/oracle_plugin.py
+++ b/projects/vdk-plugins/vdk-oracle/src/vdk/plugin/oracle/oracle_plugin.py
@@ -67,11 +67,20 @@ def vdk_start(plugin_registry: IPluginRegistry, command_line_args: List):
 # TODO: https://github.com/vmware/versatile-data-kit/issues/2940
 @click.command(
     name="oracle-query",
-    help="Execute an Oracle query against an Oracle database (should be configured with env variables)",
+    help="DEPRECATED: use sql-query, instead."
+         "Execute an Oracle query against an Oracle database (should be configured with env variables)",
 )
 @click.option("-q", "--query", type=click.STRING, required=True)
 @click.pass_context
 def oracle_query(ctx: click.Context, query):
+    """
+        Deprecated: "Use sql-query instead"
+
+        oracle-query: kept for compatibility
+        """
+    log.warning(
+        "oracle-query has been deprecated; please use sql-query instead."
+    )
     conf = ctx.obj.configuration
     conn = oracledb.connect(
         user=conf.get_value(ORACLE_USER),

--- a/projects/vdk-plugins/vdk-oracle/src/vdk/plugin/oracle/oracle_plugin.py
+++ b/projects/vdk-plugins/vdk-oracle/src/vdk/plugin/oracle/oracle_plugin.py
@@ -68,19 +68,17 @@ def vdk_start(plugin_registry: IPluginRegistry, command_line_args: List):
 @click.command(
     name="oracle-query",
     help="DEPRECATED: use sql-query, instead."
-         "Execute an Oracle query against an Oracle database (should be configured with env variables)",
+    "Execute an Oracle query against an Oracle database (should be configured with env variables)",
 )
 @click.option("-q", "--query", type=click.STRING, required=True)
 @click.pass_context
 def oracle_query(ctx: click.Context, query):
     """
-        Deprecated: "Use sql-query instead"
+    Deprecated: "Use sql-query instead"
 
-        oracle-query: kept for compatibility
-        """
-    log.warning(
-        "oracle-query has been deprecated; please use sql-query instead."
-    )
+    oracle-query: kept for compatibility
+    """
+    log.warning("oracle-query has been deprecated; please use sql-query instead.")
     conf = ctx.obj.configuration
     conn = oracledb.connect(
         user=conf.get_value(ORACLE_USER),

--- a/projects/vdk-plugins/vdk-oracle/tests/test_plugin.py
+++ b/projects/vdk-plugins/vdk-oracle/tests/test_plugin.py
@@ -166,9 +166,7 @@ def _verify_query_execution(runner):
 
 
 def _verify_ingest_execution(runner):
-    check_result = runner.invoke(
-        ["sql-query", "--query", "SELECT * FROM test_table"]
-    )
+    check_result = runner.invoke(["sql-query", "--query", "SELECT * FROM test_table"])
     expected = (
         "  ID  STR_DATA      INT_DATA    FLOAT_DATA    BOOL_DATA  "
         "TIMESTAMP_DATA         DECIMAL_DATA\n"
@@ -181,9 +179,7 @@ def _verify_ingest_execution(runner):
 
 
 def _verify_ingest_execution_special_chars(runner):
-    check_result = runner.invoke(
-        ["sql-query", "--query", "SELECT * FROM test_table"]
-    )
+    check_result = runner.invoke(["sql-query", "--query", "SELECT * FROM test_table"])
     expected = (
         "  ID  @str_data      %int_data    *float*data*    BOOL_DATA  "
         "TIMESTAMP_DATA         DECIMAL_DATA\n"
@@ -196,9 +192,7 @@ def _verify_ingest_execution_special_chars(runner):
 
 
 def _verify_ingest_execution_type_inference(runner):
-    check_result = runner.invoke(
-        ["sql-query", "--query", "SELECT * FROM test_table"]
-    )
+    check_result = runner.invoke(["sql-query", "--query", "SELECT * FROM test_table"])
     expected = (
         "  ID  STR_DATA      INT_DATA  NAN_INT_DATA      FLOAT_DATA    BOOL_DATA  "
         "TIMESTAMP_DATA         DECIMAL_DATA\n"
@@ -211,9 +205,7 @@ def _verify_ingest_execution_type_inference(runner):
 
 
 def _verify_ingest_execution_no_table(runner):
-    check_result = runner.invoke(
-        ["sql-query", "--query", "SELECT * FROM test_table"]
-    )
+    check_result = runner.invoke(["sql-query", "--query", "SELECT * FROM test_table"])
     expected = (
         "  ID  STR_DATA      INT_DATA    FLOAT_DATA    BOOL_DATA  "
         "TIMESTAMP_DATA         DECIMAL_DATA\n"
@@ -230,9 +222,7 @@ def _verify_ingest_execution_no_table(runner):
 
 
 def _verify_ingest_execution_no_table_special_chars(runner):
-    check_result = runner.invoke(
-        ["sql-query", "--query", "SELECT * FROM test_table"]
-    )
+    check_result = runner.invoke(["sql-query", "--query", "SELECT * FROM test_table"])
     expected = (
         "  ID  @str_data      %int_data    *float*data*    BOOL_DATA  "
         "TIMESTAMP_DATA         DECIMAL_DATA\n"
@@ -257,15 +247,13 @@ def _verify_ingest_execution_different_payloads_no_table(runner):
 
 
 def _verify_ingest_execution_different_payloads_no_table_special_chars(runner):
-    check_result = runner.invoke(
-        ["sql-query", "--query", "SELECT * FROM test_table"]
-    )
+    check_result = runner.invoke(["sql-query", "--query", "SELECT * FROM test_table"])
 
     # Skip the log lines until the line with the column headers
     log_lines = check_result.output.strip().split("\n")
     column_header_line_index = next(
         (index for index, line in enumerate(log_lines) if re.match(r"^\s*ID\s+", line)),
-        None
+        None,
     )
     if column_header_line_index is None:
         raise ValueError("Column header line not found in the output.")
@@ -291,9 +279,7 @@ def _verify_ingest_execution_different_payloads_no_table_special_chars(runner):
 
 
 def _verify_ingest_execution_different_payloads(runner):
-    check_result = runner.invoke(
-        ["sql-query", "--query", "SELECT * FROM test_table"]
-    )
+    check_result = runner.invoke(["sql-query", "--query", "SELECT * FROM test_table"])
     expected = (
         "  ID  STR_DATA      INT_DATA    FLOAT_DATA    BOOL_DATA  TIMESTAMP_DATA\n"
         "----  ----------  ----------  ------------  -----------  "

--- a/projects/vdk-plugins/vdk-oracle/tests/test_plugin.py
+++ b/projects/vdk-plugins/vdk-oracle/tests/test_plugin.py
@@ -161,6 +161,9 @@ def _verify_query_execution(runner):
         "----  -------------  ------\n"
         "   1  Task 1              1\n"
     )
+    print("\n\n\n\n")
+    print(check_result.output)
+    print("\n\n\n\n")
     assert check_result.output == expected
 
 
@@ -176,6 +179,9 @@ def _verify_ingest_execution(runner):
         "   5  string              12           1.2            1  2023-11-21 "
         "08:12:53             0.1\n"
     )
+    print("\n\n\n\n")
+    print(check_result.output)
+    print("\n\n\n\n")
     assert check_result.output == expected
 
 
@@ -191,6 +197,9 @@ def _verify_ingest_execution_special_chars(runner):
         "   5  string                12             1.2            1  2023-11-21 "
         "08:12:53             0.1\n"
     )
+    print("\n\n\n\n")
+    print(check_result.output)
+    print("\n\n\n\n")
     assert check_result.output == expected
 
 
@@ -206,6 +215,9 @@ def _verify_ingest_execution_type_inference(runner):
         "   5  string              12                           1.2            1  "
         "2023-11-21 08:12:53             0.1\n"
     )
+    print("\n\n\n\n")
+    print(check_result.output)
+    print("\n\n\n\n")
     assert check_result.output == expected
 
 
@@ -225,6 +237,9 @@ def _verify_ingest_execution_no_table(runner):
         "   2  string              12           1.2            1  "
         "2023-11-21T08:12:53             1.1\n"
     )
+    print("\n\n\n\n")
+    print(check_result.output)
+    print("\n\n\n\n")
     assert check_result.output == expected
 
 
@@ -244,6 +259,9 @@ def _verify_ingest_execution_no_table_special_chars(runner):
         "   2  string                12             1.2            1  "
         "2023-11-21T08:12:53             1.1\n"
     )
+    print("\n\n\n\n")
+    print(check_result.output)
+    print("\n\n\n\n")
     assert check_result.output == expected
 
 
@@ -252,6 +270,9 @@ def _verify_ingest_execution_different_payloads_no_table(runner):
         ["sql-query", "--query", "SELECT count(*) FROM test_table"]
     )
     expected = "  COUNT(*)\n----------\n         8\n"
+    print("\n\n\n\n")
+    print(check_result.output)
+    print("\n\n\n\n")
     assert check_result.output == expected
 
 
@@ -276,6 +297,9 @@ def _verify_ingest_execution_different_payloads_no_table_special_chars(runner):
     check_result = runner.invoke(
         ["sql-query", "--query", "SELECT count(*) FROM test_table"]
     )
+    print("\n\n\n\n")
+    print(check_result.output)
+    print("\n\n\n\n")
     assert check_result.output == expected_count
 
 
@@ -297,6 +321,9 @@ def _verify_ingest_execution_different_payloads(runner):
         "   5  string              12           1.2            1  2023-11-21 "
         "08:12:53\n"
     )
+    print("\n\n\n\n")
+    print(check_result.output)
+    print("\n\n\n\n")
     assert check_result.output == expected
 
 
@@ -316,4 +343,7 @@ def _verify_ingest_blob(runner):
         "And miles to go before I sleep,\n"
         "And miles to go before I sleep.\n"
     )
+    print("\n\n\n\n")
+    print(check_result.output)
+    print("\n\n\n\n")
     assert check_result.output == expected

--- a/projects/vdk-plugins/vdk-oracle/tests/test_plugin.py
+++ b/projects/vdk-plugins/vdk-oracle/tests/test_plugin.py
@@ -155,7 +155,7 @@ class OracleTests(TestCase):
 
 
 def _verify_query_execution(runner):
-    check_result = runner.invoke(["oracle-query", "--query", "SELECT * FROM todoitem"])
+    check_result = runner.invoke(["sql-query", "--query", "SELECT * FROM todoitem"])
     expected = (
         "  ID  DESCRIPTION      DONE\n"
         "----  -------------  ------\n"
@@ -166,7 +166,7 @@ def _verify_query_execution(runner):
 
 def _verify_ingest_execution(runner):
     check_result = runner.invoke(
-        ["oracle-query", "--query", "SELECT * FROM test_table"]
+        ["sql-query", "--query", "SELECT * FROM test_table"]
     )
     expected = (
         "  ID  STR_DATA      INT_DATA    FLOAT_DATA    BOOL_DATA  "
@@ -181,7 +181,7 @@ def _verify_ingest_execution(runner):
 
 def _verify_ingest_execution_special_chars(runner):
     check_result = runner.invoke(
-        ["oracle-query", "--query", "SELECT * FROM test_table"]
+        ["sql-query", "--query", "SELECT * FROM test_table"]
     )
     expected = (
         "  ID  @str_data      %int_data    *float*data*    BOOL_DATA  "
@@ -196,7 +196,7 @@ def _verify_ingest_execution_special_chars(runner):
 
 def _verify_ingest_execution_type_inference(runner):
     check_result = runner.invoke(
-        ["oracle-query", "--query", "SELECT * FROM test_table"]
+        ["sql-query", "--query", "SELECT * FROM test_table"]
     )
     expected = (
         "  ID  STR_DATA      INT_DATA  NAN_INT_DATA      FLOAT_DATA    BOOL_DATA  "
@@ -211,7 +211,7 @@ def _verify_ingest_execution_type_inference(runner):
 
 def _verify_ingest_execution_no_table(runner):
     check_result = runner.invoke(
-        ["oracle-query", "--query", "SELECT * FROM test_table"]
+        ["sql-query", "--query", "SELECT * FROM test_table"]
     )
     expected = (
         "  ID  STR_DATA      INT_DATA    FLOAT_DATA    BOOL_DATA  "
@@ -230,7 +230,7 @@ def _verify_ingest_execution_no_table(runner):
 
 def _verify_ingest_execution_no_table_special_chars(runner):
     check_result = runner.invoke(
-        ["oracle-query", "--query", "SELECT * FROM test_table"]
+        ["sql-query", "--query", "SELECT * FROM test_table"]
     )
     expected = (
         "  ID  @str_data      %int_data    *float*data*    BOOL_DATA  "
@@ -249,7 +249,7 @@ def _verify_ingest_execution_no_table_special_chars(runner):
 
 def _verify_ingest_execution_different_payloads_no_table(runner):
     check_result = runner.invoke(
-        ["oracle-query", "--query", "SELECT count(*) FROM test_table"]
+        ["sql-query", "--query", "SELECT count(*) FROM test_table"]
     )
     expected = "  COUNT(*)\n----------\n         8\n"
     assert check_result.output == expected
@@ -257,7 +257,7 @@ def _verify_ingest_execution_different_payloads_no_table(runner):
 
 def _verify_ingest_execution_different_payloads_no_table_special_chars(runner):
     check_result = runner.invoke(
-        ["oracle-query", "--query", "SELECT * FROM test_table"]
+        ["sql-query", "--query", "SELECT * FROM test_table"]
     )
 
     actual_columns = check_result.output.split("\n")[0].split()
@@ -274,14 +274,14 @@ def _verify_ingest_execution_different_payloads_no_table_special_chars(runner):
 
     expected_count = "  COUNT(*)\n----------\n         8\n"
     check_result = runner.invoke(
-        ["oracle-query", "--query", "SELECT count(*) FROM test_table"]
+        ["sql-query", "--query", "SELECT count(*) FROM test_table"]
     )
     assert check_result.output == expected_count
 
 
 def _verify_ingest_execution_different_payloads(runner):
     check_result = runner.invoke(
-        ["oracle-query", "--query", "SELECT * FROM test_table"]
+        ["sql-query", "--query", "SELECT * FROM test_table"]
     )
     expected = (
         "  ID  STR_DATA      INT_DATA    FLOAT_DATA    BOOL_DATA  TIMESTAMP_DATA\n"
@@ -303,7 +303,7 @@ def _verify_ingest_execution_different_payloads(runner):
 def _verify_ingest_blob(runner):
     check_result = runner.invoke(
         [
-            "oracle-query",
+            "sql-query",
             "--query",
             "SELECT utl_raw.cast_to_varchar2(dbms_lob.substr(blob_data,2000,1)) FROM test_table",
         ]

--- a/projects/vdk-plugins/vdk-oracle/tests/test_plugin.py
+++ b/projects/vdk-plugins/vdk-oracle/tests/test_plugin.py
@@ -161,10 +161,7 @@ def _verify_query_execution(runner):
         "----  -------------  ------\n"
         "   1  Task 1              1\n"
     )
-    print("\n\n\n\n")
-    print(check_result.output)
-    print("\n\n\n\n")
-    assert check_result.output == expected
+    assert expected in check_result.output
 
 
 def _verify_ingest_execution(runner):
@@ -179,10 +176,7 @@ def _verify_ingest_execution(runner):
         "   5  string              12           1.2            1  2023-11-21 "
         "08:12:53             0.1\n"
     )
-    print("\n\n\n\n")
-    print(check_result.output)
-    print("\n\n\n\n")
-    assert check_result.output == expected
+    assert expected in check_result.output
 
 
 def _verify_ingest_execution_special_chars(runner):
@@ -197,10 +191,7 @@ def _verify_ingest_execution_special_chars(runner):
         "   5  string                12             1.2            1  2023-11-21 "
         "08:12:53             0.1\n"
     )
-    print("\n\n\n\n")
-    print(check_result.output)
-    print("\n\n\n\n")
-    assert check_result.output == expected
+    assert expected in check_result.output
 
 
 def _verify_ingest_execution_type_inference(runner):
@@ -215,10 +206,7 @@ def _verify_ingest_execution_type_inference(runner):
         "   5  string              12                           1.2            1  "
         "2023-11-21 08:12:53             0.1\n"
     )
-    print("\n\n\n\n")
-    print(check_result.output)
-    print("\n\n\n\n")
-    assert check_result.output == expected
+    assert expected in check_result.output
 
 
 def _verify_ingest_execution_no_table(runner):
@@ -237,10 +225,7 @@ def _verify_ingest_execution_no_table(runner):
         "   2  string              12           1.2            1  "
         "2023-11-21T08:12:53             1.1\n"
     )
-    print("\n\n\n\n")
-    print(check_result.output)
-    print("\n\n\n\n")
-    assert check_result.output == expected
+    assert expected in check_result.output
 
 
 def _verify_ingest_execution_no_table_special_chars(runner):
@@ -259,10 +244,7 @@ def _verify_ingest_execution_no_table_special_chars(runner):
         "   2  string                12             1.2            1  "
         "2023-11-21T08:12:53             1.1\n"
     )
-    print("\n\n\n\n")
-    print(check_result.output)
-    print("\n\n\n\n")
-    assert check_result.output == expected
+    assert expected in check_result.output
 
 
 def _verify_ingest_execution_different_payloads_no_table(runner):
@@ -270,10 +252,7 @@ def _verify_ingest_execution_different_payloads_no_table(runner):
         ["sql-query", "--query", "SELECT count(*) FROM test_table"]
     )
     expected = "  COUNT(*)\n----------\n         8\n"
-    print("\n\n\n\n")
-    print(check_result.output)
-    print("\n\n\n\n")
-    assert check_result.output == expected
+    assert expected in check_result.output
 
 
 def _verify_ingest_execution_different_payloads_no_table_special_chars(runner):
@@ -297,10 +276,7 @@ def _verify_ingest_execution_different_payloads_no_table_special_chars(runner):
     check_result = runner.invoke(
         ["sql-query", "--query", "SELECT count(*) FROM test_table"]
     )
-    print("\n\n\n\n")
-    print(check_result.output)
-    print("\n\n\n\n")
-    assert check_result.output == expected_count
+    assert expected_count in check_result.output
 
 
 def _verify_ingest_execution_different_payloads(runner):
@@ -321,10 +297,7 @@ def _verify_ingest_execution_different_payloads(runner):
         "   5  string              12           1.2            1  2023-11-21 "
         "08:12:53\n"
     )
-    print("\n\n\n\n")
-    print(check_result.output)
-    print("\n\n\n\n")
-    assert check_result.output == expected
+    assert expected in check_result.output
 
 
 def _verify_ingest_blob(runner):
@@ -343,7 +316,4 @@ def _verify_ingest_blob(runner):
         "And miles to go before I sleep,\n"
         "And miles to go before I sleep.\n"
     )
-    print("\n\n\n\n")
-    print(check_result.output)
-    print("\n\n\n\n")
-    assert check_result.output == expected
+    assert expected in check_result.output


### PR DESCRIPTION
Solves: https://github.com/vmware/versatile-data-kit/issues/2940
The tests has been changed since sql-query adds logs to the output of the command.
Example: 
<img width="1137" alt="Screenshot 2024-03-07 at 15 16 35" src="https://github.com/vmware/versatile-data-kit/assets/87015481/7efdf273-c553-497c-b361-dcf7b7494ad2">

Signed-off-by: Duygu Hasan [hduygu@vmware.com](mailto:hduygu@vmware.com)