### PR TITLE
vdk-oracle: simple case checks

### DIFF
--- a/projects/vdk-plugins/vdk-oracle/README.md
+++ b/projects/vdk-plugins/vdk-oracle/README.md
@@ -142,6 +142,63 @@ def run(job_input):
 
     job_input.send_object_for_ingestion(payload=payload, destination_table="test_table")
 ```
+
+#### Case Sensitivity
+
+**vdk-oracle supports only lower-case and upper-case payload keys.** Oracle is case-insensitive by default. This is a
+challenge when ingesting payloads and doing type and schema inference, so we've opted for the simplest solution to
+avoid confusion on the user side.
+
+**Valid Ingestion**
+
+```python
+def run(job_input):
+    payload = {
+        "id": "5",
+        "str_data": "string",
+        "int_data": "12",
+        "float_data": "1.2",
+        "bool_data": "False",
+        "timestamp_data": "2023-11-21T08:12:53",
+        "decimal_data": "0.1",
+    }
+
+    job_input.send_object_for_ingestion(payload=payload, destination_table="test_table")
+```
+
+```python
+def run(job_input):
+    payload = {
+        "ID": "5",
+        "STR_DATA": "string",
+        "INT_DATA": "12",
+        "FLOAT_DATA": "1.2",
+        "BOOL_DATA": "False",
+        "TIMESTAMP_DATA": "2023-11-21T08:12:53",
+        "DECIMAL_DATA": "0.1",
+    }
+
+    job_input.send_object_for_ingestion(payload=payload, destination_table="TEST_TABLE")
+```
+
+**Invalid ingestion**
+
+Will infer the schema, but won't insert correctly.
+
+```python
+def run(job_input):
+    payload = {
+        "Id": "5",
+        "Str_Data": "string",
+        "Int_Data": "12",
+        "Float_Data": "1.2",
+        "Bool_Data": "False",
+        "Timestamp_Data": "2023-11-21T08:12:53",
+        "Decimal_Data": "0.1",
+    }
+    job_input.send_object_for_ingestion(payload=payload, destination_table="test_table")
+```
+
 ### Build and testing
 
 ```

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-data-frame-schema-inference/00_drop_table.sql
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-data-frame-schema-inference/00_drop_table.sql
@@ -1,4 +1,4 @@
 begin
-    execute immediate 'drop table test_table';
+    execute immediate 'drop table data_frame_schema_inference';
     exception when others then if sqlcode <> -942 then raise; end if;
 end;

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-data-frame-schema-inference/10_ingest.py
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-data-frame-schema-inference/10_ingest.py
@@ -7,4 +7,6 @@ from vdk.api.job_input import IJobInput
 def run(job_input: IJobInput):
     df = DataFrame.from_dict({"a": [1], "b": [2], "c": [3]})
 
-    job_input.send_object_for_ingestion(payload=df, destination_table="test_table")
+    job_input.send_object_for_ingestion(
+        payload=df, destination_table="data_frame_schema_inference"
+    )

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-blob/00_drop_table.sql
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-blob/00_drop_table.sql
@@ -1,4 +1,4 @@
 begin
-    execute immediate 'drop table test_table';
+    execute immediate 'drop table oracle_ingest_blob';
     exception when others then if sqlcode <> -942 then raise; end if;
 end;

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-blob/10_create_table.sql
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-blob/10_create_table.sql
@@ -1,4 +1,4 @@
-create table test_table (
+create table oracle_ingest_blob (
     id number,
     blob_data BLOB,
     primary key(id))

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-blob/20_ingest.py
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-blob/20_ingest.py
@@ -14,5 +14,5 @@ And miles to go before I sleep.
     }
 
     job_input.send_object_for_ingestion(
-        payload=payload_with_blob, destination_table="test_table"
+        payload=payload_with_blob, destination_table="oracle_ingest_blob"
     )

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-case-insensitive/00_drop_table.sql
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-case-insensitive/00_drop_table.sql
@@ -1,4 +1,4 @@
 begin
