### PR TITLE
vdk-impala: use new util function in impala

### DIFF
--- a/projects/vdk-plugins/vdk-impala/tests/impala_error_handler_test.py
+++ b/projects/vdk-plugins/vdk-impala/tests/impala_error_handler_test.py
@@ -9,7 +9,7 @@ import impala
 from impala.error import HiveServer2Error
 from impala.error import OperationalError
 from vdk.plugin.impala.impala_error_handler import ImpalaErrorHandler
-from vdk.plugin.test_utils.util_funcs import populate_mock_managed_cursor
+from vdk.plugin.test_utils.util_funcs import create_mock_managed_cursor
 
 
 @patch("time.sleep", return_value=None)
@@ -29,7 +29,8 @@ class ImpalaErrorHandlerTest(unittest.TestCase):
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=test_exception, mock_operation=self._query
         )
         mock_native_cursor.execute.side_effect = test_exception
@@ -52,7 +53,8 @@ class ImpalaErrorHandlerTest(unittest.TestCase):
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=test_exception, mock_operation=self._query
         )
         mock_native_cursor.execute.side_effect = test_exception
@@ -75,7 +77,8 @@ class ImpalaErrorHandlerTest(unittest.TestCase):
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=test_exception, mock_operation=self._query
         )
 
@@ -97,7 +100,8 @@ class ImpalaErrorHandlerTest(unittest.TestCase):
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=test_exception, mock_operation=self._query
         )
         mock_native_cursor.execute.side_effect = [None, test_exception]
@@ -124,7 +128,8 @@ class ImpalaErrorHandlerTest(unittest.TestCase):
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=original_exception_fixed_by_other_handler,
             mock_operation=self._query,
         )
@@ -153,7 +158,8 @@ class ImpalaErrorHandlerTest(unittest.TestCase):
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=test_exception, mock_operation=self._query
         )
         mock_native_cursor.execute.side_effect = [None, new_exception]
@@ -177,7 +183,8 @@ CAUSED BY: MetaException: Object with id "" is managed by a different persistenc
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=test_exception, mock_operation=self._query
         )
 
@@ -204,7 +211,8 @@ CAUSED BY: MetaException: Object with id "" is managed by a different persistenc
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=test_exception_table_1, mock_operation=self._query
         )
         mock_native_cursor.execute.side_effect = [
@@ -234,7 +242,8 @@ CAUSED BY: MetaException: Object with id "" is managed by a different persistenc
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=test_exception, mock_operation=self._query
         )
         # we must not re-try but re-raise caught exception.
@@ -264,7 +273,8 @@ CAUSED BY: MetaException: Object with id "" is managed by a different persistenc
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=test_exception, mock_operation=original_query
         )
         mock_native_cursor.execute.side_effect = [new_exception, None]
@@ -290,7 +300,8 @@ Query(0842bccde0974578:6fd468a200000000): Limit=2.00 GB Reservation=1.78 GB Rese
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=test_exception, mock_operation=self._query
         )
         mock_native_cursor.execute.side_effect = [

--- a/projects/vdk-plugins/vdk-impala/tests/impala_handle_hdfs_error_test.py
+++ b/projects/vdk-plugins/vdk-impala/tests/impala_handle_hdfs_error_test.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 from impala.error import HiveServer2Error
 from impala.error import OperationalError
 from vdk.plugin.impala.impala_error_handler import ImpalaErrorHandler
-from vdk.plugin.test_utils.util_funcs import populate_mock_managed_cursor
+from vdk.plugin.test_utils.util_funcs import create_mock_managed_cursor
 
 
 @patch("time.sleep", return_value=None)
@@ -44,7 +44,8 @@ Root cause: ConnectException: Connection refused"""
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=self._failed_to_open_exception,
             mock_operation=original_query,
             decoration_operation_callback=mock_decoration,
@@ -70,7 +71,8 @@ Root cause: ConnectException: Connection refused"""
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=exception, mock_operation=self._query
         )
         # This test was changed because it started failing due to a change of the Impala error handling, which was
@@ -95,7 +97,8 @@ Root cause: RemoteException: Path name not found: /user/hive/warehouse/starshot_
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=initial_error, mock_operation=self._query
         )
 
@@ -122,7 +125,8 @@ Root cause: RemoteException: Path name not found: /user/hive/warehouse/starshot_
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=initial_error, mock_operation=self._query
         )
 
@@ -147,7 +151,8 @@ Root cause: RemoteException: Path name not found: /user/hive/warehouse/starshot_
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=initial_error, mock_operation=self._query
         )
 
