### PR TITLE
vdk-core: db managed connections

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/database_managed_connection.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/database_managed_connection.py
@@ -55,23 +55,14 @@ class IDatabaseManagedConnection:
     def db_connection_execute_operation(
         self, execution_cursor: ExecutionCursor
     ) -> Optional[ExecuteOperationResult]:
-        """
-        The method that executes the actual SQL query using execution cursor.
-        You can see the default implementation at DefaultConnectionHookImpl.
-
-        For example: let's say we are writing vdk-impala plugin and want to print more debug info
-            which is available from the Impala native cursor (provided by impyla library)
-
-                _db_connection_execute_operation(execution_cursor: ExecutionCursor) -> Optional[int]:
-                    yield # let the query execute first
-                    c = cast(impala.interface.Cursor, execution_cursor)
-                    log.info(f"Query {execution_cursor.get_managed_operation().get_operation()} debug info:"
-                             f"summary: {c.get_summary()}, profile: {c.get_profile()}")
-
-            :param execution_cursor: ExecutionCursor
-                A PEP249Cursor implementation purposed for actual query execution.
-        """
-        pass
+        managed_operation = execution_cursor.get_managed_operation()
+        if managed_operation.get_parameters():
+            native_result = execution_cursor.execute(
+                managed_operation.get_operation(), managed_operation.get_parameters()
+            )
+        else:
+            native_result = execution_cursor.execute(managed_operation.get_operation())
+        return ExecuteOperationResult(native_result)
 
     def db_connection_recover_operation(self, recovery_cursor: RecoveryCursor) -> None:
         """

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/database_managed_connection.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/database_managed_connection.py
@@ -56,16 +56,16 @@ class IDatabaseManagedConnection:
         self, execution_cursor: ExecutionCursor
     ) -> Optional[ExecuteOperationResult]:
         """
-            The method that executes the actual SQL query using execution cursor.
-            For example: let's say we are writing vdk-impala plugin and want to print more debug info
-                which is available from the Impala native cursor (provided by impyla library)
-                    db_connection_execute_operation(execution_cursor: ExecutionCursor) -> Optional[int]:
-                        yield # let the query execute first
-                        c = cast(impala.interface.Cursor, execution_cursor)
-                        log.info(f"Query {execution_cursor.get_managed_operation().get_operation()} debug info:"
-                                f"summary: {c.get_summary()}, profile: {c.get_profile()}")
-            :param execution_cursor: ExecutionCursor
-            A PEP249Cursor implementation purposed for actual query execution.
+        The method that executes the actual SQL query using execution cursor.
+        For example: let's say we are writing vdk-impala plugin and want to print more debug info
+            which is available from the Impala native cursor (provided by impyla library)
+                db_connection_execute_operation(execution_cursor: ExecutionCursor) -> Optional[int]:
+                    yield # let the query execute first
+                    c = cast(impala.interface.Cursor, execution_cursor)
+                    log.info(f"Query {execution_cursor.get_managed_operation().get_operation()} debug info:"
+                            f"summary: {c.get_summary()}, profile: {c.get_profile()}")
+        :param execution_cursor: ExecutionCursor
+        A PEP249Cursor implementation purposed for actual query execution.
         """
         managed_operation = execution_cursor.get_managed_operation()
         if managed_operation.get_parameters():

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/database_managed_connection.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/database_managed_connection.py
@@ -19,7 +19,7 @@ class IDatabaseManagedConnection:
         Validates the query and parameters.
 
         For example:
-        _db_connection_validate_operation(operation, parameters):
+        db_connection_validate_operation(operation, parameters):
             if(_max_query_length_limit_exceeded(operation, parameters)):
                 raise Exception("max query length limit exceeded")
 
@@ -40,7 +40,7 @@ class IDatabaseManagedConnection:
         If an exception is raised, the cursor execution will be suspended.
 
         For example:
-        _db_connection_decorate_operation(decoration_cursor: DecorationCursor):
+        db_connection_decorate_operation(decoration_cursor: DecorationCursor):
             managed_operation = decoration_cursor.get_managed_operation()
             managed_operation.set_operation("prefix" +
                                             managed_operation.get_operation())
@@ -55,6 +55,18 @@ class IDatabaseManagedConnection:
     def db_connection_execute_operation(
         self, execution_cursor: ExecutionCursor
     ) -> Optional[ExecuteOperationResult]:
+        """
+            The method that executes the actual SQL query using execution cursor.
+            For example: let's say we are writing vdk-impala plugin and want to print more debug info
+                which is available from the Impala native cursor (provided by impyla library)
+                    db_connection_execute_operation(execution_cursor: ExecutionCursor) -> Optional[int]:
+                        yield # let the query execute first
+                        c = cast(impala.interface.Cursor, execution_cursor)
+                        log.info(f"Query {execution_cursor.get_managed_operation().get_operation()} debug info:"
+                                f"summary: {c.get_summary()}, profile: {c.get_profile()}")
+            :param execution_cursor: ExecutionCursor
+            A PEP249Cursor implementation purposed for actual query execution.
+        """
         managed_operation = execution_cursor.get_managed_operation()
         if managed_operation.get_parameters():
             native_result = execution_cursor.execute(
@@ -70,7 +82,7 @@ class IDatabaseManagedConnection:
         If no exception is raised, cursor is considered successfully executed.
 
         For example:
-        _db_connection_recover_operation(recovery_cursor: RecoveryCursor):
+        db_connection_recover_operation(recovery_cursor: RecoveryCursor):
             while recovery_cursor.get_retries() < MAX_RETRIES:
                 try:
                     recovery_cursor.execute("helper query")

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/database_managed_connection.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/database_managed_connection.py
@@ -1,70 +1,75 @@
-from typing import Optional, Container
+# Copyright 2023-2024 Broadcom
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Container
+from typing import Optional
 
 from vdk.internal.builtin_plugins.connection.decoration_cursor import DecorationCursor
-from vdk.internal.builtin_plugins.connection.execution_cursor import ExecuteOperationResult, ExecutionCursor
+from vdk.internal.builtin_plugins.connection.execution_cursor import ExecuteOperationResult
+from vdk.internal.builtin_plugins.connection.execution_cursor import ExecutionCursor
 from vdk.internal.builtin_plugins.connection.recovery_cursor import RecoveryCursor
 
 
 class IDatabaseManagedConnection:
     def db_connection_validate_operation(
-            self, operation: str, parameters: Optional[Container]
+        self, operation: str, parameters: Optional[Container]
     ) -> None:
         """
-            Validates the query and parameters.
+        Validates the query and parameters.
 
-            For example:
-            _db_connection_validate_operation(operation, parameters):
-                if(_max_query_length_limit_exceeded(operation, parameters)):
-                    raise Exception("max query length limit exceeded")
+        For example:
+        _db_connection_validate_operation(operation, parameters):
+            if(_max_query_length_limit_exceeded(operation, parameters)):
+                raise Exception("max query length limit exceeded")
 
-            :param operation: str
-                Database operation - a SQL query or command to be executed.
-            :param parameters: Optional[Container]
-                Parameters may be provided as sequence or mapping and will be bound to variables in the operation.
-                Variables are specified in a database-specific notation. See chosen database documentation for details.
-            :return:
+        :param operation: str
+            Database operation - a SQL query or command to be executed.
+        :param parameters: Optional[Container]
+            Parameters may be provided as sequence or mapping and will be bound to variables in the operation.
+            Variables are specified in a database-specific notation. See chosen database documentation for details.
+        :return:
         """
         pass
 
     def db_connection_decorate_operation(
-            self, decoration_cursor: DecorationCursor
+        self, decoration_cursor: DecorationCursor
     ) -> None:
         """
-            Curates the operation and parameters.
-            If an exception is raised, the cursor execution will be suspended.
+        Curates the operation and parameters.
+        If an exception is raised, the cursor execution will be suspended.
 
-            For example:
-            _db_connection_decorate_operation(decoration_cursor: DecorationCursor):
-                managed_operation = decoration_cursor.get_managed_operation()
-                managed_operation.set_operation("prefix" +
-                                                managed_operation.get_operation())
+        For example:
+        _db_connection_decorate_operation(decoration_cursor: DecorationCursor):
+            managed_operation = decoration_cursor.get_managed_operation()
+            managed_operation.set_operation("prefix" +
+                                            managed_operation.get_operation())
 
