### PR TITLE
vdk-core: remove hook checks

### DIFF
--- a/projects/vdk-core/src/vdk/api/plugin/connection_hook_spec.py
+++ b/projects/vdk-core/src/vdk/api/plugin/connection_hook_spec.py
@@ -52,28 +52,6 @@ class ConnectionHookSpec:
         pass
 
     @hookspec
-    def db_connection_decorate_operation(
-        self, decoration_cursor: DecorationCursor
-    ) -> None:
-        """
-        Curates the operation and parameters.
-        If an exception is raised, the cursor execution will be suspended.
-
-        For example:
-        @hookimpl
-        db_connection_decorate_operation(decoration_cursor: DecorationCursor):
-            managed_operation = decoration_cursor.get_managed_operation()
-            managed_operation.set_operation("prefix" +
-                                             managed_operation.get_operation())
-
-        :param decoration_cursor: DecorationCursor
-            A PEP249Cursor implementation purposed for query and parameters decoration.
-            Provides operation details and tooling.
-        :return:
-        """
-        pass
-
-    @hookspec
     def db_connection_before_operation(self, operation: ManagedOperation) -> None:
         """
         Curates the operation and parameters.
@@ -87,93 +65,6 @@ class ConnectionHookSpec:
 
         :param operation: ManagedOperation
             ManagedOperation object. Provides the operation (usually an SQL expression and some metadata)
-        :return:
-        """
-        pass
-
-    @hookspec(firstresult=True)
-    def db_connection_execute_operation(
-        self, execution_cursor: ExecutionCursor
-    ) -> Optional[ExecuteOperationResult]:
-        """
-        The method that executes the actual SQL query using execution cursor.
-
-        When the hook is called the call loop will only invoke up to
-        the first hookimpl which returns a result other then None.
-        It is then taken as result of the overall hook call.
-
-        You can see the default implementation at DefaultConnectionHookImpl.
-
-        If you want to override the default implementation return a non-None result using tryfirst=True or no decorator.
-        But in most cases you would not need to overwrite the default implementation (hence return None).
-        If some hookimpl function raises an exception, the behaviour is as outlined in hook_markers module
-
-        Often it may be needed to wrap around it so that you can track the execution of the query.
-
-        For example:
-
-        .. code-block::
-
-            @hookimpl(hookwrapper=True)
-            db_connection_execute_operation(execution_cursor: ExecutionCursor) -> Optional[int]:
-                # let's track duration of the query
-                start = time.time()
-                log.info(f"Starting query: {execution_cursor.get_managed_operation().get_operation()}")
-                outcome: HookCallResult
-                outcome = yield # we yield the execution to other implementations (including default one)
-                is_success: bool = outcome.excinfo is None
-                log.info(f"Query finished. duration: {time.time() - start}. is_success: {is_success}")
-                # no return!
-
-        Another example - we want to change the result
-
-        .. code-block::
-
-            @hookimpl(hookwrapper=True)
-            db_connection_execute_operation(execution_cursor: ExecutionCursor) -> Optional[int]:
-                outcome: HookCallResult
-                outcome = yield #
-                outcome.force_result(new_result)  # set new return result
-
-        Another example - let's say we are writing vdk-impala plugin and want to print more debug info
-        which is available from the Impala native cursor (provided by impyla library)
-
-        .. code-block::
-
-            @hookimpl(hookwrapper=True)
-            db_connection_execute_operation(execution_cursor: ExecutionCursor) -> Optional[int]:
-                yield # let the query execute first
-                c = cast(impala.interface.Cursor, execution_cursor)
-                log.info(f"Query {execution_cursor.get_managed_operation().get_operation()} debug info:"
-                         f"summary: {c.get_summary()}, profile: {c.get_profile()}")
-
-
-        :param execution_cursor: ExecutionCursor
-            A PEP249Cursor implementation purposed for actual query execution.
-        """
-        pass
-
-    @hookspec
-    def db_connection_recover_operation(self, recovery_cursor: RecoveryCursor) -> None:
-        """
-        Recovers the operation initiated. Retries made number is auto-incremented.
-        If no exception is raised, cursor is considered successfully executed.
-
-        For example:
-        @hookimpl
-        db_connection_recover_operation(recovery_cursor: RecoveryCursor):
-            while recovery_cursor.get_retries() < MAX_RETRIES:
-                try:
-                    recovery_cursor.execute("helper query")
-                    recovery_cursor.retry_operation()
-                    return
-                except:
-                    time.sleep(3 * recovery_cursor.get_retries()) # backoff
-            raise recovery_cursor.get_exception()
-
-        :param recovery_cursor: RecoveryCursor
-            A PEP249Cursor implementation purposed for query and parameters recovery.
-            Provides operation details and tooling.
         :return:
         """
         pass

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/connection_plugin.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/connection_plugin.py
@@ -23,16 +23,13 @@ class QueryDecoratorPlugin:
         self._op_id = context.state.get(CommonStoreKeys.OP_ID)
 
     @hookimpl
