### PR TITLE
control-service: use correct tag

### DIFF
--- a/projects/control-service/cicd/deploy-testing-pipelines-service.sh
+++ b/projects/control-service/cicd/deploy-testing-pipelines-service.sh
@@ -93,7 +93,7 @@ fi
 # We are using here embedded database, and we need to set the storageclass since in our test k8s no default storage class is not set.
 helm upgrade --install --debug ${HELM_EXTRA_ARGUMENTS} --wait --timeout 10m0s $RELEASE_NAME . \
       -f "$TESTING_PIPELINES_SERVICE_VALUES_FILE" \
-      --set image.tag=1017842 \
+      --set image.tag="$TAG" \
       --set operationsUi.image.tag="$FRONTEND_TAG" \
       --set credentials.repository="EMPTY" \
       --set-file vdkOptions=$VDK_OPTIONS_SUBSTITUTED \


### PR DESCRIPTION
# Why 
In a previous merge I forgot to remove this. 