### PR TITLE
vdk-core: on-failure hook exception argument

### DIFF
--- a/projects/vdk-core/src/vdk/api/plugin/connection_hook_spec.py
+++ b/projects/vdk-core/src/vdk/api/plugin/connection_hook_spec.py
@@ -179,7 +179,9 @@ class ConnectionHookSpec:
         pass
 
     @hookspec
-    def db_connection_on_operation_failure(self, operation: ManagedOperation) -> None:
+    def db_connection_on_operation_failure(
+        self, operation: ManagedOperation, exception: Exception
+    ) -> None:
         """
         Executes if a database operation fails. Gives the caller a chance to log the error,
         send metrics or otherwise take action on failure.
@@ -192,6 +194,8 @@ class ConnectionHookSpec:
 
         :param operation: ManagedOperation
             ManagedOperation object. Provides the operation (usually an SQL expression and some metadata)
+        :param exception: Exception
+            the exception that was thrown
         :return:
         """
         pass

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
@@ -366,7 +366,7 @@ class ManagedCursor(ProxyCursor):
             and self.__connection_hook_spec.db_connection_on_operation_failure.get_hookimpls()
         ):
             self.__connection_hook_spec.db_connection_on_operation_failure(
-                operation=managed_operation
+                operation=managed_operation, exception=exception
             )
 
         recovery_cursor = RecoveryCursor(

--- a/projects/vdk-core/tests/functional/run/test_run_restricted_hooks.py
+++ b/projects/vdk-core/tests/functional/run/test_run_restricted_hooks.py
@@ -74,8 +74,11 @@ class OperationFailureSqLite3MemoryDbPlugin:
             self._counter += 1
 
     @hookimpl(trylast=True)
-    def db_connection_on_operation_failure(self, operation: ManagedOperation) -> None:
+    def db_connection_on_operation_failure(
+        self, operation: ManagedOperation, exception: Exception
+    ) -> None:
         log.info(f"Operation {operation.get_operation()} went horribly wrong")
+        log.exception(exception)
 
 
 @mock.patch.dict(os.environ, {VDK_DB_DEFAULT_TYPE: DB_TYPE_SQLITE_MEMORY})
@@ -117,7 +120,11 @@ def test_on_failure_hook():
         "INSERT INTO stocks VALUES ('2020-01-01', 'GOOG', Syntax error )\n"
         " went horribly wrong\n"
     )
+
+    expected_exception_on_failure = 'near "error": syntax error'
+
     assert expected_on_failure in result.output
+    assert expected_exception_on_failure in result.output
 
     # Make sure the before hook was called for the on-failure operation
     expected_before = "Operation -- count: 2"


### PR DESCRIPTION
## Why?

Hook implementations for the failure hook also require that we expose the exception as an argument

## What?

Add the exception as an argument to the on-failure hook

## How was this tested?

Functional test

## What kind of change is this?

Feature/non-breaking