### PR TITLE
vdk-oracle: test data frames with schema inference

### DIFF
--- a/projects/vdk-plugins/vdk-oracle/requirements.txt
+++ b/projects/vdk-plugins/vdk-oracle/requirements.txt
@@ -1,7 +1,7 @@
 # this file is used to provide testing requirements
 # for requirements (dependencies) needed during and after installation of the plugin see (and update) setup.py install_requires section
 
-
+pandas
 pytest
 pytest-httpserver
 testcontainers

--- a/projects/vdk-plugins/vdk-oracle/src/vdk/plugin/oracle/ingest_to_oracle.py
+++ b/projects/vdk-plugins/vdk-oracle/src/vdk/plugin/oracle/ingest_to_oracle.py
@@ -246,6 +246,5 @@ class IngestToOracle(IIngesterPlugin):
         self._add_columns(destination_table, payload)
         self._insert_data(destination_table, payload)
 
-        # TODO: test if we need this commit statement (most probably we don't, the connection already commits after every transaction)
         self.conn.commit()
         return metadata

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-data-frame-schema-inference/00_drop_table.sql
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-data-frame-schema-inference/00_drop_table.sql
@@ -1,0 +1,4 @@
+begin
+    execute immediate 'drop table test_table';
+    exception when others then if sqlcode <> -942 then raise; end if;
+end;

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-data-frame-schema-inference/10_ingest.py
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-data-frame-schema-inference/10_ingest.py
@@ -1,0 +1,10 @@
+# Copyright 2023-2024 Broadcom
+# SPDX-License-Identifier: Apache-2.0
+from pandas import DataFrame
+from vdk.api.job_input import IJobInput
+
+
+def run(job_input: IJobInput):
+    df = DataFrame.from_dict({"A": [1], "B": [2], "C": [3]})
+
+    job_input.send_object_for_ingestion(payload=df, destination_table="test_table")

--- a/projects/vdk-plugins/vdk-oracle/tests/test_plugin.py
+++ b/projects/vdk-plugins/vdk-oracle/tests/test_plugin.py
@@ -162,6 +162,19 @@ class OracleTests(TestCase):
         cli_assert_equal(0, result)
         _verify_ingest_nan_and_none_execution(runner)
 
+    def test_oracle_ingest_data_frame_schema_inference(self):
+        runner = CliEntryBasedTestRunner(oracle_plugin)
+        result: Result = runner.invoke(
+            [
+                "run",
+                jobs_path_from_caller_directory(
+                    "oracle-ingest-data-frame-schema-inference"
+                ),
+            ]
+        )
+        cli_assert_equal(0, result)
+        _verify_ingest_data_frame_schema_inference(runner)
+
 
 def _verify_query_execution(runner):
     check_result = runner.invoke(["sql-query", "--query", "SELECT * FROM todoitem"])
@@ -308,7 +321,7 @@ def _verify_ingest_execution_different_payloads(runner):
 def _verify_ingest_blob(runner):
     check_result = runner.invoke(
         [
-            "oracle-query",
+            "sql-query",
             "--query",
             "SELECT utl_raw.cast_to_varchar2(dbms_lob.substr(blob_data,2000,1)) FROM test_table",
         ]
@@ -321,13 +334,11 @@ def _verify_ingest_blob(runner):
         "And miles to go before I sleep,\n"
         "And miles to go before I sleep.\n"
     )
-    assert check_result.output == expected
+    assert expected in check_result.output
 
 
 def _verify_ingest_nan_and_none_execution(runner):
-    check_result = runner.invoke(
-        ["oracle-query", "--query", "SELECT * FROM test_table"]
-    )
+    check_result = runner.invoke(["sql-query", "--query", "SELECT * FROM test_table"])
     expected = (
         "  ID  STR_DATA    INT_DATA    FLOAT_DATA      BOOL_DATA  "
         "TIMESTAMP_DATA         DECIMAL_DATA\n"
@@ -336,4 +347,10 @@ def _verify_ingest_nan_and_none_execution(runner):
         "   5  string                                          1  2023-11-21 "
         "08:12:53             0.1\n"
     )
-    assert check_result.output == expected
+    assert expected in check_result.output
+
+
+def _verify_ingest_data_frame_schema_inference(runner):
+    check_result = runner.invoke(["sql-query", "--query", "SELECT * FROM test_table"])
+    expected = "  A    B    C\n---  ---  ---\n  1    2    3\n"
+    assert expected in check_result.output


### PR DESCRIPTION
## Why?

After https://github.com/vmware/versatile-data-kit/pull/3181 we have to make sure schema inference works with data frames

## What?

Add data frame schema inference functional test

## What kind of change is this?

Non-breaking

## How was this tested?

Functional test