-    execute immediate 'drop table ingest_no_table';
+    execute immediate 'drop table oracle_ingest_case_insensitive';
     exception when others then if sqlcode <> -942 then raise; end if;
 end;

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-case-insensitive/10_create_table.sql
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-case-insensitive/10_create_table.sql
@@ -1,9 +1,8 @@
-create table oracle_ingest (
+create table oracle_ingest_case_insensitive (
     id number,
     str_data varchar2(255),
     int_data number,
     float_data float,
     bool_data number(1),
     timestamp_data timestamp,
-    decimal_data decimal(14,8),
     primary key(id))

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-case-insensitive/20_ingest.py
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-case-insensitive/20_ingest.py
@@ -1,0 +1,37 @@
+# Copyright 2023-2024 Broadcom
+# SPDX-License-Identifier: Apache-2.0
+import datetime
+
+
+def run(job_input):
+    payloads = [
+        # do not infer columns regardless of case
+        {
+            "id": 1,
+            "str_data": "string",
+            "int_data": 12,
+            "float_data": 1.2,
+            "bool_data": True,
+            "timestamp_data": datetime.datetime.utcfromtimestamp(1700554373),
+        },
+        {
+            "ID": 2,
+            "STR_DATA": "string",
+            "INT_DATA": 12,
+            "FLOAT_DATA": 1.2,
+            "BOOL_DATA": True,
+            "TIMESTAMP_DATA": datetime.datetime.utcfromtimestamp(1700554373),
+        },
+        {
+            "id": 3,
+            "str_data": "string",
+            "int_data": 12,
+            "float_data": 1.2,
+            "bool_data": True,
+            "timestamp_data": datetime.datetime.utcfromtimestamp(1700554373),
+        },
+    ]
+    for payload in payloads:
+        job_input.send_object_for_ingestion(
+            payload=payload, destination_table="oracle_ingest_case_insensitive"
+        )

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-different-payloads-no-table-special-chars/00_drop_table.sql
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-different-payloads-no-table-special-chars/00_drop_table.sql
@@ -1,4 +1,4 @@
 begin
-    execute immediate 'drop table test_table';
+    execute immediate 'drop table ingest_different_payloads_no_table_special_chars';
     exception when others then if sqlcode <> -942 then raise; end if;
 end;

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-different-payloads-no-table-special-chars/10_ingest.py
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-different-payloads-no-table-special-chars/10_ingest.py
@@ -54,5 +54,6 @@ def run(job_input):
     ]
     for payload in payloads:
         job_input.send_object_for_ingestion(
-            payload=payload, destination_table="test_table"
+            payload=payload,
+            destination_table="ingest_different_payloads_no_table_special_chars",
         )

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-different-payloads-no-table/00_drop_table.sql
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-different-payloads-no-table/00_drop_table.sql
@@ -1,4 +1,4 @@
 begin
-    execute immediate 'drop table test_table';
+    execute immediate 'drop table ingest_different_payloads_no_table';
     exception when others then if sqlcode <> -942 then raise; end if;
 end;

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-different-payloads-no-table/10_ingest.py
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-different-payloads-no-table/10_ingest.py
@@ -54,5 +54,5 @@ def run(job_input):
     ]
     for payload in payloads:
         job_input.send_object_for_ingestion(
-            payload=payload, destination_table="test_table"
+            payload=payload, destination_table="ingest_different_payloads_no_table"
         )

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-different-payloads/00_drop_table.sql
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-different-payloads/00_drop_table.sql
@@ -1,4 +1,4 @@
 begin
