### PR TITLE
control-service: remove support for old k8s

### DIFF
--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -51,7 +51,6 @@ control_service_build_image:
     - ./gradlew -p ./model build publishToMavenLocal --info --stacktrace
     - ./gradlew build jacocoTestReport -x integrationTest --info --stacktrace
 #    - ./gradlew :pipelines_control_service:docker --info --stacktrace -Pversion=$TAG
-
   retry: !reference [.control_service_retry, retry_options]
   coverage: "/    - Line Coverage: ([0-9.]+)%/"
   artifacts:

--- a/projects/control-service/cicd/.gitlab-ci.yml
+++ b/projects/control-service/cicd/.gitlab-ci.yml
@@ -39,78 +39,78 @@
     - apk --no-cache add openjdk17-jdk git zip curl zip py-pip
     - pip install --upgrade pip && pip install awscli
 
-#control_service_build_image:
-#  extends:
-#    - .control_service_base_build
-#    - .images:dind
-#  stage: build
-#  script:
-#    - apk --no-cache add git openjdk17-jdk
-#    - export TAG=$(git rev-parse --short HEAD)
-#    - cd projects/control-service/projects
-#    - ./gradlew -p ./model build publishToMavenLocal --info --stacktrace
-#    - ./gradlew build jacocoTestReport -x integrationTest --info --stacktrace
-##    - ./gradlew :pipelines_control_service:docker --info --stacktrace -Pversion=$TAG
-#  retry: !reference [.control_service_retry, retry_options]
-#  coverage: "/    - Line Coverage: ([0-9.]+)%/"
-#  artifacts:
-#    when: always
-#    paths:
-#      - ./projects/control-service/projects/*/build/reports/**
-#    expire_in: 1 week
-#    reports:
-#      junit: ./projects/control-service/projects/**/build/test-results/test/TEST-*.xml
-#  only:
-#    refs:
-#      - external_pull_requests
-#    changes: *control_service_code_change_locations
+control_service_build_image:
+  extends:
+    - .control_service_base_build
+    - .images:dind
+  stage: build
+  script:
+    - apk --no-cache add git openjdk17-jdk
+    - export TAG=$(git rev-parse --short HEAD)
+    - cd projects/control-service/projects
+    - ./gradlew -p ./model build publishToMavenLocal --info --stacktrace
+    - ./gradlew build jacocoTestReport -x integrationTest --info --stacktrace
+  #    - ./gradlew :pipelines_control_service:docker --info --stacktrace -Pversion=$TAG
+  retry: !reference [.control_service_retry, retry_options]
+  coverage: "/    - Line Coverage: ([0-9.]+)%/"
+  artifacts:
+    when: always
+    paths:
+      - ./projects/control-service/projects/*/build/reports/**
+    expire_in: 1 week
+    reports:
+      junit: ./projects/control-service/projects/**/build/test-results/test/TEST-*.xml
+  only:
+    refs:
+      - external_pull_requests
+    changes: *control_service_code_change_locations
 
-#control_service_integration_test:
-#  extends:
-#    - .control_service_base_build
-#    - .images:dind
-#  stage: build
-#  variables:
-#    DEPLOYMENT_K8S_KUBECONFIG: "~/.kube/config"
-#    DEPLOYMENT_K8S_NAMESPACE: cicd-deployment
-#    CONTROL_K8S_KUBECONFIG: "~/.kube/config"
-#    CONTROL_K8S_NAMESPACE: cicd-control
-#    DOCKER_REGISTRY_URL: $CICD_CONTAINER_REGISTRY_URI
-#    DOCKER_REGISTRY_USERNAME: $CICD_CONTAINER_REGISTRY_USER_NAME
-#    DOCKER_REGISTRY_PASSWORD: $CICD_CONTAINER_REGISTRY_USER_PASSWORD
-#    GIT_URL: $CICD_GIT_URI
-#    GIT_USERNAME: $CICD_GIT_USER
-#    GIT_PASSWORD: $CICD_GIT_PASSWORD
-#    GIT_USERNAME_READ_WRITE: $CICD_GIT_USER
-#    GIT_PASSWORD_READ_WRITE: $CICD_GIT_PASSWORD
-#    DATAJOBS_AWS_SERVICE_ACCOUNT_ACCESS_KEY_ID: $DATAJOBS_AWS_SERVICE_ACCOUNT_ACCESS_KEY_ID
-#    DATAJOBS_AWS_SERVICE_ACCOUNT_SECRET_ACCESS_KEY: $DATAJOBS_AWS_SERVICE_ACCOUNT_SECRET_ACCESS_KEY
-#  script:
-#    - cd projects/control-service/projects
-#    - ./gradlew -p ./model build publishToMavenLocal
-#    - mkdir -p ~/.kube
-#    - cp $KUBECONFIG ~/.kube/config
-#    - ./gradlew -v
-#    - ./gradlew projects --info
-#    - ./gradlew -Djdk.tls.client.protocols=TLSv1.2 :pipelines_control_service:integrationTest --info --stacktrace --fail-fast
-#  retry: !reference [.control_service_retry, retry_options]
-#  artifacts:
-#    when: always
-#    paths:
-#      - ./projects/control-service/projects/*/build/reports/**
-#    expire_in: 1 week
-#    reports:
-#      junit: ./projects/control-service/projects/**/build/test-results/integrationTest/TEST-*.xml
-#  only:
-#    refs:
-#      - external_pull_requests
-#    changes: *control_service_code_change_locations
-#  except:
-#    changes:
-#      - projects/control-service/projects/helm_charts/pipelines-control-service/version.txt
-#      - projects/control-service/projects/model/CONTRIBUTING.MD
-#      - projects/control-service/projects/**/README.md
-#      - projects/control-service/projects/model/apidefs/datajob-api/config-python.json
+control_service_integration_test:
+  extends:
+    - .control_service_base_build
+    - .images:dind
+  stage: build
+  variables:
+    DEPLOYMENT_K8S_KUBECONFIG: "~/.kube/config"
+    DEPLOYMENT_K8S_NAMESPACE: cicd-deployment
+    CONTROL_K8S_KUBECONFIG: "~/.kube/config"
+    CONTROL_K8S_NAMESPACE: cicd-control
+    DOCKER_REGISTRY_URL: $CICD_CONTAINER_REGISTRY_URI
+    DOCKER_REGISTRY_USERNAME: $CICD_CONTAINER_REGISTRY_USER_NAME
+    DOCKER_REGISTRY_PASSWORD: $CICD_CONTAINER_REGISTRY_USER_PASSWORD
+    GIT_URL: $CICD_GIT_URI
+    GIT_USERNAME: $CICD_GIT_USER
+    GIT_PASSWORD: $CICD_GIT_PASSWORD
+    GIT_USERNAME_READ_WRITE: $CICD_GIT_USER
+    GIT_PASSWORD_READ_WRITE: $CICD_GIT_PASSWORD
+    DATAJOBS_AWS_SERVICE_ACCOUNT_ACCESS_KEY_ID: $DATAJOBS_AWS_SERVICE_ACCOUNT_ACCESS_KEY_ID
+    DATAJOBS_AWS_SERVICE_ACCOUNT_SECRET_ACCESS_KEY: $DATAJOBS_AWS_SERVICE_ACCOUNT_SECRET_ACCESS_KEY
+  script:
+    - cd projects/control-service/projects
+    - ./gradlew -p ./model build publishToMavenLocal
+    - mkdir -p ~/.kube
+    - cp $KUBECONFIG ~/.kube/config
+    - ./gradlew -v
+    - ./gradlew projects --info
+    - ./gradlew -Djdk.tls.client.protocols=TLSv1.2 :pipelines_control_service:integrationTest --info --stacktrace --fail-fast
+  retry: !reference [.control_service_retry, retry_options]
+  artifacts:
+    when: always
+    paths:
+      - ./projects/control-service/projects/*/build/reports/**
+    expire_in: 1 week
+    reports:
+      junit: ./projects/control-service/projects/**/build/test-results/integrationTest/TEST-*.xml
+  only:
+    refs:
+      - external_pull_requests
+    changes: *control_service_code_change_locations
+  except:
+    changes:
+      - projects/control-service/projects/helm_charts/pipelines-control-service/version.txt
+      - projects/control-service/projects/model/CONTRIBUTING.MD
+      - projects/control-service/projects/**/README.md
+      - projects/control-service/projects/model/apidefs/datajob-api/config-python.json
 
 control_service_test_helm_chart:
   stage: build