-    def db_connection_decorate_operation(
-        self, decoration_cursor: DecorationCursor
-    ) -> None:
-        managed_operation = decoration_cursor.get_managed_operation()
-        managed_operation.set_operation(
+    def db_connection_before_operation(self, operation: ManagedOperation) -> None:
+        operation.set_operation(
             "\n".join(
                 ["-- job_name: {job_name}", "-- op_id: {op_id}", "{operation}"]
             ).format(
                 job_name=self._job_name,
                 op_id=self._op_id,
-                operation=managed_operation.get_operation(),
+                operation=operation.get_operation(),
             )
         )

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/database_managed_connection.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/database_managed_connection.py
@@ -97,7 +97,7 @@ class IDatabaseManagedConnection:
             Provides operation details and tooling.
         :return:
         """
-        pass
+        raise recovery_cursor.get_exception()
 
     def db_connection_after_operation(self, execution_cursor: ExecutionCursor) -> None:
         """

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/connection/managed_cursor.py
@@ -129,31 +129,11 @@ class ManagedCursor(ProxyCursor):
                 raise e
 
     def _decorate_operation(self, managed_operation: ManagedOperation, operation: str):
-        decorate_operation = None
+        decorate_operation = (
+            self.__managed_database_connection.db_connection_decorate_operation
+        )
 
-        # Check if database decorate operation is overridden by a plugin.
-        # Use the overridden method if available.
-        # Otherwise, verify the presence of hooks; if absent, use the default hook implementation.
-        if (
-            self.__managed_database_connection
-            and type(
-                self.__managed_database_connection
-            ).db_connection_decorate_operation
-            != IDatabaseManagedConnection.db_connection_decorate_operation
-        ):
-            decorate_operation = (
-                self.__managed_database_connection.db_connection_decorate_operation
-            )
-
-        elif (
-            self.__connection_hook_spec
-            and self.__connection_hook_spec.db_connection_decorate_operation.get_hookimpls()
-        ):
-            decorate_operation = (
-                self.__connection_hook_spec.db_connection_decorate_operation
-            )
-
-        # apply any changes @hookimpls to the managed operation
+        # apply any changes from @hookimpls to the managed operation
         if (
             self.__connection_hook_spec
             and self.__connection_hook_spec.db_connection_before_operation.get_hookimpls()
@@ -182,77 +162,48 @@ class ManagedCursor(ProxyCursor):
                 raise e
 
     def _validate_operation(self, operation: str, parameters: Optional[Container]):
-        validate_operation = None
+        hook_validate_operation = None
 
-        # Check if database validate operation is overridden by a plugin.
-        # Use the overridden method if available.
-        # Otherwise, verify the presence of hooks; if absent, use the default hook implementation.
+        db_validate_operation = (
+            self.__managed_database_connection.db_connection_validate_operation
+        )
+
         if (
-            self.__managed_database_connection
-            and type(
-                self.__managed_database_connection
-            ).db_connection_validate_operation
-            != IDatabaseManagedConnection.db_connection_validate_operation
-        ):
-            validate_operation = (
-                self.__managed_database_connection.db_connection_validate_operation
-            )
-
-        elif (
             self.__connection_hook_spec
             and self.__connection_hook_spec.db_connection_validate_operation.get_hookimpls()
         ):
-            validate_operation = (
+            hook_validate_operation = (
                 self.__connection_hook_spec.db_connection_validate_operation
             )
 
-        if validate_operation:
-            self._log.debug("Validating query:\n%s" % operation)
-            try:
-                validate_operation(operation=operation, parameters=parameters)
-            except Exception as e:
-                self._log.error(
-                    "\n".join(
-                        [
-                            "Validating query FAILED.",
-                            errors.MSG_WHY_FROM_EXCEPTION(e),
-                        ]
-                    )
+        self._log.debug("Validating query:\n%s" % operation)
+        try:
+            if hook_validate_operation:
+                hook_validate_operation(operation=operation, parameters=parameters)
+            if db_validate_operation:
+                db_validate_operation(operation=operation, parameters=parameters)
+        except Exception as e:
+            self._log.error(
+                "\n".join(
+                    [
+                        "Validating query FAILED.",
+                        errors.MSG_WHY_FROM_EXCEPTION(e),
+                    ]
                 )
-                errors.report(
-                    errors.ResolvableBy.USER_ERROR,
-                    exception=e,
-                )
-                raise e
+            )
+            errors.report(
+                errors.ResolvableBy.USER_ERROR,
+                exception=e,
+            )
+            raise e
 
     def _execute_operation(self, managed_operation: ManagedOperation):
         self._log.info("Executing query:\n%s" % managed_operation.get_operation())
         execution_cursor = ExecutionCursor(self._cursor, managed_operation, self._log)
 
-        # Check if database execute operation is overridden by a plugin.
-        # Use the overridden method if available.
-        # Otherwise, verify the presence of hooks; if absent, use the default hook implementation.
-        if (
-            self.__managed_database_connection
-            and type(self.__managed_database_connection).db_connection_execute_operation
-            != IDatabaseManagedConnection.db_connection_execute_operation
-        ):
-            result = self.__managed_database_connection.db_connection_execute_operation(
-                execution_cursor=execution_cursor
-            )
-
-        elif self.__connection_hook_spec:
-            result = self.__connection_hook_spec.db_connection_execute_operation(
-                execution_cursor=execution_cursor
-            )
-        else:
-            self._log.debug(
-                "No connection hook spec defined. "
-                "Will invoke standard cursor execute implementation."
-            )
-            result = DefaultConnectionHookImpl().db_connection_execute_operation(
-                execution_cursor
-            )
+        result = self.__managed_database_connection.db_connection_execute_operation(
+            execution_cursor=execution_cursor
+        )
         return result
 
     def _after_operation(self, managed_operation: ManagedOperation):
@@ -302,54 +253,12 @@ class ManagedCursor(ProxyCursor):
     def _recover_operation(self, exception, managed_operation):
         # TODO: configurable generic re-try.
 
-        # Check if database recover and decorate operations are overridden by a plugin.
-        # Use the overridden methods if available.
-        # Otherwise, verify the presence of hooks; if absent, use the default hook implementation.
-
-        available_recovery_plugin_implementation = (
-            self.__managed_database_connection
-            and (
-                type(self.__managed_database_connection).db_connection_recover_operation
-                != IDatabaseManagedConnection.db_connection_recover_operation
-            )
+        decorate_operation = (
+            self.__managed_database_connection.db_connection_decorate_operation
         )
-
-        available_decoration_plugin_implementation = (
-            self.__managed_database_connection
-            and type(
-                self.__managed_database_connection
-            ).db_connection_decorate_operation
-            != IDatabaseManagedConnection.db_connection_decorate_operation
+        recover_operation = (
+            self.__managed_database_connection.db_connection_recover_operation
         )
-
-        if (
-            not self.__connection_hook_spec
-            or not self.__connection_hook_spec.db_connection_recover_operation.get_hookimpls()
-        ) and not available_recovery_plugin_implementation:
-            raise exception
-
-        if available_decoration_plugin_implementation:
-            decorate_operation = (
-                self.__managed_database_connection.db_connection_decorate_operation
-            )
-        elif (
-            self.__connection_hook_spec
-            and self.__connection_hook_spec.db_connection_decorate_operation.get_hookimpls()
-        ):
-            decorate_operation = (
-                self.__connection_hook_spec.db_connection_decorate_operation
-            )
-        else:
-            decorate_operation = None
-
-        if available_recovery_plugin_implementation:
-            recover_operation = (
-                self.__managed_database_connection.db_connection_recover_operation
-            )
-        else:
-            recover_operation = (
-                self.__connection_hook_spec.db_connection_recover_operation
-            )
 
         # apply any changes from @hookimpls to the managed operation
         if (

--- a/projects/vdk-core/tests/functional/run/test_run_restricted_hooks.py
+++ b/projects/vdk-core/tests/functional/run/test_run_restricted_hooks.py
@@ -37,7 +37,7 @@ class BeforeOperationSqLite3MemoryDbPlugin:
 
     @hookimpl(trylast=True)
     def db_connection_before_operation(self, operation: ManagedOperation):
-        log.info(f"Changing operation {operation.get_operation()}")
+        log.info(f"{operation.get_operation()} was changed")
 
 
 class OperationFailureSqLite3MemoryDbPlugin:
@@ -95,8 +95,9 @@ def test_before_operation_hook():
 
     cli_assert_equal(0, result)
     expected = (
-        "Changing operation CREATE TABLE stocks\n"
+        "CREATE TABLE stocks\n"
         "        (date text, symbol text, price real)\n"
+        " was changed\n"
     )
     assert expected in result.output
 

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_managed_cursor.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_managed_cursor.py
@@ -4,14 +4,9 @@ import logging
 from typing import Container
 from typing import Optional
 from unittest.mock import call
-from unittest.mock import MagicMock
 from unittest.mock import Mock
 
 import pytest
-from vdk.api.plugin.connection_hook_spec import ConnectionHookSpec
-from vdk.internal.builtin_plugins.connection.connection_hooks import (
-    ConnectionHookSpecFactory,
-)
 from vdk.internal.builtin_plugins.connection.database_managed_connection import (
     IDatabaseManagedConnection,
 )
@@ -21,11 +16,6 @@ from vdk.internal.builtin_plugins.connection.execution_cursor import (
     ExecuteOperationResult,
 )
 from vdk.internal.builtin_plugins.connection.execution_cursor import ExecutionCursor
-from vdk.internal.builtin_plugins.connection.managed_connection_base import (
-    ManagedConnectionBase,
-)
-from vdk.internal.builtin_plugins.connection.managed_cursor import ManagedCursor
-from vdk.internal.builtin_plugins.connection.pep249.interfaces import PEP249Cursor
 from vdk.internal.builtin_plugins.connection.recovery_cursor import RecoveryCursor
 from vdk.plugin.test_utils.util_funcs import create_mock_managed_cursor
 from vdk.plugin.test_utils.util_funcs import populate_mock_managed_cursor_no_hook
@@ -40,7 +30,7 @@ def test_validation__query_valid__execute():
         _,
         _,
         mock_connection_hook_spec,
-        mock_managed_connection,
+        _,
     ) = create_mock_managed_cursor()
 
     mock_managed_cursor.execute(_query)
@@ -79,7 +69,7 @@ def test_before_operation__success__execute():
         _,
         _,
         mock_connection_hook_spec,
-        mock_managed_connection,
+        _,
     ) = create_mock_managed_cursor()
 
     def mock_before_hook(operation: ManagedOperation):
@@ -103,7 +93,7 @@ def test_before_operation__failure__execute():
         _,
         _,
         mock_connection_hook_spec,
-        mock_managed_connection,
+        _,
     ) = create_mock_managed_cursor()
 
     mock_connection_hook_spec.db_connection_before_operation.side_effect = Exception(
@@ -213,7 +203,7 @@ def test_query_timing_failed_query(caplog):
         mock_managed_cursor,
         _,
         _,
-        mock_connection_hook_spec,
+        _,
         mock_managed_connection,
     ) = create_mock_managed_cursor()
 
@@ -226,34 +216,9 @@ def test_query_timing_failed_query(caplog):
     assert "Failed query duration 00h:00m:" in str(caplog.records)
 
 
-class ManagedDatabaseConnectionTestImpl(IDatabaseManagedConnection):
-    def db_connection_validate_operation(
-        self, operation: str, parameters: Optional[Container]
-    ) -> None:
-        print("Validate called not from Base class")
-
-    def db_connection_decorate_operation(
-        self, decoration_cursor: DecorationCursor
-    ) -> None:
-        print("Decorate called not from Base class")
-
-    def db_connection_execute_operation(
-        self, execution_cursor: ExecutionCursor
-    ) -> Optional[ExecuteOperationResult]:
-        print("Execute called not from Base class")
-
-    def db_connection_recover_operation(self, recovery_cursor: RecoveryCursor) -> None:
-        print("Recover called not from Base class")
-
-    def db_connection_after_operation(
-        self, execution_cursor: ExecutionCursor
-    ) -> Optional[ExecuteOperationResult]:
-        print("After called")
-
-
 @pytest.fixture
 def managed_connection():
-    return ManagedDatabaseConnectionTestImpl()
+    return IDatabaseManagedConnection()
 
 
 def test_no_hook_db_validate_operations(managed_connection):

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_managed_cursor.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_managed_cursor.py
@@ -4,22 +4,93 @@ import logging
 from typing import Container
 from typing import Optional
 from unittest.mock import call
+from unittest.mock import MagicMock
 from unittest.mock import Mock
 
 import pytest
+from vdk.api.plugin.connection_hook_spec import ConnectionHookSpec
+from vdk.internal.builtin_plugins.connection.connection_hooks import (
+    ConnectionHookSpecFactory,
+)
 from vdk.internal.builtin_plugins.connection.database_managed_connection import (
     IDatabaseManagedConnection,
 )
 from vdk.internal.builtin_plugins.connection.decoration_cursor import DecorationCursor
+from vdk.internal.builtin_plugins.connection.decoration_cursor import ManagedOperation
 from vdk.internal.builtin_plugins.connection.execution_cursor import (
     ExecuteOperationResult,
 )
 from vdk.internal.builtin_plugins.connection.execution_cursor import ExecutionCursor
+from vdk.internal.builtin_plugins.connection.managed_connection_base import (
+    ManagedConnectionBase,
+)
+from vdk.internal.builtin_plugins.connection.managed_cursor import ManagedCursor
+from vdk.internal.builtin_plugins.connection.pep249.interfaces import PEP249Cursor
 from vdk.internal.builtin_plugins.connection.recovery_cursor import RecoveryCursor
-from vdk.plugin.test_utils.util_funcs import populate_mock_managed_cursor
 from vdk.plugin.test_utils.util_funcs import populate_mock_managed_cursor_no_hook
 
 _query = "select 1"
+
+
+def create_mock_managed_cursor(
+    mock_exception_to_recover=None,
+    mock_operation=None,
+    mock_parameters=None,
+    before_operation_callback=None,
+) -> (
+    PEP249Cursor,
+    ManagedCursor,
+    DecorationCursor,
+    RecoveryCursor,
+    ConnectionHookSpec,
+    ManagedConnectionBase,
+):
+    import logging
+
+    managed_operation = ManagedOperation(mock_operation, mock_parameters)
+    mock_connection_hook_spec = MagicMock(spec=ConnectionHookSpec)
+    connection_hook_spec_factory = MagicMock(spec=ConnectionHookSpecFactory)
+    connection_hook_spec_factory.get_connection_hook_spec.return_value = (
+        mock_connection_hook_spec
+    )
+    mock_native_cursor = MagicMock(spec=PEP249Cursor)
+    mock_managed_connection = MagicMock(spec=ManagedConnectionBase)
+
+    managed_cursor = ManagedCursor(
+        cursor=mock_native_cursor,
+        log=logging.getLogger(),
+        connection_hook_spec_factory=connection_hook_spec_factory,
+        managed_database_connection=mock_managed_connection,
+    )
+
+    decoration_cursor = DecorationCursor(mock_native_cursor, None, managed_operation)
+    recovery_cursor = (
+        RecoveryCursor(
+            native_cursor=mock_native_cursor,
+            log=logging.getLogger(),
+            exception=mock_exception_to_recover,
+            managed_operation=managed_operation,
+            decoration_operation_callback=None,
+        ),
+    )
+
+    def stub_db_connection_execute_operation(execution_cursor: ExecutionCursor):
+        return IDatabaseManagedConnection().db_connection_execute_operation(
+            execution_cursor
+        )
+
+    mock_managed_connection.db_connection_execute_operation = (
+        stub_db_connection_execute_operation
+    )
+
+    return (
+        mock_native_cursor,
+        managed_cursor,
+        decoration_cursor,
+        recovery_cursor,
+        mock_connection_hook_spec,
+        mock_managed_connection,
+    )
 
 
 def test_validation__query_valid__execute():
@@ -29,13 +100,15 @@ def test_validation__query_valid__execute():
         _,
         _,
         mock_connection_hook_spec,
-    ) = populate_mock_managed_cursor()
+        mock_managed_connection,
+    ) = create_mock_managed_cursor()
 
     mock_managed_cursor.execute(_query)
 
     mock_connection_hook_spec.db_connection_validate_operation.assert_called_once_with(
         operation=_query, parameters=None
     )
+
     mock_native_cursor.execute.assert_called_once()
 
 
@@ -46,7 +119,8 @@ def test_validation__query_nonvalid__execute():
         _,
         _,
         mock_connection_hook_spec,
-    ) = populate_mock_managed_cursor()
+        _,
+    ) = create_mock_managed_cursor()
     mock_connection_hook_spec.db_connection_validate_operation.side_effect = Exception(
         "Validation exception"
     )