-            :param decoration_cursor: DecorationCursor
-                A PEP249Cursor implementation purposed for query and parameters decoration.
-                Provides operation details and tooling.
-            :return:
+        :param decoration_cursor: DecorationCursor
+            A PEP249Cursor implementation purposed for query and parameters decoration.
+            Provides operation details and tooling.
+        :return:
         """
         pass
 
     def db_connection_execute_operation(
-            self, execution_cursor: ExecutionCursor
+        self, execution_cursor: ExecutionCursor
     ) -> Optional[ExecuteOperationResult]:
         """
-            The method that executes the actual SQL query using execution cursor.
-            You can see the default implementation at DefaultConnectionHookImpl.
+        The method that executes the actual SQL query using execution cursor.
+        You can see the default implementation at DefaultConnectionHookImpl.
 
-            For example: let's say we are writing vdk-impala plugin and want to print more debug info
-                which is available from the Impala native cursor (provided by impyla library)
+        For example: let's say we are writing vdk-impala plugin and want to print more debug info
+            which is available from the Impala native cursor (provided by impyla library)
 
-                    _db_connection_execute_operation(execution_cursor: ExecutionCursor) -> Optional[int]:
-                        yield # let the query execute first
-                        c = cast(impala.interface.Cursor, execution_cursor)
-                        log.info(f"Query {execution_cursor.get_managed_operation().get_operation()} debug info:"
-                                 f"summary: {c.get_summary()}, profile: {c.get_profile()}")
+                _db_connection_execute_operation(execution_cursor: ExecutionCursor) -> Optional[int]:
+                    yield # let the query execute first
+                    c = cast(impala.interface.Cursor, execution_cursor)
+                    log.info(f"Query {execution_cursor.get_managed_operation().get_operation()} debug info:"
+                             f"summary: {c.get_summary()}, profile: {c.get_profile()}")
 
-                :param execution_cursor: ExecutionCursor
-                    A PEP249Cursor implementation purposed for actual query execution.
-                """
+            :param execution_cursor: ExecutionCursor
+                A PEP249Cursor implementation purposed for actual query execution.
+        """
         pass
 
     def db_connection_recover_operation(self, recovery_cursor: RecoveryCursor) -> None:

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/database_managed_connection.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/database_managed_connection.py
@@ -1,0 +1,91 @@
+from typing import Optional, Container
+
+from vdk.internal.builtin_plugins.connection.decoration_cursor import DecorationCursor
+from vdk.internal.builtin_plugins.connection.execution_cursor import ExecuteOperationResult, ExecutionCursor
+from vdk.internal.builtin_plugins.connection.recovery_cursor import RecoveryCursor
+
+
+class IDatabaseManagedConnection:
+    def db_connection_validate_operation(
+            self, operation: str, parameters: Optional[Container]
+    ) -> None:
+        """
+            Validates the query and parameters.
+
+            For example:
+            _db_connection_validate_operation(operation, parameters):
+                if(_max_query_length_limit_exceeded(operation, parameters)):
+                    raise Exception("max query length limit exceeded")
+
+            :param operation: str
+                Database operation - a SQL query or command to be executed.
+            :param parameters: Optional[Container]
+                Parameters may be provided as sequence or mapping and will be bound to variables in the operation.
+                Variables are specified in a database-specific notation. See chosen database documentation for details.
+            :return:
+        """
+        pass
+
+    def db_connection_decorate_operation(
+            self, decoration_cursor: DecorationCursor
+    ) -> None:
+        """
+            Curates the operation and parameters.
+            If an exception is raised, the cursor execution will be suspended.
+
+            For example:
+            _db_connection_decorate_operation(decoration_cursor: DecorationCursor):
+                managed_operation = decoration_cursor.get_managed_operation()
+                managed_operation.set_operation("prefix" +
+                                                managed_operation.get_operation())
+
+            :param decoration_cursor: DecorationCursor
+                A PEP249Cursor implementation purposed for query and parameters decoration.
+                Provides operation details and tooling.
+            :return:
+        """
+        pass
+
+    def db_connection_execute_operation(
+            self, execution_cursor: ExecutionCursor
+    ) -> Optional[ExecuteOperationResult]:
+        """
+            The method that executes the actual SQL query using execution cursor.
+            You can see the default implementation at DefaultConnectionHookImpl.
+
+            For example: let's say we are writing vdk-impala plugin and want to print more debug info
+                which is available from the Impala native cursor (provided by impyla library)
+
+                    _db_connection_execute_operation(execution_cursor: ExecutionCursor) -> Optional[int]:
+                        yield # let the query execute first
+                        c = cast(impala.interface.Cursor, execution_cursor)
+                        log.info(f"Query {execution_cursor.get_managed_operation().get_operation()} debug info:"
+                                 f"summary: {c.get_summary()}, profile: {c.get_profile()}")
+
+                :param execution_cursor: ExecutionCursor
+                    A PEP249Cursor implementation purposed for actual query execution.
+                """
+        pass
+
+    def db_connection_recover_operation(self, recovery_cursor: RecoveryCursor) -> None:
+        """
+        Recovers the operation initiated. Retries made number is auto-incremented.
+        If no exception is raised, cursor is considered successfully executed.
+
+        For example:
+        _db_connection_recover_operation(recovery_cursor: RecoveryCursor):
+            while recovery_cursor.get_retries() < MAX_RETRIES:
+                try:
+                    recovery_cursor.execute("helper query")
+                    recovery_cursor.retry_operation()
+                    return
+                except:
+                    time.sleep(3 * recovery_cursor.get_retries()) # backoff
+            raise recovery_cursor.get_exception()
+
+        :param recovery_cursor: RecoveryCursor
+            A PEP249Cursor implementation purposed for query and parameters recovery.
+            Provides operation details and tooling.
+        :return:
+        """
+        pass

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/database_managed_connection.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/database_managed_connection.py
@@ -1,11 +1,12 @@
 # Copyright 2023-2024 Broadcom
 # SPDX-License-Identifier: Apache-2.0
-
 from typing import Container
 from typing import Optional
 
 from vdk.internal.builtin_plugins.connection.decoration_cursor import DecorationCursor
