### PR TITLE
vdk-control-service: update helm chart documentation

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/README.md
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/README.md
@@ -1,6 +1,10 @@
 # Versatile Data Kit Service
 Versatile Data Kit is a platform that enables Data Engineers to implement automated pull ingestion (E in ELT) and batch data transformation into a database (T in ELT).
 
+**Note:** These helm charts are intended for production use only. To test a control service deployment locally,
+please install [quickstart-vdk](https://github.com/vmware/versatile-data-kit/wiki/Quickstart-VDK) and use [vdk-server](https://github.
+com/vmware/versatile-data-kit/tree/main/projects/vdk-plugins/vdk-server)
+
 ## Prerequisites
 - Kubernetes 1.24<
 - Helm 3.0


### PR DESCRIPTION
## Why?

Customers we were onboarding were confused about where to use the helm charts in our repo

## What?

Add not to the helm charts that they're only intended for production use

## How was this tested?

n/a

## What kind of change is this?

Docs