@@ -58,147 +132,135 @@ def test_validation__query_nonvalid__execute():
     mock_native_cursor.execute.assert_not_called()
 
 
-def test_decoration__success__execute():
+def test_before_operation__success__execute():
     (
         mock_native_cursor,
         mock_managed_cursor,
         _,
         _,
         mock_connection_hook_spec,
-    ) = populate_mock_managed_cursor()
+        mock_managed_connection,
+    ) = create_mock_managed_cursor()
 
-    def mock_decorate(decoration_cursor: DecorationCursor):
-        managed_operation = decoration_cursor.get_managed_operation()
-        managed_operation.set_operation(
-            f"decorated {managed_operation.get_operation()}"
-        )
+    def mock_before_hook(operation: ManagedOperation):
+        operation.set_operation(f"HOOK: Before {operation.get_operation()}")
 
-    mock_connection_hook_spec.db_connection_decorate_operation.side_effect = (
-        mock_decorate
+    mock_connection_hook_spec.db_connection_before_operation.side_effect = (
+        mock_before_hook
     )
 
     mock_managed_cursor.execute(_query)
 
-    mock_connection_hook_spec.db_connection_decorate_operation.assert_called_once()
-    calls = [call(f"decorated {_query}")]
-    mock_native_cursor.execute.assert_has_calls(calls)
+    mock_connection_hook_spec.db_connection_before_operation.assert_called_once()
+    hook_calls = [call(f"HOOK: Before {_query}")]
+    mock_native_cursor.execute.assert_has_calls(hook_calls)
 
 
-def test_decoration__failure__execute():
+def test_before_operation__failure__execute():
     (
         mock_native_cursor,
         mock_managed_cursor,
         _,
         _,
         mock_connection_hook_spec,
-    ) = populate_mock_managed_cursor()
-    mock_connection_hook_spec.db_connection_decorate_operation.side_effect = Exception(
-        "Decoration exception"
+        mock_managed_connection,
+    ) = create_mock_managed_cursor()
+
+    mock_connection_hook_spec.db_connection_before_operation.side_effect = Exception(
+        "On before exception"
     )
 
     with pytest.raises(Exception) as e:
         mock_managed_cursor.execute(_query)
 
-    assert True == mock_connection_hook_spec.db_connection_decorate_operation.called
-    assert "Decoration exception" == e.value.args[0]
+    assert mock_connection_hook_spec.db_connection_before_operation.called
+    assert "On before exception" == e.value.args[0]
     mock_native_cursor.execute.assert_not_called()
 
 
-def test_recovery__success__execute():
+def test_on_failure__success__execute():
     (
         mock_native_cursor,
         mock_managed_cursor,
         _,
         _,
         mock_connection_hook_spec,
-    ) = populate_mock_managed_cursor()
+        mock_managed_connection,
+    ) = create_mock_managed_cursor()
 