@@ -164,7 +169,7 @@ Error(2): No such file or directory
 Root cause: RemoteException: Path name not found: /user/hive/warehouse/starshot_csp_jira_dw.db/csp_customfieldoption/554fce0f545e17a0-739e2bfa0000006f_954094502_data.0.parq"""
         initial_error = OperationalError(error_message)
         error_handler = ImpalaErrorHandler(logging.getLogger(), num_retries=1)
-        _, _, _, mock_recovery_cursor, _ = populate_mock_managed_cursor(
+        _, _, _, mock_recovery_cursor, _, _ = create_mock_managed_cursor(
             mock_exception_to_recover=initial_error, mock_operation=self._query
         )
 
@@ -186,7 +191,8 @@ Root cause: RemoteException: Path name not found: /user/hive/warehouse/starshot_
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=initial_error, mock_operation=self._query
         )
         mock_native_cursor.execute.side_effect = secondary_error

--- a/projects/vdk-plugins/vdk-impala/tests/impala_handle_metadata_exception_with_backoff.py
+++ b/projects/vdk-plugins/vdk-impala/tests/impala_handle_metadata_exception_with_backoff.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from impala.error import HiveServer2Error
 from impala.error import OperationalError
 from vdk.plugin.impala.impala_error_handler import ImpalaErrorHandler
-from vdk.plugin.test_utils.util_funcs import populate_mock_managed_cursor
+from vdk.plugin.test_utils.util_funcs import create_mock_managed_cursor
 
 
 @patch("time.sleep", return_value=None)
@@ -27,7 +27,8 @@ class ImpalaMetadataExceptionWithBackoff(unittest.TestCase):
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=exception, mock_operation=self._query
         )
         error_handler.handle_error(
@@ -51,7 +52,8 @@ CAUSED BY: MetaException: Object with id "" is managed by a different persistenc
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=exception, mock_operation=self._query
         )
         error_handler.handle_error(
@@ -75,7 +77,8 @@ CAUSED BY: MetaException: Object with id "" is managed by a different persistenc
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=exception, mock_operation=self._query
         )
         error_handler.handle_error(
@@ -96,7 +99,8 @@ CAUSED BY: MetaException: Object with id "" is managed by a different persistenc
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=exception, mock_operation=self._query
         )
         error_handler.handle_error(

--- a/projects/vdk-plugins/vdk-impala/tests/impala_handle_metadata_exception_with_invalidate_and_backoff.py
+++ b/projects/vdk-plugins/vdk-impala/tests/impala_handle_metadata_exception_with_invalidate_and_backoff.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 from impala.error import HiveServer2Error
 from impala.error import OperationalError
 from vdk.plugin.impala.impala_error_handler import ImpalaErrorHandler
-from vdk.plugin.test_utils.util_funcs import populate_mock_managed_cursor
+from vdk.plugin.test_utils.util_funcs import create_mock_managed_cursor
 
 
 @patch("time.sleep", return_value=None)
@@ -32,7 +32,8 @@ Will issue invalidate metadata and try again."""
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=exception, mock_operation=self._query
         )
         error_handler.handle_error(
@@ -61,7 +62,8 @@ Will issue invalidate metadata and try again."""
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=exception, mock_operation=self._query
         )
         error_handler.handle_error(
@@ -90,7 +92,8 @@ CAUSED BY: MetaException: Object with id "" is managed by a different persistenc
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=exception, mock_operation=self._query
         )
         error_handler.handle_error(
@@ -117,7 +120,8 @@ CAUSED BY: MetaException: Object with id "" is managed by a different persistenc
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=exception, mock_operation=self._query
         )
         error_handler.handle_error(

--- a/projects/vdk-plugins/vdk-impala/tests/impala_handle_metadata_exception_with_invalidate_and_retry_test.py
+++ b/projects/vdk-plugins/vdk-impala/tests/impala_handle_metadata_exception_with_invalidate_and_retry_test.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 from impala.error import HiveServer2Error
 from vdk.plugin.impala.impala_error_handler import ImpalaErrorHandler
-from vdk.plugin.test_utils.util_funcs import populate_mock_managed_cursor
+from vdk.plugin.test_utils.util_funcs import create_mock_managed_cursor
 
 
 @patch("time.sleep", return_value=None)
@@ -16,13 +16,7 @@ def test_AnalysisException_could_not_resolve_table_reference(patched_time_sleep)
     exception = HiveServer2Error(error_message)
 
     error_handler = ImpalaErrorHandler(logging.getLogger(), num_retries=1)
-    (
-        mock_native_cursor,
-        _,
-        _,
-        mock_recovery_cursor,
-        _,
-    ) = populate_mock_managed_cursor(
+    (mock_native_cursor, _, _, mock_recovery_cursor, _, _) = create_mock_managed_cursor(
         mock_exception_to_recover=exception, mock_operation=_query
     )
     error_handler.handle_error(
@@ -41,13 +35,7 @@ def test_AlreadyExistsException_table_already_exists(patched_time_sleep):
     error_message = "AlreadyExistsException: Table test_table already exists"
     exception = HiveServer2Error(error_message)
     original_query = "CREATE TABLE test_schema.test_table AS SELECT * FROM test_mart.view_test_table;"
-    (
-        mock_native_cursor,
-        _,
-        _,
-        mock_recovery_cursor,
-        _,
-    ) = populate_mock_managed_cursor(
+    (mock_native_cursor, _, _, mock_recovery_cursor, _, _) = create_mock_managed_cursor(
         mock_exception_to_recover=exception, mock_operation=original_query
     )
 
@@ -72,7 +60,7 @@ def test_AlreadyExistsException_view_already_exists(patched_time_sleep):
         "SELECT * "
         "FROM test_mart.view_test_table;"
     )
-    (mock_native_cursor, _, _, mock_recovery_cursor, _) = populate_mock_managed_cursor(
+    (mock_native_cursor, _, _, mock_recovery_cursor, _, _) = create_mock_managed_cursor(
         mock_exception_to_recover=exception, mock_operation=original_query
     )
 

--- a/projects/vdk-plugins/vdk-impala/tests/impala_handle_network_error_test.py
+++ b/projects/vdk-plugins/vdk-impala/tests/impala_handle_network_error_test.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from impala.error import HiveServer2Error
 from impala.error import OperationalError
 from vdk.plugin.impala.impala_error_handler import ImpalaErrorHandler
-from vdk.plugin.test_utils.util_funcs import populate_mock_managed_cursor
+from vdk.plugin.test_utils.util_funcs import create_mock_managed_cursor
 
 
 @patch("time.sleep", return_value=None)
@@ -27,7 +27,8 @@ class ImpalaHandleNetworkErrorTest(unittest.TestCase):
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=exception, mock_operation=self._query
         )
         error_handler.handle_error(
@@ -48,7 +49,8 @@ class ImpalaHandleNetworkErrorTest(unittest.TestCase):
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=exception, mock_operation=self._query
         )
         error_handler.handle_error(
@@ -69,7 +71,8 @@ class ImpalaHandleNetworkErrorTest(unittest.TestCase):
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=exception, mock_operation=self._query
         )
         error_handler.handle_error(
@@ -90,7 +93,8 @@ class ImpalaHandleNetworkErrorTest(unittest.TestCase):
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=exception, mock_operation=self._query
         )
         error_handler.handle_error(
@@ -115,7 +119,8 @@ class ImpalaHandleNetworkErrorTest(unittest.TestCase):
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=exception, mock_operation=self._query
         )
         error_handler.handle_error(
@@ -136,7 +141,8 @@ class ImpalaHandleNetworkErrorTest(unittest.TestCase):
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=exception, mock_operation=self._query
         )
         error_handler.handle_error(

--- a/projects/vdk-plugins/vdk-impala/tests/impala_handle_pool_error_test.py
+++ b/projects/vdk-plugins/vdk-impala/tests/impala_handle_pool_error_test.py
@@ -8,7 +8,7 @@ import pytest
 from impala.error import OperationalError
 from vdk.internal.core.errors import UserCodeError
 from vdk.plugin.impala.impala_error_handler import ImpalaErrorHandler
-from vdk.plugin.test_utils.util_funcs import populate_mock_managed_cursor
+from vdk.plugin.test_utils.util_funcs import create_mock_managed_cursor
 
 
 @patch("time.sleep", return_value=None)
@@ -22,7 +22,7 @@ class ImpalaHandlePoolError(unittest.TestCase):
         exception = OperationalError(error_message)
 
         error_handler = ImpalaErrorHandler(logging.getLogger(), num_retries=1)
-        _, _, _, mock_recovery_cursor, _ = populate_mock_managed_cursor(
+        _, _, _, mock_recovery_cursor, _, _ = create_mock_managed_cursor(
             mock_exception_to_recover=exception, mock_operation=self._query
         )
 
@@ -37,7 +37,7 @@ class ImpalaHandlePoolError(unittest.TestCase):
         exception = OperationalError(error_message)
 
         error_handler = ImpalaErrorHandler(logging.getLogger(), num_retries=1)
-        _, _, _, mock_recovery_cursor, _ = populate_mock_managed_cursor(
+        _, _, _, mock_recovery_cursor, _, _ = create_mock_managed_cursor(
             mock_exception_to_recover=exception, mock_operation=self._query
         )
 

--- a/projects/vdk-plugins/vdk-impala/tests/impala_handle_should_not_retry_error_test.py
+++ b/projects/vdk-plugins/vdk-impala/tests/impala_handle_should_not_retry_error_test.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 from impala.error import OperationalError
 from vdk.plugin.impala.impala_error_handler import ImpalaErrorHandler
-from vdk.plugin.test_utils.util_funcs import populate_mock_managed_cursor
+from vdk.plugin.test_utils.util_funcs import create_mock_managed_cursor
 
 
 @patch("time.sleep", return_value=None)
@@ -26,7 +26,8 @@ class ImpalaHandleShouldNotRetryErrorTest(unittest.TestCase):
             _,
             mock_recovery_cursor,
             _,
-        ) = populate_mock_managed_cursor(
+            _,
+        ) = create_mock_managed_cursor(
             mock_exception_to_recover=exception, mock_operation=self._query
         )
         error_handler.handle_error(


### PR DESCRIPTION
The old util funcition will be deprecated and removed with the changes in https://github.com/vmware/versatile-data-kit/pull/3283
We cannot change vdk-core and vdk-plugins in one pr, so we need to have the new funcition for impala beforehand since its tests run on vdk-core release, which fail in https://github.com/vmware/versatile-data-kit/pull/3283 because of core changes
