### PR TITLE
control-service: increase cockroach mem

### DIFF
--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -631,7 +631,7 @@ cockroachdb:
     enabled: false
    storage:
       persistentVolume:
-         size: 1Gi
+         size: 5Gi
    statefulset:
       replicas: 3
       resources:


### PR DESCRIPTION
# Why
CICD pipeline is failing because cockroach doesn't have enough mem