-    def mock_decorate(decoration_cursor: DecorationCursor):
-        managed_operation = decoration_cursor.get_managed_operation()
-        managed_operation.set_operation(
-            f"decorated {managed_operation.get_operation()}"
+    def mock_on_failure(operation: ManagedOperation, exception: Exception):
+        operation.set_operation(
+            f"HOOK: On failure {operation.get_operation()} with {exception}"
         )
+
+    mock_connection_hook_spec.db_connection_on_operation_failure.side_effect = (
+        mock_on_failure
+    )
 
     def mock_recover(recovery_cursor: RecoveryCursor):
         recovery_cursor.execute("recovery")
         recovery_cursor.retry_operation()
         assert recovery_cursor.get_retries() == 1
 
-    mock_connection_hook_spec.db_connection_decorate_operation.side_effect = (
-        mock_decorate
-    )
-    mock_connection_hook_spec.db_connection_recover_operation.side_effect = mock_recover
+    mock_managed_connection.db_connection_recover_operation.side_effect = mock_recover
 
-    exception = Exception()
-    mock_native_cursor.execute.side_effect = [exception, None, None]
+    ex = Exception("Fancy exception")
+    mock_native_cursor.execute.side_effect = [ex, None, None]
 
     mock_managed_cursor.execute(_query)
 
-    mock_connection_hook_spec.db_connection_recover_operation.assert_called_once()
-    calls = [
-        call(f"decorated {_query}"),
-        call(f"decorated recovery"),
-        call(f"decorated {_query}"),
-    ]
-    mock_native_cursor.execute.assert_has_calls(calls)
+    mock_connection_hook_spec.db_connection_on_operation_failure.assert_called_once()
+
+    hook_calls = [call(f"HOOK: On failure {_query} with {ex}")]
+    mock_native_cursor.execute.assert_has_calls(hook_calls)
 
 
-def test_recovery__failure__execute():
+def test_on_failure__failure__execute():
     (
         mock_native_cursor,
         mock_managed_cursor,
         _,
         _,
         mock_connection_hook_spec,
-    ) = populate_mock_managed_cursor()
+        mock_managed_connection,
+    ) = create_mock_managed_cursor()
 