@@ -243,17 +243,24 @@ control_service_publish_image:
     - cd projects/control-service/projects
     - ./gradlew -p ./model build publishToMavenLocal --info --stacktrace
     - ./gradlew build -x test --info --stacktrace
-    - ./gradlew :pipelines_control_service:dockerTag --info --stacktrace -Pversion=paul_test
-    - docker_push_vdk.sh "versatiledatakit/pipelines-control-service:paul_test"
+    - ./gradlew :pipelines_control_service:dockerTag --info --stacktrace -Pversion=$TAG
+    - docker_push_vdk.sh "versatiledatakit/pipelines-control-service:$TAG"
+    - docker_push_vdk.sh "versatiledatakit/pipelines-control-service:latest"
   retry: !reference [.control_service_retry, retry_options]
   artifacts:
     when: always
     reports:
       junit: ./projects/control-serviceprojects/**/build/test-results/test/TEST-*.xml
-  only:
-    refs:
-      - external_pull_requests
-    changes: *control_service_code_change_locations
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes: [ projects/control-service/projects/helm_charts/pipelines-control-service/version.txt ]
+      when: never
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes: *control_service_code_change_locations
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      changes: *control_service_helm_change_locations
 
 control_service_publish_api_client:
   image: docker:23.0.1

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/README.md
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/README.md
@@ -2,8 +2,7 @@
 Versatile Data Kit is a platform that enables Data Engineers to implement automated pull ingestion (E in ELT) and batch data transformation into a database (T in ELT).
 
 ## Prerequisites
-- Kubernetes 1.19<=x>1.25 works with no config changes
-- for kubernetes 1.25+ the datajob template needs to be changed in the [values.yaml](./values.yaml). Specifically `enabled` needs to be set to `true` and `apiVersion` needs to be set to `batch/v1`
+- Kubernetes 1.24<
 - Helm 3.0
 - PV provisioner support in the underlying infrastructure if using the embedded database.
 - During helm install - CRUD on Kubernetes Deployment, Service, ServiceAccount, Role, Rolebindings. Control Service itself manages CronJob(Job and Pod as well), Secret resources. Statefulset and PVC if using the embedded database

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -974,7 +974,7 @@ customStartupProbeProbe: {}
 datajobTemplate:
   enabled: false
   template:
