### PR TITLE
vdk-core: introduce sections to configurations

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/config_help.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/config_help.py
@@ -116,7 +116,7 @@ def config_help(ctx: click.Context) -> None:
         description = configuration.get_description(k)
         if description:
             if k.startswith("__config_provider__"):
-                name = k[len("__config_provider__"):].strip()
+                name = k[len("__config_provider__") :].strip()
                 providers_descriptions[name] = description
             else:
                 vars_to_descriptions[k] = description

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/config_help.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/config_help.py
@@ -112,15 +112,14 @@ def config_help(ctx: click.Context) -> None:
 
     vars_to_descriptions = {}
     providers_descriptions = {}
-    for s in configuration.list_sections():
-        for k in configuration.list_keys_in_section(s):
-            description = configuration.get_description(k)
-            if description:
-                if k.startswith("__config_provider__"):
-                    name = k[len("__config_provider__") :].strip()
-                    providers_descriptions[name] = description
-                else:
-                    vars_to_descriptions[k] = description
+    for k in configuration.list_config_keys_from_main_sections():
+        description = configuration.get_description(k)
+        if description:
+            if k.startswith("__config_provider__"):
+                name = k[len("__config_provider__"):].strip()
+                providers_descriptions[name] = description
+            else:
+                vars_to_descriptions[k] = description
 
     click.echo(
         CONFIG_HELP.format(

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/config_help.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/config_help.py
@@ -112,14 +112,15 @@ def config_help(ctx: click.Context) -> None:
 
     vars_to_descriptions = {}
     providers_descriptions = {}
-    for k in configuration.list_config_keys():
-        description = configuration.get_description(k)
-        if description:
-            if k.startswith("__config_provider__"):
-                name = k[len("__config_provider__") :].strip()
-                providers_descriptions[name] = description
-            else:
-                vars_to_descriptions[k] = description
+    for s in configuration.list_sections():
+        for k in configuration.list_keys_in_section(s):
+            description = configuration.get_description(k)
+            if description:
+                if k.startswith("__config_provider__"):
+                    name = k[len("__config_provider__") :].strip()
+                    providers_descriptions[name] = description
+                else:
+                    vars_to_descriptions[k] = description
 
     click.echo(
         CONFIG_HELP.format(

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/vdk_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/vdk_config.py
@@ -187,7 +187,7 @@ Configuration for cloud execution is done in 'config.ini' file or the vdk cli.
             description=description,
         )
 
-        config_keys = config_builder.list_config_keys()
+        config_keys = config_builder.list_config_keys_from_main_sections()  # TODO: make it work with all sections
         log.debug(
             f"Founds config keys: {config_keys}. Will check if environment variable is set for any"
         )
@@ -289,7 +289,5 @@ It can be overridden by environment variables configuration (set by operators in
                 for key, value in job_config.get_vdk_subsection_values(
                     subsection
                 ).items():
-                    # TODO: after the configuration builder is changed, we need to pass the subsection as
-                    #  section not as key
-                    config_builder.add(key=subsection + "_" + key, default_value="")
-                    config_builder.set_value(key=subsection + "_" + key, value=value)
+                    config_builder.add(key=key, default_value="", section=subsection)
+                    config_builder.set_value(key=key, value=value, section=subsection)

--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/vdk_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/vdk_config.py
@@ -187,7 +187,9 @@ Configuration for cloud execution is done in 'config.ini' file or the vdk cli.
             description=description,
         )
 
-        config_keys = config_builder.list_config_keys_from_main_sections()  # TODO: make it work with all sections
+        config_keys = (
+            config_builder.list_config_keys_from_main_sections()
+        )  # TODO: make it work with all sections
         log.debug(
             f"Founds config keys: {config_keys}. Will check if environment variable is set for any"
         )

--- a/projects/vdk-core/src/vdk/internal/core/config.py
+++ b/projects/vdk-core/src/vdk/internal/core/config.py
@@ -108,6 +108,20 @@ class Configuration:
             section = _normalize_config_string(section)
             return self._sections.get(section, {}).get(key, ConfigEntry()).value
 
+    def override_value(self, key: ConfigKey, value: Any, section: str = None):
+        key = _normalize_config_string(key)
+        if section is None:
+            for sec, entries in self._sections.items():
+                if not sec.startswith("vdk_") and key in entries:
+                    entries[key].value = value
+        else:
+            section = _normalize_config_string(section)
+            if section in self._sections and key in self._sections[section].keys():
+                self._sections[section][key].value = value
+            else:
+                raise VdkConfigurationError("The value you are trying to override is not existing. "
+                                            f"Check the {section} section and {key} key, again!")
+
     def get_required_value(self, key: str, section: Optional[str] = None) -> Any:
         """
         Retrieve the required value of a configuration key, optionally from a specific section or
@@ -248,6 +262,10 @@ class Configuration:
             if not section.startswith("vdk_"):
                 keys.extend(entries.keys())
         return list(keys)
+
+    def list_config_keys(self) -> List[str]:
+        # this is used in many plugins to be removed after the change in plugins is done
+        return self.list_config_keys_from_main_sections()
 
     def __getitem__(self, key: Union[str, Tuple[str, Optional[str]]]) -> Any:
         """

--- a/projects/vdk-core/src/vdk/internal/core/config.py
+++ b/projects/vdk-core/src/vdk/internal/core/config.py
@@ -358,6 +358,46 @@ class ConfigurationBuilder:
         self.__sections[section][key].value = value
         return self
 
+    def list_config_keys_from_main_sections(self) -> List[str]:
+        """
+        List all configuration keys from sections that do not start with 'vdk_'.
+        The vdk_ are considered subsections of vdk.
+
+        Returns:
+            List[str]: A list of all configuration keys in non-'vdk_' prefixed sections.
+        """
+        keys = []
+        for section, entries in self.__sections.items():
+            if not section.startswith("vdk_"):
+                keys.extend(entries.keys())
+        return list(keys)
+
+    def list_config_keys_for_section(self, section: str) -> List[str]:
+        """
+        List all keys within a specified section of the configuration.
+
+        Args:
+            section (str): The name of the section from which to list keys.
+
+        Returns:
+            List[str]: A list of all configuration keys within the specified section.
+            Raises ValueError if the section does not exist.
+        """
+        section = _normalize_config_string(section)
+        if section in self.__sections:
+            return list(self.__sections[section].keys())
+        else:
+            raise ValueError(f"Section '{section}' does not exist.")
+
+    def list_all_section_names(self) -> List[str]:
+        """
+        List all section names in the configuration.
+
+        Returns:
+            List[str]: A list of all section names currently defined in the configuration.
+        """
+        return list(self.__sections.keys())
+
     def build(self) -> 'Configuration':
         """
         Finalizes the building process and constructs an immutable Configuration object from the accumulated data.

--- a/projects/vdk-core/src/vdk/internal/core/config.py
+++ b/projects/vdk-core/src/vdk/internal/core/config.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
-from dataclasses import field
-from typing import Any
 
 from vdk.internal.core.errors import VdkConfigurationError
+from dataclasses import dataclass, field
+from typing import Dict, Any, Optional
 
 # Consider ConfigValue should be primitive type perhaps? and not just any object
 ConfigValue = Any
@@ -16,250 +15,245 @@ ConfigKey = str
 log = logging.getLogger(__name__)
 
 
-def convert_value_to_type_of_default_type(
-    key: ConfigKey, v: ConfigValue, default_value: ConfigValue
-) -> ConfigValue:
+def convert_value_to_type_of_default_type(key: str, v: Any, default_value: Any) -> Any:
     """
-    Allows for configurations to be converted to the type of their default value.
+    Converts a given configuration value to the type of its default value if a default is provided.
 
-    E.g. IMPALA_PORT is converted to int, because it's default value is int.
+    Args:
+        key (str): The key for the configuration setting.
+        v (Any): The value to be converted.
+        default_value (Any): The default value which defines the type to which the value should be converted.
+
+    Returns:
+        Any: The value converted to the type of the default value.
+
+    Raises:
+        VdkConfigurationError: If the value cannot be converted to the required type or if an invalid value is provided for a boolean.
     """
     if default_value is not None:
-        if type(default_value) == bool and type(v) != bool:
+        if isinstance(default_value, bool):
             allowed_values = ["true", "false", "1", "0", "yes", "no", "y", "n"]
-            if str(v).lower() not in allowed_values:
-                msg = (
-                    f"Provided configuration "
-                    f'"{key}={v}" is invalid. Allowed values for {key} are {allowed_values}'
+            v_str = str(v).lower()
+            if v_str not in allowed_values:
+                raise VdkConfigurationError(
+                    f"Provided configuration '{key}={v}' is invalid. Allowed values for {key} are {allowed_values}"
                 )
-                raise VdkConfigurationError(msg)
-            v = str(v).lower() in ["true", "1", "yes", "y"]
+            return v_str in ["true", "1", "yes", "y"]
         else:
             try:
-                v = type(default_value)(v)  # cast to type of default_value:
+                return type(default_value)(v)
             except ValueError:
-                msg = (
-                    f'Provided configuration "{key}={v}" is invalid. '
-                    f'Cannot cast "{v}" to {str(type(default_value).__name__)}'
+                raise VdkConfigurationError(
+                    f'Provided configuration "{key}={v}" is invalid. Cannot cast "{v}" to {type(default_value).__name__}'
                 )
-                raise VdkConfigurationError(msg)
     return v
 
 
-def _normalize_config_key(key: ConfigKey):
+def _normalize_config_string(key: str):
     return str(key).lower()
+
+
+@dataclass
+class ConfigEntry:
+    """
+    A dataclass to store individual configuration item properties.
+
+    Attributes:
+        value: The current value of the configuration item.
+        default: The default value of the configuration item.
+        description: A string describing the configuration item.
+        sensitive: A boolean indicating if the configuration item is sensitive.
+    """
+    value: Any = None
+    default: Any = None
+    description: Optional[str] = None
+    sensitive: bool = False
 
 
 @dataclass(frozen=True)
 class Configuration:
     """
-    The configuration of the application. It's immutable.
+    The immutable configuration for an application, organized by sections.
 
-    Use ConfigurationBuilder to build it.
+    Each section contains configuration entries defined by the ConfigEntry dataclass,
+    allowing complex configuration setups with multiple sections, each potentially having
+    overlapping key names but distinct settings.
+
+    Attributes:
+        __sections (Dict[str, Dict[ConfigKey, ConfigEntry]]): A dictionary where each key is a section name
+                                                        and each value is another dictionary mapping
+                                                        configuration keys to ConfigEntry instances.
     """
+    __sections: Dict[str, Dict[ConfigKey, ConfigEntry]] = field(default_factory=dict)
 
-    __config_key_to_description: dict[ConfigKey, str]
-    __config_key_to_value: dict[ConfigKey, ConfigValue]
-    __config_key_to_default_value: dict[ConfigKey, ConfigValue] = field(
-        default_factory=dict
-    )
-    __config_key_to_sensitive: dict[ConfigKey, bool] = field(default_factory=dict)
-
-    def __getitem__(self, key: ConfigKey):
-        key = _normalize_config_key(key)
-        return self.get_value(key)
-
-    def override_value(self, key: ConfigKey, value: ConfigValue):
-        key = _normalize_config_key(key)
-        if key in self.__config_key_to_default_value:
-            self.__config_key_to_value[key] = value
-
-    def get_value(self, key: ConfigKey) -> ConfigValue:
+    def get_value(self, section: str, key: str) -> Optional[Any]:
         """
-        Return configuration value associated with a given key or None if it does not exists.
+        Retrieve the current value of a configuration key within a specified section.
 
-        For required configuration see get_required_value
+        Args:
+            section (str): The name of the section.
+            key (str): The configuration key.
 
-        :param key: the configuration key (e.g db_host, service_uri, etc.)
-        :return: the value corresponding to the configuration key
+        Returns:
+            Any: The current value of the configuration key if it exists, None otherwise.
         """
-        key = _normalize_config_key(key)
-        default_value = self.__config_key_to_default_value.get(key)
-        value = self.__config_key_to_value.get(key, default_value)
-        return value
+        section = _normalize_config_string(section)
+        key = _normalize_config_string(key)
+        return self.__sections.get(section, {}).get(key, ConfigEntry()).value
 
-    def get_required_value(self, key: ConfigKey) -> ConfigValue:
+    def get_required_value(self, section: str, key: str) -> Any:
         """
-        Return configuration value associated with a given key or throws VdkConfigurationError if it's missing.
+        Retrieve the current value of a configuration key within a specified section and raise
+        an error if it is not set.
 
-        Use get_value if configuration is not required
+        Args:
+            section (str): The name of the section.
+            key (str): The configuration key.
 
-        :param key: the configuration key (e.g db_host, service_uri, etc.)
-        :return: the value corresponding to the configuration key
-        :raises VdkConfigurationError
+        Returns:
+            Any: The current value of the configuration key.
+
+        Raises:
+            ValueError: If the configuration key is not set.
         """
-        key = _normalize_config_key(key)
-        value = self.get_value(key)
+        section = _normalize_config_string(section)
+        key = _normalize_config_string(key)
+        value = self.get_value(section, key)
         if value is None:
-            raise VdkConfigurationError(
-                f"Required configuration {key} is missing."
-                f"This will cause configuration error and some functionality may not work."
-                f"Please provide correct configuration value. "
-                f"See help for how to configure the tool"
-            )
+            raise ValueError(f"Required configuration {key} in section {section} is missing.")
         return value
 
-    def get_description(self, key: ConfigKey) -> str | None:
+    def get_description(self, section: str, key: str) -> Optional[str]:
         """
-        Get description of hte configuration with that key. It will be used to be printed in help.
+        Retrieve the description of a configuration key within a specified section.
 
-        :param key: the config key
-        :return: description
+        Args:
+            section (str): The name of the section.
+            key (str): The configuration key.
+
+        Returns:
+            Optional[str]: The description of the configuration key if it exists, None otherwise.
         """
-        key = _normalize_config_key(key)
-        return self.__config_key_to_description.get(key)
+        section = _normalize_config_string(section)
+        key = _normalize_config_string(key)
+        return self.__sections.get(section, {}).get(key, ConfigEntry()).description
 
-    def is_sensitive(self, key: ConfigKey) -> bool | None:
+    def is_sensitive(self, section: str, key: str) -> bool:
         """
-        Check if config key is sensitive, e.g. password
+        Check if a configuration key within a specified section is marked as sensitive.
 
-        :param key: the config key
-        :return: True if sensitive, else False
+        Args:
+            section (str): The name of the section.
+            key (str): The configuration key.
+
+        Returns:
+            bool: True if the configuration key is marked as sensitive, False otherwise.
         """
-        return self.__config_key_to_sensitive.get(key)
-
-    def is_default(self, key: ConfigKey) -> bool:
-        """
-        Return True if the configuration value for a given key uses the default value.
-        If set_value is called for a specific key, this will return False, even if
-        value == default_value
-
-        :param key: the configuration key (e.g db_host, service_uri, etc.)
-        :return: the value corresponding to the configuration key
-        """
-        return key not in self.__config_key_to_value
-
-    def list_config_keys(self) -> list[ConfigKey]:
-        """
-        List all added (defined) config keys
-
-        :return: list of key names.
-        """
-        return [k for k in self.__config_key_to_default_value.keys()]
+        section = _normalize_config_string(section)
+        key = _normalize_config_string(key)
+        return self.__sections.get(section, {}).get(key, ConfigEntry()).sensitive
 
 
-@dataclass()
+@dataclass
 class ConfigurationBuilder:
     """
-    Builder used to configure the app.
+    A builder class for creating a Configuration object, structured to allow detailed control
+    over configuration data organized by sections and keys.
 
-    Usually a plugin would define what variables it needs using add method.
-    While other plugins will populate them using set_value method (e.g environment variable plugin. yaml file plugin, etc.).
+    This builder supports defining complex configurations that can handle multiple sections,
+    with each section potentially containing overlapping key names but with distinct settings.
+
+    Attributes:
+        __sections (Dict[str, Dict[ConfigKey, ConfigEntry]]): Stores all configuration data during the building process.
+                                                Each section maps configuration keys to their respective ConfigEntry.
     """
+    __sections: Dict[str, Dict[ConfigKey, ConfigEntry]] = field(default_factory=dict)
 
-    __config_key_to_description: dict[ConfigKey, str]
-    __config_key_to_value: dict[ConfigKey, ConfigValue]
-    __config_key_to_default_value: dict[ConfigKey, ConfigValue]
-    __config_key_to_sensitive: dict[ConfigKey, bool]
-
-    def __init__(self):
-        self.__config_key_to_description = dict()
-        self.__config_key_to_default_value = dict()
-        self.__config_key_to_value = dict()
-        self.__config_key_to_sensitive = dict()
-
-    def add(
-        self,
-        key: ConfigKey,
-        default_value: ConfigValue,
-        show_default_value=True,
-        description=None,
-        is_sensitive=False,
-    ) -> ConfigurationBuilder:
+    def add(self, section: str, key: str, default_value: Optional[Any] = None, description: Optional[str] = None,
+            is_sensitive: bool = False) -> 'ConfigurationBuilder':
         """
-        Add new configuration variable definition.
+        Adds a configuration key with its associated properties to a specified section. If the section does not
+        already exist, it is created.
 
-        :param key: The configuration key. If already exist variable will be updated.
-        :param default_value: Default value for the configuration Can be None.
-        :param show_default_value: default value will appear in help as well.
-        The default value type will enforce the type of the option. Can be None - in this case the type would str.
-        :param description: Set description if you want config variable to appear in command line help .
-        :param is_sensitive: Set to True if the configuration variable represents sensitive data, e.g. password.
-        False by default. Appends 'This option is marked as sensitive' to the description if set to True
-        It is strongly recommended to set description. If no description is set the config key will be hidden.
-        TODO: in the future we should require description always and have separate hidden=True/False instead
-        :return: self so it can be chained like builder.add(..).set_value(...)...
+        Args:
+            section (str): The name of the section to which the configuration key will be added.
+            key (str): The configuration key to add.
+            default_value (Optional[Any]): The default value for the configuration key, used if no value is explicitly set.
+            description (Optional[str]): A human-readable description of the configuration key.
+            is_sensitive (bool): Indicates whether the configuration key contains sensitive information.
+
+        Returns:
+            ConfigurationBuilder: Returns the builder instance to enable method chaining.
         """
-        key = _normalize_config_key(key)
-        self.__config_key_to_default_value[key] = default_value
-        self.__config_key_to_sensitive[key] = is_sensitive
-        if description and show_default_value:
-            self.__add_public(key, description, is_sensitive, default_value)
-        elif description:
-            self.__add_public(key, description, is_sensitive)
-        self.__adjust_type_if_value_set(key, default_value)
+        section = _normalize_config_string(section)
+        key = _normalize_config_string(key)
+        self.__add_public(section, key, default_value, description, is_sensitive)
         return self
 
-    def set_value(self, key: ConfigKey, value: ConfigValue) -> ConfigurationBuilder:
+    def __add_public(self, section: str, key: str, default_value: Optional[Any], description: Optional[str],
+                     is_sensitive: bool) -> None:
         """
-        This will set or update the value for a configuration with a given key.
+        Handles the internal logic of adding a new configuration key to a section, including managing descriptions
+        and sensitivity settings. This method encapsulates additional formatting and initialization operations
+        that are abstracted from the user.
 
-        It will try to cast it to the specified default type inferred from default value (set with #add method)
-        :param key: the configuration key
-        :param value: the configuration value.
-        :return: self so it can be chained like builder.set_value(..).add(...)...
+        Args:
+            section (str): The name of the section where the key will be added.
+            key (str): The configuration key to be added.
+            default_value (Optional[Any]): The default value for the configuration key.
+            description (Optional[str]): The description of the configuration key; enhances user documentation.
+            is_sensitive (bool): Specifies if the configuration key is sensitive.
+
+        Raises:
+            ValueError: If the key already exists and the function is intended to only handle new additions.
         """
-        key = _normalize_config_key(key)
-        default_value = self.__config_key_to_default_value.get(key)
-        self.__config_key_to_value[key] = convert_value_to_type_of_default_type(
-            key, value, default_value
-        )
-        return self
+        section = _normalize_config_string(section)
+        key = _normalize_config_string(key)
+        if section not in self.__sections:
+            self.__sections[section] = {}
 
-    def list_config_keys(self) -> list[ConfigKey]:
-        """
-        List all added (defined) config keys
-
-        :return: list of key names.
-        """
-        return [k for k in self.__config_key_to_default_value.keys()]
-
-    def __add_public(
-        self,
-        key: ConfigKey,
-        description: str,
-        is_sensitive: bool = False,
-        default_value: ConfigValue = None,
-    ) -> None:
-        if not isinstance(description, str):
-            log.warning(
-                f"Description for key {key} is not of type string. Converting to type string."
-            )
-            description = str(description)
-
-        if default_value is not None:
-            description += "\nDefault value is: '%s'." % default_value
+        formatted_description = description if description else "No description provided."
         if is_sensitive:
-            description += "\nThis option is marked as sensitive."
-        self.__config_key_to_description[key] = description
+            formatted_description += " This option is marked as sensitive."
 
-    def __adjust_type_if_value_set(self, key: ConfigKey, default_value: ConfigValue):
+        self.__sections[section][key] = ConfigEntry(
+            value=default_value,
+            default=default_value,
+            description=formatted_description,
+            sensitive=is_sensitive
+        )
+
+    def set_value(self, section: str, key: str, value: Any) -> 'ConfigurationBuilder':
         """
-        As set_value can be called before add (which defines the configuration) we may need to adjust
-        the type of the value if it's already set.
+        Sets or updates the value for a specific configuration key within a designated section.
+
+        Args:
+            section (str): The name of the section containing the configuration key.
+            key (str): The configuration key whose value is to be updated.
+            value (Any): The new value to assign to the configuration key.
+
+        Returns:
+            ConfigurationBuilder: Returns the builder instance to enable method chaining.
+
+        Raises:
+            ValueError: If the key does not exist in the given section, indicating it must be added first.
         """
-        if default_value is not None and key in self.__config_key_to_value:
-            self.__config_key_to_value[key] = convert_value_to_type_of_default_type(
-                key, self.__config_key_to_value[key], default_value
-            )
+        section = _normalize_config_string(section)
+        key = _normalize_config_string(key)
+        if section not in self.__sections or key not in self.__sections[section]:
+            raise ValueError(f"Key {key} does not exist in section {section}. Please add it first.")
+        default_value = self.__sections[section][key].default
+        converted_value = convert_value_to_type_of_default_type(key, value, default_value)
+        self.__sections[section][key].value = converted_value
+        return self
 
     def build(self) -> Configuration:
         """
-        :return: immutable version of the Configuration
+        Finalizes the building process and constructs an immutable Configuration object from the accumulated data.
+
+        Returns:
+            Configuration: The constructed immutable configuration object, ready to be used within the application.
         """
-        return Configuration(
-            self.__config_key_to_description,
-            self.__config_key_to_value,
-            self.__config_key_to_default_value,
-            self.__config_key_to_sensitive,
-        )
+        return Configuration(__sections=self.__sections)
+
+

--- a/projects/vdk-core/src/vdk/internal/core/config.py
+++ b/projects/vdk-core/src/vdk/internal/core/config.py
@@ -397,6 +397,12 @@ class ConfigurationBuilder:
         Raises:
             ValueError: If the key already exists and the function is intended to only handle new additions.
         """
+        if not isinstance(description, str):
+            log.warning(
+                f"Description for key {key} is not of type string. Converting to type string."
+            )
+            description = str(description)
+
         formatted_description = description or "No description provided."
         if is_sensitive:
             formatted_description += " This option is marked as sensitive."

--- a/projects/vdk-core/src/vdk/internal/core/config.py
+++ b/projects/vdk-core/src/vdk/internal/core/config.py
@@ -446,7 +446,7 @@ class ConfigurationBuilder:
             self.__add_public(
                 section=section,
                 key=key,
-                default_value=None,
+                default_value=None, # it should be = value
                 value=value,
                 description="",
             )

--- a/projects/vdk-core/src/vdk/internal/core/config.py
+++ b/projects/vdk-core/src/vdk/internal/core/config.py
@@ -8,10 +8,6 @@ from vdk.internal.core.errors import VdkConfigurationError
 from dataclasses import dataclass, field
 from typing import Dict, Any, Optional, List, Union, Tuple
 
-# Consider ConfigValue should be primitive type perhaps? and not just any object
-ConfigValue = Any
-ConfigKey = str
-
 log = logging.getLogger(__name__)
 
 
@@ -108,7 +104,7 @@ class Configuration:
             section = _normalize_config_string(section)
             return self._sections.get(section, {}).get(key, ConfigEntry()).value
 
-    def override_value(self, key: ConfigKey, value: Any, section: str = None):
+    def override_value(self, key: str, value: Any, section: str = None):
         key = _normalize_config_string(key)
         if section is None:
             for sec, entries in self._sections.items():

--- a/projects/vdk-core/src/vdk/internal/core/config.py
+++ b/projects/vdk-core/src/vdk/internal/core/config.py
@@ -341,15 +341,24 @@ class ConfigurationBuilder:
         """
         section = _normalize_config_string(section) if section else "vdk"
         key = _normalize_config_string(key)
+        if not description:
+            description = "No description provided."
         if section in self.__sections and key in self.__sections[section].keys()\
                 and self.__sections[section][key].value != self.__sections[section][key].default:
-            self.__sections[section][key].description = description
-            self.__sections[section][key].default = default_value
-            self.__sections[section][key].sensitive = is_sensitive
-            self.set_value(key=key, value=convert_value_to_type_of_default_type(
+            preserved_value = value=convert_value_to_type_of_default_type(
                 key=key,
                 v=self.__sections[section][key].value,
-                default_value=default_value), section=section)
+                default_value=default_value)
+            self.__add_public(
+                section,
+                key,
+                default_value,
+                None,
+                description,
+                is_sensitive,
+                show_default_value,
+            )
+            self.set_value(key=key, value=preserved_value, section=section)
         else:
             self.__add_public(
                 section,

--- a/projects/vdk-core/src/vdk/internal/core/config.py
+++ b/projects/vdk-core/src/vdk/internal/core/config.py
@@ -343,12 +343,17 @@ class ConfigurationBuilder:
         key = _normalize_config_string(key)
         if not description:
             description = "No description provided."
-        if section in self.__sections and key in self.__sections[section].keys()\
-                and self.__sections[section][key].value != self.__sections[section][key].default:
-            preserved_value = value=convert_value_to_type_of_default_type(
+        if (
+            section in self.__sections
+            and key in self.__sections[section].keys()
+            and self.__sections[section][key].value
+            != self.__sections[section][key].default
+        ):
+            preserved_value = value = convert_value_to_type_of_default_type(
                 key=key,
                 v=self.__sections[section][key].value,
-                default_value=default_value)
+                default_value=default_value,
+            )
             self.__add_public(
                 section,
                 key,
@@ -422,7 +427,6 @@ class ConfigurationBuilder:
             sensitive=is_sensitive,
         )
 
-
     def set_value(
         self, key: str, value: Any, section: str | None = "vdk"
     ) -> ConfigurationBuilder:
@@ -446,14 +450,15 @@ class ConfigurationBuilder:
             self.__add_public(
                 section=section,
                 key=key,
-                default_value=None, # it should be = value
+                default_value=None,  # it should be = value
                 value=value,
                 description="",
             )
 
         if self.__sections[section][key].default is not None:
-            self.__sections[section][key].value = convert_value_to_type_of_default_type(key=key, v=value,
-                                                                                 default_value= self.__sections[section][key].default)
+            self.__sections[section][key].value = convert_value_to_type_of_default_type(
+                key=key, v=value, default_value=self.__sections[section][key].default
+            )
         else:
             self.__sections[section][key].value = value
         return self

--- a/projects/vdk-core/src/vdk/internal/core/config.py
+++ b/projects/vdk-core/src/vdk/internal/core/config.py
@@ -403,7 +403,7 @@ class ConfigurationBuilder:
             )
             description = str(description)
 
-        formatted_description = description or "No description provided."
+        formatted_description = description
         if is_sensitive:
             formatted_description += " This option is marked as sensitive."
         if show_default_value and default_value is not None:
@@ -450,7 +450,12 @@ class ConfigurationBuilder:
                 value=value,
                 description="",
             )
-        self.__sections[section][key].value = value
+
+        if self.__sections[section][key].default is not None:
+            self.__sections[section][key].value = convert_value_to_type_of_default_type(key=key, v=value,
+                                                                                 default_value= self.__sections[section][key].default)
+        else:
+            self.__sections[section][key].value = value
         return self
 
     def list_config_keys_from_main_sections(self) -> list[str]:

--- a/projects/vdk-core/src/vdk/internal/core/config.py
+++ b/projects/vdk-core/src/vdk/internal/core/config.py
@@ -341,15 +341,25 @@ class ConfigurationBuilder:
         """
         section = _normalize_config_string(section) if section else "vdk"
         key = _normalize_config_string(key)
-        self.__add_public(
-            section,
-            key,
-            default_value,
-            None,
-            description,
-            is_sensitive,
-            show_default_value,
-        )
+        if section in self.__sections and key in self.__sections[section].keys()\
+                and self.__sections[section][key].value != self.__sections[section][key].default:
+            self.__sections[section][key].description = description
+            self.__sections[section][key].default = default_value
+            self.__sections[section][key].sensitive = is_sensitive
+            self.set_value(key=key, value=convert_value_to_type_of_default_type(
+                key=key,
+                v=self.__sections[section][key].value,
+                default_value=default_value), section=section)
+        else:
+            self.__add_public(
+                section,
+                key,
+                default_value,
+                None,
+                description,
+                is_sensitive,
+                show_default_value,
+            )
         return self
 
     def __add_public(
@@ -396,6 +406,7 @@ class ConfigurationBuilder:
             description=formatted_description,
             sensitive=is_sensitive,
         )
+
 
     def set_value(
         self, key: str, value: Any, section: str | None = "vdk"

--- a/projects/vdk-core/src/vdk/internal/core/config.py
+++ b/projects/vdk-core/src/vdk/internal/core/config.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Union
 
 from vdk.internal.core.errors import VdkConfigurationError
-from dataclasses import dataclass, field
-from typing import Dict, Any, Optional, List, Union, Tuple
 
 log = logging.getLogger(__name__)
 
@@ -60,9 +66,10 @@ class ConfigEntry:
         description: A string describing the configuration item.
         sensitive: A boolean indicating if the configuration item is sensitive.
     """
+
     value: Any = None
     default: Any = None
-    description: Optional[str] = None
+    description: str | None = None
     sensitive: bool = False
 
 
@@ -79,9 +86,10 @@ class Configuration:
         _sections (Dict[str, Dict[str, ConfigEntry]]): A dictionary where each key represents a section name
         and each value is a dictionary of configuration keys to ConfigEntry instances.
     """
-    _sections: Dict[str, Dict[str, ConfigEntry]] = field(default_factory=dict)
 
-    def get_value(self, key: str, section: Optional[str] = None) -> Optional[Any]:
+    _sections: dict[str, dict[str, ConfigEntry]] = field(default_factory=dict)
+
+    def get_value(self, key: str, section: str | None = None) -> Any | None:
         """
         Retrieve the current value of a configuration key, optionally searching only within a specific section or
         across all non-prefixed sections if no section is provided.
@@ -115,10 +123,12 @@ class Configuration:
             if section in self._sections and key in self._sections[section].keys():
                 self._sections[section][key].value = value
             else:
-                raise VdkConfigurationError("The value you are trying to override is not existing. "
-                                            f"Check the {section} section and {key} key, again!")
+                raise VdkConfigurationError(
+                    "The value you are trying to override is not existing. "
+                    f"Check the {section} section and {key} key, again!"
+                )
 
-    def get_required_value(self, key: str, section: Optional[str] = None) -> Any:
+    def get_required_value(self, key: str, section: str | None = None) -> Any:
         """
         Retrieve the required value of a configuration key, optionally from a specific section or
         across all non-prefixed sections, raising an error if the key is not found.
@@ -137,12 +147,16 @@ class Configuration:
         value = self.get_value(key, section)
         if value is None:
             if section:
-                raise VdkConfigurationError(f"Required configuration {key} in section {section} is missing.")
+                raise VdkConfigurationError(
+                    f"Required configuration {key} in section {section} is missing."
+                )
             else:
-                raise VdkConfigurationError(f"Required configuration {key} is missing in non-vdk prefixed sections.")
+                raise VdkConfigurationError(
+                    f"Required configuration {key} is missing in non-vdk prefixed sections."
+                )
         return value
 
-    def get_description(self, key: str, section: Optional[str] = None) -> Optional[str]:
+    def get_description(self, key: str, section: str | None = None) -> str | None:
         """
         Retrieve the description of a configuration key, optionally from a specific section or
         across all non-prefixed sections.
@@ -165,7 +179,7 @@ class Configuration:
             section = _normalize_config_string(section)
             return self._sections.get(section, {}).get(key, ConfigEntry()).description
 
-    def is_sensitive(self, key: str, section: Optional[str] = None) -> bool:
+    def is_sensitive(self, key: str, section: str | None = None) -> bool:
         """
         Check if a configuration key within a specified section or across all non-prefixed sections
         is marked as sensitive.
@@ -188,7 +202,7 @@ class Configuration:
             section = _normalize_config_string(section)
             return self._sections.get(section, {}).get(key, ConfigEntry()).sensitive
 
-    def is_default(self, key: str, section: Optional[str] = None) -> bool:
+    def is_default(self, key: str, section: str | None = None) -> bool:
         """
         Return True if the configuration value for a given key uses the default value.
         If set_value is called for a specific key, this will return False, even if value == default_value.
@@ -217,7 +231,7 @@ class Configuration:
             return entry.value == entry.default
         return False
 
-    def list_sections(self) -> List[str]:
+    def list_sections(self) -> list[str]:
         """
         List all section names in the configuration.
 
@@ -226,7 +240,7 @@ class Configuration:
         """
         return list(self._sections.keys())
 
-    def list_keys_in_section(self, section: str) -> List[str]:
+    def list_keys_in_section(self, section: str) -> list[str]:
         """
         List all keys within a specified section of the configuration.
 
@@ -245,7 +259,7 @@ class Configuration:
             return list(self._sections[section].keys())
         raise ValueError(f"Section '{section}' does not exist in the configuration.")
 
-    def list_config_keys_from_main_sections(self) -> List[str]:
+    def list_config_keys_from_main_sections(self) -> list[str]:
         """
         List all configuration keys from sections that do not start with 'vdk_'.
         The vdk_ are considered subsections of vdk.
@@ -259,11 +273,11 @@ class Configuration:
                 keys.extend(entries.keys())
         return list(keys)
 
-    def list_config_keys(self) -> List[str]:
+    def list_config_keys(self) -> list[str]:
         # this is used in many plugins to be removed after the change in plugins is done
         return self.list_config_keys_from_main_sections()
 
-    def __getitem__(self, key: Union[str, Tuple[str, Optional[str]]]) -> Any:
+    def __getitem__(self, key: str | tuple[str, str | None]) -> Any:
         """
         Allows the Configuration object to be accessed using subscript notation. Supports accessing
         with a single key or a tuple containing section and key.
@@ -298,12 +312,18 @@ class ConfigurationBuilder:
         __sections (Dict[str, Dict[str, ConfigEntry]]): Stores all configuration data during the building process.
                                                         Each section maps configuration keys to their respective ConfigEntry.
     """
-    __sections: Dict[str, Dict[str, ConfigEntry]] = field(default_factory=dict)
 
-    def add(self, key: str, default_value: Optional[Any] = None,
-            show_default_value: bool = True,
-            description: Optional[str] = None, is_sensitive: bool = False,
-            section: Optional[str] = "vdk") -> 'ConfigurationBuilder':
+    __sections: dict[str, dict[str, ConfigEntry]] = field(default_factory=dict)
+
+    def add(
+        self,
+        key: str,
+        default_value: Any | None = None,
+        show_default_value: bool = True,
+        description: str | None = None,
+        is_sensitive: bool = False,
+        section: str | None = "vdk",
+    ) -> ConfigurationBuilder:
         """
         Adds a configuration key with its associated properties to a specified section. If the section does not
         already exist, it is created. If no section is specified, the configuration is added to the 'vdk' section.
@@ -321,12 +341,27 @@ class ConfigurationBuilder:
         """
         section = _normalize_config_string(section) if section else "vdk"
         key = _normalize_config_string(key)
-        self.__add_public(section, key, default_value, None, description, is_sensitive, show_default_value)
+        self.__add_public(
+            section,
+            key,
+            default_value,
+            None,
+            description,
+            is_sensitive,
+            show_default_value,
+        )
         return self
 
-    def __add_public(self, section: str, key: str, default_value: Optional[Any], value: Optional[Any],
-                     description: Optional[str],
-                     is_sensitive: bool = False, show_default_value: bool = True) -> None:
+    def __add_public(
+        self,
+        section: str,
+        key: str,
+        default_value: Any | None,
+        value: Any | None,
+        description: str | None,
+        is_sensitive: bool = False,
+        show_default_value: bool = True,
+    ) -> None:
         """
         Handles the internal logic of adding a new configuration key to a section, including managing descriptions
         and sensitivity settings. This method encapsulates additional formatting and initialization operations
@@ -354,19 +389,26 @@ class ConfigurationBuilder:
 
         value = value if value else default_value
         if key in self.__sections[section] and value == default_value:
-            if self.__sections[section][key].value != self.__sections[section][key].default:
+            if (
+                self.__sections[section][key].value
+                != self.__sections[section][key].default
+            ):
                 value = self.__sections[section][key].value
         if default_value:
-            value = convert_value_to_type_of_default_type(key=key, v=value, default_value=default_value)
+            value = convert_value_to_type_of_default_type(
+                key=key, v=value, default_value=default_value
+            )
 
         self.__sections[section][key] = ConfigEntry(
             value=value,
             default=default_value,
             description=formatted_description,
-            sensitive=is_sensitive
+            sensitive=is_sensitive,
         )
 
-    def set_value(self, key: str, value: Any, section: Optional[str] = "vdk") -> 'ConfigurationBuilder':
+    def set_value(
+        self, key: str, value: Any, section: str | None = "vdk"
+    ) -> ConfigurationBuilder:
         """
         Sets or updates the value for a specific configuration key within a designated section.
 
@@ -384,11 +426,17 @@ class ConfigurationBuilder:
         section = _normalize_config_string(section)
         key = _normalize_config_string(key)
         if section not in self.__sections or key not in self.__sections[section]:
-            self.__add_public(section=section, key=key, default_value=None, value=value, description="")
+            self.__add_public(
+                section=section,
+                key=key,
+                default_value=None,
+                value=value,
+                description="",
+            )
         self.__sections[section][key].value = value
         return self
 
-    def list_config_keys_from_main_sections(self) -> List[str]:
+    def list_config_keys_from_main_sections(self) -> list[str]:
         """
         List all configuration keys from sections that do not start with 'vdk_'.
         The vdk_ are considered subsections of vdk.
@@ -402,7 +450,7 @@ class ConfigurationBuilder:
                 keys.extend(entries.keys())
         return list(keys)
 
-    def list_config_keys_for_section(self, section: str) -> List[str]:
+    def list_config_keys_for_section(self, section: str) -> list[str]:
         """
         List all keys within a specified section of the configuration.
 
@@ -419,7 +467,7 @@ class ConfigurationBuilder:
         else:
             raise ValueError(f"Section '{section}' does not exist.")
 
-    def list_all_section_names(self) -> List[str]:
+    def list_all_section_names(self) -> list[str]:
         """
         List all section names in the configuration.
 
@@ -428,7 +476,7 @@ class ConfigurationBuilder:
         """
         return list(self.__sections.keys())
 
-    def build(self) -> 'Configuration':
+    def build(self) -> Configuration:
         """
         Finalizes the building process and constructs an immutable Configuration object from the accumulated data.
 
@@ -436,7 +484,3 @@ class ConfigurationBuilder:
             Configuration: The constructed immutable configuration object, ready to be used within the application.
         """
         return Configuration(_sections=self.__sections)
-
-
-
-

--- a/projects/vdk-core/src/vdk/internal/core/config.py
+++ b/projects/vdk-core/src/vdk/internal/core/config.py
@@ -387,17 +387,8 @@ class ConfigurationBuilder:
         if section not in self.__sections:
             self.__sections[section] = {}
 
-        value = value if value else default_value
-        if key in self.__sections[section] and value == default_value:
-            if (
-                self.__sections[section][key].value
-                != self.__sections[section][key].default
-            ):
-                value = self.__sections[section][key].value
-        if default_value:
-            value = convert_value_to_type_of_default_type(
-                key=key, v=value, default_value=default_value
-            )
+        if not value:
+            value = default_value
 
         self.__sections[section][key] = ConfigEntry(
             value=value,

--- a/projects/vdk-core/src/vdk/internal/core/config.py
+++ b/projects/vdk-core/src/vdk/internal/core/config.py
@@ -6,11 +6,6 @@ import logging
 from dataclasses import dataclass
 from dataclasses import field
 from typing import Any
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Tuple
-from typing import Union
 
 from vdk.internal.core.errors import VdkConfigurationError
 
@@ -349,7 +344,7 @@ class ConfigurationBuilder:
             and self.__sections[section][key].value
             != self.__sections[section][key].default
         ):
-            preserved_value = value = convert_value_to_type_of_default_type(
+            preserved_value = convert_value_to_type_of_default_type(
                 key=key,
                 v=self.__sections[section][key].value,
                 default_value=default_value,

--- a/projects/vdk-core/src/vdk/internal/core/config.py
+++ b/projects/vdk-core/src/vdk/internal/core/config.py
@@ -235,6 +235,20 @@ class Configuration:
             return list(self._sections[section].keys())
         raise ValueError(f"Section '{section}' does not exist in the configuration.")
 
+    def list_config_keys_from_main_sections(self) -> List[str]:
+        """
+        List all configuration keys from sections that do not start with 'vdk_'.
+        The vdk_ are considered subsections of vdk.
+
+        Returns:
+            List[str]: A list of all configuration keys in non-'vdk_' prefixed sections.
+        """
+        keys = []
+        for section, entries in self._sections.items():
+            if not section.startswith("vdk_"):
+                keys.extend(entries.keys())
+        return list(keys)
+
     def __getitem__(self, key: Union[str, Tuple[str, Optional[str]]]) -> Any:
         """
         Allows the Configuration object to be accessed using subscript notation. Supports accessing

--- a/projects/vdk-core/tests/functional/run/test_run_notifications.py
+++ b/projects/vdk-core/tests/functional/run/test_run_notifications.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
 from email.message import Message
+from random import randint
 from unittest import mock
 
 from click.testing import Result
@@ -18,7 +19,7 @@ os.environ["SMTPD_SSL_CERTS_PATH"] = "."
 
 def __get_smtp_env(smtpd: SMTPDFix):
     # https://github.com/bebleo/smtpdfix#using
-    smtpd.config.host = "127.0.0.1"
+    # smtpd.config.host = "127.0.0.1"
     env = {
         "VDK_NOTIFICATION_ENABLED": "true",
         "VDK_ENABLE_ATTEMPT_NOTIFICATIONS": "true",
@@ -33,88 +34,101 @@ def __get_smtp_env(smtpd: SMTPDFix):
     return env
 
 
-def test_run_successfull(smtpd: SMTPDFix):
+def test_run_successfull():
     errors.resolvable_context().clear()
-    with mock.patch.dict(
-        os.environ,
-        {
-            **__get_smtp_env(smtpd),
-            "VDK_NOTIFIED_ON_JOB_SUCCESS": "tester@unittest.test",
-        },
-    ):
-        runner = CliEntryBasedTestRunner()
 
-        result: Result = runner.invoke(["run", util.job_path("simple-job")])
+    port = randint(10000, 20000)
+    host = "127.0.0.1"
+    with SMTPDFix(host, port) as server:
+        with mock.patch.dict(
+            os.environ,
+            {
+                **__get_smtp_env(server),
+                "VDK_NOTIFIED_ON_JOB_SUCCESS": "tester@unittest.test",
+            },
+        ):
+            runner = CliEntryBasedTestRunner()
 
-        cli_assert_equal(0, result)
+            result: Result = runner.invoke(["run", util.job_path("simple-job")])
 
-        assert len(smtpd.messages) == 1
-        message: Message = smtpd.messages[0]
-        assert "tester@unittest.test" == message.get("To")
-        assert "simple-job" in message.get("Subject")
+            cli_assert_equal(0, result)
+
+            assert len(server.messages) == 1
+            message: Message = server.messages[0]
+            assert "tester@unittest.test" == message.get("To")
+            assert "simple-job" in message.get("Subject")
 
 
-def test_run_successfull_notify_multiple_users(smtpd: SMTPDFix):
+def test_run_successfull_notify_multiple_users():
     errors.resolvable_context().clear()
-    with mock.patch.dict(
-        os.environ,
-        {
-            **__get_smtp_env(smtpd),
-            "VDK_NOTIFIED_ON_JOB_SUCCESS": "t1@unittest.test;t2@unittest.test;t3@unittest.test",
-        },
-    ):
-        runner = CliEntryBasedTestRunner()
+    port = randint(10000, 20000)
+    host = "127.0.0.1"
+    with SMTPDFix(host, port) as server:
+        with mock.patch.dict(
+            os.environ,
+            {
+                **__get_smtp_env(server),
+                "VDK_NOTIFIED_ON_JOB_SUCCESS": "t1@unittest.test;t2@unittest.test;t3@unittest.test",
+            },
+        ):
+            runner = CliEntryBasedTestRunner()
 
-        result: Result = runner.invoke(["run", util.job_path("simple-job")])
+            result: Result = runner.invoke(["run", util.job_path("simple-job")])
 
-        cli_assert_equal(0, result)
+            cli_assert_equal(0, result)
 
-        assert len(smtpd.messages) == 1
-        message: Message = smtpd.messages[0]
-        assert "t1@unittest.test" in message.get("To")
-        assert "t2@unittest.test" in message.get("To")
-        assert "t3@unittest.test" in message.get("To")
+            assert len(server.messages) == 1
+            message: Message = server.messages[0]
+            assert "t1@unittest.test" in message.get("To")
+            assert "t2@unittest.test" in message.get("To")
+            assert "t3@unittest.test" in message.get("To")
 
 
 @mock.patch.dict(os.environ, {"VDK_DB_DEFAULT_TYPE": DB_TYPE_SQLITE_MEMORY})
-def test_run_query_failed_user_error_notification_sent(smtpd: SMTPDFix):
+def test_run_query_failed_user_error_notification_sent():
     errors.resolvable_context().clear()
     db_plugin = DecoratedSqLite3MemoryDbPlugin()
     runner = CliEntryBasedTestRunner(db_plugin)
 
-    with mock.patch.dict(
-        os.environ,
-        {
-            **__get_smtp_env(smtpd),
-            "VDK_NOTIFIED_ON_JOB_FAILURE_USER_ERROR": "tester@unittest.test",
-        },
-    ):
-        result: Result = runner.invoke(
-            ["run", util.job_path("simple-create-insert-failed")]
-        )
+    port = randint(10000, 20000)
+    host = "127.0.0.1"
+    with SMTPDFix(host, port) as server:
+        with mock.patch.dict(
+            os.environ,
+            {
+                **__get_smtp_env(server),
+                "VDK_NOTIFIED_ON_JOB_FAILURE_USER_ERROR": "tester@unittest.test",
+            },
+        ):
+            result: Result = runner.invoke(
+                ["run", util.job_path("simple-create-insert-failed")]
+            )
 
-        cli_assert_equal(1, result)
-        assert len(smtpd.messages) == 1
+            cli_assert_equal(1, result)
+            assert len(server.messages) == 1
 
 
 @mock.patch.dict(os.environ, {"VDK_DB_DEFAULT_TYPE": DB_TYPE_SQLITE_MEMORY})
-def test_run_query_failed_user_error_no_notification_configured(smtpd: SMTPDFix):
+def test_run_query_failed_user_error_no_notification_configured():
     errors.resolvable_context().clear()
     db_plugin = DecoratedSqLite3MemoryDbPlugin()
     runner = CliEntryBasedTestRunner(db_plugin)
 
-    with mock.patch.dict(
-        os.environ,
-        {
-            **__get_smtp_env(smtpd),
-            # our job will fail with user error but we have configure platform error
-            # so we should NOT get mail
-            "NOTIFIED_ON_JOB_FAILURE_PLATFORM_ERROR": "tester@unittest.test",
-        },
-    ):
-        result: Result = runner.invoke(
-            ["run", util.job_path("simple-create-insert-failed")]
-        )
+    port = randint(10000, 20000)
+    host = "127.0.0.1"
+    with SMTPDFix(host, port) as server:
+        with mock.patch.dict(
+            os.environ,
+            {
+                **__get_smtp_env(server),
+                # our job will fail with user error but we have configure platform error
+                # so we should NOT get mail
+                "NOTIFIED_ON_JOB_FAILURE_PLATFORM_ERROR": "tester@unittest.test",
+            },
+        ):
+            result: Result = runner.invoke(
+                ["run", util.job_path("simple-create-insert-failed")]
+            )
 
-        cli_assert_equal(1, result)
-        assert len(smtpd.messages) == 0
+            cli_assert_equal(1, result)
+            assert len(server.messages) == 0

--- a/projects/vdk-core/tests/functional/run/test_run_notifications.py
+++ b/projects/vdk-core/tests/functional/run/test_run_notifications.py
@@ -19,7 +19,6 @@ os.environ["SMTPD_SSL_CERTS_PATH"] = "."
 
 def __get_smtp_env(smtpd: SMTPDFix):
     # https://github.com/bebleo/smtpdfix#using
-    # smtpd.config.host = "127.0.0.1"
     env = {
         "VDK_NOTIFICATION_ENABLED": "true",
         "VDK_ENABLE_ATTEMPT_NOTIFICATIONS": "true",

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_config_help.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_config_help.py
@@ -43,7 +43,7 @@ def test_cli_config_help():
     assert "to-be-shown-default-value" in result.output
     assert "key_bool" in result.output
     assert "key_int" in result.output
-    assert "key_no_description" not in result.output
+    assert "key_no_description" in result.output
     assert "key_misconfigured_description" in result.output
     assert "key_sensitive" in result.output
     assert "This option is marked as sensitive." in result.output

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/ingestion/test_ingester_base.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/ingestion/test_ingester_base.py
@@ -15,7 +15,7 @@ from vdk.internal.builtin_plugins.ingestion.ingester_configuration import (
     IngesterConfiguration,
 )
 from vdk.internal.core import errors
-from vdk.internal.core.config import Configuration
+from vdk.internal.core.config import Configuration, ConfigurationBuilder
 
 shared_test_values = {
     "test_payload1": {"key1": "val1", "key2": "val2", "key3": "val3"},
@@ -42,7 +42,11 @@ def create_ingester_base(kwargs=None, config_dict=None, ingester=None) -> Ingest
     }
     if config_dict is not None:
         config_key_value_pairs.update(config_dict)
-    test_config = Configuration(None, config_key_value_pairs, {})
+    test_config_builder = ConfigurationBuilder()
+    for k, v in config_key_value_pairs.items():
+        test_config_builder.add(key=k, default_value=v)
+
+    test_config = test_config_builder.build()
 
     return IngesterBase(
         data_job_name="test_job",

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/ingestion/test_ingester_base.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/ingestion/test_ingester_base.py
@@ -15,7 +15,8 @@ from vdk.internal.builtin_plugins.ingestion.ingester_configuration import (
     IngesterConfiguration,
 )
 from vdk.internal.core import errors
-from vdk.internal.core.config import Configuration, ConfigurationBuilder
+from vdk.internal.core.config import Configuration
+from vdk.internal.core.config import ConfigurationBuilder
 
 shared_test_values = {
     "test_payload1": {"key1": "val1", "key2": "val2", "key3": "val3"},

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/ingestion/test_ingester_router.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/ingestion/test_ingester_router.py
@@ -7,7 +7,7 @@ import pytest
 from vdk.api.plugin.plugin_input import IIngesterPlugin
 from vdk.internal.builtin_plugins.ingestion.ingester_base import IngesterBase
 from vdk.internal.builtin_plugins.ingestion.ingester_router import IngesterRouter
-from vdk.internal.core.config import Configuration
+from vdk.internal.core.config import Configuration, ConfigEntry
 from vdk.internal.core.errors import UserCodeError
 from vdk.internal.core.errors import VdkConfigurationError
 from vdk.internal.core.statestore import StateStore
@@ -15,15 +15,17 @@ from vdk.internal.core.statestore import StateStore
 
 def create_ingester_router(configs) -> IngesterRouter:
     config_key_value_pairs = {
-        "ingester_number_of_worker_threads": 1,
-        "ingester_payload_size_bytes_threshold": 100,
-        "ingester_objects_queue_size": 1,
-        "ingester_payloads_queue_size": 1,
-        "ingester_log_upload_errors": False,
-        "ingestion_payload_aggregator_timeout_seconds": 2,
+        "ingester_number_of_worker_threads": ConfigEntry(value=1),
+        "ingester_payload_size_bytes_threshold": ConfigEntry(value=100),
+        "ingester_objects_queue_size": ConfigEntry(value=1),
+        "ingester_payloads_queue_size": ConfigEntry(value=1),
+        "ingester_log_upload_errors": ConfigEntry(value=False),
+        "ingestion_payload_aggregator_timeout_seconds": ConfigEntry(value=2),
     }
-    config_key_value_pairs.update(configs)
-    test_config = Configuration({}, config_key_value_pairs, {})
+    for i in configs.keys():
+        config_key_value_pairs[i] = ConfigEntry(configs[i])
+    section = {"vdk": config_key_value_pairs}
+    test_config = Configuration(section)
     state_store = MagicMock(spec=StateStore)
     return IngesterRouter(test_config, state_store)
 

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/ingestion/test_ingester_router.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/ingestion/test_ingester_router.py
@@ -7,7 +7,8 @@ import pytest
 from vdk.api.plugin.plugin_input import IIngesterPlugin
 from vdk.internal.builtin_plugins.ingestion.ingester_base import IngesterBase
 from vdk.internal.builtin_plugins.ingestion.ingester_router import IngesterRouter
-from vdk.internal.core.config import Configuration, ConfigEntry
+from vdk.internal.core.config import ConfigEntry
+from vdk.internal.core.config import Configuration
 from vdk.internal.core.errors import UserCodeError
 from vdk.internal.core.errors import VdkConfigurationError
 from vdk.internal.core.statestore import StateStore

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/job_properties/test_properties_router.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/job_properties/test_properties_router.py
@@ -12,7 +12,8 @@ from vdk.internal.builtin_plugins.job_properties.properties_router import (
     PropertiesRouter,
 )
 from vdk.internal.core import errors
-from vdk.internal.core.config import Configuration, ConfigEntry
+from vdk.internal.core.config import ConfigEntry
+from vdk.internal.core.config import Configuration
 from vdk.internal.core.errors import ResolvableBy
 from vdk.internal.core.errors import UserCodeError
 from vdk.internal.core.errors import VdkConfigurationError
@@ -20,9 +21,7 @@ from vdk.internal.core.errors import VdkConfigurationError
 
 def test_routing():
     section = {"owner": {JobConfigKeys.TEAM: ConfigEntry(value="test-team")}}
-    router = PropertiesRouter(
-        "foo", Configuration(section)
-    )
+    router = PropertiesRouter("foo", Configuration(section))
     mock_client = MagicMock(spec=IPropertiesServiceClient)
     router.set_properties_factory_method("default", lambda: mock_client)
 
@@ -64,9 +63,7 @@ def test_routing_choose_single_registered():
 
 def test_routing_choose_default_type_chosen():
     section = {"vdk": {"properties_default_type": ConfigEntry(value="foo")}}
-    router = PropertiesRouter(
-        "foo", Configuration(section)
-    )
+    router = PropertiesRouter("foo", Configuration(section))
     foo_mock_client = MagicMock(spec=IPropertiesServiceClient)
     bar_mock_client = MagicMock(spec=IPropertiesServiceClient)
     router.set_properties_factory_method("foo", lambda: foo_mock_client)
@@ -78,7 +75,6 @@ def test_routing_choose_default_type_chosen():
 
 
 def test_routing_choose_too_many_choices():
-
     router = PropertiesRouter("foo", Configuration({}))
     foo_mock_client = MagicMock(spec=IPropertiesServiceClient)
     bar_mock_client = MagicMock(spec=IPropertiesServiceClient)
@@ -94,14 +90,10 @@ def test_preprocessing_sequence_success():
         "owner": {JobConfigKeys.TEAM: ConfigEntry(value="test-team")},
         "vdk": {
             "properties_default_type": ConfigEntry(value="foo"),
-            "properties_write_preprocess_sequence": ConfigEntry(value="bar1,bar2")
-        }
-
+            "properties_write_preprocess_sequence": ConfigEntry(value="bar1,bar2"),
+        },
     }
-    router = PropertiesRouter(
-        "foo",
-        Configuration(sections)
-    )
+    router = PropertiesRouter("foo", Configuration(sections))
     foo_mock_client = MagicMock(spec=IPropertiesServiceClient)
     bar1_mock_client = MagicMock(spec=IPropertiesServiceClient)
     bar1_mock_client.write_properties.return_value = {"a1": "b1"}
@@ -126,9 +118,8 @@ def test_preprocessing_sequence_success_outerscope_immutable():
         "owner": {JobConfigKeys.TEAM: ConfigEntry(value="test-team")},
         "vdk": {
             "properties_default_type": ConfigEntry(value="foo"),
-            "properties_write_preprocess_sequence": ConfigEntry(value="bar")
-        }
-
+            "properties_write_preprocess_sequence": ConfigEntry(value="bar"),
+        },
     }
     router = PropertiesRouter(
         "foo",
@@ -155,9 +146,8 @@ def test_preprocessing_sequence_error():
         "owner": {JobConfigKeys.TEAM: ConfigEntry(value="test-team")},
         "vdk": {
             "properties_default_type": ConfigEntry(value="foo"),
-            "properties_write_preprocess_sequence": ConfigEntry(value="bar")
-        }
-
+            "properties_write_preprocess_sequence": ConfigEntry(value="bar"),
+        },
     }
     router = PropertiesRouter(
         "foo",
@@ -181,14 +171,10 @@ def test_preprocessing_sequence_misconfigured():
     sections = {
         "vdk": {
             "properties_default_type": ConfigEntry(value="foo"),
-            "properties_write_preprocess_sequence": ConfigEntry(value="bar")
+            "properties_write_preprocess_sequence": ConfigEntry(value="bar"),
         }
-
     }
-    router = PropertiesRouter(
-        "foo",
-        Configuration(sections)
-    )
+    router = PropertiesRouter("foo", Configuration(sections))
     foo_mock_client = MagicMock(spec=IPropertiesServiceClient)
     router.set_properties_factory_method("foo", lambda: foo_mock_client)
 

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/job_secrets/test_secrets_router.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/job_secrets/test_secrets_router.py
@@ -12,14 +12,16 @@ from vdk.internal.builtin_plugins.job_secrets.secrets_router import (
     SecretsRouter,
 )
 from vdk.internal.core import errors
-from vdk.internal.core.config import Configuration
+from vdk.internal.core.config import Configuration, ConfigEntry
 from vdk.internal.core.errors import ResolvableBy
 from vdk.internal.core.errors import UserCodeError
 from vdk.internal.core.errors import VdkConfigurationError
 
 
 def test_routing():
-    router = SecretsRouter("foo", Configuration({}, {JobConfigKeys.TEAM: "test-team"}))
+    entry = ConfigEntry(value="test-team")
+    section = {"owner": {JobConfigKeys.TEAM: entry}}
+    router = SecretsRouter("foo", Configuration(section))
     mock_client = MagicMock(spec=ISecretsServiceClient)
     router.set_secrets_factory_method("default", lambda: mock_client)
 
@@ -31,7 +33,8 @@ def test_routing():
 
 
 def test_routing_error():
-    router = SecretsRouter("foo", Configuration({}, {}))
+    section = {}
+    router = SecretsRouter("foo", Configuration(section))
 
     def raise_error():
         raise AttributeError("dummy exception")
@@ -43,14 +46,16 @@ def test_routing_error():
 
 
 def test_routing_empty_error():
-    router = SecretsRouter("foo", Configuration({}, {}))
+    router = SecretsRouter("foo", Configuration({}))
 
     with pytest.raises(VdkConfigurationError):
         router.set_all_secrets({"a": "b"})
 
 
 def test_routing_choose_single_registered():
-    router = SecretsRouter("foo", Configuration({}, {"team": "test-team"}))
+    entry = ConfigEntry(value="test-team")
+    section = {"owner": {JobConfigKeys.TEAM: entry}}
+    router = SecretsRouter("foo", Configuration(section))
     mock_client = MagicMock(spec=ISecretsServiceClient)
     router.set_secrets_factory_method("foo", lambda: mock_client)
 
@@ -59,7 +64,9 @@ def test_routing_choose_single_registered():
 
 
 def test_routing_choose_default_type_chosen():
-    router = SecretsRouter("foo", Configuration({}, {"secrets_default_type": "foo"}))
+    entry = ConfigEntry(value="foo")
+    section = {"vdk": {"secrets_default_type": entry}}
+    router = SecretsRouter("foo", Configuration(section))
     foo_mock_client = MagicMock(spec=ISecretsServiceClient)
     bar_mock_client = MagicMock(spec=ISecretsServiceClient)
     router.set_secrets_factory_method("foo", lambda: foo_mock_client)
@@ -71,7 +78,7 @@ def test_routing_choose_default_type_chosen():
 
 
 def test_routing_choose_too_many_choices():
-    router = SecretsRouter("foo", Configuration({}, {}))
+    router = SecretsRouter("foo", Configuration({}))
     foo_mock_client = MagicMock(spec=ISecretsServiceClient)
     bar_mock_client = MagicMock(spec=ISecretsServiceClient)
     router.set_secrets_factory_method("foo", lambda: foo_mock_client)
@@ -82,15 +89,20 @@ def test_routing_choose_too_many_choices():
 
 
 def test_preprocessing_sequence_success():
+    sections = {
+        "vdk": {
+            "secrets_default_type": ConfigEntry(value="foo"),
+            "secrets_write_preprocess_sequence": ConfigEntry(value="bar1,bar2")
+        },
+        "owner": {
+            JobConfigKeys.TEAM: ConfigEntry(value="test-team"),
+        }
+
+    }
     router = SecretsRouter(
         "foo",
         Configuration(
-            {},
-            {
-                JobConfigKeys.TEAM: "test-team",
-                "secrets_default_type": "foo",
-                "secrets_write_preprocess_sequence": "bar1,bar2",
-            },
+            sections
         ),
     )
     foo_mock_client = MagicMock(spec=ISecretsServiceClient)
@@ -109,15 +121,20 @@ def test_preprocessing_sequence_success():
 
 
 def test_preprocessing_sequence_success_outerscope_immutable():
+    sections = {
+        "vdk": {
+            "secrets_default_type": ConfigEntry(value="foo"),
+            "secrets_write_preprocess_sequence": ConfigEntry(value="bar")
+        },
+        "owner": {
+            JobConfigKeys.TEAM: ConfigEntry(value="test-team"),
+        }
+
+    }
     router = SecretsRouter(
         "foo",
         Configuration(
-            {},
-            {
-                JobConfigKeys.TEAM: "test-team",
-                "secrets_default_type": "foo",
-                "secrets_write_preprocess_sequence": "bar",
-            },
+           sections
         ),
     )
     foo_mock_client = MagicMock(spec=ISecretsServiceClient)
@@ -135,15 +152,20 @@ def test_preprocessing_sequence_success_outerscope_immutable():
 
 
 def test_preprocessing_sequence_error():
+    sections = {
+        "vdk": {
+            "secrets_default_type": ConfigEntry(value="foo"),
+            "secrets_write_preprocess_sequence": ConfigEntry(value="bar")
+        },
+        "owner": {
+            JobConfigKeys.TEAM: ConfigEntry(value="test-team"),
+        }
+
+    }
     router = SecretsRouter(
         "foo",
         Configuration(
-            {},
-            {
-                JobConfigKeys.TEAM: "test-team",
-                "secrets_default_type": "foo",
-                "secrets_write_preprocess_sequence": "bar",
-            },
+           sections
         ),
     )
     foo_mock_client = MagicMock(spec=ISecretsServiceClient)
@@ -155,20 +177,23 @@ def test_preprocessing_sequence_error():
     with pytest.raises(WritePreProcessSecretsException) as exc_info:
         router.set_all_secrets({"a": "b"})
         assert (
-            errors.get_exception_resolvable_by(exc_info.value)
-            == ResolvableBy.USER_ERROR
+                errors.get_exception_resolvable_by(exc_info.value)
+                == ResolvableBy.USER_ERROR
         )
 
 
 def test_preprocessing_sequence_misconfigured():
+    sections = {
+        "vdk": {
+            "secrets_default_type": ConfigEntry(value="foo"),
+            "secrets_write_preprocess_sequence": ConfigEntry(value="bar")
+        },
+
+    }
     router = SecretsRouter(
         "foo",
         Configuration(
-            {},
-            {
-                "secrets_default_type": "foo",
-                "secrets_write_preprocess_sequence": "bar",
-            },
+            sections
         ),
     )
     foo_mock_client = MagicMock(spec=ISecretsServiceClient)

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/job_secrets/test_secrets_router.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/job_secrets/test_secrets_router.py
@@ -19,8 +19,7 @@ from vdk.internal.core.errors import VdkConfigurationError
 
 
 def test_routing():
-    entry = ConfigEntry(value="test-team")
-    section = {"owner": {JobConfigKeys.TEAM: entry}}
+    section = {"owner": {JobConfigKeys.TEAM: ConfigEntry(value="test-team")}}
     router = SecretsRouter("foo", Configuration(section))
     mock_client = MagicMock(spec=ISecretsServiceClient)
     router.set_secrets_factory_method("default", lambda: mock_client)

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/job_secrets/test_secrets_router.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/job_secrets/test_secrets_router.py
@@ -12,7 +12,8 @@ from vdk.internal.builtin_plugins.job_secrets.secrets_router import (
     SecretsRouter,
 )
 from vdk.internal.core import errors
-from vdk.internal.core.config import Configuration, ConfigEntry
+from vdk.internal.core.config import ConfigEntry
+from vdk.internal.core.config import Configuration
 from vdk.internal.core.errors import ResolvableBy
 from vdk.internal.core.errors import UserCodeError
 from vdk.internal.core.errors import VdkConfigurationError
@@ -91,18 +92,15 @@ def test_preprocessing_sequence_success():
     sections = {
         "vdk": {
             "secrets_default_type": ConfigEntry(value="foo"),
-            "secrets_write_preprocess_sequence": ConfigEntry(value="bar1,bar2")
+            "secrets_write_preprocess_sequence": ConfigEntry(value="bar1,bar2"),
         },
         "owner": {
             JobConfigKeys.TEAM: ConfigEntry(value="test-team"),
-        }
-
+        },
     }
     router = SecretsRouter(
         "foo",
-        Configuration(
-            sections
-        ),
+        Configuration(sections),
     )
     foo_mock_client = MagicMock(spec=ISecretsServiceClient)
     bar1_mock_client = MagicMock(spec=ISecretsServiceClient)
@@ -123,18 +121,15 @@ def test_preprocessing_sequence_success_outerscope_immutable():
     sections = {
         "vdk": {
             "secrets_default_type": ConfigEntry(value="foo"),
-            "secrets_write_preprocess_sequence": ConfigEntry(value="bar")
+            "secrets_write_preprocess_sequence": ConfigEntry(value="bar"),
         },
         "owner": {
             JobConfigKeys.TEAM: ConfigEntry(value="test-team"),
-        }
-
+        },
     }
     router = SecretsRouter(
         "foo",
-        Configuration(
-           sections
-        ),
+        Configuration(sections),
     )
     foo_mock_client = MagicMock(spec=ISecretsServiceClient)
     bar_mock_client = MagicMock(spec=ISecretsServiceClient)
@@ -154,18 +149,15 @@ def test_preprocessing_sequence_error():
     sections = {
         "vdk": {
             "secrets_default_type": ConfigEntry(value="foo"),
-            "secrets_write_preprocess_sequence": ConfigEntry(value="bar")
+            "secrets_write_preprocess_sequence": ConfigEntry(value="bar"),
         },
         "owner": {
             JobConfigKeys.TEAM: ConfigEntry(value="test-team"),
-        }
-
+        },
     }
     router = SecretsRouter(
         "foo",
-        Configuration(
-           sections
-        ),
+        Configuration(sections),
     )
     foo_mock_client = MagicMock(spec=ISecretsServiceClient)
     bar_mock_client = MagicMock(spec=ISecretsServiceClient)
@@ -176,8 +168,8 @@ def test_preprocessing_sequence_error():
     with pytest.raises(WritePreProcessSecretsException) as exc_info:
         router.set_all_secrets({"a": "b"})
         assert (
-                errors.get_exception_resolvable_by(exc_info.value)
-                == ResolvableBy.USER_ERROR
+            errors.get_exception_resolvable_by(exc_info.value)
+            == ResolvableBy.USER_ERROR
         )
 
 
@@ -185,15 +177,12 @@ def test_preprocessing_sequence_misconfigured():
     sections = {
         "vdk": {
             "secrets_default_type": ConfigEntry(value="foo"),
-            "secrets_write_preprocess_sequence": ConfigEntry(value="bar")
+            "secrets_write_preprocess_sequence": ConfigEntry(value="bar"),
         },
-
     }
     router = SecretsRouter(
         "foo",
-        Configuration(
-            sections
-        ),
+        Configuration(sections),
     )
     foo_mock_client = MagicMock(spec=ISecretsServiceClient)
     router.set_secrets_factory_method("foo", lambda: foo_mock_client)

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/run/test_substitute_query_params.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/run/test_substitute_query_params.py
@@ -10,7 +10,8 @@ from vdk.internal.builtin_plugins.job_properties.properties_router import (
 )
 from vdk.internal.builtin_plugins.run.data_job import JobArguments
 from vdk.internal.builtin_plugins.run.job_input import JobInput
-from vdk.internal.core.config import Configuration, ConfigurationBuilder
+from vdk.internal.core.config import Configuration
+from vdk.internal.core.config import ConfigurationBuilder
 
 
 def _get_properties_in_memory():

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/run/test_substitute_query_params.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/run/test_substitute_query_params.py
@@ -10,11 +10,12 @@ from vdk.internal.builtin_plugins.job_properties.properties_router import (
 )
 from vdk.internal.builtin_plugins.run.data_job import JobArguments
 from vdk.internal.builtin_plugins.run.job_input import JobInput
-from vdk.internal.core.config import Configuration
+from vdk.internal.core.config import Configuration, ConfigurationBuilder
 
 
 def _get_properties_in_memory():
-    router = PropertiesRouter("foo", Configuration({}, {}))
+    test_config_builder = ConfigurationBuilder()
+    router = PropertiesRouter("foo", cfg=test_config_builder.build())
     router.set_properties_factory_method(
         "default", lambda: InMemPropertiesServiceClient()
     )

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/termination_message/test_writer.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/termination_message/test_writer.py
@@ -23,16 +23,18 @@ class TestTerminationMessageWriterPlugin(unittest.TestCase):
         self.termination_plugin = TerminationMessageWriterPlugin()
         configuration_builder = ConfigurationBuilder()
         self.termination_plugin.vdk_configure(configuration_builder)
-
+        configuration_builder.add(
+            key="TERMINATION_MESSAGE_WRITER_OUTPUT_FILE",
+            default_value="filename.txt",
+            section="vdk"
+        )
+        configuration_builder.add(
+            key=vdk_config.LOG_CONFIG,
+            default_value="local",
+            section="vdk"
+        )
         self.configuration = (
-            configuration_builder.add(
-                key="TERMINATION_MESSAGE_WRITER_OUTPUT_FILE",
-                default_value="filename.txt",
-            )
-            .add(
-                key=vdk_config.LOG_CONFIG,
-                default_value="local",
-            )
+            configuration_builder
             .build()
         )
 

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/termination_message/test_writer.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/termination_message/test_writer.py
@@ -26,17 +26,12 @@ class TestTerminationMessageWriterPlugin(unittest.TestCase):
         configuration_builder.add(
             key="TERMINATION_MESSAGE_WRITER_OUTPUT_FILE",
             default_value="filename.txt",
-            section="vdk"
+            section="vdk",
         )
         configuration_builder.add(
-            key=vdk_config.LOG_CONFIG,
-            default_value="local",
-            section="vdk"
+            key=vdk_config.LOG_CONFIG, default_value="local", section="vdk"
         )
-        self.configuration = (
-            configuration_builder
-            .build()
-        )
+        self.configuration = configuration_builder.build()
 
     def tearDown(self) -> None:
         os.remove(

--- a/projects/vdk-core/tests/vdk/internal/core/test_config.py
+++ b/projects/vdk-core/tests/vdk/internal/core/test_config.py
@@ -40,7 +40,7 @@ def test_unknown_key():
     assert cfg["no-such-key"] is None
     assert cfg.get_description("no-such-key") is None
 
-    assert cfg.get_description("key") is None
+    assert cfg.get_description("key") == "No description provided. Default value: 1."
     assert cfg.get_value("key") == 1
 
 
@@ -85,13 +85,13 @@ def test_set_value_overrides_default():
     assert not cfg.is_default("key")
 
 
-def test_set_value_eq_default_is_not_default():
+def test_set_value_eq_default_is_default():
     builder = ConfigurationBuilder()
     builder.add("key", "value", False, "key description")
     builder.set_value("key", "value")
     cfg = builder.build()
     assert cfg.get_value("key") == "value"
-    assert not cfg.is_default("key")
+    assert cfg.is_default("key")
 
 
 def test_set_value_overrides_default_preserve_types():
@@ -107,16 +107,6 @@ def test_set_value_overrides_default_preserve_types():
     builder.set_value("int", "bad-value")
     with pytest.raises(VdkConfigurationError):
         builder.add("int", 1, False, "key description")
-
-
-def test_list_config_keys():
-    builder = ConfigurationBuilder()
-    builder.add("key1", 1)
-    builder.add("key2", "two")
-    builder.add("key3", None)
-    builder.add("key4", False, False, "description")
-    builder.add("key5", 1.2, True, "description")
-    assert {"key1", "key2", "key3", "key4", "key5"} == set(builder.list_config_keys())
 
 
 def test_conversions():

--- a/projects/vdk-core/tests/vdk/internal/core/test_config.py
+++ b/projects/vdk-core/tests/vdk/internal/core/test_config.py
@@ -8,11 +8,11 @@ from vdk.internal.core.errors import VdkConfigurationError
 @pytest.mark.parametrize(
     "key, default_value, show_default_value, description",
     (
-        ("int_key", 1, True, "int key"),
-        ("bool_key", True, False, "bool key"),
-        ("array_key", [], None, None),
-        ("str_key", "string", None, None),
-        ("str_key", None, None, None),
+            ("int_key", 1, True, "int key"),
+            ("bool_key", True, False, "bool key"),
+            ("array_key", [], None, None),
+            ("str_key", "string", None, None),
+            ("str_key", None, None, None),
     ),
 )
 def test_add(key, default_value, show_default_value, description):
@@ -62,10 +62,10 @@ def test_key_case_insensitive():
 @pytest.mark.parametrize(
     "key, value",
     (
-        ("int_key", 1),
-        ("bool_key", True),
-        ("array_key", []),
-        ("str_key", "string"),
+            ("int_key", 1),
+            ("bool_key", True),
+            ("array_key", []),
+            ("str_key", "string"),
     ),
 )
 def test_set_value(key, value):
@@ -107,6 +107,153 @@ def test_set_value_overrides_default_preserve_types():
     builder.set_value("int", "bad-value")
     with pytest.raises(VdkConfigurationError):
         builder.add("int", 1, False, "key description")
+
+
+@pytest.mark.parametrize(
+    "section, key, value, description",
+    [
+        ("section1", "key1", 100, "Description for key1 in section1"),
+        ("section1", "key2", 200, "Description for key2 in section1"),
+        ("section2", "key1", 300, "Description for key1 in section2"),
+        ("section2", "key2", 400, "Description for key2 in section2"),
+        ("section3", "key1", 500, "Description for key1 in section3"),
+    ]
+)
+def test_add_with_sections(section, key, value, description):
+    builder = ConfigurationBuilder()
+    builder.add(key=key, default_value=value, show_default_value=False, description=description, section=section)
+    config = builder.build()
+
+    assert config.get_value(key, section) == value
+    assert config.get_description(key, section) == description
+    assert config.is_default(key, section)
+
+
+def test_non_existent_section():
+    builder = ConfigurationBuilder()
+    builder.add("key1", 100, section="existent")
+    config = builder.build()
+
+    assert config.get_value("key1", "nonexistent") is None
+
+
+def test_section_isolation():
+    builder = ConfigurationBuilder()
+    builder.add("key1", 100, section="section1")
+    builder.add("key1", 200, section="section2")
+    config = builder.build()
+
+    assert config.get_value("key1", "section1") == 100
+    assert config.get_value("key1", "section2") == 200
+
+    assert config.list_keys_in_section("section1") == ["key1"]
+    assert config.list_keys_in_section("section2") == ["key1"]
+
+
+def test_sensitive_keys_across_sections():
+    builder = ConfigurationBuilder()
+    builder.add("key1", "password123", is_sensitive=True, section="secure")
+    builder.add("key1", "not-sensitive", is_sensitive=False, section="general")
+    config = builder.build()
+
+    assert config.is_sensitive("key1", "secure")
+    assert not config.is_sensitive("key1", "general")
+
+
+@pytest.mark.parametrize(
+    "section, key, initial_value, new_value, expected_default",
+    [
+        ("default_section", "overwrite_key", 150, 250, False),
+        ("default_section", "single_key", 350, 350, True),
+    ]
+)
+def test_overwrite_values(section, key, initial_value, new_value, expected_default):
+    builder = ConfigurationBuilder()
+    builder.add(key, initial_value, section=section)
+    builder.set_value(key, new_value, section=section)
+    config = builder.build()
+
+    assert config.get_value(key, section) == new_value
+    assert config.is_default(key, section) == expected_default
+
+
+def test_list_sections_and_keys():
+    builder = ConfigurationBuilder()
+    builder.add("key1", 100, section="section1")
+    builder.add("key2", 200, section="section1")
+    builder.add("key3", 300, section="section2")
+    config = builder.build()
+
+    assert set(config.list_sections()) == {"section1", "section2"}
+    assert set(config.list_keys_in_section("section1")) == {"key1", "key2"}
+    assert set(config.list_keys_in_section("section2")) == {"key3"}
+
+
+def test_get_value_without_section():  # it should work with all sections but vdk subsections following: vdk_<string>
+    builder = ConfigurationBuilder()
+    builder.add("global_key", "global_value", section="global")
+    config = builder.build()
+
+    assert config.get_value("global_key") == "global_value"
+
+
+def test_missing_key_across_sections():
+    builder = ConfigurationBuilder()
+    builder.add("unique_key", 123, section="unique_section")
+    config = builder.build()
+
+    assert config.get_value("nonexistent_key") is None
+
+
+@pytest.mark.parametrize(
+    "key, value, section",
+    [("user_setting", True, "user_prefs"), ("system_setting", False, "system_configs")]
+)
+def test_add_multiple_keys_same_name_different_sections(key, value, section):
+    builder = ConfigurationBuilder()
+    builder.add(key, value, section=section)
+    config = builder.build()
+
+    assert config.get_value(key, section) == value
+
+
+# sections starting with vdk_ are considered subsections for vdk and are handled differenly
+# that's why we introduce separate tests for them
+
+@pytest.mark.parametrize(
+    "section, key, value, expected",
+    [
+        ("vdk_test_db", "connection_string", "test-server-url", "test-server-url"),
+        ("vdk_prod_db", "connection_string", "prod-server-url", "prod-server-url"),
+        ("vdk_test_db", "max_connections", 10, 10),
+        ("vdk_prod_db", "max_connections", 100, 100),
+    ]
+)
+def test_add_and_retrieve_db_configurations(section, key, value, expected):
+    builder = ConfigurationBuilder()
+    builder.add(key, value, section=section)
+    config = builder.build()
+
+    assert config.get_value(key, section) == expected
+
+
+def test_ensure_environment_isolation():
+    builder = ConfigurationBuilder()
+    builder.add("timeout", 30, section="vdk_test_db")
+    builder.add("timeout", 300, section="vdk_prod_db")
+    config = builder.build()
+
+    assert config.get_value("timeout", "vdk_test_db") == 30
+    assert config.get_value("timeout", "vdk_prod_db") == 300
+
+
+def test_access_db_config_without_section_specified():
+    builder = ConfigurationBuilder()
+    builder.add("cache_enabled", True, section="vdk_test_db")
+    config = builder.build()
+
+    # no access to options in vdk subsections without specifying the subsection
+    assert config.get_value("cache_enabled") is None
 
 
 def test_conversions():

--- a/projects/vdk-core/tests/vdk/internal/core/test_config.py
+++ b/projects/vdk-core/tests/vdk/internal/core/test_config.py
@@ -8,11 +8,11 @@ from vdk.internal.core.errors import VdkConfigurationError
 @pytest.mark.parametrize(
     "key, default_value, show_default_value, description",
     (
-            ("int_key", 1, True, "int key"),
-            ("bool_key", True, False, "bool key"),
-            ("array_key", [], None, None),
-            ("str_key", "string", None, None),
-            ("str_key", None, None, None),
+        ("int_key", 1, True, "int key"),
+        ("bool_key", True, False, "bool key"),
+        ("array_key", [], None, None),
+        ("str_key", "string", None, None),
+        ("str_key", None, None, None),
     ),
 )
 def test_add(key, default_value, show_default_value, description):
@@ -62,10 +62,10 @@ def test_key_case_insensitive():
 @pytest.mark.parametrize(
     "key, value",
     (
-            ("int_key", 1),
-            ("bool_key", True),
-            ("array_key", []),
-            ("str_key", "string"),
+        ("int_key", 1),
+        ("bool_key", True),
+        ("array_key", []),
+        ("str_key", "string"),
     ),
 )
 def test_set_value(key, value):
@@ -117,11 +117,17 @@ def test_set_value_overrides_default_preserve_types():
         ("section2", "key1", 300, "Description for key1 in section2"),
         ("section2", "key2", 400, "Description for key2 in section2"),
         ("section3", "key1", 500, "Description for key1 in section3"),
-    ]
+    ],
 )
 def test_add_with_sections(section, key, value, description):
     builder = ConfigurationBuilder()