-    execute immediate 'drop table test_table';
+    execute immediate 'drop table ingest_different_payloads';
     exception when others then if sqlcode <> -942 then raise; end if;
 end;

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-different-payloads/10_create_table.sql
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-different-payloads/10_create_table.sql
@@ -1,4 +1,4 @@
-create table test_table (
+create table ingest_different_payloads (
     id number,
     str_data varchar2(255),
     int_data number,

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-different-payloads/20_ingest.py
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-different-payloads/20_ingest.py
@@ -54,5 +54,5 @@ def run(job_input):
     ]
     for payload in payloads:
         job_input.send_object_for_ingestion(
-            payload=payload, destination_table="test_table"
+            payload=payload, destination_table="ingest_different_payloads"
         )

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-mixed-case-error/00_drop_table.sql
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-mixed-case-error/00_drop_table.sql
@@ -1,4 +1,4 @@
 begin
-    execute immediate 'drop table ingest_no_table';
+    execute immediate 'drop table oracle_ingest_mixed_case_error';
     exception when others then if sqlcode <> -942 then raise; end if;
 end;

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-mixed-case-error/10_create_table.sql
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-mixed-case-error/10_create_table.sql
@@ -1,0 +1,8 @@
+create table oracle_ingest_mixed_case_error (
+    "id" number,
+    "Str_Data" varchar2(255),
+    "Int_Data" number,
+    "Float_Data" float,
+    "Bool_Data" number(1),
+    "Timestamp_Data" timestamp,
+    primary key("id"))

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-mixed-case-error/20_ingest.py
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-mixed-case-error/20_ingest.py
@@ -1,0 +1,38 @@
+# Copyright 2023-2024 Broadcom
+# SPDX-License-Identifier: Apache-2.0
+import datetime
+
+
+def run(job_input):
+    payloads = [
+        # do not infer columns regardless of case
+        {
+            "id": 1,
+            "str_data": "string",
+            "int_data": 12,
+            "float_data": 1.2,
+            "bool_data": True,
+            "timestamp_data": datetime.datetime.utcfromtimestamp(1700554373),
+        },
+        {
+            "ID": 2,
+            "STR_DATA": "string",
+            "INT_DATA": 12,
+            "FLOAT_DATA": 1.2,
+            "BOOL_DATA": True,
+            "TIMESTAMP_DATA": datetime.datetime.utcfromtimestamp(1700554373),
+        },
+        # ID column won't be recognized
+        {
+            "Id": 3,
+            "Str_Data": "string",
+            "Int_Data": 12,
+            "Float_Data": 1.2,
+            "Bool_Data": True,
+            "Timestamp_Data": datetime.datetime.utcfromtimestamp(1700554373),
+        },
+    ]
+    for payload in payloads:
+        job_input.send_object_for_ingestion(
+            payload=payload, destination_table="oracle_ingest_mixed_case_no_inference"
+        )

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-mixed-case-no-inference/00_drop_table.sql
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-mixed-case-no-inference/00_drop_table.sql
@@ -1,4 +1,4 @@
 begin
-    execute immediate 'drop table ingest_no_table';
+    execute immediate 'drop table oracle_mixed_case_no_inference';
     exception when others then if sqlcode <> -942 then raise; end if;
 end;

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-mixed-case-no-inference/20_ingest.py
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-mixed-case-no-inference/20_ingest.py
@@ -1,0 +1,29 @@
+# Copyright 2023-2024 Broadcom
+# SPDX-License-Identifier: Apache-2.0
+import datetime
+
+
+def run(job_input):
+    payloads = [
+        # Schema wil be inferred but nothing will be ingested
+        {
+            "Id": 1,
+            "Str_Data": "string",
+            "Int_Data": 12,
+            "Float_Data": 1.2,
+            "Bool_Data": True,
+            "Timestamp_Data": datetime.datetime.utcfromtimestamp(1700554373),
+        },
+        {
+            "Id": 2,
+            "Str_Data": "string",
+            "Int_Data": 12,
+            "Float_Data": 1.2,
+            "Bool_Data": True,
+            "Timestamp_Data": datetime.datetime.utcfromtimestamp(1700554373),
+        },
+    ]
+    for payload in payloads:
+        job_input.send_object_for_ingestion(
+            payload=payload, destination_table="oracle_ingest_mixed_case_no_inference"
+        )

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-no-table-special-chars/00_drop_table.sql
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-no-table-special-chars/00_drop_table.sql
@@ -1,4 +1,4 @@
 begin
-    execute immediate 'drop table test_table';
+    execute immediate 'drop table no_table_special_chars';
     exception when others then if sqlcode <> -942 then raise; end if;
 end;

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-no-table-special-chars/10_ingest.py
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-no-table-special-chars/10_ingest.py
@@ -44,5 +44,7 @@ def run(job_input):
         ],
     ]
     job_input.send_tabular_data_for_ingestion(
-        rows=row_data, column_names=col_names, destination_table="test_table"
+        rows=row_data,
+        column_names=col_names,
+        destination_table="no_table_special_chars",
     )

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-no-table/10_ingest.py
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-no-table/10_ingest.py
@@ -44,5 +44,5 @@ def run(job_input):
         ],
     ]
     job_input.send_tabular_data_for_ingestion(
-        rows=row_data, column_names=col_names, destination_table="test_table"
+        rows=row_data, column_names=col_names, destination_table="ingest_no_table"
     )

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-special-chars/00_drop_table.sql
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-special-chars/00_drop_table.sql
@@ -1,4 +1,4 @@
 begin
