### PR TITLE
vdk-server: Upgrade k8s version

### DIFF
--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/installer.py
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/installer.py
@@ -484,7 +484,7 @@ class Installer:
                         "--name",
                         self.kind_cluster_name,
                         "--image",
-                        "kindest/node:v1.20.15",
+                        "kindest/node:v1.24.17",
                     ],
                     capture_output=True,
                 )


### PR DESCRIPTION
# Why
We have always used an old version of k8s in the installer because internally VDK was running on an old version and we would use it to catch regressions. 
They are now using a newer version so we can upgrade the version here accordingly

# How was this tested? 

Deployed it locally, created and ran a job. 