-    builder.add(key=key, default_value=value, show_default_value=False, description=description, section=section)
+    builder.add(
+        key=key,
+        default_value=value,
+        show_default_value=False,
+        description=description,
+        section=section,
+    )
     config = builder.build()
 
     assert config.get_value(key, section) == value
@@ -165,7 +171,7 @@ def test_sensitive_keys_across_sections():
     [
         ("default_section", "overwrite_key", 150, 250, False),
         ("default_section", "single_key", 350, 350, True),
-    ]
+    ],
 )
 def test_overwrite_values(section, key, initial_value, new_value, expected_default):
     builder = ConfigurationBuilder()
@@ -207,7 +213,7 @@ def test_missing_key_across_sections():
 
 @pytest.mark.parametrize(
     "key, value, section",
-    [("user_setting", True, "user_prefs"), ("system_setting", False, "system_configs")]
+    [("user_setting", True, "user_prefs"), ("system_setting", False, "system_configs")],
 )
 def test_add_multiple_keys_same_name_different_sections(key, value, section):
     builder = ConfigurationBuilder()
@@ -220,6 +226,7 @@ def test_add_multiple_keys_same_name_different_sections(key, value, section):
 # sections starting with vdk_ are considered subsections for vdk and are handled differenly
 # that's why we introduce separate tests for them
 
+
 @pytest.mark.parametrize(
     "section, key, value, expected",
     [
@@ -227,7 +234,7 @@ def test_add_multiple_keys_same_name_different_sections(key, value, section):
         ("vdk_prod_db", "connection_string", "prod-server-url", "prod-server-url"),
         ("vdk_test_db", "max_connections", 10, 10),
         ("vdk_prod_db", "max_connections", 100, 100),
-    ]
+    ],
 )
 def test_add_and_retrieve_db_configurations(section, key, value, expected):
     builder = ConfigurationBuilder()


### PR DESCRIPTION
Solving: https://github.com/vmware/versatile-data-kit/issues/3305

The main change is that now we have sections list in Configuration and ConfigurationBuilder instead of having only key-value lists