-    execute immediate 'drop table test_table';
+    execute immediate 'drop table ingest_special_chars';
     exception when others then if sqlcode <> -942 then raise; end if;
 end;

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-special-chars/10_create_table.sql
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-special-chars/10_create_table.sql
@@ -1,4 +1,4 @@
-create table test_table (
+create table ingest_special_chars (
     id number,
     "@str_data" varchar2(255),
     "%int_data" number,

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-special-chars/20_ingest.py
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-special-chars/20_ingest.py
@@ -16,5 +16,5 @@ def run(job_input):
     }
 
     job_input.send_object_for_ingestion(
-        payload=payload_with_types, destination_table="test_table"
+        payload=payload_with_types, destination_table="ingest_special_chars"
     )

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-type-inference/00_drop_table.sql
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-type-inference/00_drop_table.sql
@@ -1,4 +1,4 @@
 begin
-    execute immediate 'drop table test_table';
+    execute immediate 'drop table ingest_type_inference';
     exception when others then if sqlcode <> -942 then raise; end if;
 end;

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-type-inference/10_create_table.sql
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-type-inference/10_create_table.sql
@@ -1,4 +1,4 @@
-create table test_table (
+create table ingest_type_inference (
     id number,
     str_data varchar2(255),
     int_data number,

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-type-inference/20_ingest.py
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job-type-inference/20_ingest.py
@@ -15,4 +15,6 @@ def run(job_input):
         "decimal_data": "0.1",
     }
 
-    job_input.send_object_for_ingestion(payload=payload, destination_table="test_table")
+    job_input.send_object_for_ingestion(
+        payload=payload, destination_table="ingest_type_inference"
+    )

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job/00_drop_table.sql
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job/00_drop_table.sql
@@ -1,4 +1,4 @@
 begin
-    execute immediate 'drop table test_table';
+    execute immediate 'drop table oracle_ingest';
     exception when others then if sqlcode <> -942 then raise; end if;
 end;

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job/20_ingest.py
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-job/20_ingest.py
@@ -16,5 +16,5 @@ def run(job_input):
     }
 
     job_input.send_object_for_ingestion(
-        payload=payload_with_types, destination_table="test_table"
+        payload=payload_with_types, destination_table="oracle_ingest"
     )

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-nan-job/00_drop_table.sql
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-nan-job/00_drop_table.sql
@@ -1,4 +1,4 @@
 begin
-    execute immediate 'drop table test_table';
+    execute immediate 'drop table ingest_nan_table';
     exception when others then if sqlcode <> -942 then raise; end if;
 end;

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-nan-job/10_create_table.sql
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-nan-job/10_create_table.sql
@@ -1,4 +1,4 @@
-create table test_table (
+create table ingest_nan_table (
     id number,
     str_data varchar2(255),
     int_data number,

--- a/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-nan-job/20_ingest.py
+++ b/projects/vdk-plugins/vdk-oracle/tests/jobs/oracle-ingest-nan-job/20_ingest.py
@@ -18,5 +18,7 @@ def run(job_input: IJobInput):
     }
 
     job_input.send_object_for_ingestion(
-        payload=payload_with_types, destination_table="test_table", method="oracle"
+        payload=payload_with_types,
+        destination_table="ingest_nan_table",
+        method="oracle",
     )


### PR DESCRIPTION
## Why?

Oracle is case-insesitive. This makes it hard to support variable-case ingestion payload keys.

## What?

Precess only upper and lower-case payload keys.
Payload keys with special chars get processed as is.
Update tests to not write to the same table and use different tables.
Update documentation

## What kind of change is this?

Feature/non-breaking

## How was this tested?

Functional tests