-    def mock_decorate(decoration_cursor: DecorationCursor):
-        managed_operation = decoration_cursor.get_managed_operation()
-        managed_operation.set_operation(
-            f"decorated {managed_operation.get_operation()}"
+    def mock_on_failure(operation: ManagedOperation, exception: Exception):
+        operation.set_operation(
+            f"HOOK: On failure {operation.get_operation()} with {exception}"
         )
 
-    def mock_recover(recovery_cursor: RecoveryCursor):
-        raise Exception("Could not handle execution exception")
-
-    mock_connection_hook_spec.db_connection_decorate_operation.side_effect = (
-        mock_decorate
+    mock_connection_hook_spec.db_connection_on_operation_failure.side_effect = (
+        mock_on_failure
     )
-    mock_connection_hook_spec.db_connection_recover_operation.side_effect = mock_recover
 
-    exception = Exception()
-    mock_native_cursor.execute.side_effect = exception
+    def mock_recover(recovery_cursor: RecoveryCursor):
+        raise Exception(
+            f"Could not recover operation: {recovery_cursor.get_managed_operation().get_operation()}"
+        )
 
+    mock_managed_connection.db_connection_recover_operation.side_effect = mock_recover
+
+    ex = Exception()
+    mock_native_cursor.execute.side_effect = [ex, None, None]
     with pytest.raises(Exception) as e:
         mock_managed_cursor.execute(_query)
 
-    assert "Could not handle execution exception" == e.value.args[0]
-    mock_connection_hook_spec.db_connection_recover_operation.assert_called_once()
+    mock_connection_hook_spec.db_connection_on_operation_failure.assert_called_once()
+
     mock_native_cursor.execute.assert_called_once()
 
 
 def test_query_timing_successful_query(caplog):
     caplog.set_level(logging.INFO)
-    (
-        _,
-        mock_managed_cursor,
-        _,
-        _,
-        _,
-    ) = populate_mock_managed_cursor()
+    (_, mock_managed_cursor, _, _, _, _) = create_mock_managed_cursor()
     mock_managed_cursor.execute(_query)
     assert "Query duration 00h:00m:" in str(caplog.records)
 
 
 def test_query_timing_recovered_query(caplog):
     caplog.set_level(logging.INFO)
-    (
-        mock_native_cursor,
-        mock_managed_cursor,
-        _,
-        _,
-        _,
-    ) = populate_mock_managed_cursor()
+    (mock_native_cursor, mock_managed_cursor, _, _, _, _) = create_mock_managed_cursor()
     mock_native_cursor.execute.side_effect = [Exception("Mock exception")]
     mock_managed_cursor.execute(_query)
     assert "Recovered query duration 00h:00m:" in str(caplog.records)
@@ -212,11 +274,12 @@ def test_query_timing_failed_query(caplog):
         _,
         _,
         mock_connection_hook_spec,
-    ) = populate_mock_managed_cursor()
+        mock_managed_connection,
+    ) = create_mock_managed_cursor()
 
     exception = Exception("Mock exception")
     mock_native_cursor.execute.side_effect = [exception]
