### PR TITLE
vdk-plugins: fix build pipeline

### DIFF
--- a/projects/vdk-plugins/vdk-greenplum/requirements.txt
+++ b/projects/vdk-plugins/vdk-greenplum/requirements.txt
@@ -1,3 +1,4 @@
 
 testcontainers
+typing-extensions
 vdk-test-utils

--- a/projects/vdk-plugins/vdk-impala/requirements.txt
+++ b/projects/vdk-plugins/vdk-impala/requirements.txt
@@ -1,3 +1,4 @@
 
 testcontainers
+typing-extensions
 vdk-test-utils

--- a/projects/vdk-plugins/vdk-oracle/requirements.txt
+++ b/projects/vdk-plugins/vdk-oracle/requirements.txt
@@ -5,6 +5,7 @@ pandas
 pytest
 pytest-httpserver
 testcontainers
+typing-extensions
 vdk-core
 vdk-plugin-control-cli
 vdk-test-utils

--- a/projects/vdk-plugins/vdk-postgres/requirements.txt
+++ b/projects/vdk-plugins/vdk-postgres/requirements.txt
@@ -1,3 +1,4 @@
 
 testcontainers
+typing-extensions
 vdk-test-utils

--- a/projects/vdk-plugins/vdk-trino/requirements.txt
+++ b/projects/vdk-plugins/vdk-trino/requirements.txt
@@ -4,6 +4,6 @@ click
 
 testcontainers
 trino
+typing-extensions
 vdk-core
 vdk-test-utils
-typing-extensions

--- a/projects/vdk-plugins/vdk-trino/requirements.txt
+++ b/projects/vdk-plugins/vdk-trino/requirements.txt
@@ -6,3 +6,4 @@ testcontainers
 trino
 vdk-core
 vdk-test-utils
+typing-extensions


### PR DESCRIPTION
# Why
A new version of testcontainers was release yesterday that needs typing extensions but doesn't include it as a dependency. 



Tested on CICD