-    apiVersion: batch/v1beta1
+    apiVersion: batch/v1
     kind: CronJob
     metadata:
       annotations:                   # merged with additional annotations from TPCS

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudAsyncIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudAsyncIT.java
@@ -20,7 +20,6 @@ import org.springframework.test.web.servlet.MvcResult;
 
 @TestPropertySource(
     properties = {
-      "datajobs.control.k8s.k8sSupportsV1CronJob=true",
       "datajobs.deployment.configuration.persistence.writeTos=DB",
       "datajobs.deployment.configuration.persistence.readDataSource=DB",
       "datajobs.deployment.configuration.synchronization.task.enabled=true",

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/DataJobDeploymentCrudIT.java
@@ -21,7 +21,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @TestPropertySource(
     properties = {
-      "datajobs.control.k8s.k8sSupportsV1CronJob=true",
       "datajobs.deployment.configuration.persistence.writeTos=K8S",
       "datajobs.deployment.configuration.persistence.readDataSource=K8S",
       "datajobs.deployment.configuration.synchronization.task.enabled=false"

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/TestJobDeployTempCredsIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/TestJobDeployTempCredsIT.java
@@ -53,7 +53,6 @@ import org.springframework.test.web.servlet.MvcResult;
 @Import({TestJobDeployTempCredsIT.TaskExecutorConfig.class})
 @TestPropertySource(
     properties = {
-      "datajobs.control.k8s.k8sSupportsV1CronJob=true",
       "datajobs.aws.assumeIAMRole=true",
       "datajobs.aws.RoleArn=arn:aws:iam::320807031117:role/svc.ecr-integration-test",
       "datajobs.docker.registryType=ecr",

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/TestJobImageBuilderDynamicVdkImageIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/datajobs/it/TestJobImageBuilderDynamicVdkImageIT.java
@@ -45,7 +45,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import({TestJobImageBuilderDynamicVdkImageIT.TaskExecutorConfig.class})
 @TestPropertySource(
     properties = {
-      "datajobs.control.k8s.k8sSupportsV1CronJob=true",
       "datajobs.deployment.supportedPythonVersions={3.8: {vdkImage:"
           + " 'registry.hub.docker.com/versatiledatakit/quickstart-vdk:pre-release', baseImage:"
           + " 'versatiledatakit/data-job-base-python-3.8:latest', builderImage:"

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/service/deploy/DataJobDeploymentCrudITV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/service/deploy/DataJobDeploymentCrudITV2.java
@@ -51,7 +51,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import({DataJobDeploymentCrudITV2.TaskExecutorConfig.class})
 @TestPropertySource(
     properties = {
-      "datajobs.control.k8s.k8sSupportsV1CronJob=true",
       "datajobs.deployment.configuration.synchronization.task.enabled=true",
       "datajobs.deployment.configuration.synchronization.task.initial.delay.ms=1000000",
       // Setting this value to 1000000 effectively disables the scheduled execution of

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-test.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-test.properties
@@ -13,7 +13,6 @@ datajobs.vdk_options_ini=
 
 datajobs.deployment.k8s.kubeconfig=${DEPLOYMENT_K8S_KUBECONFIG:}
 datajobs.deployment.k8s.namespace=${DEPLOYMENT_K8S_NAMESPACE:default}
-datajobs.control.k8s.k8sSupportsV1CronJob=false
 
 datajobs.control.k8s.kubeconfig=${CONTROL_K8S_KUBECONFIG:}
 datajobs.control.k8s.namespace=${CONTROL_K8S_NAMESPACE:default}

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/data_job_templates/backoff_limit_exceeded_cron_job.yaml
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/data_job_templates/backoff_limit_exceeded_cron_job.yaml
@@ -1,7 +1,7 @@
 # Copyright 2023-2024 Broadcom
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations:                   # merged with additional annotations from TPCS

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/data_job_templates/fast_failing_cron_job.yaml
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/data_job_templates/fast_failing_cron_job.yaml
@@ -1,7 +1,7 @@
 # Copyright 2023-2024 Broadcom
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations:                   # merged with additional annotations from TPCS

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/fast_failing_cron_job.yaml
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/fast_failing_cron_job.yaml
@@ -1,7 +1,7 @@
 # Copyright 2023-2024 Broadcom
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations:                   # merged with additional annotations from TPCS

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -193,36 +193,25 @@ public abstract class KubernetesService {
   private Logger log;
   private final ApiClient client;
   protected final BatchV1Api batchV1Api;
-  protected final BatchV1beta1Api batchV1beta1Api;
-  private boolean k8sSupportsV1CronJob;
 
   @Autowired private final JobCommandProvider jobCommandProvider;
 
   /**
    * @param namespace the namespace where the kubernetes operation will act on. leave empty to infer
    *     from kubeconfig
-   * @param k8sSupportsV1CronJob Whether the target K8s cluster supports the V1CronJob API
    * @param log log to use - used in subclasses in order to set classname to subclass.
    */
   protected KubernetesService(
       String namespace,
-      boolean k8sSupportsV1CronJob,
       Logger log,
       ApiClient client,
       BatchV1Api batchV1Api,
-      BatchV1beta1Api batchV1beta1Api,
       JobCommandProvider jobCommandProvider) {
     this.namespace = namespace;
-    this.k8sSupportsV1CronJob = k8sSupportsV1CronJob;
     this.log = log;
     this.client = client;
     this.batchV1Api = batchV1Api;
-    this.batchV1beta1Api = batchV1beta1Api;
     this.jobCommandProvider = jobCommandProvider;
-  }
-
-  protected boolean getK8sSupportsV1CronJob() {
-    return this.k8sSupportsV1CronJob;
   }
 
   private V1CronJob loadV1CronjobTemplate() {
@@ -238,31 +227,6 @@ public abstract class KubernetesService {
     return cronjobTemplate;
   }
 
-  private V1beta1CronJob loadV1beta1CronjobTemplate() {
-    if (StringUtils.isEmpty(datajobTemplateFileLocation)) {
-      log.trace("Datajob template file location is not set. Using internal datajob template.");
-      return loadInternalV1beta1CronjobTemplate();
-    }
-    V1beta1CronJob cronjobTemplate = loadConfigurableV1beta1CronjobTemplate();
-    if (cronjobTemplate == null) {
-      return loadInternalV1beta1CronjobTemplate();
-    }
-
-    return cronjobTemplate;
-  }
-
-  private V1beta1CronJob loadInternalV1beta1CronjobTemplate() {
-    try {
-      return loadV1beta1CronjobTemplate(
-          new ClassPathResource(K8S_DATA_JOB_TEMPLATE_RESOURCE).getFile());
-    } catch (Exception e) {
-      // This should never happen unless we are testing locally and we've messed up
-      // with the internal template resource file.
-      throw new RuntimeException(
-          "Unrecoverable error while loading the internal datajob template. Cannot continue.", e);
-    }
-  }
-
   private V1CronJob loadInternalV1CronjobTemplate() {
     try {
       return loadV1CronjobTemplate(
@@ -272,23 +236,6 @@ public abstract class KubernetesService {
       // with the internal template resource file.
       throw new RuntimeException(
           "Unrecoverable error while loading the internal datajob template. Cannot continue.", e);
-    }
-  }
-
-  private V1beta1CronJob loadConfigurableV1beta1CronjobTemplate() {
-    // Check whether to use configurable datajob template at all.
-    if (StringUtils.isEmpty(datajobTemplateFileLocation)) {
-      log.trace("Datajob template file location is not set.");
-      return null;
-    }
-
-    try {
-      // Load the configurable datajob template file.
-      return loadV1beta1CronjobTemplate(
-          new ClassPathResource(datajobTemplateFileLocation).getFile());
-    } catch (Exception e) {
-      log.error("Error while loading the datajob template file.", e);
-      return null;
     }
   }
 
@@ -306,14 +253,6 @@ public abstract class KubernetesService {
       log.error("Error while loading the datajob template file.", e);
       return null;
     }
-  }
-
-  private V1beta1CronJob loadV1beta1CronjobTemplate(File datajobTemplateFile) throws Exception {
-    String cronjobTemplateString = Files.readString(datajobTemplateFile.toPath());
-    // Check whether the string template is a valid datajob template.
-    V1beta1CronJob cronjobTemplate = Yaml.loadAs(cronjobTemplateString, V1beta1CronJob.class);
-
-    return cronjobTemplate;
   }
 
   private V1CronJob loadV1CronjobTemplate(File datajobTemplateFile) throws Exception {
@@ -371,24 +310,7 @@ public abstract class KubernetesService {
    *     Optional if the cron job does not exist or cannot be read
    */
   public Optional<JobDeploymentStatus> readCronJob(String cronJobName) {
-    var jobStatus = readV1beta1CronJob(cronJobName);
-
-    return jobStatus.isPresent() ? jobStatus : readV1CronJob(cronJobName);
-  }
-
-  public Optional<JobDeploymentStatus> readV1beta1CronJob(String cronJobName) {
-    log.debug("Reading k8s V1beta1 cron job: {}", cronJobName);
-    V1beta1CronJob cronJob = null;
-    try {
-      cronJob = batchV1beta1Api.readNamespacedCronJob(cronJobName, namespace, null);
-    } catch (ApiException e) {
-      log.warn(
-          "Could not read cron job: {}; reason: {}",
-          cronJobName,
-          new KubernetesException("", e).toString());
-    }
-
-    return mapV1beta1CronJobToDeploymentStatus(cronJob, cronJobName);
+    return readV1CronJob(cronJobName);
   }
 
   public Optional<JobDeploymentStatus> readV1CronJob(String cronJobName) {
@@ -413,33 +335,7 @@ public abstract class KubernetesService {
    *     data
    */
   public List<JobDeploymentStatus> readJobDeploymentStatuses() {
-    if (getK8sSupportsV1CronJob()) {
-      return Stream.concat(
-              readV1CronJobDeploymentStatuses().stream(),
-              readV1beta1CronJobDeploymentStatuses().stream())
-          .collect(Collectors.toList());
-    } else {
-      return readV1beta1CronJobDeploymentStatuses();
-    }
-  }
-
-  public List<JobDeploymentStatus> readV1beta1CronJobDeploymentStatuses() {
-    log.debug("Reading all k8s V1beta1 cron jobs");
-    V1beta1CronJobList cronJobs = null;
-    try {
-      cronJobs =
-          batchV1beta1Api.listNamespacedCronJob(
-              namespace, null, null, null, null, null, null, null, null, null, null);
-    } catch (ApiException e) {
-      log.warn("Failed to read k8s cron jobs: ", new KubernetesException("", e));
-    }
-
-    return cronJobs == null
-        ? Collections.emptyList()
-        : cronJobs.getItems().stream()
-            .map(cronJob -> mapV1beta1CronJobToDeploymentStatus(cronJob, null))
-            .flatMap(Optional::stream)
-            .collect(Collectors.toList());
+    return readV1CronJobDeploymentStatuses();
   }
 
   public List<JobDeploymentStatus> readV1CronJobDeploymentStatuses() {
@@ -469,76 +365,8 @@ public abstract class KubernetesService {
       Map<String, Object> extraJobArguments,
       String jobName)
       throws ApiException {
-    if (getK8sSupportsV1CronJob()) {
-      startNewV1CronJobExecution(
-          cronJobName, executionId, annotations, envs, extraJobArguments, jobName);
-    } else {
-      startNewV1beta1CronJobExecution(
-          cronJobName, executionId, annotations, envs, extraJobArguments, jobName);
-    }
-  }
-
-  private void startNewV1beta1CronJobExecution(
-      String cronJobName,
-      String executionId,
-      Map<String, String> annotations,
-      Map<String, String> envs,
-      Map<String, Object> extraJobArguments,
-      String jobName)
-      throws ApiException {
-    var cron = batchV1beta1Api.readNamespacedCronJob(cronJobName, namespace, null);
-    Optional<V1beta1JobTemplateSpec> jobTemplateSpec =
-        Optional.ofNullable(cron)
-            .map(V1beta1CronJob::getSpec)
-            .map(V1beta1CronJobSpec::getJobTemplate);
-
-    Map<String, String> jobLabels =
-        jobTemplateSpec
-            .map(V1beta1JobTemplateSpec::getMetadata)
-            .map(V1ObjectMeta::getLabels)
-            .orElse(Collections.emptyMap());
-
-    Map<String, String> jobAnnotations =
-        jobTemplateSpec
-            .map(V1beta1JobTemplateSpec::getMetadata)
-            .map(V1ObjectMeta::getAnnotations)
-            .map(
-                v1ObjectMetaAnnotations -> {
-                  v1ObjectMetaAnnotations.putAll(annotations);
-                  return v1ObjectMetaAnnotations;
-                })
-            .orElse(annotations);
-
-    V1JobSpec jobSpec =
-        jobTemplateSpec
-            .map(V1beta1JobTemplateSpec::getSpec)
-            .orElseThrow(
-                () ->
-                    new ApiException(
-                        String.format(
-                            "K8S Cron Job '%s' does not exist or is not properly defined.",
-                            cronJobName)));
-
-    jobSpec.setTtlSecondsAfterFinished(jobTTLAfterFinishedSeconds);
-
-    V1Container v1Container =
-        Optional.ofNullable(jobSpec.getTemplate())
-            .map(V1PodTemplateSpec::getSpec)
-            .map(V1PodSpec::getContainers)
-            .map(v1Containers -> v1Containers.get(0))
-            .orElseThrow(
-                () ->
-                    new ApiException(
-                        String.format("K8S Cron Job '%s' is not properly defined.", cronJobName)));
-    if (!CollectionUtils.isEmpty(envs)) {
-      envs.forEach((name, value) -> v1Container.addEnvItem(new V1EnvVar().name(name).value(value)));
-    }
-
-    if (!CollectionUtils.isEmpty(extraJobArguments)) {
-      addExtraJobArgumentsToVdkContainer(v1Container, extraJobArguments, jobName);
-    }
-
-    createNewJob(executionId, jobSpec, jobLabels, jobAnnotations);
+    startNewV1CronJobExecution(
+        cronJobName, executionId, annotations, envs, extraJobArguments, jobName);
   }
 
   private void startNewV1CronJobExecution(
@@ -628,43 +456,6 @@ public abstract class KubernetesService {
 
   // TODO:  container/volume args are breaking a bit abstraction of KubernetesService by leaking
   // impl. details
-  public void createV1beta1CronJob(
-      String name,
-      String image,
-      String schedule,
-      boolean enable,
-      V1Container jobContainer,
-      V1Container initContainer,
-      List<V1Volume> volumes,
-      Map<String, String> jobAnnotations,
-      Map<String, String> jobLabels,
-      List<String> imagePullSecrets)
-      throws ApiException {
-    log.debug("Creating k8s V1beta1 cron job name:{}, image:{}", name, image);
-    var cronJob =
-        v1beta1CronJobFromTemplate(
-            name,
-            schedule,
-            !enable,
-            jobContainer,
-            initContainer,
-            volumes,
-            jobAnnotations,
-            jobLabels,
-            imagePullSecrets);
-    V1beta1CronJob nsJob =
-        batchV1beta1Api.createNamespacedCronJob(namespace, cronJob, null, null, null, null);
-    log.debug("Created k8s V1beta1 cron job: {}", cronJob);
-    log.debug(
-        "Created k8s cron job name: {}, api_version:{}, uid:{}, link:{}",
-        nsJob.getMetadata().getName(),
-        nsJob.getApiVersion(),
-        nsJob.getMetadata().getUid(),
-        nsJob.getMetadata().getSelfLink());
-  }
-
-  // TODO:  container/volume args are breaking a bit abstraction of KubernetesService by leaking
-  // impl. details
   public void createV1CronJob(
       String name,
       String image,
@@ -696,41 +487,6 @@ public abstract class KubernetesService {
         "Created k8s cron job name: {}, api_version: {}, uid:{}, link:{}",
         nsJob.getMetadata().getName(),
         nsJob.getApiVersion(),
-        nsJob.getMetadata().getUid(),
-        nsJob.getMetadata().getSelfLink());
-  }
-
-  public void updateV1beta1CronJob(
-      String name,
-      String image,
-      String schedule,
-      boolean enable,
-      V1Container jobContainer,
-      V1Container initContainer,
-      List<V1Volume> volumes,
-      Map<String, String> jobAnnotations,
-      Map<String, String> jobLabels,
-      List<String> imagePullSecrets)
-      throws ApiException {
-    var cronJob =
-        v1beta1CronJobFromTemplate(
-            name,
-            schedule,
-            !enable,
-            jobContainer,
-            initContainer,
-            volumes,
-            jobAnnotations,
-            jobLabels,
-            imagePullSecrets);
-
-    V1beta1CronJob nsJob =
-        batchV1beta1Api.replaceNamespacedCronJob(name, namespace, cronJob, null, null, null, null);
-    log.debug("Updated k8s V1 cron job: {}", cronJob);
-    log.debug(
-        "Updated k8s V1beta1 cron job status for name:{}, image:{}, uid:{}, link:{}",
-        name,
-        image,
         nsJob.getMetadata().getUid(),
         nsJob.getMetadata().getSelfLink());
   }
@@ -1531,67 +1287,6 @@ public abstract class KubernetesService {
     return Optional.empty();
   }
 
-  // TODO - in the future we want to merge the (1) configurable datajob template
-  //        with the (2) default internal datajob template when something from (1)
-  //        is missing. For now we just check for missing entries in (1) and overwrite
-  //        them with the corresponding entries in (2).
-  private void v1beta1checkForMissingEntries(V1beta1CronJob cronjob) {
-    V1beta1CronJob internalCronjobTemplate = loadInternalV1beta1CronjobTemplate();
-    if (cronjob.getMetadata() == null) {
-      cronjob.setMetadata(internalCronjobTemplate.getMetadata());
-    }
-    V1ObjectMeta metadata = cronjob.getMetadata();
-    if (metadata.getAnnotations() == null) {
-      metadata.setAnnotations(new HashMap<>());
-    }
-    if (cronjob.getSpec() == null) {
-      cronjob.setSpec(internalCronjobTemplate.getSpec());
-    }
-    V1beta1CronJobSpec spec = cronjob.getSpec();
-    if (spec.getJobTemplate() == null) {
-      spec.setJobTemplate(internalCronjobTemplate.getSpec().getJobTemplate());
-    }
-    if (spec.getJobTemplate().getMetadata() == null) {
-      spec.getJobTemplate()
-          .setMetadata(internalCronjobTemplate.getSpec().getJobTemplate().getMetadata());
-    }
-    if (spec.getJobTemplate().getMetadata().getLabels() == null) {
-      spec.getJobTemplate().getMetadata().setLabels(new HashMap<>());
-    }
-    if (spec.getJobTemplate().getMetadata().getAnnotations() == null) {
-      spec.getJobTemplate().getMetadata().setAnnotations(new HashMap<>());
-    }
-    if (spec.getJobTemplate().getSpec() == null) {
-      spec.getJobTemplate().setSpec(internalCronjobTemplate.getSpec().getJobTemplate().getSpec());
-    }
-    if (spec.getJobTemplate().getSpec().getTemplate() == null) {
-      spec.getJobTemplate()
-          .getSpec()
-          .setTemplate(internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate());
-    }
-    if (spec.getJobTemplate().getSpec().getTemplate().getSpec() == null) {
-      spec.getJobTemplate()
-          .getSpec()
-          .getTemplate()
-          .setSpec(
-              internalCronjobTemplate.getSpec().getJobTemplate().getSpec().getTemplate().getSpec());
-    }
-    if (spec.getJobTemplate().getSpec().getTemplate().getMetadata() == null) {
-      spec.getJobTemplate()
-          .getSpec()
-          .getTemplate()
-          .setMetadata(
-              internalCronjobTemplate
-                  .getSpec()
-                  .getJobTemplate()
-                  .getSpec()
-                  .getTemplate()
-                  .getMetadata());
-    }
-    if (spec.getJobTemplate().getSpec().getTemplate().getMetadata().getLabels() == null) {
-      spec.getJobTemplate().getSpec().getTemplate().getMetadata().setLabels(new HashMap<>());
-    }
-  }
 
   private void v1checkForMissingEntries(V1CronJob cronjob) {
     V1CronJob internalCronjobTemplate = loadInternalV1CronjobTemplate();
@@ -1649,60 +1344,6 @@ public abstract class KubernetesService {
     if (spec.getJobTemplate().getSpec().getTemplate().getMetadata().getLabels() == null) {
       spec.getJobTemplate().getSpec().getTemplate().getMetadata().setLabels(new HashMap<>());
     }
-  }
-
-  protected V1beta1CronJob v1beta1CronJobFromTemplate(
-      String name,
-      String schedule,
-      boolean suspend,
-      V1Container jobContainer,
-      V1Container initContainer,
-      List<V1Volume> volumes,
-      Map<String, String> jobAnnotations,
-      Map<String, String> jobLabels,
-      List<String> imagePullSecrets) {
-    V1beta1CronJob cronjob = loadV1beta1CronjobTemplate();
-    v1beta1checkForMissingEntries(cronjob);
-    cronjob.getMetadata().setName(name);
-    cronjob.getSpec().setSchedule(schedule);
-    cronjob.getSpec().setSuspend(suspend);
-    cronjob
-        .getSpec()
-        .getJobTemplate()
-        .getSpec()
-        .getTemplate()
-        .getSpec()
-        .setContainers(Collections.singletonList(jobContainer));
-    cronjob
-        .getSpec()
-        .getJobTemplate()
-        .getSpec()
-        .getTemplate()
-        .getSpec()
-        .setInitContainers(Collections.singletonList(initContainer));
-    cronjob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().setVolumes(volumes);
-
-    cronjob.getSpec().getJobTemplate().getMetadata().getAnnotations().putAll(jobAnnotations);
-    cronjob.getSpec().getJobTemplate().getMetadata().getLabels().putAll(jobLabels);
-
-    List<V1LocalObjectReference> imagePullSecretsObj =
-        Optional.ofNullable(imagePullSecrets).stream()
-            .flatMap(secrets -> secrets.stream())
-            .filter(secret -> StringUtils.isNotEmpty(secret))
-            .map(secret -> new V1LocalObjectReferenceBuilder().withName(secret).build())
-            .collect(Collectors.toList());
-
-    if (!CollectionUtils.isEmpty(imagePullSecretsObj)) {
-      cronjob
-          .getSpec()
-          .getJobTemplate()
-          .getSpec()
-          .getTemplate()
-          .getSpec()
-          .setImagePullSecrets(imagePullSecretsObj);
-    }
-
-    return cronjob;
   }
 
   protected V1CronJob v1CronJobFromTemplate(
@@ -1964,68 +1605,6 @@ public abstract class KubernetesService {
         .endMetadata()
         .withData(data)
         .build();
-  }
-
-  private Optional<JobDeploymentStatus> mapV1beta1CronJobToDeploymentStatus(
-      V1beta1CronJob cronJob, String cronJobName) {
-    JobDeploymentStatus deployment = null;
-    String apiVersion = null;
-
-    try {
-      apiVersion = cronJob.getApiVersion();
-    } catch (NullPointerException e) {
-      log.debug("Could not get API version for cronjob {}", cronJobName);
-    }
-
-    if (cronJob != null) {
-      deployment = new JobDeploymentStatus();
-      deployment.setEnabled(!cronJob.getSpec().getSuspend());
-      deployment.setDataJobName(cronJob.getMetadata().getName());
-      deployment.setMode(
-          "release"); // TODO: Get from cron job config when we support testing environments
-      deployment.setCronJobName(
-          cronJobName == null ? cronJob.getMetadata().getName() : cronJobName);
-
-      // all fields until pod spec are required so no need to check for null
-      var annotations = cronJob.getSpec().getJobTemplate().getMetadata().getAnnotations();
-      if (annotations != null) {
-        deployment.setLastDeployedBy(annotations.get(JobAnnotation.DEPLOYED_BY.getValue()));
-        deployment.setLastDeployedDate(annotations.get(JobAnnotation.DEPLOYED_DATE.getValue()));
-        deployment.setPythonVersion(annotations.get(JobAnnotation.PYTHON_VERSION.getValue()));
-      }
-
-      List<V1Container> containers =
-          cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getContainers();
-      if (!containers.isEmpty()) {
-        String image =
-            containers.get(0).getImage(); // TODO: Have 2 containers. 1 for VDK and 1 for the job.
-        deployment.setImageName(image); // TODO do we really need to return image_name?
-      }
-      var initContainers =
-          cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getInitContainers();
-      if (!CollectionUtils.isEmpty(initContainers)) {
-        String vdkImage = initContainers.get(0).getImage();
-        deployment.setVdkImageName(vdkImage);
-        deployment.setVdkVersion(DockerImageName.getTag(vdkImage));
-      } else {
-        log.warn("Missing init container for cronjob {}", cronJobName);
-      }
-
-      var labels = cronJob.getSpec().getJobTemplate().getMetadata().getLabels();
-      if (labels == null) {
-        log.warn(
-            "The cronjob of data job '{}' does not have any labels defined.",
-            deployment.getDataJobName());
-      }
-      if (labels != null && labels.containsKey(JobLabel.VERSION.getValue())) {
-        deployment.setGitCommitSha(labels.get(JobLabel.VERSION.getValue()));
-      } else {
-        // Legacy approach to get version:
-        deployment.setGitCommitSha(DockerImageName.getTag(deployment.getImageName()));
-      }
-    }
-
-    return Optional.ofNullable(deployment);
   }
 
   private Optional<JobDeploymentStatus> mapV1CronJobToDeploymentStatus(

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -51,7 +51,6 @@ import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * A facade over Kubernetes (https://en.wikipedia.org/wiki/Facade_pattern) (not complete see
@@ -1286,7 +1285,6 @@ public abstract class KubernetesService {
     }
     return Optional.empty();
   }
-
 
   private void v1checkForMissingEntries(V1CronJob cronjob) {
     V1CronJob internalCronjobTemplate = loadInternalV1CronjobTemplate();

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesServiceConfiguration.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesServiceConfiguration.java
@@ -7,7 +7,6 @@ package com.vmware.taurus.service;
 
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
-import io.kubernetes.client.openapi.apis.BatchV1beta1Api;
 import io.kubernetes.client.util.ClientBuilder;
 import io.kubernetes.client.util.KubeConfig;
 import lombok.extern.slf4j.Slf4j;
@@ -46,12 +45,6 @@ public class KubernetesServiceConfiguration {
   public BatchV1Api deploymentBatchV1Api(
       @Qualifier("deploymentApiClient") ApiClient deploymentApiClient) {
     return new BatchV1Api(deploymentApiClient);
-  }
-
-  @Bean
-  public BatchV1beta1Api deploymentBatchV1beta1Api(
-      @Qualifier("deploymentApiClient") ApiClient deploymentApiClient) {
-    return new BatchV1beta1Api(deploymentApiClient);
   }
 
   @Bean

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/ControlKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/ControlKubernetesService.java
@@ -25,10 +25,9 @@ public class ControlKubernetesService extends KubernetesService {
   // those should be null/empty when Control service is deployed in k8s hence default is empty
   public ControlKubernetesService(
       @Qualifier("controlNamespace") String namespace,
-      @Value("${datajobs.control.k8s.k8sSupportsV1CronJob}") boolean k8sSupportsV1CronJob,
       @Qualifier("controlApiClient") ApiClient client,
       @Qualifier("controlBatchV1Api") BatchV1Api batchV1Api,
       JobCommandProvider jobCommandProvider) {
-    super(namespace, k8sSupportsV1CronJob, log, client, batchV1Api, null, jobCommandProvider);
+    super(namespace, log, client, batchV1Api, jobCommandProvider);
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/ControlKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/ControlKubernetesService.java
@@ -11,7 +11,6 @@ import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /**

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/kubernetes/DataJobsKubernetesService.java
@@ -22,7 +22,6 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.SerializationUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -43,12 +42,7 @@ public class DataJobsKubernetesService extends KubernetesService {
       @Qualifier("deploymentApiClient") ApiClient client,
       @Qualifier("deploymentBatchV1Api") BatchV1Api batchV1Api,
       JobCommandProvider jobCommandProvider) {
-    super(
-        namespace,
-        log,
-        client,
-        batchV1Api,
-        jobCommandProvider);
+    super(namespace, log, client, batchV1Api, jobCommandProvider);
   }
 
   public void createCronJob(KubernetesService.CronJob cronJob) throws ApiException {
@@ -77,17 +71,17 @@ public class DataJobsKubernetesService extends KubernetesService {
       Map<String, String> jobLabels,
       List<String> imagePullSecrets)
       throws ApiException {
-      createV1CronJob(
-          name,
-          image,
-          schedule,
-          enable,
-          jobContainer,
-          initContainer,
-          volumes,
-          jobAnnotations,
-          jobLabels,
-          imagePullSecrets);
+    createV1CronJob(
+        name,
+        image,
+        schedule,
+        enable,
+        jobContainer,
+        initContainer,
+        volumes,
+        jobAnnotations,
+        jobLabels,
+        imagePullSecrets);
   }
 
   public String getCronJobSha512(
@@ -100,18 +94,18 @@ public class DataJobsKubernetesService extends KubernetesService {
       jobAnnotations.remove(excludeAnnotation.getValue());
     }
 
-      cronJobString =
-          v1CronJobFromTemplate(
-                  cronJob.getName(),
-                  cronJob.getSchedule(),
-                  !cronJob.isEnable(),
-                  cronJob.getJobContainer(),
-                  cronJob.getInitContainer(),
-                  cronJob.getVolumes(),
-                  jobAnnotations,
-                  cronJob.getJobLabels(),
-                  cronJob.getImagePullSecret())
-              .toString();
+    cronJobString =
+        v1CronJobFromTemplate(
+                cronJob.getName(),
+                cronJob.getSchedule(),
+                !cronJob.isEnable(),
+                cronJob.getJobContainer(),
+                cronJob.getInitContainer(),
+                cronJob.getVolumes(),
+                jobAnnotations,
+                cronJob.getJobLabels(),
+                cronJob.getImagePullSecret())
+            .toString();
     return DigestUtils.sha1Hex(cronJobString);
   }
 
@@ -141,17 +135,17 @@ public class DataJobsKubernetesService extends KubernetesService {
       Map<String, String> jobLabels,
       List<String> imagePullSecrets)
       throws ApiException {
-      updateV1CronJob(
-          name,
-          image,
-          schedule,
-          enable,
-          jobContainer,
-          initContainer,
-          volumes,
-          jobAnnotations,
-          jobLabels,
-          imagePullSecrets);
+    updateV1CronJob(
+        name,
+        image,
+        schedule,
+        enable,
+        jobContainer,
+        initContainer,
+        volumes,
+        jobAnnotations,
+        jobLabels,
+        imagePullSecrets);
   }
 
   /**

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -140,7 +140,6 @@ logging.level.io.swagger.models.parameters.AbstractSerializableParameter=ERROR
 
 
 datajobs.control.k8s.kubeconfig=${HOME}/.kube/config
-datajobs.control.k8s.k8sSupportsV1CronJob=false
 datajobs.control.k8s.jobTTLAfterFinishedSeconds=3600
 # Location to a K8s cronjob yaml file which will be used as a template
 # for all data jobs. If the location is missing, the default internal

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/k8s-data-job-template.yaml
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/k8s-data-job-template.yaml
@@ -1,7 +1,7 @@
 # Copyright 2023-2024 Broadcom
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations:                   # merged with additional annotations from TPCS

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
@@ -96,6 +96,9 @@ public class KubernetesServiceCancelRunningCronJobTest {
         .thenReturn(response);
 
     return new DataJobsKubernetesService(
-        "default", false, new ApiClient(), batchV1Api, new JobCommandProvider());
+        "default",
+        new ApiClient(),
+        batchV1Api,
+        new JobCommandProvider());
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
@@ -11,7 +11,6 @@ import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.ApiResponse;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
-import io.kubernetes.client.openapi.apis.BatchV1beta1Api;
 import io.kubernetes.client.openapi.models.V1Status;
 import io.kubernetes.client.openapi.models.V1StatusDetails;
 import org.junit.jupiter.api.Assertions;
@@ -101,7 +100,6 @@ public class KubernetesServiceCancelRunningCronJobTest {
         false,
         new ApiClient(),
         batchV1Api,
-        new BatchV1beta1Api(),
         new JobCommandProvider());
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
@@ -96,9 +96,6 @@ public class KubernetesServiceCancelRunningCronJobTest {
         .thenReturn(response);
 
     return new DataJobsKubernetesService(
-        "default",
-        new ApiClient(),
-        batchV1Api,
-        new JobCommandProvider());
+        "default", new ApiClient(), batchV1Api, new JobCommandProvider());
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceCancelRunningCronJobTest.java
@@ -96,10 +96,6 @@ public class KubernetesServiceCancelRunningCronJobTest {
         .thenReturn(response);
 
     return new DataJobsKubernetesService(
-        "default",
-        false,
-        new ApiClient(),
-        batchV1Api,
-        new JobCommandProvider());
+        "default", false, new ApiClient(), batchV1Api, new JobCommandProvider());
   }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceIsRunningJobTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceIsRunningJobTest.java
@@ -12,7 +12,6 @@ import com.vmware.taurus.service.kubernetes.DataJobsKubernetesService;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
-import io.kubernetes.client.openapi.apis.BatchV1beta1Api;
 import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1JobCondition;
 import io.kubernetes.client.openapi.models.V1JobList;
@@ -97,10 +96,8 @@ public class KubernetesServiceIsRunningJobTest {
     KubernetesService kubernetesService =
         new DataJobsKubernetesService(
             "default",
-            true,
             new ApiClient(),
             batchV1Api,
-            new BatchV1beta1Api(),
             new JobCommandProvider());
     boolean actualResult = kubernetesService.isRunningJob("test-job");
 

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceIsRunningJobTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceIsRunningJobTest.java
@@ -95,10 +95,7 @@ public class KubernetesServiceIsRunningJobTest {
 
     KubernetesService kubernetesService =
         new DataJobsKubernetesService(
-            "default",
-            new ApiClient(),
-            batchV1Api,
-            new JobCommandProvider());
+            "default", new ApiClient(), batchV1Api, new JobCommandProvider());
     boolean actualResult = kubernetesService.isRunningJob("test-job");
 
     Assertions.assertEquals(expectedResult, actualResult);

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartJobWithArgumentsIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartJobWithArgumentsIT.java
@@ -9,9 +9,8 @@ import com.vmware.taurus.service.deploy.JobCommandProvider;
 import com.vmware.taurus.service.kubernetes.DataJobsKubernetesService;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
-import io.kubernetes.client.openapi.apis.BatchV1beta1Api;
+import io.kubernetes.client.openapi.models.V1CronJob;
 import io.kubernetes.client.openapi.models.V1JobSpec;
-import io.kubernetes.client.openapi.models.V1beta1CronJob;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,29 +30,25 @@ public class KubernetesServiceStartJobWithArgumentsIT {
 
   @BeforeEach
   public void getMockKubernetesServiceForVdkRunExtraArgsTests() throws Exception {
-
-    BatchV1beta1Api mockBatch = Mockito.mock(BatchV1beta1Api.class);
     BatchV1Api mockBatchV1 = Mockito.mock(BatchV1Api.class);
 
     kubernetesService =
         new DataJobsKubernetesService(
-            "default", false, new ApiClient(), mockBatchV1, mockBatch, new JobCommandProvider());
-    V1beta1CronJob internalCronjobTemplate = getValidCronJobForVdkRunExtraArgsTests();
+            "default", new ApiClient(), mockBatchV1, new JobCommandProvider());
+    V1CronJob internalCronjobTemplate = getValidCronJobForVdkRunExtraArgsTests();
 
     kubernetesService =
         Mockito.spy(
             new DataJobsKubernetesService(
                 "default",
-                false,
                 new ApiClient(),
                 mockBatchV1,
-                mockBatch,
                 new JobCommandProvider()));
     Mockito.doNothing()
         .when(kubernetesService)
         .createNewJob(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
 
-    Mockito.when(mockBatch.readNamespacedCronJob(any(), any(), any()))
+    Mockito.when(mockBatchV1.readNamespacedCronJob(any(), any(), any()))
         .thenReturn(internalCronjobTemplate);
   }
 
@@ -165,24 +160,22 @@ public class KubernetesServiceStartJobWithArgumentsIT {
     }
   }
 
-  private V1beta1CronJob getValidCronJobForVdkRunExtraArgsTests() throws Exception {
+  private V1CronJob getValidCronJobForVdkRunExtraArgsTests() throws Exception {
     KubernetesService service =
         new DataJobsKubernetesService(
             "default",
-            false,
             new ApiClient(),
             new BatchV1Api(),
-            new BatchV1beta1Api(),
             new JobCommandProvider());
     // V1betaCronJob initializing snippet copied from tests above, using reflection
-    Method loadInternalV1beta1CronjobTemplate =
-        KubernetesService.class.getDeclaredMethod("loadInternalV1beta1CronjobTemplate");
-    if (loadInternalV1beta1CronjobTemplate == null) {
-      Assertions.fail("The method 'loadInternalV1beta1CronjobTemplate' does not exist.");
+    Method loadInternalV1CronjobTemplate =
+        KubernetesService.class.getDeclaredMethod("loadInternalV1CronjobTemplate");
+    if (loadInternalV1CronjobTemplate == null) {
+      Assertions.fail("The method 'loadInternalV1CronjobTemplate' does not exist.");
     }
-    loadInternalV1beta1CronjobTemplate.setAccessible(true);
-    V1beta1CronJob internalCronjobTemplate =
-        (V1beta1CronJob) loadInternalV1beta1CronjobTemplate.invoke(service);
+    loadInternalV1CronjobTemplate.setAccessible(true);
+    V1CronJob internalCronjobTemplate =
+        (V1CronJob) loadInternalV1CronjobTemplate.invoke(service);
     var container =
         internalCronjobTemplate
             .getSpec()

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartJobWithArgumentsIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartJobWithArgumentsIT.java
@@ -40,10 +40,7 @@ public class KubernetesServiceStartJobWithArgumentsIT {
     kubernetesService =
         Mockito.spy(
             new DataJobsKubernetesService(
-                "default",
-                new ApiClient(),
-                mockBatchV1,
-                new JobCommandProvider()));
+                "default", new ApiClient(), mockBatchV1, new JobCommandProvider()));
     Mockito.doNothing()
         .when(kubernetesService)
         .createNewJob(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
@@ -163,10 +160,7 @@ public class KubernetesServiceStartJobWithArgumentsIT {
   private V1CronJob getValidCronJobForVdkRunExtraArgsTests() throws Exception {
     KubernetesService service =
         new DataJobsKubernetesService(
-            "default",
-            new ApiClient(),
-            new BatchV1Api(),
-            new JobCommandProvider());
+            "default", new ApiClient(), new BatchV1Api(), new JobCommandProvider());
     // V1betaCronJob initializing snippet copied from tests above, using reflection
     Method loadInternalV1CronjobTemplate =
         KubernetesService.class.getDeclaredMethod("loadInternalV1CronjobTemplate");
@@ -174,8 +168,7 @@ public class KubernetesServiceStartJobWithArgumentsIT {
       Assertions.fail("The method 'loadInternalV1CronjobTemplate' does not exist.");
     }
     loadInternalV1CronjobTemplate.setAccessible(true);
-    V1CronJob internalCronjobTemplate =
-        (V1CronJob) loadInternalV1CronjobTemplate.invoke(service);
+    V1CronJob internalCronjobTemplate = (V1CronJob) loadInternalV1CronjobTemplate.invoke(service);
     var container =
         internalCronjobTemplate
             .getSpec()

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartNewCronJobExecutionTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartNewCronJobExecutionTest.java
@@ -12,7 +12,6 @@ import com.vmware.taurus.service.model.JobEnvVar;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
-import io.kubernetes.client.openapi.apis.BatchV1beta1Api;
 import io.kubernetes.client.openapi.models.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
@@ -53,11 +52,11 @@ public class KubernetesServiceStartNewCronJobExecutionTest {
   public void testStartNewCronJobExecution_incorrectCronJobDefinition_shouldThrowException()
       throws ApiException {
     String jobName = "test-job";
-    V1beta1CronJob expectedResult =
-        new V1beta1CronJob()
+    V1CronJob expectedResult =
+        new V1CronJob()
             .spec(
-                new V1beta1CronJobSpec()
-                    .jobTemplate(new V1beta1JobTemplateSpec().spec(new V1JobSpec())));
+                new V1CronJobSpec()
+                    .jobTemplate(new V1JobTemplateSpec().spec(new V1JobSpec())));
     var kubernetesService = mockKubernetesService(jobName, expectedResult);
 
     Exception exception =
@@ -84,12 +83,12 @@ public class KubernetesServiceStartNewCronJobExecutionTest {
     String executionId = "test-execution-id";
     V1EnvVar vdkOpIdEnv = new V1EnvVar().name(JobEnvVar.VDK_OP_ID.getValue()).value("test-op-id");
     V1EnvVar testEnv = new V1EnvVar().name("test-env-name").value("test-env-value");
-    V1beta1CronJob expectedResult =
-        new V1beta1CronJob()
+    V1CronJob expectedResult =
+        new V1CronJob()
             .spec(
-                new V1beta1CronJobSpec()
+                new V1CronJobSpec()
                     .jobTemplate(
-                        new V1beta1JobTemplateSpec()
+                        new V1JobTemplateSpec()
                             .spec(
                                 new V1JobSpec()
                                     .template(
@@ -153,12 +152,12 @@ public class KubernetesServiceStartNewCronJobExecutionTest {
             expectedAnnotationKey2,
             "test-annotation-value-1");
 
-    V1beta1CronJob expectedResult =
-        new V1beta1CronJob()
+    V1CronJob expectedResult =
+        new V1CronJob()
             .spec(
-                new V1beta1CronJobSpec()
+                new V1CronJobSpec()
                     .jobTemplate(
-                        new V1beta1JobTemplateSpec()
+                        new V1JobTemplateSpec()
                             .metadata(
                                 new V1ObjectMeta()
                                     .putAnnotationsItem(
@@ -206,26 +205,24 @@ public class KubernetesServiceStartNewCronJobExecutionTest {
     Assertions.assertEquals(expectedAnnotations, annotationsArgumentCaptor.getValue());
   }
 
-  private KubernetesService mockKubernetesService(String jobName, V1beta1CronJob result)
+  private KubernetesService mockKubernetesService(String jobName, V1CronJob result)
       throws ApiException {
-    BatchV1beta1Api batchV1beta1Api = Mockito.mock(BatchV1beta1Api.class);
+    BatchV1Api batchV1Api = Mockito.mock(BatchV1Api.class);
     Mockito.when(
-            batchV1beta1Api.readNamespacedCronJob(
+                    batchV1Api.readNamespacedCronJob(
                 Mockito.eq(jobName), Mockito.isNull(), Mockito.isNull()))
         .thenReturn(result);
 
     Mockito.when(
-            batchV1beta1Api.readNamespacedCronJob(
+            batchV1Api.readNamespacedCronJob(
                 Mockito.eq(jobName), Mockito.anyString(), Mockito.isNull()))
         .thenReturn(result);
     DataJobsKubernetesService spy =
         Mockito.spy(
             new DataJobsKubernetesService(
                 "default",
-                false,
                 new ApiClient(),
-                new BatchV1Api(),
-                batchV1beta1Api,
+                    batchV1Api,
                 new JobCommandProvider()));
     Mockito.doNothing()
         .when(spy)

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartNewCronJobExecutionTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceStartNewCronJobExecutionTest.java
@@ -54,9 +54,7 @@ public class KubernetesServiceStartNewCronJobExecutionTest {
     String jobName = "test-job";
     V1CronJob expectedResult =
         new V1CronJob()
-            .spec(
-                new V1CronJobSpec()
-                    .jobTemplate(new V1JobTemplateSpec().spec(new V1JobSpec())));
+            .spec(new V1CronJobSpec().jobTemplate(new V1JobTemplateSpec().spec(new V1JobSpec())));
     var kubernetesService = mockKubernetesService(jobName, expectedResult);
 
     Exception exception =
@@ -209,7 +207,7 @@ public class KubernetesServiceStartNewCronJobExecutionTest {
       throws ApiException {
     BatchV1Api batchV1Api = Mockito.mock(BatchV1Api.class);
     Mockito.when(
-                    batchV1Api.readNamespacedCronJob(
+            batchV1Api.readNamespacedCronJob(
                 Mockito.eq(jobName), Mockito.isNull(), Mockito.isNull()))
         .thenReturn(result);
 
@@ -220,10 +218,7 @@ public class KubernetesServiceStartNewCronJobExecutionTest {
     DataJobsKubernetesService spy =
         Mockito.spy(
             new DataJobsKubernetesService(
-                "default",
-                new ApiClient(),
-                    batchV1Api,
-                new JobCommandProvider()));
+                "default", new ApiClient(), batchV1Api, new JobCommandProvider()));
     Mockito.doNothing()
         .when(spy)
         .createNewJob(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any());

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -28,8 +28,6 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class KubernetesServiceTest {
 
@@ -219,10 +217,7 @@ public class KubernetesServiceTest {
   private static DataJobsKubernetesService newDataJobKubernetesService() {
     return Mockito.spy(
         new DataJobsKubernetesService(
-            "default",
-            new ApiClient(),
-            new BatchV1Api(),
-            new JobCommandProvider()));
+            "default", new ApiClient(), new BatchV1Api(), new JobCommandProvider()));
   }
 
   @Test
@@ -330,7 +325,6 @@ public class KubernetesServiceTest {
   public void testReadJobDeploymentStatuses() {
     var mock = newDataJobKubernetesService();
     List<JobDeploymentStatus> v1TestList = new ArrayList<>();
-
 
     JobDeploymentStatus v1DeploymentStatus = new JobDeploymentStatus();
     v1DeploymentStatus.setEnabled(false);

--- a/projects/control-service/projects/pipelines_control_service/src/test/resources/k8s-data-job-template.yaml
+++ b/projects/control-service/projects/pipelines_control_service/src/test/resources/k8s-data-job-template.yaml
@@ -1,7 +1,7 @@
 # Copyright 2023-2024 Broadcom
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations:                   # merged with additional annotations from TPCS


### PR DESCRIPTION
# Why 
External customers are looking to run on newer versions of k8s than we support. 
We are using a very old batch/V1Beta1 api. 
We need to remove all references to this.

# What 
I deleted all code which was referencing it. This looks like a massive PR but it should actually be fairly simple to review because it is just deleting code. 
 
# How was this tested??
Existing unit and integration tests. 
I will also be deploying it to newer versions of k8s this week.



Signed-off-by: murphp15 <murphp15@tcd.ie>