### PR TITLE
vdk-server: Wrap installation/uninstallation to catch any uncaught errors

### DIFF
--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/installer.py
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/installer.py
@@ -63,7 +63,6 @@ class Installer:
         log.info(
             f"Starting installation of Versatile Data Kit Control Service (this may take several minutes)"
         )
-        raise Exception("install fail")
         self.__create_kind_cluster()
         self.__create_docker_registry_container()
         self.__create_git_server_container()

--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/installer.py
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/installer.py
@@ -63,6 +63,7 @@ class Installer:
         log.info(
             f"Starting installation of Versatile Data Kit Control Service (this may take several minutes)"
         )
+        raise Exception("install fail")
         self.__create_kind_cluster()
         self.__create_docker_registry_container()
         self.__create_git_server_container()

--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/server_plugin.py
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/server_plugin.py
@@ -4,12 +4,24 @@
 VDK Server plugin script.
 """
 import logging
+from typing import Callable
 
 import click
 from vdk.api.plugin.hook_markers import hookimpl
 from vdk.plugin.server.installer import Installer
 
 log = logging.getLogger(__name__)
+
+
+# wrap a vdk-server command to account for any uncaught exceptions
+def uncaught_exception_wrapper(server_command: Callable):
+    try:
+        server_command()
+    except Exception as e:
+        import traceback
+        tb = traceback.format_exc()
+        log.info(tb)
+        log.info("Uncaught exception during installation: " + str(e))
 
 
 @click.command(
@@ -71,9 +83,9 @@ def server(install, uninstall, status):
     else:
         installer = Installer()
         if install:
-            installer.install()
+            uncaught_exception_wrapper(installer.install)
         elif uninstall:
-            installer.uninstall()
+            uncaught_exception_wrapper(installer.uninstall)
         else:
             installer.check_status()
 

--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/server_plugin.py
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/server_plugin.py
@@ -13,16 +13,7 @@ from vdk.plugin.server.installer import Installer
 log = logging.getLogger(__name__)
 
 
-# wrap a vdk-server command to account for any uncaught exceptions
-def uncaught_exception_wrapper(server_command: Callable):
-    try:
-        server_command()
-    except Exception as e:
-        import traceback
 
-        tb = traceback.format_exc()
-        log.info(tb)
-        log.info("Uncaught exception during installation: " + str(e))
 
 
 @click.command(
@@ -69,27 +60,29 @@ def uncaught_exception_wrapper(server_command: Callable):
     help="Returns whether a local Control Service is currently installed.",
 )
 def server(install, uninstall, status):
-    flags = 0
-    if install:
-        flags += 1
-    if uninstall:
-        flags += 1
-    if status:
-        flags += 1
-
-    if flags != 1:
-        click.echo(
-            "Exactly one of --install, --uninstall, or --status options should be specified"
-        )
-    else:
-        installer = Installer()
+    try:
+        flags = 0
         if install:
-            uncaught_exception_wrapper(installer.install)
-        elif uninstall:
-            uncaught_exception_wrapper(installer.uninstall)
+            flags += 1
+        if uninstall:
+            flags += 1
+        if status:
+            flags += 1
+        if flags != 1:
+            click.echo(
+                "Exactly one of --install, --uninstall, or --status options should be specified"
+            )
         else:
-            installer.check_status()
-
+            raise Exception("paul test")
+            installer = Installer()
+            if install:
+                installer.install()
+            elif uninstall:
+                installer.uninstall()
+            else:
+                installer.check_status()
+    except Exception as e:
+        log.exception("VDK CLI command failed")
 
 @hookimpl
 def vdk_command_line(root_command: click.Group):

--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/server_plugin.py
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/server_plugin.py
@@ -13,9 +13,6 @@ from vdk.plugin.server.installer import Installer
 log = logging.getLogger(__name__)
 
 
-
-
-
 @click.command(
     name="server",
     help="Installs (and runs) or uninstalls a local Control Service."
@@ -83,6 +80,7 @@ def server(install, uninstall, status):
                 installer.check_status()
     except Exception as e:
         log.exception("VDK CLI command failed")
+
 
 @hookimpl
 def vdk_command_line(root_command: click.Group):

--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/server_plugin.py
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/server_plugin.py
@@ -19,6 +19,7 @@ def uncaught_exception_wrapper(server_command: Callable):
         server_command()
     except Exception as e:
         import traceback
+
         tb = traceback.format_exc()
         log.info(tb)
         log.info("Uncaught exception during installation: " + str(e))

--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/server_plugin.py
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/server_plugin.py
@@ -4,7 +4,6 @@
 VDK Server plugin script.
 """
 import logging
-from typing import Callable
 
 import click
 from vdk.api.plugin.hook_markers import hookimpl

--- a/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/server_plugin.py
+++ b/projects/vdk-plugins/vdk-server/src/vdk/plugin/server/server_plugin.py
@@ -69,7 +69,6 @@ def server(install, uninstall, status):
                 "Exactly one of --install, --uninstall, or --status options should be specified"
             )
         else:
-            raise Exception("paul test")
             installer = Installer()
             if install:
                 installer.install()


### PR DESCRIPTION
This PR wraps both the `installer.install` and `installer.uninstall` in a wrapper function to ensure any uncaught exceptions can still alert the user.

This is a somewhat hacky solution and I'm not 100% clear on why this behavior appears here.

Testing done: raised exception inside installer code manually and checked output