### PR TITLE
vdk-dag: add status checks functionalities

### DIFF
--- a/projects/vdk-plugins/vdk-dag/README.md
+++ b/projects/vdk-plugins/vdk-dag/README.md
@@ -119,6 +119,20 @@ def run(job_input: IJobInput) -> None:
     DagInput().run_dag(JOBS_RUN_ORDER)
 ```
 
+You can also check the statuses of the jobs after the DAG run using the DagInput API.
+
+```python
+
+
+def run(job_input: IJobInput) -> None:
+    ...
+
+    job_one_status = DagInput().get_status("job1") # get the status of a single job
+    all_statuses = DagInput().get_all_jobs_execution_status() # fetches the statuses of all the jobs in the latest dag execution
+    select_statuses = DagInput().get_jobs_execution_status(["job1", "job3"]) # fetches the execution statuses of job 1 and job 3
+```
+
+
 
 ### Runtime sequencing
 

--- a/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/api/dag.py
+++ b/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/api/dag.py
@@ -4,7 +4,9 @@ import abc
 from abc import abstractmethod
 from dataclasses import dataclass
 from dataclasses import field
-from typing import List
+from typing import List, Optional, Dict
+
+from vdk.plugin.dag.remote_data_job import JobStatus
 
 
 @dataclass
@@ -59,7 +61,7 @@ class IDagJobStatus(abc.ABC):
     """
 
     @abstractmethod
-    def get_job_status(self, job_name: str):
+    def get_job_status(self, job_name: str) -> Optional[JobStatus]:
         """
         Get job status.
         :return: JobStatus
@@ -67,7 +69,7 @@ class IDagJobStatus(abc.ABC):
         pass
 
     @abstractmethod
-    def get_all_jobs_execution_status(self):
+    def get_all_jobs_execution_status(self) -> Optional[Dict[str, JobStatus]]:
         """
         Fetches the statuses of all jobs in the latest DAG execution.
 
@@ -76,7 +78,7 @@ class IDagJobStatus(abc.ABC):
         pass
 
     @abstractmethod
-    def get_jobs_execution_status(self, job_names: List[str]):
+    def get_jobs_execution_status(self, job_names: List[str]) -> Optional[Dict[str, JobStatus]]:
         """
         Fetches the execution statuses of specified jobs.
 

--- a/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/api/dag.py
+++ b/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/api/dag.py
@@ -51,3 +51,37 @@ class IDagInput(abc.ABC):
         :return:
         """
         pass
+
+
+class IDagJobStatus(abc.ABC):
+    """
+    This class is responsible for the DAG job status checks.
+    """
+
+    @abstractmethod
+    def get_job_status(self, job_name: str):
+        """
+        Get job status.
+        :return: JobStatus
+        """
+        pass
+
+    @abstractmethod
+    def get_all_jobs_execution_status(self):
+        """
+        Fetches the statuses of all jobs in the latest DAG execution.
+
+        :return: Dict[str, JobStatus] - A dictionary where keys are job names and values are their statuses.
+        """
+        pass
+
+    @abstractmethod
+    def get_jobs_execution_status(self, job_names: List[str]):
+        """
+        Fetches the execution statuses of specified jobs.
+
+        :param job_names: List[str] - A list of job names whose statuses are to be fetched.
+        :return: Dict[str, JobStatus] - A dictionary where keys are job names from the input list and values are their
+         statuses.
+        """
+        pass

--- a/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/api/dag.py
+++ b/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/api/dag.py
@@ -4,7 +4,9 @@ import abc
 from abc import abstractmethod
 from dataclasses import dataclass
 from dataclasses import field
-from typing import List, Optional, Dict
+from typing import Dict
+from typing import List
+from typing import Optional
 
 from vdk.plugin.dag.remote_data_job import JobStatus
 
@@ -78,7 +80,9 @@ class IDagJobStatus(abc.ABC):
         pass
 
     @abstractmethod
-    def get_jobs_execution_status(self, job_names: List[str]) -> Optional[Dict[str, JobStatus]]:
+    def get_jobs_execution_status(
+        self, job_names: List[str]
+    ) -> Optional[Dict[str, JobStatus]]:
         """
         Fetches the execution statuses of specified jobs.
 

--- a/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/dag.py
+++ b/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/dag.py
@@ -34,11 +34,11 @@ def get_job_executor(executor_type: str):
 
 class Dag:
     def __init__(
-            self,
-            team_name: str,
-            dags_config: DagPluginConfiguration,
-            job_name: str = None,
-            execution_id: str = None,
+        self,
+        team_name: str,
+        dags_config: DagPluginConfiguration,
+        job_name: str = None,
+        execution_id: str = None,
     ):
         """
         This module deals with all the DAG-related operations such as build and execute.
@@ -68,11 +68,11 @@ class Dag:
             if execution_id is not None:
                 try:
                     self._started_by = (
-                            self._job_executor.execution_type(
-                                job_name, team_name, execution_id
-                            )
-                            + "/"
-                            + job_name
+                        self._job_executor.execution_type(
+                            job_name, team_name, execution_id
+                        )
+                        + "/"
+                        + job_name
                     )
                 except ApiException as e:
                     if e.status == 404:
@@ -145,8 +145,8 @@ class Dag:
 
     def _start_delayed_jobs(self):
         while (
-                len(self._job_executor.get_currently_running_jobs())
-                < self._max_concurrent_running_jobs
+            len(self._job_executor.get_currently_running_jobs())
+            < self._max_concurrent_running_jobs
         ):
             job = self._delayed_starting_jobs.dequeue()
             if job is None:
@@ -215,7 +215,9 @@ class Dag:
         :return: Dict[str, JobStatus] - A dictionary where keys are job names and values are their statuses.
         """
         all_jobs = self._job_executor.get_all_jobs()
-        all_jobs_status = {job.job_name: self._job_executor.status(job.job_name) for job in all_jobs}
+        all_jobs_status = {
+            job.job_name: self._job_executor.status(job.job_name) for job in all_jobs
+        }
         return all_jobs_status
 
     def get_jobs_execution_status(self, job_names: List[str]):
@@ -226,6 +228,7 @@ class Dag:
         :return: Dict[str, JobStatus] - A dictionary where keys are job names from the input list and values are their
          statuses.
         """
-        jobs_status = {job_name: self._job_executor.status(job_name) for job_name in job_names}
+        jobs_status = {
+            job_name: self._job_executor.status(job_name) for job_name in job_names
+        }
         return jobs_status
-

--- a/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/dag.py
+++ b/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/dag.py
@@ -34,11 +34,11 @@ def get_job_executor(executor_type: str):
 
 class Dag:
     def __init__(
-        self,
-        team_name: str,
-        dags_config: DagPluginConfiguration,
-        job_name: str = None,
-        execution_id: str = None,
+            self,
+            team_name: str,
+            dags_config: DagPluginConfiguration,
+            job_name: str = None,
+            execution_id: str = None,
     ):
         """
         This module deals with all the DAG-related operations such as build and execute.
@@ -68,11 +68,11 @@ class Dag:
             if execution_id is not None:
                 try:
                     self._started_by = (
-                        self._job_executor.execution_type(
-                            job_name, team_name, execution_id
-                        )
-                        + "/"
-                        + job_name
+                            self._job_executor.execution_type(
+                                job_name, team_name, execution_id
+                            )
+                            + "/"
+                            + job_name
                     )
                 except ApiException as e:
                     if e.status == 404:
@@ -145,8 +145,8 @@ class Dag:
 
     def _start_delayed_jobs(self):
         while (
-            len(self._job_executor.get_currently_running_jobs())
-            < self._max_concurrent_running_jobs
+                len(self._job_executor.get_currently_running_jobs())
+                < self._max_concurrent_running_jobs
         ):
             job = self._delayed_starting_jobs.dequeue()
             if job is None:
@@ -198,3 +198,34 @@ class Dag:
                 self._delayed_starting_jobs.enqueue(node)
             else:
                 raise
+
+    def get_job_status(self, job_name: str):
+        """
+        Get job status.
+
+        :param job_name: str - Job name whose status is to be fetched.
+        :return: JobStatus
+        """
+        return self._job_executor.status(job_name)
+
+    def get_all_jobs_execution_status(self):
+        """
+        Fetches the statuses of all jobs in the latest DAG execution.
+
+        :return: Dict[str, JobStatus] - A dictionary where keys are job names and values are their statuses.
+        """
+        all_jobs = self._job_executor.get_all_jobs()
+        all_jobs_status = {job.job_name: self._job_executor.status(job.job_name) for job in all_jobs}
+        return all_jobs_status
+
+    def get_jobs_execution_status(self, job_names: List[str]):
+        """
+        Fetches the execution statuses of specified jobs.
+
+        :param job_names: List[str] - A list of job names whose statuses are to be fetched.
+        :return: Dict[str, JobStatus] - A dictionary where keys are job names from the input list and values are their
+         statuses.
+        """
+        jobs_status = {job_name: self._job_executor.status(job_name) for job_name in job_names}
+        return jobs_status
+

--- a/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/dag_runner.py
+++ b/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/dag_runner.py
@@ -6,7 +6,8 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-from vdk.plugin.dag.api.dag import IDagInput, IDagJobStatus
+from vdk.plugin.dag.api.dag import IDagInput
+from vdk.plugin.dag.api.dag import IDagJobStatus
 from vdk.plugin.dag.dag import Dag
 from vdk.plugin.dag.remote_data_job import JobStatus
 
@@ -26,8 +27,8 @@ class DagInput(IDagInput, IDagJobStatus):
     """
     This module is responsible for the execution of DAG of Data Jobs and status checks after the run.
     """
-    def __init__(self):
-        self._running_dag = None
+
+    _running_dag = None  # class variable to hold the DAG instance
 
     def run_dag(self, jobs: List[Dict]):
         """
@@ -36,35 +37,44 @@ class DagInput(IDagInput, IDagJobStatus):
         :param jobs: the list of jobs that are part of the DAG
         :return:
         """
-        self._running_dag = Dag(TEAM_NAME, DAG_CONFIG, JOB_NAME, EXECUTION_ID)
-        self._running_dag.build_dag(jobs)
-        self._running_dag.execute_dag()
-        log.info(f"DAG summary:\n{self._running_dag}")
+        DagInput._running_dag = Dag(TEAM_NAME, DAG_CONFIG, JOB_NAME, EXECUTION_ID)
+        DagInput._running_dag.build_dag(jobs)
+        DagInput._running_dag.execute_dag()
+        log.info(f"DAG summary:\n{DagInput._running_dag}")
 
-    def get_job_status(self, job_name: str) -> Optional[JobStatus]:
+    @classmethod
+    def get_job_status(cls, job_name: str) -> Optional[JobStatus]:
         """
         Get job status.
         :return: JobStatus
         """
-        if self._running_dag:
-            return self._running_dag.get_job_status(job_name)
+        if cls._running_dag:
+            return cls._running_dag.get_job_status(job_name)
         else:
-            log.warning(f"Job status cannot be checked since there are no registered DAG runs!")
+            log.warning(
+                f"Job status cannot be checked since there are no registered DAG runs!"
+            )
             return None
 
-    def get_all_jobs_execution_status(self) -> Optional[Dict[str, JobStatus]]:
+    @classmethod
+    def get_all_jobs_execution_status(cls) -> Optional[Dict[str, JobStatus]]:
         """
         Fetches the statuses of all jobs in the latest DAG execution.
 
         :return: Dict[str, JobStatus] - A dictionary where keys are job names and values are their statuses.
         """
-        if self._running_dag:
-            return self._running_dag.get_all_jobs_execution_status()
+        if cls._running_dag:
+            return cls._running_dag.get_all_jobs_execution_status()
         else:
-            log.warning(f"Job statuses cannot be checked since there are no registered DAG runs!")
+            log.warning(
+                f"Job statuses cannot be checked since there are no registered DAG runs!"
+            )
             return None
 
-    def get_jobs_execution_status(self, job_names: List[str]) -> Optional[Dict[str, JobStatus]]:
+    @classmethod
+    def get_jobs_execution_status(
+        cls, job_names: List[str]
+    ) -> Optional[Dict[str, JobStatus]]:
         """
         Fetches the execution statuses of specified jobs.
 
@@ -72,8 +82,10 @@ class DagInput(IDagInput, IDagJobStatus):
         :return: Dict[str, JobStatus] - A dictionary where keys are job names from the input list and values are their
          statuses.
         """
-        if self._running_dag:
-            self._running_dag.get_jobs_execution_status(job_names)
+        if cls._running_dag:
+            cls._running_dag.get_jobs_execution_status(job_names)
         else:
-            log.warning(f"Job statuses cannot be checked since there are no registered DAG runs!!")
+            log.warning(
+                f"Job statuses cannot be checked since there are no registered DAG runs!!"
+            )
             return None

--- a/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/dag_runner.py
+++ b/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/dag_runner.py
@@ -83,7 +83,7 @@ class DagInput(IDagInput, IDagJobStatus):
          statuses.
         """
         if cls._running_dag:
-            cls._running_dag.get_jobs_execution_status(job_names)
+            return cls._running_dag.get_jobs_execution_status(job_names)
         else:
             log.warning(
                 f"Job statuses cannot be checked since there are no registered DAG runs!!"

--- a/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/dag_runner.py
+++ b/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/dag_runner.py
@@ -6,8 +6,9 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-from vdk.plugin.dag.api.dag import IDagInput
+from vdk.plugin.dag.api.dag import IDagInput, IDagJobStatus
 from vdk.plugin.dag.dag import Dag
+from vdk.plugin.dag.remote_data_job import JobStatus
 
 TEAM_NAME: Optional[str] = None
 DAG_CONFIG = None
@@ -21,10 +22,12 @@ def get_json(obj):
     return json.loads(json.dumps(obj, default=lambda o: o.__dict__))
 
 
-class DagInput(IDagInput):
+class DagInput(IDagInput, IDagJobStatus):
     """
-    This module is responsible for the execution of DAG of Data Jobs.
+    This module is responsible for the execution of DAG of Data Jobs and status checks after the run.
     """
+    def __init__(self):
+        self._running_dag = None
 
     def run_dag(self, jobs: List[Dict]):
         """
@@ -33,7 +36,44 @@ class DagInput(IDagInput):
         :param jobs: the list of jobs that are part of the DAG
         :return:
         """
-        dag = Dag(TEAM_NAME, DAG_CONFIG, JOB_NAME, EXECUTION_ID)
-        dag.build_dag(jobs)
-        dag.execute_dag()
-        log.info(f"DAG summary:\n{dag}")
+        self._running_dag = Dag(TEAM_NAME, DAG_CONFIG, JOB_NAME, EXECUTION_ID)
+        self._running_dag.build_dag(jobs)
+        self._running_dag.execute_dag()
+        log.info(f"DAG summary:\n{self._running_dag}")
+
+    def get_job_status(self, job_name: str) -> Optional[JobStatus]:
+        """
+        Get job status.
+        :return: JobStatus
+        """
+        if self._running_dag:
+            return self._running_dag.get_job_status(job_name)
+        else:
+            log.warning(f"Job status cannot be checked since there are no registered DAG runs!")
+            return None
+
+    def get_all_jobs_execution_status(self) -> Optional[Dict[str, JobStatus]]:
+        """
+        Fetches the statuses of all jobs in the latest DAG execution.
+
+        :return: Dict[str, JobStatus] - A dictionary where keys are job names and values are their statuses.
+        """
+        if self._running_dag:
+            return self._running_dag.get_all_jobs_execution_status()
+        else:
+            log.warning(f"Job statuses cannot be checked since there are no registered DAG runs!")
+            return None
+
+    def get_jobs_execution_status(self, job_names: List[str]) -> Optional[Dict[str, JobStatus]]:
+        """
+        Fetches the execution statuses of specified jobs.
+
+        :param job_names: List[str] - A list of job names whose statuses are to be fetched.
+        :return: Dict[str, JobStatus] - A dictionary where keys are job names from the input list and values are their
+         statuses.
+        """
+        if self._running_dag:
+            self._running_dag.get_jobs_execution_status(job_names)
+        else:
+            log.warning(f"Job statuses cannot be checked since there are no registered DAG runs!!")
+            return None

--- a/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/dag_runner.py
+++ b/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/dag_runner.py
@@ -52,7 +52,7 @@ class DagInput(IDagInput, IDagJobStatus):
             return cls._running_dag.get_job_status(job_name)
         else:
             log.warning(
-                f"Job status cannot be checked since there are no registered DAG runs!"
+                "Job status cannot be checked since there are no registered DAG runs!"
             )
             return None
 
@@ -67,7 +67,7 @@ class DagInput(IDagInput, IDagJobStatus):
             return cls._running_dag.get_all_jobs_execution_status()
         else:
             log.warning(
-                f"Job statuses cannot be checked since there are no registered DAG runs!"
+                "Job statuses cannot be checked since there are no registered DAG runs!"
             )
             return None
 
@@ -86,6 +86,6 @@ class DagInput(IDagInput, IDagJobStatus):
             return cls._running_dag.get_jobs_execution_status(job_names)
         else:
             log.warning(
-                f"Job statuses cannot be checked since there are no registered DAG runs!!"
+                "Job statuses cannot be checked since there are no registered DAG runs!!"
             )
             return None

--- a/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/dag_runner.py
+++ b/projects/vdk-plugins/vdk-dag/src/vdk/plugin/dag/dag_runner.py
@@ -45,7 +45,7 @@ class DagInput(IDagInput, IDagJobStatus):
     @classmethod
     def get_job_status(cls, job_name: str) -> Optional[JobStatus]:
         """
-        Get job status.
+        Get status of a specified job in the latest DAG execution.
         :return: JobStatus
         """
         if cls._running_dag:
@@ -76,7 +76,7 @@ class DagInput(IDagInput, IDagJobStatus):
         cls, job_names: List[str]
     ) -> Optional[Dict[str, JobStatus]]:
         """
-        Fetches the execution statuses of specified jobs.
+        Fetches the execution statuses of specified jobs in the latest DAG execution.
 
         :param job_names: List[str] - A list of job names whose statuses are to be fetched.
         :return: Dict[str, JobStatus] - A dictionary where keys are job names from the input list and values are their

--- a/projects/vdk-plugins/vdk-dag/tests/jobs/dag-all-status-check/config.ini
+++ b/projects/vdk-plugins/vdk-dag/tests/jobs/dag-all-status-check/config.ini
@@ -1,0 +1,2 @@
+[owner]
+team = team-awesome

--- a/projects/vdk-plugins/vdk-dag/tests/jobs/dag-all-status-check/dag.py
+++ b/projects/vdk-plugins/vdk-dag/tests/jobs/dag-all-status-check/dag.py
@@ -1,0 +1,21 @@
+# Copyright 2023-2024 Broadcom
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+from vdk.api.job_input import IJobInput
+from vdk.plugin.dag.dag_runner import DagInput
+
+log = logging.getLogger(__name__)
+
+
+def run(job_input: IJobInput):
+    log.info(f"Dummy arguments {job_input.get_arguments()}")
+
+    job1 = dict(job_name="job1", depends_on=[])
+    job2 = dict(job_name="job2", depends_on=["job1"], fail_dag_on_error=False)
+    job3 = dict(job_name="job3", depends_on=["job1"])
+    job4 = dict(job_name="job4", depends_on=["job2", "job3"])
+    DagInput().run_dag([job1, job2, job3, job4])
+    jobs_statuses = DagInput().get_all_jobs_execution_status()
+    if jobs_statuses:
+        log.info(f"All job statuses were fetched. Status: {jobs_statuses} ")

--- a/projects/vdk-plugins/vdk-dag/tests/jobs/dag-specified-status-checks/config.ini
+++ b/projects/vdk-plugins/vdk-dag/tests/jobs/dag-specified-status-checks/config.ini
@@ -1,0 +1,2 @@
+[owner]
+team = team-awesome

--- a/projects/vdk-plugins/vdk-dag/tests/jobs/dag-specified-status-checks/dag.py
+++ b/projects/vdk-plugins/vdk-dag/tests/jobs/dag-specified-status-checks/dag.py
@@ -1,0 +1,24 @@
+# Copyright 2023-2024 Broadcom
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+from vdk.api.job_input import IJobInput
+from vdk.plugin.dag.dag_runner import DagInput
+
+log = logging.getLogger(__name__)
+
+
+def run(job_input: IJobInput):
+    log.info(f"Dummy arguments {job_input.get_arguments()}")
+
+    job1 = dict(job_name="job1", depends_on=[])
+    job2 = dict(job_name="job2", depends_on=["job1"], fail_dag_on_error=False)
+    job3 = dict(job_name="job3", depends_on=["job1"])
+    job4 = dict(job_name="job4", depends_on=["job2", "job3"])
+    DagInput().run_dag([job1, job2, job3, job4])
+    job1_status = DagInput().get_job_status(job_name="job1")
+    job2_job3_status = DagInput().get_jobs_execution_status(job_names=["job2", "job3"])
+    if job1_status:
+        log.info(f"Job 1 status was fetched. Status: {job1_status} ")
+    if job2_job3_status:
+        log.info(f"Job 2 and 3 statuses were fetched. Statuses: {job2_job3_status}")

--- a/projects/vdk-plugins/vdk-dag/tests/test_dag.py
+++ b/projects/vdk-plugins/vdk-dag/tests/test_dag.py
@@ -501,3 +501,36 @@ class TestDAG:
             and req.path.split("/jobs/")[1].split("/")[0] == job_name
         ]
         return job_post_req[0].json["args"]
+
+    def test_dag_specified_status_check(self):
+        dag = "dag-specified-status-checks"
+        self._set_up(dag_name=dag)
+        with mock.patch.dict(
+            os.environ,
+            self.env_vars,
+        ):
+            self.runner = CliEntryBasedTestRunner(dag_plugin)
+            result = self._run_dag(dag)
+            cli_assert_equal(0, result)
+            assert "Job 1 status was fetched. Status: succeeded" in result.output
+            assert (
+                "Job 2 and 3 statuses were fetched. Statuses: {'job2': 'succeeded', 'job3': 'succeeded'}"
+                in result.output
+            )
+            self.httpserver.stop()
+
+    def test_dag_all_status_check(self):
+        dag = "dag-all-status-check"
+        self._set_up(dag_name=dag)
+        with mock.patch.dict(
+            os.environ,
+            self.env_vars,
+        ):
+            self.runner = CliEntryBasedTestRunner(dag_plugin)
+            result = self._run_dag(dag)
+            cli_assert_equal(0, result)
+            assert (
+                "All job statuses were fetched. Status: {'job1': 'succeeded', 'job2': 'succeeded', 'job3': 'succeeded', 'job4': 'succeeded'} "
+                in result.output
+            )
+            self.httpserver.stop()


### PR DESCRIPTION
Solving: https://github.com/vmware/versatile-data-kit/issues/3236

Note: this implementation assumes that the user wants to check the statuses of the DAG jobs after the DAG run not during the run 

Tested: functional tests

Signed-off-by: Duygu Hasan [hduygu@vmware.com](mailto:hduygu@vmware.com)