-from vdk.internal.builtin_plugins.connection.execution_cursor import ExecuteOperationResult
+from vdk.internal.builtin_plugins.connection.execution_cursor import (
+    ExecuteOperationResult,
+)
 from vdk.internal.builtin_plugins.connection.execution_cursor import ExecutionCursor
 from vdk.internal.builtin_plugins.connection.recovery_cursor import RecoveryCursor
 

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
@@ -169,6 +169,7 @@ class ManagedConnectionBase(PEP249Connection, IManagedConnection, IDatabaseManag
                 self._db_con.cursor(*args, **kwargs),
                 self._log,
                 self._connection_hook_spec_factory,
+                self
             )
         return super().cursor()
 

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 class IDatabaseManagedConnection:
-    def _db_connection_validate_operation(
+    def db_connection_validate_operation(
             self, operation: str, parameters: Optional[Container]
     ) -> None:
         """
@@ -52,7 +52,7 @@ class IDatabaseManagedConnection:
         """
         pass
 
-    def _db_connection_decorate_operation(
+    def db_connection_decorate_operation(
             self, decoration_cursor: DecorationCursor
     ) -> None:
         """
@@ -72,7 +72,7 @@ class IDatabaseManagedConnection:
         """
         pass
 
-    def _db_connection_execute_operation(
+    def db_connection_execute_operation(
             self, execution_cursor: ExecutionCursor
     ) -> Optional[ExecuteOperationResult]:
         """
@@ -93,7 +93,7 @@ class IDatabaseManagedConnection:
                 """
         pass
 
-    def _db_connection_recover_operation(self, recovery_cursor: RecoveryCursor) -> None:
+    def db_connection_recover_operation(self, recovery_cursor: RecoveryCursor) -> None:
         """
         Recovers the operation initiated. Retries made number is auto-incremented.
         If no exception is raised, cursor is considered successfully executed.

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
@@ -4,7 +4,7 @@ import logging
 import types
 from abc import abstractmethod
 from types import TracebackType
-from typing import Any
+from typing import Any, Container
 from typing import cast
 from typing import List
 from typing import Optional
@@ -19,8 +19,11 @@ from vdk.api.job_input import IManagedConnection
 from vdk.internal.builtin_plugins.connection.connection_hooks import (
     ConnectionHookSpecFactory,
 )
+from vdk.internal.builtin_plugins.connection.decoration_cursor import DecorationCursor
+from vdk.internal.builtin_plugins.connection.execution_cursor import ExecutionCursor, ExecuteOperationResult
 from vdk.internal.builtin_plugins.connection.managed_cursor import ManagedCursor
 from vdk.internal.builtin_plugins.connection.pep249.interfaces import PEP249Connection
+from vdk.internal.builtin_plugins.connection.recovery_cursor import RecoveryCursor
 from vdk.internal.builtin_plugins.run import job_input_error_classifier
 from vdk.internal.core import errors
 from vdk.internal.util.decorators import closing_noexcept_on_close
@@ -28,7 +31,93 @@ from vdk.internal.util.decorators import closing_noexcept_on_close
 logger = logging.getLogger(__name__)
 
 
-class ManagedConnectionBase(PEP249Connection, IManagedConnection):
+class IDatabaseManagedConnection:
+    def _db_connection_validate_operation(
+            self, operation: str, parameters: Optional[Container]
+    ) -> None:
+        """
+            Validates the query and parameters.
+
+            For example:
+            _db_connection_validate_operation(operation, parameters):
+                if(_max_query_length_limit_exceeded(operation, parameters)):
+                    raise Exception("max query length limit exceeded")
+
+            :param operation: str
+                Database operation - a SQL query or command to be executed.
+            :param parameters: Optional[Container]
+                Parameters may be provided as sequence or mapping and will be bound to variables in the operation.
+                Variables are specified in a database-specific notation. See chosen database documentation for details.
+            :return:
+        """
+        pass
+
+    def _db_connection_decorate_operation(
+            self, decoration_cursor: DecorationCursor
+    ) -> None:
+        """
+            Curates the operation and parameters.
+            If an exception is raised, the cursor execution will be suspended.
+
+            For example:
+            _db_connection_decorate_operation(decoration_cursor: DecorationCursor):
+                managed_operation = decoration_cursor.get_managed_operation()
+                managed_operation.set_operation("prefix" +
+                                                managed_operation.get_operation())
+
+            :param decoration_cursor: DecorationCursor
+                A PEP249Cursor implementation purposed for query and parameters decoration.
+                Provides operation details and tooling.
+            :return:
+        """
+        pass
+
+    def _db_connection_execute_operation(
+            self, execution_cursor: ExecutionCursor
+    ) -> Optional[ExecuteOperationResult]:
+        """
+            The method that executes the actual SQL query using execution cursor.
+            You can see the default implementation at DefaultConnectionHookImpl.
+
+            For example: let's say we are writing vdk-impala plugin and want to print more debug info
+                which is available from the Impala native cursor (provided by impyla library)
+
+                    _db_connection_execute_operation(execution_cursor: ExecutionCursor) -> Optional[int]:
+                        yield # let the query execute first
+                        c = cast(impala.interface.Cursor, execution_cursor)
+                        log.info(f"Query {execution_cursor.get_managed_operation().get_operation()} debug info:"
+                                 f"summary: {c.get_summary()}, profile: {c.get_profile()}")
+
+                :param execution_cursor: ExecutionCursor
+                    A PEP249Cursor implementation purposed for actual query execution.
+                """
+        pass
+
+    def _db_connection_recover_operation(self, recovery_cursor: RecoveryCursor) -> None:
+        """
+        Recovers the operation initiated. Retries made number is auto-incremented.
+        If no exception is raised, cursor is considered successfully executed.
+
+        For example:
+        _db_connection_recover_operation(recovery_cursor: RecoveryCursor):
+            while recovery_cursor.get_retries() < MAX_RETRIES:
+                try:
+                    recovery_cursor.execute("helper query")
+                    recovery_cursor.retry_operation()
+                    return
+                except:
+                    time.sleep(3 * recovery_cursor.get_retries()) # backoff
+            raise recovery_cursor.get_exception()
+
+        :param recovery_cursor: RecoveryCursor
+            A PEP249Cursor implementation purposed for query and parameters recovery.
+            Provides operation details and tooling.
+        :return:
+        """
+        pass
+
+
+class ManagedConnectionBase(PEP249Connection, IManagedConnection, IDatabaseManagedConnection):
     """
     Different database providers can subclass this class to provide raw connection (by implement _connect)
 

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
@@ -4,7 +4,7 @@ import logging
 import types
 from abc import abstractmethod
 from types import TracebackType
-from typing import Any, Container
+from typing import Any
 from typing import cast
 from typing import List
 from typing import Optional
@@ -19,102 +19,14 @@ from vdk.api.job_input import IManagedConnection
 from vdk.internal.builtin_plugins.connection.connection_hooks import (
     ConnectionHookSpecFactory,
 )
-from vdk.internal.builtin_plugins.connection.decoration_cursor import DecorationCursor
-from vdk.internal.builtin_plugins.connection.execution_cursor import ExecutionCursor, ExecuteOperationResult
+from vdk.internal.builtin_plugins.connection.database_managed_connection import IDatabaseManagedConnection
 from vdk.internal.builtin_plugins.connection.managed_cursor import ManagedCursor
 from vdk.internal.builtin_plugins.connection.pep249.interfaces import PEP249Connection
-from vdk.internal.builtin_plugins.connection.recovery_cursor import RecoveryCursor
 from vdk.internal.builtin_plugins.run import job_input_error_classifier
 from vdk.internal.core import errors
 from vdk.internal.util.decorators import closing_noexcept_on_close
 
 logger = logging.getLogger(__name__)
-
-
-class IDatabaseManagedConnection:
-    def db_connection_validate_operation(
-            self, operation: str, parameters: Optional[Container]
-    ) -> None:
-        """
-            Validates the query and parameters.
-
-            For example:
-            _db_connection_validate_operation(operation, parameters):
-                if(_max_query_length_limit_exceeded(operation, parameters)):
-                    raise Exception("max query length limit exceeded")
-
-            :param operation: str
-                Database operation - a SQL query or command to be executed.
-            :param parameters: Optional[Container]
-                Parameters may be provided as sequence or mapping and will be bound to variables in the operation.
-                Variables are specified in a database-specific notation. See chosen database documentation for details.
-            :return:
-        """
-        pass
-
-    def db_connection_decorate_operation(
-            self, decoration_cursor: DecorationCursor
-    ) -> None:
-        """
-            Curates the operation and parameters.
-            If an exception is raised, the cursor execution will be suspended.
-
-            For example:
-            _db_connection_decorate_operation(decoration_cursor: DecorationCursor):
-                managed_operation = decoration_cursor.get_managed_operation()
-                managed_operation.set_operation("prefix" +
-                                                managed_operation.get_operation())
-
-            :param decoration_cursor: DecorationCursor
-                A PEP249Cursor implementation purposed for query and parameters decoration.
-                Provides operation details and tooling.
-            :return:
-        """
-        pass
-
-    def db_connection_execute_operation(
-            self, execution_cursor: ExecutionCursor
-    ) -> Optional[ExecuteOperationResult]:
-        """
-            The method that executes the actual SQL query using execution cursor.
-            You can see the default implementation at DefaultConnectionHookImpl.
-
-            For example: let's say we are writing vdk-impala plugin and want to print more debug info
-                which is available from the Impala native cursor (provided by impyla library)
-
-                    _db_connection_execute_operation(execution_cursor: ExecutionCursor) -> Optional[int]:
-                        yield # let the query execute first
-                        c = cast(impala.interface.Cursor, execution_cursor)
-                        log.info(f"Query {execution_cursor.get_managed_operation().get_operation()} debug info:"
-                                 f"summary: {c.get_summary()}, profile: {c.get_profile()}")
-
-                :param execution_cursor: ExecutionCursor
-                    A PEP249Cursor implementation purposed for actual query execution.
-                """
-        pass
-
-    def db_connection_recover_operation(self, recovery_cursor: RecoveryCursor) -> None:
-        """
-        Recovers the operation initiated. Retries made number is auto-incremented.
-        If no exception is raised, cursor is considered successfully executed.
-
-        For example:
-        _db_connection_recover_operation(recovery_cursor: RecoveryCursor):
-            while recovery_cursor.get_retries() < MAX_RETRIES:
-                try:
-                    recovery_cursor.execute("helper query")
-                    recovery_cursor.retry_operation()
-                    return
-                except:
-                    time.sleep(3 * recovery_cursor.get_retries()) # backoff
-            raise recovery_cursor.get_exception()
-
-        :param recovery_cursor: RecoveryCursor
-            A PEP249Cursor implementation purposed for query and parameters recovery.
-            Provides operation details and tooling.
-        :return:
-        """
-        pass
 
 
 class ManagedConnectionBase(PEP249Connection, IManagedConnection, IDatabaseManagedConnection):

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_connection_base.py
@@ -19,7 +19,9 @@ from vdk.api.job_input import IManagedConnection
 from vdk.internal.builtin_plugins.connection.connection_hooks import (
     ConnectionHookSpecFactory,
 )
-from vdk.internal.builtin_plugins.connection.database_managed_connection import IDatabaseManagedConnection
+from vdk.internal.builtin_plugins.connection.database_managed_connection import (
+    IDatabaseManagedConnection,
+)
 from vdk.internal.builtin_plugins.connection.managed_cursor import ManagedCursor
 from vdk.internal.builtin_plugins.connection.pep249.interfaces import PEP249Connection
 from vdk.internal.builtin_plugins.run import job_input_error_classifier
@@ -29,7 +31,9 @@ from vdk.internal.util.decorators import closing_noexcept_on_close
 logger = logging.getLogger(__name__)
 
 
-class ManagedConnectionBase(PEP249Connection, IManagedConnection, IDatabaseManagedConnection):
+class ManagedConnectionBase(
+    PEP249Connection, IManagedConnection, IDatabaseManagedConnection
+):
     """
     Different database providers can subclass this class to provide raw connection (by implement _connect)
 
@@ -169,7 +173,7 @@ class ManagedConnectionBase(PEP249Connection, IManagedConnection, IDatabaseManag
                 self._db_con.cursor(*args, **kwargs),
                 self._log,
                 self._connection_hook_spec_factory,
-                self
+                self,
             )
         return super().cursor()
 

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
@@ -134,21 +134,13 @@ class ManagedCursor(ProxyCursor):
     def _decorate_operation(self, managed_operation: ManagedOperation, operation: str):
         decorate_operation = None
 
-        if (
-            self.__managed_database_connection
-            and type(
-                self.__managed_database_connection
-            ).db_connection_decorate_operation
-            != IDatabaseManagedConnection.db_connection_decorate_operation
-        ):
+        if self.__managed_database_connection and \
+                type(self.__managed_database_connection).db_connection_decorate_operation != IDatabaseManagedConnection.db_connection_decorate_operation:
             decorate_operation = (
                 self.__managed_database_connection.db_connection_decorate_operation
             )
 
-        elif (
-            self.__connection_hook_spec
-            and self.__connection_hook_spec.db_connection_validate_operation.get_hookimpls()
-        ):
+        elif self.__connection_hook_spec and self.__connection_hook_spec.db_connection_validate_operation.get_hookimpls():
             decorate_operation = (
                 self.__connection_hook_spec.db_connection_decorate_operation
             )
@@ -175,21 +167,13 @@ class ManagedCursor(ProxyCursor):
     def _validate_operation(self, operation: str, parameters: Optional[Container]):
         validate_operation = None
 
-        if (
-            self.__managed_database_connection
-            and type(
-                self.__managed_database_connection
-            ).db_connection_validate_operation
-            != IDatabaseManagedConnection.db_connection_validate_operation
-        ):
+        if self.__managed_database_connection \
+                and type(self.__managed_database_connection).db_connection_validate_operation != IDatabaseManagedConnection.db_connection_validate_operation:
             validate_operation = (
                 self.__managed_database_connection.db_connection_validate_operation
             )
 
-        elif (
-            self.__connection_hook_spec
-            and self.__connection_hook_spec.db_connection_validate_operation.get_hookimpls()
-        ):
+        elif self.__connection_hook_spec and self.__connection_hook_spec.db_connection_validate_operation.get_hookimpls():
             validate_operation = (
                 self.__connection_hook_spec.db_connection_validate_operation
             )
@@ -217,11 +201,8 @@ class ManagedCursor(ProxyCursor):
         self._log.info("Executing query:\n%s" % managed_operation.get_operation())
         execution_cursor = ExecutionCursor(self._cursor, managed_operation, self._log)
 
-        if (
-            self.__managed_database_connection
-            and type(self.__managed_database_connection).db_connection_execute_operation
-            != IDatabaseManagedConnection.db_connection_execute_operation
-        ):
+        if self.__managed_database_connection\
+                and type(self.__managed_database_connection).db_connection_execute_operation != IDatabaseManagedConnection.db_connection_execute_operation:
             result = self.__managed_database_connection.db_connection_execute_operation(
                 execution_cursor=execution_cursor
             )

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
@@ -143,7 +143,7 @@ class ManagedCursor(ProxyCursor):
                 self._cursor, self._log, managed_operation
             )
             try:
-                self.__connection_hook_spec.db_connection_decorate_operation(
+                decorate_operation(
                     decoration_cursor=decoration_cursor
                 )
             except Exception as e:

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
@@ -134,6 +134,9 @@ class ManagedCursor(ProxyCursor):
     def _decorate_operation(self, managed_operation: ManagedOperation, operation: str):
         decorate_operation = None
 
+        # Check if database decorate operation is overridden by a plugin.
+        # Use the overridden method if available.
+        # Otherwise, verify the presence of hooks; if absent, use the default hook implementation.
         if self.__managed_database_connection and \
                 type(self.__managed_database_connection).db_connection_decorate_operation != IDatabaseManagedConnection.db_connection_decorate_operation:
             decorate_operation = (
@@ -167,6 +170,9 @@ class ManagedCursor(ProxyCursor):
     def _validate_operation(self, operation: str, parameters: Optional[Container]):
         validate_operation = None
 
+        # Check if database validate operation is overridden by a plugin.
+        # Use the overridden method if available.
+        # Otherwise, verify the presence of hooks; if absent, use the default hook implementation.
         if self.__managed_database_connection \
                 and type(self.__managed_database_connection).db_connection_validate_operation != IDatabaseManagedConnection.db_connection_validate_operation:
             validate_operation = (
@@ -201,6 +207,9 @@ class ManagedCursor(ProxyCursor):
         self._log.info("Executing query:\n%s" % managed_operation.get_operation())
         execution_cursor = ExecutionCursor(self._cursor, managed_operation, self._log)
 
+        # Check if database execute operation is overridden by a plugin.
+        # Use the overridden method if available.
+        # Otherwise, verify the presence of hooks; if absent, use the default hook implementation.
         if self.__managed_database_connection\
                 and type(self.__managed_database_connection).db_connection_execute_operation != IDatabaseManagedConnection.db_connection_execute_operation:
             result = self.__managed_database_connection.db_connection_execute_operation(
@@ -238,6 +247,11 @@ class ManagedCursor(ProxyCursor):
 
     def _recover_operation(self, exception, managed_operation):
         # TODO: configurable generic re-try.
+
+        # Check if database recover and decorate operations are overridden by a plugin.
+        # Use the overridden methods if available.
+        # Otherwise, verify the presence of hooks; if absent, use the default hook implementation.
+
         available_plugin_implementation = self.__managed_database_connection and (
             type(self.__managed_database_connection).db_connection_recover_operation
             != IDatabaseManagedConnection.db_connection_recover_operation

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
@@ -137,13 +137,21 @@ class ManagedCursor(ProxyCursor):
         # Check if database decorate operation is overridden by a plugin.
         # Use the overridden method if available.
         # Otherwise, verify the presence of hooks; if absent, use the default hook implementation.
-        if self.__managed_database_connection and \
-                type(self.__managed_database_connection).db_connection_decorate_operation != IDatabaseManagedConnection.db_connection_decorate_operation:
+        if (
+            self.__managed_database_connection
+            and type(
+                self.__managed_database_connection
+            ).db_connection_decorate_operation
+            != IDatabaseManagedConnection.db_connection_decorate_operation
+        ):
             decorate_operation = (
                 self.__managed_database_connection.db_connection_decorate_operation
             )
 
-        elif self.__connection_hook_spec and self.__connection_hook_spec.db_connection_decorate_operation.get_hookimpls():
+        elif (
+            self.__connection_hook_spec
+            and self.__connection_hook_spec.db_connection_decorate_operation.get_hookimpls()
+        ):
             decorate_operation = (
                 self.__connection_hook_spec.db_connection_decorate_operation
             )
@@ -173,13 +181,21 @@ class ManagedCursor(ProxyCursor):
         # Check if database validate operation is overridden by a plugin.
         # Use the overridden method if available.
         # Otherwise, verify the presence of hooks; if absent, use the default hook implementation.
-        if self.__managed_database_connection \
-                and type(self.__managed_database_connection).db_connection_validate_operation != IDatabaseManagedConnection.db_connection_validate_operation:
+        if (
+            self.__managed_database_connection
+            and type(
+                self.__managed_database_connection
+            ).db_connection_validate_operation
+            != IDatabaseManagedConnection.db_connection_validate_operation
+        ):
             validate_operation = (
                 self.__managed_database_connection.db_connection_validate_operation
             )
 
-        elif self.__connection_hook_spec and self.__connection_hook_spec.db_connection_validate_operation.get_hookimpls():
+        elif (
+            self.__connection_hook_spec
+            and self.__connection_hook_spec.db_connection_validate_operation.get_hookimpls()
+        ):
             validate_operation = (
                 self.__connection_hook_spec.db_connection_validate_operation
             )
@@ -210,8 +226,11 @@ class ManagedCursor(ProxyCursor):
         # Check if database execute operation is overridden by a plugin.
         # Use the overridden method if available.
         # Otherwise, verify the presence of hooks; if absent, use the default hook implementation.
-        if self.__managed_database_connection\
-                and type(self.__managed_database_connection).db_connection_execute_operation != IDatabaseManagedConnection.db_connection_execute_operation:
+        if (
+            self.__managed_database_connection
+            and type(self.__managed_database_connection).db_connection_execute_operation
+            != IDatabaseManagedConnection.db_connection_execute_operation
+        ):
             result = self.__managed_database_connection.db_connection_execute_operation(
                 execution_cursor=execution_cursor
             )

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
@@ -130,7 +130,7 @@ class ManagedCursor(ProxyCursor):
     def _decorate_operation(self, managed_operation: ManagedOperation, operation: str):
         decorate_operation = None
 
-        if type(self.__managed_database_connection).db_connection_decorate_operation != \
+        if self.__managed_database_connection and type(self.__managed_database_connection).db_connection_decorate_operation != \
                 IDatabaseManagedConnection.db_connection_decorate_operation:
             decorate_operation = self.__managed_database_connection.db_connection_decorate_operation
 
@@ -161,7 +161,7 @@ class ManagedCursor(ProxyCursor):
     def _validate_operation(self, operation: str, parameters: Optional[Container]):
         validate_operation = None
 
-        if type(self.__managed_database_connection).db_connection_validate_operation != \
+        if self.__managed_database_connection and type(self.__managed_database_connection).db_connection_validate_operation != \
                 IDatabaseManagedConnection.db_connection_validate_operation:
             validate_operation = self.__managed_database_connection.db_connection_validate_operation
 
@@ -191,7 +191,7 @@ class ManagedCursor(ProxyCursor):
         self._log.info("Executing query:\n%s" % managed_operation.get_operation())
         execution_cursor = ExecutionCursor(self._cursor, managed_operation, self._log)
 
-        if type(self.__managed_database_connection).db_connection_execute_operation != \
+        if self.__managed_database_connection and type(self.__managed_database_connection).db_connection_execute_operation != \
                 IDatabaseManagedConnection.db_connection_execute_operation:
             result = self.__managed_database_connection.db_connection_execute_operation(
                 execution_cursor=execution_cursor
@@ -228,7 +228,7 @@ class ManagedCursor(ProxyCursor):
 
     def _recover_operation(self, exception, managed_operation):
         # TODO: configurable generic re-try.
-        available_plugin_implementation = (type(
+        available_plugin_implementation = self.__managed_database_connection and (type(
             self.__managed_database_connection).db_connection_recover_operation != IDatabaseManagedConnection.db_connection_recover_operation
                                            and type(
                     self.__managed_database_connection).db_connection_decorate_operation != IDatabaseManagedConnection.db_connection_decorate_operation

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
@@ -143,7 +143,7 @@ class ManagedCursor(ProxyCursor):
                 self.__managed_database_connection.db_connection_decorate_operation
             )
 
-        elif self.__connection_hook_spec and self.__connection_hook_spec.db_connection_validate_operation.get_hookimpls():
+        elif self.__connection_hook_spec and self.__connection_hook_spec.db_connection_decorate_operation.get_hookimpls():
             decorate_operation = (
                 self.__connection_hook_spec.db_connection_decorate_operation
             )

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
@@ -19,10 +19,10 @@ from vdk.internal.builtin_plugins.connection.connection_hooks import (
 from vdk.internal.builtin_plugins.connection.decoration_cursor import DecorationCursor
 from vdk.internal.builtin_plugins.connection.decoration_cursor import ManagedOperation
 from vdk.internal.builtin_plugins.connection.execution_cursor import ExecutionCursor
+from vdk.internal.builtin_plugins.connection.database_managed_connection import IDatabaseManagedConnection
 from vdk.internal.builtin_plugins.connection.proxy_cursor import ProxyCursor
 from vdk.internal.builtin_plugins.connection.recovery_cursor import RecoveryCursor
 from vdk.internal.core import errors
-from managed_connection_base import IDatabaseManagedConnection
 
 
 class ManagedCursor(ProxyCursor):

--- a/projects/vdk-core/tests/functional/run/test_run_sql_queries.py
+++ b/projects/vdk-core/tests/functional/run/test_run_sql_queries.py
@@ -146,7 +146,7 @@ def test_run_managed_connection_and_check_query_comments():
     )
 
     cli_assert_equal(0, result)
-    assert len(db_plugin.statements_history) == 3
+    # assert len(db_plugin.statements_history) == 3
     # assert those are automatically added as comments
     assert all(
         ["-- op_id" in statement for statement in db_plugin.statements_history]

--- a/projects/vdk-core/tests/functional/run/test_run_sql_queries.py
+++ b/projects/vdk-core/tests/functional/run/test_run_sql_queries.py
@@ -146,7 +146,7 @@ def test_run_managed_connection_and_check_query_comments():
     )
 
     cli_assert_equal(0, result)
-    # assert len(db_plugin.statements_history) == 3
+    assert len(db_plugin.statements_history) == 3
     # assert those are automatically added as comments
     assert all(
         ["-- op_id" in statement for statement in db_plugin.statements_history]

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_managed_cursor.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_managed_cursor.py
@@ -1,12 +1,16 @@
 # Copyright 2023-2024 Broadcom
 # SPDX-License-Identifier: Apache-2.0
 import logging
-from unittest.mock import call
+from typing import Optional, Container
+from unittest.mock import call, Mock
 
 import pytest
+
+from vdk.internal.builtin_plugins.connection.database_managed_connection import IDatabaseManagedConnection
 from vdk.internal.builtin_plugins.connection.decoration_cursor import DecorationCursor
+from vdk.internal.builtin_plugins.connection.execution_cursor import ExecutionCursor, ExecuteOperationResult
 from vdk.internal.builtin_plugins.connection.recovery_cursor import RecoveryCursor
-from vdk.plugin.test_utils.util_funcs import populate_mock_managed_cursor
+from vdk.plugin.test_utils.util_funcs import populate_mock_managed_cursor, populate_mock_managed_cursor_no_hook
 
 _query = "select 1"
 
@@ -210,3 +214,168 @@ def test_query_timing_failed_query(caplog):
         mock_managed_cursor.execute(_query)
 
     assert "Failed query duration 00h:00m:" in str(caplog.records)
+
+
+class ManagedDatabaseConnectionTestImpl(IDatabaseManagedConnection):
+    def db_connection_validate_operation(
+            self, operation: str, parameters: Optional[Container]
+    ) -> None:
+        print("Validate called not from Base class")
+
+    def db_connection_decorate_operation(
+            self, decoration_cursor: DecorationCursor
+    ) -> None:
+        print("Decorate called not from Base class")
+
+    def db_connection_execute_operation(
+            self, execution_cursor: ExecutionCursor
+    ) -> Optional[ExecuteOperationResult]:
+        print("Execute called not from Base class")
+
+    def db_connection_recover_operation(self, recovery_cursor: RecoveryCursor) -> None:
+        print("Recover called not from Base class")
+
+
+@pytest.fixture
+def managed_connection():
+    return ManagedDatabaseConnectionTestImpl()
+
+
+def test_no_hook_db_validate_operations(managed_connection):
+    managed_connection.db_connection_validate_operation = Mock()
+
+    (mock_native_cursor, mock_managed_cursor, _, _, mock_managed_connection) = populate_mock_managed_cursor_no_hook(
+        managed_database_connection=managed_connection)
+
+    mock_managed_cursor.execute(_query)
+
+    mock_managed_connection.db_connection_validate_operation.assert_called_once_with(
+        operation=_query, parameters=None
+    )
+
+    mock_native_cursor.execute.assert_called_once()
+
+
+def test_no_hook_validation__query_nonvalid__execute(managed_connection):
+    managed_connection.db_connection_validate_operation = Mock()
+
+    (mock_native_cursor, mock_managed_cursor, _, _, mock_managed_connection) = populate_mock_managed_cursor_no_hook(
+        managed_database_connection=managed_connection)
+
+    managed_connection.db_connection_validate_operation.side_effect = Exception("Validation exception")
+
+    with pytest.raises(Exception) as e:
+        mock_managed_cursor.execute(_query)
+
+    assert "Validation exception" == e.value.args[0]
+    mock_native_cursor.execute.assert_not_called()
+
+
+def test_no_hook_decoration__success__execute(managed_connection):
+    managed_connection.db_connection_decorate_operation = Mock()
+
+    (mock_native_cursor, mock_managed_cursor, _, _, mock_managed_connection) = populate_mock_managed_cursor_no_hook(
+        managed_database_connection=managed_connection)
+
+    def mock_decorate(decoration_cursor: DecorationCursor):
+        managed_operation = decoration_cursor.get_managed_operation()
+        managed_operation.set_operation(
+            f"decorated {managed_operation.get_operation()}"
+        )
+
+    managed_connection.db_connection_decorate_operation.side_effect = (
+        mock_decorate
+    )
+
+    mock_managed_cursor.execute(_query)
+
+    managed_connection.db_connection_decorate_operation.assert_called_once()
+    calls = [call(f"decorated {_query}")]
+    mock_native_cursor.execute.assert_has_calls(calls)
+
+
+def test_no_hook_decoration__failure__execute(managed_connection):
+    managed_connection.db_connection_decorate_operation = Mock()
+
+    (mock_native_cursor, mock_managed_cursor, _, _, mock_managed_connection) = populate_mock_managed_cursor_no_hook(
+        managed_database_connection=managed_connection)
+
+    managed_connection.db_connection_decorate_operation.side_effect = Exception(
+        "Decoration exception"
+    )
+
+    with pytest.raises(Exception) as e:
+        mock_managed_cursor.execute(_query)
+
+    assert True == managed_connection.db_connection_decorate_operation.called
+    assert "Decoration exception" == e.value.args[0]
+    mock_native_cursor.execute.assert_not_called()
+
+
+def test_no_hook_recovery__success__execute(managed_connection):
+    managed_connection.db_connection_decorate_operation = Mock()
+    managed_connection.db_connection_recover_operation = Mock()
+
+    (mock_native_cursor, mock_managed_cursor, _, _, mock_managed_connection) = populate_mock_managed_cursor_no_hook(
+        managed_database_connection=managed_connection)
+
+    def mock_decorate(decoration_cursor: DecorationCursor):
+        managed_operation = decoration_cursor.get_managed_operation()
+        managed_operation.set_operation(
+            f"decorated {managed_operation.get_operation()}"
+        )
+
+    def mock_recover(recovery_cursor: RecoveryCursor):
+        recovery_cursor.execute("recovery")
+        recovery_cursor.retry_operation()
+        assert recovery_cursor.get_retries() == 1
+
+    managed_connection.db_connection_decorate_operation.side_effect = (
+        mock_decorate
+    )
+    managed_connection.db_connection_recover_operation.side_effect = mock_recover
+
+    exception = Exception()
+    mock_native_cursor.execute.side_effect = [exception, None, None]
+
+    mock_managed_cursor.execute(_query)
+
+    managed_connection.db_connection_recover_operation.assert_called_once()
+    calls = [
+        call(f"decorated {_query}"),
+        call(f"decorated recovery"),
+        call(f"decorated {_query}"),
+    ]
+    mock_native_cursor.execute.assert_has_calls(calls)
+
+
+def test_no_hook_recovery__failure__execute(managed_connection):
+    managed_connection.db_connection_decorate_operation = Mock()
+    managed_connection.db_connection_recover_operation = Mock()
+
+    (mock_native_cursor, mock_managed_cursor, _, _, mock_managed_connection) = populate_mock_managed_cursor_no_hook(
+        managed_database_connection=managed_connection)
+
+    def mock_decorate(decoration_cursor: DecorationCursor):
+        managed_operation = decoration_cursor.get_managed_operation()
+        managed_operation.set_operation(
+            f"decorated {managed_operation.get_operation()}"
+        )
+
+    def mock_recover(recovery_cursor: RecoveryCursor):
+        raise Exception("Could not handle execution exception")
+
+    managed_connection.db_connection_decorate_operation.side_effect = (
+        mock_decorate
+    )
+    managed_connection.db_connection_recover_operation.side_effect = mock_recover
+
+    exception = Exception()
+    mock_native_cursor.execute.side_effect = exception
+
+    with pytest.raises(Exception) as e:
+        mock_managed_cursor.execute(_query)
+
+    assert "Could not handle execution exception" == e.value.args[0]
+    managed_connection.db_connection_recover_operation.assert_called_once()
+    mock_native_cursor.execute.assert_called_once()

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_managed_cursor.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_managed_cursor.py
@@ -283,7 +283,7 @@ def test_no_hook_validation__query_nonvalid__execute(managed_connection):
         managed_database_connection=managed_connection
     )
 
-    managed_connection.db_connection_validate_operation.side_effect = Exception(
+    mock_managed_connection.db_connection_validate_operation.side_effect = Exception(
         "Validation exception"
     )
 
@@ -313,11 +313,11 @@ def test_no_hook_decoration__success__execute(managed_connection):
             f"decorated {managed_operation.get_operation()}"
         )
 
-    managed_connection.db_connection_decorate_operation.side_effect = mock_decorate
+    mock_managed_connection.db_connection_decorate_operation.side_effect = mock_decorate
 
     mock_managed_cursor.execute(_query)
 
-    managed_connection.db_connection_decorate_operation.assert_called_once()
+    mock_managed_connection.db_connection_decorate_operation.assert_called_once()
     calls = [call(f"decorated {_query}")]
     mock_native_cursor.execute.assert_has_calls(calls)
 
@@ -335,14 +335,14 @@ def test_no_hook_decoration__failure__execute(managed_connection):
         managed_database_connection=managed_connection
     )
 
-    managed_connection.db_connection_decorate_operation.side_effect = Exception(
+    mock_managed_connection.db_connection_decorate_operation.side_effect = Exception(
         "Decoration exception"
     )
 
     with pytest.raises(Exception) as e:
         mock_managed_cursor.execute(_query)
 
-    assert True == managed_connection.db_connection_decorate_operation.called
+    assert True == mock_managed_connection.db_connection_decorate_operation.called
     assert "Decoration exception" == e.value.args[0]
     mock_native_cursor.execute.assert_not_called()
 
@@ -372,15 +372,15 @@ def test_no_hook_recovery__success__execute(managed_connection):
         recovery_cursor.retry_operation()
         assert recovery_cursor.get_retries() == 1
 
-    managed_connection.db_connection_decorate_operation.side_effect = mock_decorate
-    managed_connection.db_connection_recover_operation.side_effect = mock_recover
+    mock_managed_connection.db_connection_decorate_operation.side_effect = mock_decorate
+    mock_managed_connection.db_connection_recover_operation.side_effect = mock_recover
 
     exception = Exception()
     mock_native_cursor.execute.side_effect = [exception, None, None]
 
     mock_managed_cursor.execute(_query)
 
-    managed_connection.db_connection_recover_operation.assert_called_once()
+    mock_managed_connection.db_connection_recover_operation.assert_called_once()
     calls = [
         call(f"decorated {_query}"),
         call(f"decorated recovery"),
@@ -412,8 +412,8 @@ def test_no_hook_recovery__failure__execute(managed_connection):
     def mock_recover(recovery_cursor: RecoveryCursor):
         raise Exception("Could not handle execution exception")
 
-    managed_connection.db_connection_decorate_operation.side_effect = mock_decorate
-    managed_connection.db_connection_recover_operation.side_effect = mock_recover
+    mock_managed_connection.db_connection_decorate_operation.side_effect = mock_decorate
+    mock_managed_connection.db_connection_recover_operation.side_effect = mock_recover
 
     exception = Exception()
     mock_native_cursor.execute.side_effect = exception
@@ -422,5 +422,5 @@ def test_no_hook_recovery__failure__execute(managed_connection):
         mock_managed_cursor.execute(_query)
 
     assert "Could not handle execution exception" == e.value.args[0]
-    managed_connection.db_connection_recover_operation.assert_called_once()
+    mock_managed_connection.db_connection_recover_operation.assert_called_once()
     mock_native_cursor.execute.assert_called_once()

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_managed_cursor.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_managed_cursor.py
@@ -1,16 +1,21 @@
 # Copyright 2023-2024 Broadcom
 # SPDX-License-Identifier: Apache-2.0
 import logging
-from typing import Optional, Container
-from unittest.mock import call, Mock
+from typing import Container
+from typing import Optional
+from unittest.mock import call
+from unittest.mock import Mock
 
 import pytest
-
-from vdk.internal.builtin_plugins.connection.database_managed_connection import IDatabaseManagedConnection
+from vdk.internal.builtin_plugins.connection.database_managed_connection import (
+    IDatabaseManagedConnection,
+)
 from vdk.internal.builtin_plugins.connection.decoration_cursor import DecorationCursor
-from vdk.internal.builtin_plugins.connection.execution_cursor import ExecutionCursor, ExecuteOperationResult
+from vdk.internal.builtin_plugins.connection.execution_cursor import ExecuteOperationResult
+from vdk.internal.builtin_plugins.connection.execution_cursor import ExecutionCursor
 from vdk.internal.builtin_plugins.connection.recovery_cursor import RecoveryCursor
-from vdk.plugin.test_utils.util_funcs import populate_mock_managed_cursor, populate_mock_managed_cursor_no_hook
+from vdk.plugin.test_utils.util_funcs import populate_mock_managed_cursor
+from vdk.plugin.test_utils.util_funcs import populate_mock_managed_cursor_no_hook
 
 _query = "select 1"
 
@@ -218,17 +223,17 @@ def test_query_timing_failed_query(caplog):
 
 class ManagedDatabaseConnectionTestImpl(IDatabaseManagedConnection):
     def db_connection_validate_operation(
-            self, operation: str, parameters: Optional[Container]
+        self, operation: str, parameters: Optional[Container]
     ) -> None:
         print("Validate called not from Base class")
 
     def db_connection_decorate_operation(
-            self, decoration_cursor: DecorationCursor
+        self, decoration_cursor: DecorationCursor
     ) -> None:
         print("Decorate called not from Base class")
 
     def db_connection_execute_operation(
-            self, execution_cursor: ExecutionCursor
+        self, execution_cursor: ExecutionCursor
     ) -> Optional[ExecuteOperationResult]:
         print("Execute called not from Base class")
 
@@ -244,8 +249,15 @@ def managed_connection():
 def test_no_hook_db_validate_operations(managed_connection):
     managed_connection.db_connection_validate_operation = Mock()
 
-    (mock_native_cursor, mock_managed_cursor, _, _, mock_managed_connection) = populate_mock_managed_cursor_no_hook(
-        managed_database_connection=managed_connection)
+    (
+        mock_native_cursor,
+        mock_managed_cursor,
+        _,
+        _,
+        mock_managed_connection,
+    ) = populate_mock_managed_cursor_no_hook(
+        managed_database_connection=managed_connection
+    )
 
     mock_managed_cursor.execute(_query)
 
@@ -259,10 +271,19 @@ def test_no_hook_db_validate_operations(managed_connection):
 def test_no_hook_validation__query_nonvalid__execute(managed_connection):
     managed_connection.db_connection_validate_operation = Mock()
 
-    (mock_native_cursor, mock_managed_cursor, _, _, mock_managed_connection) = populate_mock_managed_cursor_no_hook(
-        managed_database_connection=managed_connection)
+    (
+        mock_native_cursor,
+        mock_managed_cursor,
+        _,
+        _,
+        mock_managed_connection,
+    ) = populate_mock_managed_cursor_no_hook(
+        managed_database_connection=managed_connection
+    )
 
-    managed_connection.db_connection_validate_operation.side_effect = Exception("Validation exception")
+    managed_connection.db_connection_validate_operation.side_effect = Exception(
+        "Validation exception"
+    )
 
     with pytest.raises(Exception) as e:
         mock_managed_cursor.execute(_query)
@@ -274,8 +295,15 @@ def test_no_hook_validation__query_nonvalid__execute(managed_connection):
 def test_no_hook_decoration__success__execute(managed_connection):
     managed_connection.db_connection_decorate_operation = Mock()
 
-    (mock_native_cursor, mock_managed_cursor, _, _, mock_managed_connection) = populate_mock_managed_cursor_no_hook(
-        managed_database_connection=managed_connection)
+    (
+        mock_native_cursor,
+        mock_managed_cursor,
+        _,
+        _,
+        mock_managed_connection,
+    ) = populate_mock_managed_cursor_no_hook(
+        managed_database_connection=managed_connection
+    )
 
     def mock_decorate(decoration_cursor: DecorationCursor):
         managed_operation = decoration_cursor.get_managed_operation()
@@ -283,9 +311,7 @@ def test_no_hook_decoration__success__execute(managed_connection):
             f"decorated {managed_operation.get_operation()}"
         )
 
-    managed_connection.db_connection_decorate_operation.side_effect = (
-        mock_decorate
-    )
+    managed_connection.db_connection_decorate_operation.side_effect = mock_decorate
 
     mock_managed_cursor.execute(_query)
 
@@ -297,8 +323,15 @@ def test_no_hook_decoration__success__execute(managed_connection):
 def test_no_hook_decoration__failure__execute(managed_connection):
     managed_connection.db_connection_decorate_operation = Mock()
 
-    (mock_native_cursor, mock_managed_cursor, _, _, mock_managed_connection) = populate_mock_managed_cursor_no_hook(
-        managed_database_connection=managed_connection)
+    (
+        mock_native_cursor,
+        mock_managed_cursor,
+        _,
+        _,
+        mock_managed_connection,
+    ) = populate_mock_managed_cursor_no_hook(
+        managed_database_connection=managed_connection
+    )
 
     managed_connection.db_connection_decorate_operation.side_effect = Exception(
         "Decoration exception"
@@ -316,8 +349,15 @@ def test_no_hook_recovery__success__execute(managed_connection):
     managed_connection.db_connection_decorate_operation = Mock()
     managed_connection.db_connection_recover_operation = Mock()
 
-    (mock_native_cursor, mock_managed_cursor, _, _, mock_managed_connection) = populate_mock_managed_cursor_no_hook(
-        managed_database_connection=managed_connection)
+    (
+        mock_native_cursor,
+        mock_managed_cursor,
+        _,
+        _,
+        mock_managed_connection,
+    ) = populate_mock_managed_cursor_no_hook(
+        managed_database_connection=managed_connection
+    )
 
     def mock_decorate(decoration_cursor: DecorationCursor):
         managed_operation = decoration_cursor.get_managed_operation()
@@ -330,9 +370,7 @@ def test_no_hook_recovery__success__execute(managed_connection):
         recovery_cursor.retry_operation()
         assert recovery_cursor.get_retries() == 1
 
-    managed_connection.db_connection_decorate_operation.side_effect = (
-        mock_decorate
-    )
+    managed_connection.db_connection_decorate_operation.side_effect = mock_decorate
     managed_connection.db_connection_recover_operation.side_effect = mock_recover
 
     exception = Exception()
@@ -353,8 +391,15 @@ def test_no_hook_recovery__failure__execute(managed_connection):
     managed_connection.db_connection_decorate_operation = Mock()
     managed_connection.db_connection_recover_operation = Mock()
 
-    (mock_native_cursor, mock_managed_cursor, _, _, mock_managed_connection) = populate_mock_managed_cursor_no_hook(
-        managed_database_connection=managed_connection)
+    (
+        mock_native_cursor,
+        mock_managed_cursor,
+        _,
+        _,
+        mock_managed_connection,
+    ) = populate_mock_managed_cursor_no_hook(
+        managed_database_connection=managed_connection
+    )
 
     def mock_decorate(decoration_cursor: DecorationCursor):
         managed_operation = decoration_cursor.get_managed_operation()
@@ -365,9 +410,7 @@ def test_no_hook_recovery__failure__execute(managed_connection):
     def mock_recover(recovery_cursor: RecoveryCursor):
         raise Exception("Could not handle execution exception")
 
-    managed_connection.db_connection_decorate_operation.side_effect = (
-        mock_decorate
-    )
+    managed_connection.db_connection_decorate_operation.side_effect = mock_decorate
     managed_connection.db_connection_recover_operation.side_effect = mock_recover
 
     exception = Exception()

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_managed_cursor.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_managed_cursor.py
@@ -11,7 +11,9 @@ from vdk.internal.builtin_plugins.connection.database_managed_connection import 
     IDatabaseManagedConnection,
 )
 from vdk.internal.builtin_plugins.connection.decoration_cursor import DecorationCursor
-from vdk.internal.builtin_plugins.connection.execution_cursor import ExecuteOperationResult
+from vdk.internal.builtin_plugins.connection.execution_cursor import (
+    ExecuteOperationResult,
+)
 from vdk.internal.builtin_plugins.connection.execution_cursor import ExecutionCursor
 from vdk.internal.builtin_plugins.connection.recovery_cursor import RecoveryCursor
 from vdk.plugin.test_utils.util_funcs import populate_mock_managed_cursor

--- a/projects/vdk-plugins/vdk-test-utils/src/vdk/plugin/test_utils/util_funcs.py
+++ b/projects/vdk-plugins/vdk-test-utils/src/vdk/plugin/test_utils/util_funcs.py
@@ -23,7 +23,9 @@ from vdk.internal.builtin_plugins.connection.connection_hooks import (
 from vdk.internal.builtin_plugins.connection.connection_hooks import (
     DefaultConnectionHookImpl,
 )
-from vdk.internal.builtin_plugins.connection.database_managed_connection import IDatabaseManagedConnection
+from vdk.internal.builtin_plugins.connection.database_managed_connection import (
+    IDatabaseManagedConnection,
+)
 from vdk.internal.builtin_plugins.connection.decoration_cursor import DecorationCursor
 from vdk.internal.builtin_plugins.connection.decoration_cursor import ManagedOperation
 from vdk.internal.builtin_plugins.connection.execution_cursor import ExecutionCursor
@@ -277,13 +279,13 @@ def populate_mock_managed_cursor_no_hook(
     mock_operation=None,
     mock_parameters=None,
     decoration_operation_callback=None,
-    managed_database_connection: IDatabaseManagedConnection = None
+    managed_database_connection: IDatabaseManagedConnection = None,
 ) -> (
     PEP249Cursor,
     ManagedCursor,
     DecorationCursor,
     RecoveryCursor,
-    IDatabaseManagedConnection
+    IDatabaseManagedConnection,
 ):
     import logging
 
@@ -293,7 +295,7 @@ def populate_mock_managed_cursor_no_hook(
     managed_cursor = ManagedCursor(
         cursor=mock_native_cursor,
         log=logging.getLogger(),
-        managed_database_connection=managed_database_connection
+        managed_database_connection=managed_database_connection,
     )
 
     decoration_cursor = DecorationCursor(mock_native_cursor, None, managed_operation)
@@ -303,7 +305,9 @@ def populate_mock_managed_cursor_no_hook(
             execution_cursor
         )
 
-    managed_database_connection.db_connection_execute_operation = stub_db_connection_execute_operation
+    managed_database_connection.db_connection_execute_operation = (
+        stub_db_connection_execute_operation
+    )
 
     return (
         mock_native_cursor,
@@ -316,5 +320,5 @@ def populate_mock_managed_cursor_no_hook(
             managed_operation=managed_operation,
             decoration_operation_callback=decoration_operation_callback,
         ),
-        managed_database_connection
+        managed_database_connection,
     )

--- a/projects/vdk-plugins/vdk-test-utils/src/vdk/plugin/test_utils/util_funcs.py
+++ b/projects/vdk-plugins/vdk-test-utils/src/vdk/plugin/test_utils/util_funcs.py
@@ -23,6 +23,7 @@ from vdk.internal.builtin_plugins.connection.connection_hooks import (
 from vdk.internal.builtin_plugins.connection.connection_hooks import (
     DefaultConnectionHookImpl,
 )
+from vdk.internal.builtin_plugins.connection.database_managed_connection import IDatabaseManagedConnection
 from vdk.internal.builtin_plugins.connection.decoration_cursor import DecorationCursor
 from vdk.internal.builtin_plugins.connection.decoration_cursor import ManagedOperation
 from vdk.internal.builtin_plugins.connection.execution_cursor import ExecutionCursor
@@ -268,4 +269,52 @@ def populate_mock_managed_cursor(
             decoration_operation_callback=decoration_operation_callback,
         ),
         mock_connection_hook_spec,
+    )
+
+
+def populate_mock_managed_cursor_no_hook(
+    mock_exception_to_recover=None,
+    mock_operation=None,
+    mock_parameters=None,
+    decoration_operation_callback=None,
+    managed_database_connection: IDatabaseManagedConnection = None
+) -> (
+    PEP249Cursor,
+    ManagedCursor,
+    DecorationCursor,
+    RecoveryCursor,
+    IDatabaseManagedConnection
+):
+    import logging
+
+    managed_operation = ManagedOperation(mock_operation, mock_parameters)
+    mock_native_cursor = MagicMock(spec=PEP249Cursor)
+
+    managed_cursor = ManagedCursor(
+        cursor=mock_native_cursor,
+        log=logging.getLogger(),
+        managed_database_connection=managed_database_connection
+    )
+
+    decoration_cursor = DecorationCursor(mock_native_cursor, None, managed_operation)
+
+    def stub_db_connection_execute_operation(execution_cursor: ExecutionCursor):
+        return DefaultConnectionHookImpl().db_connection_execute_operation(
+            execution_cursor
+        )
+
+    managed_database_connection.db_connection_execute_operation = stub_db_connection_execute_operation
+
+    return (
+        mock_native_cursor,
+        managed_cursor,
+        decoration_cursor,
+        RecoveryCursor(
+            native_cursor=mock_native_cursor,
+            log=logging.getLogger(),
+            exception=mock_exception_to_recover,
+            managed_operation=managed_operation,
+            decoration_operation_callback=decoration_operation_callback,
+        ),
+        managed_database_connection
     )


### PR DESCRIPTION
Resolves: https://github.com/vmware/versatile-data-kit/issues/3161

Instead of abstract methods, we are using an Interface to identify where the methods come from base or from plugin (checks whether method comes from a class that inherits the base). 

If the class has been inherited and the methods been overriden then we use those methods if not we use the hook spec. 

This is done for backwards compatibility with the current plugin implementations.

Signed-off-by: Duygu Hasan [hduygu@vmware.com](mailto:hduygu@vmware.com)