### PR TITLE
control-service: remove useless method

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -309,19 +309,15 @@ public abstract class KubernetesService {
    *     Optional if the cron job does not exist or cannot be read
    */
   public Optional<JobDeploymentStatus> readCronJob(String cronJobName) {
-    return readV1CronJob(cronJobName);
-  }
-
-  public Optional<JobDeploymentStatus> readV1CronJob(String cronJobName) {
     log.debug("Reading k8s V1 cron job: {}", cronJobName);
     V1CronJob cronJob = null;
     try {
       cronJob = batchV1Api.readNamespacedCronJob(cronJobName, namespace, null);
     } catch (ApiException e) {
       log.warn(
-          "Could not read cron job: {}; reason: {}",
-          cronJobName,
-          new KubernetesException("", e).toString());
+              "Could not read cron job: {}; reason: {}",
+              cronJobName,
+              new KubernetesException("", e).toString());
     }
 
     return mapV1CronJobToDeploymentStatus(cronJob, cronJobName);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/KubernetesService.java
@@ -315,9 +315,9 @@ public abstract class KubernetesService {
       cronJob = batchV1Api.readNamespacedCronJob(cronJobName, namespace, null);
     } catch (ApiException e) {
       log.warn(
-              "Could not read cron job: {}; reason: {}",
-              cronJobName,
-              new KubernetesException("", e).toString());
+          "Could not read cron job: {}; reason: {}",
+          cronJobName,
+          new KubernetesException("", e).toString());
     }
 
     return mapV1CronJobToDeploymentStatus(cronJob, cronJobName);

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/KubernetesServiceTest.java
@@ -338,24 +338,6 @@ public class KubernetesServiceTest {
   }
 
   @Test
-  public void testReadCronJob_readV1CronJobShouldReturnStatus() {
-    String testCronjobName = "testCronjob";
-    var mock = newDataJobKubernetesService();
-
-    JobDeploymentStatus testDeploymentStatus = new JobDeploymentStatus();
-    testDeploymentStatus.setEnabled(false);
-    testDeploymentStatus.setDataJobName(testCronjobName);
-    testDeploymentStatus.setCronJobName(testCronjobName);
-
-    doReturn(Optional.of(testDeploymentStatus)).when(mock).readV1CronJob(testCronjobName);
-
-    Assertions.assertNotNull(mock.readCronJob(testCronjobName));
-    Assertions.assertEquals(
-        testCronjobName, mock.readCronJob(testCronjobName).get().getCronJobName());
-    verify(mock, times(2)).readV1CronJob(testCronjobName);
-  }
-
-  @Test
   public void testQuantityToMbConversionMegabytes() throws Exception {
     var hundredMb = "100M";
     testQuantityToMbConversion(100, hundredMb);


### PR DESCRIPTION
# Why
The method was only calling another public method in the same class. 
It is left over mess from supporting multiple versions of k8s. 