-    mock_connection_hook_spec.db_connection_recover_operation.side_effect = [exception]
+    mock_managed_connection.db_connection_recover_operation.side_effect = [exception]
     with pytest.raises(Exception):
         mock_managed_cursor.execute(_query)
 

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_managed_cursor.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_managed_cursor.py
@@ -27,70 +27,9 @@ from vdk.internal.builtin_plugins.connection.managed_connection_base import (
 from vdk.internal.builtin_plugins.connection.managed_cursor import ManagedCursor
 from vdk.internal.builtin_plugins.connection.pep249.interfaces import PEP249Cursor
 from vdk.internal.builtin_plugins.connection.recovery_cursor import RecoveryCursor
-from vdk.plugin.test_utils.util_funcs import populate_mock_managed_cursor_no_hook
+from vdk.plugin.test_utils.util_funcs import populate_mock_managed_cursor_no_hook, create_mock_managed_cursor
 
 _query = "select 1"
-
-
-def create_mock_managed_cursor(
-    mock_exception_to_recover=None,
-    mock_operation=None,
-    mock_parameters=None,
-    before_operation_callback=None,
-) -> (
-    PEP249Cursor,
-    ManagedCursor,
-    DecorationCursor,
-    RecoveryCursor,
-    ConnectionHookSpec,
-    ManagedConnectionBase,
-):
-    import logging
-
-    managed_operation = ManagedOperation(mock_operation, mock_parameters)
-    mock_connection_hook_spec = MagicMock(spec=ConnectionHookSpec)
-    connection_hook_spec_factory = MagicMock(spec=ConnectionHookSpecFactory)
-    connection_hook_spec_factory.get_connection_hook_spec.return_value = (
-        mock_connection_hook_spec
-    )
-    mock_native_cursor = MagicMock(spec=PEP249Cursor)
-    mock_managed_connection = MagicMock(spec=ManagedConnectionBase)
-
-    managed_cursor = ManagedCursor(
-        cursor=mock_native_cursor,
-        log=logging.getLogger(),
-        connection_hook_spec_factory=connection_hook_spec_factory,
-        managed_database_connection=mock_managed_connection,
-    )
-
-    decoration_cursor = DecorationCursor(mock_native_cursor, None, managed_operation)
-    recovery_cursor = (
-        RecoveryCursor(
-            native_cursor=mock_native_cursor,
-            log=logging.getLogger(),
-            exception=mock_exception_to_recover,
-            managed_operation=managed_operation,
-            decoration_operation_callback=None,
-        ),
-    )
-
-    def stub_db_connection_execute_operation(execution_cursor: ExecutionCursor):
-        return IDatabaseManagedConnection().db_connection_execute_operation(
-            execution_cursor
-        )
-
-    mock_managed_connection.db_connection_execute_operation = (
-        stub_db_connection_execute_operation
-    )
-
-    return (
-        mock_native_cursor,
-        managed_cursor,
-        decoration_cursor,
-        recovery_cursor,
-        mock_connection_hook_spec,
-        mock_managed_connection,
-    )
 
 
 def test_validation__query_valid__execute():

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_managed_cursor.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/connection/test_managed_cursor.py
@@ -27,7 +27,8 @@ from vdk.internal.builtin_plugins.connection.managed_connection_base import (
 from vdk.internal.builtin_plugins.connection.managed_cursor import ManagedCursor
 from vdk.internal.builtin_plugins.connection.pep249.interfaces import PEP249Cursor
 from vdk.internal.builtin_plugins.connection.recovery_cursor import RecoveryCursor
-from vdk.plugin.test_utils.util_funcs import populate_mock_managed_cursor_no_hook, create_mock_managed_cursor
+from vdk.plugin.test_utils.util_funcs import create_mock_managed_cursor
+from vdk.plugin.test_utils.util_funcs import populate_mock_managed_cursor_no_hook
 
 _query = "select 1"
 


### PR DESCRIPTION
## Why?

All hooks that expose a cursor are now methods in ManagedConnectionBase We can stop checking for hook overrides

## What?

Remove unused hooks
Remove the hook overrides checks
Introduce default for db_connection_recover_operation
Fix tests

## What kind of change is this?

Potentially breaking
We should first merge https://gitlab.eng.vmware.com/product-analytics/data-pipelines/supercollider-vdk/-/merge_requests/271

## How was this tested?

Integration/functional tests