### PR TITLE
control-service: rewrite correctly for spies

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -5,9 +5,6 @@
 
 package com.vmware.taurus.service;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 import com.vmware.taurus.service.deploy.JobCommandProvider;
 import com.vmware.taurus.service.kubernetes.DataJobsKubernetesService;
 import com.vmware.taurus.service.model.JobAnnotation;
@@ -28,6 +25,8 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
+
+import static org.mockito.Mockito.*;
 
 public class KubernetesServiceTest {
 
@@ -332,13 +331,10 @@ public class KubernetesServiceTest {
     v1DeploymentStatus.setCronJobName("v1TestJob");
     v1TestList.add(v1DeploymentStatus);
 
-    var mergedTestLists = v1TestList;
-
-    Mockito.when(mock.readV1CronJobDeploymentStatuses()).thenReturn(v1TestList);
-    Mockito.when(mock.readJobDeploymentStatuses()).thenCallRealMethod();
+    doReturn(v1TestList).when(mock).readV1CronJobDeploymentStatuses();
     List<JobDeploymentStatus> resultStatuses = mock.readJobDeploymentStatuses();
 
-    Assertions.assertEquals(mergedTestLists, resultStatuses);
+    Assertions.assertEquals(v1TestList, resultStatuses);
   }
 
   @Test
@@ -351,7 +347,7 @@ public class KubernetesServiceTest {
     testDeploymentStatus.setDataJobName(testCronjobName);
     testDeploymentStatus.setCronJobName(testCronjobName);
 
-    Mockito.when(mock.readV1CronJob(testCronjobName)).thenReturn(Optional.of(testDeploymentStatus));
+    doReturn(Optional.of(testDeploymentStatus)).when(mock).readV1CronJob(testCronjobName);
 
     Assertions.assertNotNull(mock.readCronJob(testCronjobName));
     Assertions.assertEquals(


### PR DESCRIPTION
# Why
The previous code is not written assuming assuming the object in a mock when infact it is a spy. 
The difference between a mock and a spy is that with a spy the real functions are called. 

That is why we can remove the line with `.callRealMethod`.
I have also rewritten how we return mocked functions response objects. 
They way they were written was resulting in the actual function being called when we are first mocking it. 

However now it never calls it. 


I didn't rename it from mock to spy. because this is everywhere in the code and can be done in a different PR if ppl think it is important. 




Tested on CICD 

