### PR TITLE
control-service: errors should be correctly propagated.

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -312,13 +312,13 @@ public abstract class KubernetesService {
     log.debug("Reading k8s V1 cron job: {}", cronJobName);
     try {
       return mapV1CronJobToDeploymentStatus(
-              batchV1Api.readNamespacedCronJob(cronJobName, namespace, null), cronJobName);
+          batchV1Api.readNamespacedCronJob(cronJobName, namespace, null), cronJobName);
     } catch (ApiException e) {
       if (e.getCode() == 404) {
         log.warn(
-                "Could not read cron job: {}; reason: {}",
-                cronJobName,
-                new KubernetesException("", e).toString());
+            "Could not read cron job: {}; reason: {}",
+            cronJobName,
+            new KubernetesException("", e).toString());
         return Optional.empty();
       } else {
         throw new KubernetesException("", e);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -309,22 +309,21 @@ public abstract class KubernetesService {
    *     Optional if the cron job does not exist or cannot be read
    */
   public Optional<JobDeploymentStatus> readCronJob(String cronJobName) {
-    return readV1CronJob(cronJobName);
-  }
-
-  public Optional<JobDeploymentStatus> readV1CronJob(String cronJobName) {
     log.debug("Reading k8s V1 cron job: {}", cronJobName);
-    V1CronJob cronJob = null;
     try {
-      cronJob = batchV1Api.readNamespacedCronJob(cronJobName, namespace, null);
+      return mapV1CronJobToDeploymentStatus(
+              batchV1Api.readNamespacedCronJob(cronJobName, namespace, null), cronJobName);
     } catch (ApiException e) {
-      log.warn(
-          "Could not read cron job: {}; reason: {}",
-          cronJobName,
-          new KubernetesException("", e).toString());
+      if (e.getCode() == 404) {
+        log.warn(
+                "Could not read cron job: {}; reason: {}",
+                cronJobName,
+                new KubernetesException("", e).toString());
+        return Optional.empty();
+      } else {
+        throw new KubernetesException("", e);
+      }
     }
-
-    return mapV1CronJobToDeploymentStatus(cronJob, cronJobName);
   }
 
   /**

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/DataJobsDeploymentControllerTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/DataJobsDeploymentControllerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023-2024 Broadcom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.datajobs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vmware.taurus.ControlplaneApplication;
+import com.vmware.taurus.controlplane.model.data.DataJob;
+import com.vmware.taurus.controlplane.model.data.DataJobConfig;
+import com.vmware.taurus.service.JobsService;
+import com.vmware.taurus.service.kubernetes.DataJobsKubernetesService;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.BatchV1Api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+@AutoConfigureMockMvc
+@ExtendWith(MockitoExtension.class)
+@SpringBootTest(
+        classes = {ControlplaneApplication.class},
+        properties = {"datajobs.control.k8s.k8sSupportsV1CronJob=true"})
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class DataJobsDeploymentControllerTest {
+
+    @Autowired protected MockMvc mockMvc;
+    @Autowired protected JobsService jobService;
+
+    @MockBean(name = "deploymentBatchV1Api")
+    private BatchV1Api batchV1Api;
+
+    @SpyBean private DataJobsKubernetesService dataJobsKubernetesService;
+
+    @Test
+    public void whenKubernetesIsUnavailableTheControlPlaneShouldReturnAnErrorInsteadOfSayingNoJobs()
+            throws Exception {
+        Mockito.doNothing().when(dataJobsKubernetesService).saveSecretData(any(), any());
+        //   This exception encompasses random exceptions from k8s but also version incompatibility
+        // issues.
+        Mockito.when(batchV1Api.readNamespacedCronJob(Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenThrow(new ApiException("", null, 500, null, ""));
+
+        mockMvc
+                .perform(
+                        post("/data-jobs/for-team/team-name/jobs")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        new ObjectMapper()
+                                                .writeValueAsString(new DataJob("job-name", "desc", new DataJobConfig()))))
+                .andExpect(status().is(201));
+        mockMvc
+                .perform(get("/data-jobs/for-team/team-name/jobs/job-name/deployments"))
+                .andExpect(status().is(503));
+    }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/DataJobsDeploymentControllerTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/datajobs/DataJobsDeploymentControllerTest.java
@@ -36,38 +36,38 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 @AutoConfigureMockMvc
 @ExtendWith(MockitoExtension.class)
 @SpringBootTest(
-        classes = {ControlplaneApplication.class},
-        properties = {"datajobs.control.k8s.k8sSupportsV1CronJob=true"})
+    classes = {ControlplaneApplication.class},
+    properties = {"datajobs.control.k8s.k8sSupportsV1CronJob=true"})
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class DataJobsDeploymentControllerTest {
 
-    @Autowired protected MockMvc mockMvc;
-    @Autowired protected JobsService jobService;
+  @Autowired protected MockMvc mockMvc;
+  @Autowired protected JobsService jobService;
 
-    @MockBean(name = "deploymentBatchV1Api")
-    private BatchV1Api batchV1Api;
+  @MockBean(name = "deploymentBatchV1Api")
+  private BatchV1Api batchV1Api;
 
-    @SpyBean private DataJobsKubernetesService dataJobsKubernetesService;
+  @SpyBean private DataJobsKubernetesService dataJobsKubernetesService;
 
-    @Test
-    public void whenKubernetesIsUnavailableTheControlPlaneShouldReturnAnErrorInsteadOfSayingNoJobs()
-            throws Exception {
-        Mockito.doNothing().when(dataJobsKubernetesService).saveSecretData(any(), any());
-        //   This exception encompasses random exceptions from k8s but also version incompatibility
-        // issues.
-        Mockito.when(batchV1Api.readNamespacedCronJob(Mockito.any(), Mockito.any(), Mockito.any()))
-                .thenThrow(new ApiException("", null, 500, null, ""));
+  @Test
+  public void whenKubernetesIsUnavailableTheControlPlaneShouldReturnAnErrorInsteadOfSayingNoJobs()
+      throws Exception {
+    Mockito.doNothing().when(dataJobsKubernetesService).saveSecretData(any(), any());
+    //   This exception encompasses random exceptions from k8s but also version incompatibility
+    // issues.
+    Mockito.when(batchV1Api.readNamespacedCronJob(Mockito.any(), Mockito.any(), Mockito.any()))
+        .thenThrow(new ApiException("", null, 500, null, ""));
 
-        mockMvc
-                .perform(
-                        post("/data-jobs/for-team/team-name/jobs")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(
-                                        new ObjectMapper()
-                                                .writeValueAsString(new DataJob("job-name", "desc", new DataJobConfig()))))
-                .andExpect(status().is(201));
-        mockMvc
-                .perform(get("/data-jobs/for-team/team-name/jobs/job-name/deployments"))
-                .andExpect(status().is(503));
-    }
+    mockMvc
+        .perform(
+            post("/data-jobs/for-team/team-name/jobs")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    new ObjectMapper()
+                        .writeValueAsString(new DataJob("job-name", "desc", new DataJobConfig()))))
+        .andExpect(status().is(201));
+    mockMvc
+        .perform(get("/data-jobs/for-team/team-name/jobs/job-name/deployments"))
+        .andExpect(status().is(503));
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -351,12 +351,12 @@ public class KubernetesServiceTest {
     testDeploymentStatus.setDataJobName(testCronjobName);
     testDeploymentStatus.setCronJobName(testCronjobName);
 
-    Mockito.when(mock.readV1CronJob(testCronjobName)).thenReturn(Optional.of(testDeploymentStatus));
+    Mockito.when(mock.readCronJob(testCronjobName)).thenReturn(Optional.of(testDeploymentStatus));
 
     Assertions.assertNotNull(mock.readCronJob(testCronjobName));
     Assertions.assertEquals(
         testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
-    verify(mock, times(2)).readV1CronJob(testCronjobName);
+    verify(mock, times(2)).readCronJob(testCronjobName);
   }
 
   @Test


### PR DESCRIPTION
# Why
At the moment if the kubernetes client throws and error then we assume that the job is not there. 
This is obviously not correct. We should only consider the job not there if it is a 404. 

# What
Now we check to see the status to decide what to do. 

# How was this tested
New unit test which mock k8s responses.


Signed-off-by: murphp15 <murphp15@tcd.ie>