### PR TITLE
control-service: add additional logging to synchronizer task

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobsSynchronizer.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DataJobsSynchronizer.java
@@ -77,12 +77,14 @@ public class DataJobsSynchronizer {
 
     UUID syncId = UUID.randomUUID();
     log.info("[{}] Data job deployments synchronization has started.", syncId);
-    log.info("[{}] DataJobsSynchronizerTaskExecutor [pool size = {}, active threads = {}, queue size = {}, queue capacity = {}]",
-            syncId,
-            dataJobsSynchronizerTaskExecutor.getPoolSize(),
-            dataJobsSynchronizerTaskExecutor.getActiveCount(),
-            dataJobsSynchronizerTaskExecutor.getQueueSize(),
-            dataJobsSynchronizerTaskExecutor.getQueueCapacity());
+    log.info(
+        "[{}] DataJobsSynchronizerTaskExecutor [pool size = {}, active threads = {}, queue size ="
+            + " {}, queue capacity = {}]",
+        syncId,
+        dataJobsSynchronizerTaskExecutor.getPoolSize(),
+        dataJobsSynchronizerTaskExecutor.getActiveCount(),
+        dataJobsSynchronizerTaskExecutor.getQueueSize(),
+        dataJobsSynchronizerTaskExecutor.getQueueCapacity());
 
     Map<String, DataJob> dataJobsFromDBMap =
         StreamSupport.stream(jobsService.findAllDataJobs().spliterator(), false)
@@ -94,9 +96,10 @@ public class DataJobsSynchronizer {
           deploymentService.findAllActualDeploymentNamesFromKubernetes();
     } catch (KubernetesException e) {
       log.error(
-          "[{}] Skipping data job deployment synchronization because deployment names cannot be loaded"
-              + " from Kubernetes.",
-          syncId, e);
+          "[{}] Skipping data job deployment synchronization because deployment names cannot be"
+              + " loaded from Kubernetes.",
+          syncId,
+          e);
       dataJobSynchronizerMonitor.countSynchronizerFailures();
       return;
     }
@@ -219,13 +222,15 @@ public class DataJobsSynchronizer {
   private void waitForSynchronizationCompletion(CountDownLatch countDownLatch, UUID syncId) {
     try {
       log.debug(
-          "[{}] Waiting for data job deployments' synchronization to complete. This process may take"
-              + " some time...", syncId);
+          "[{}] Waiting for data job deployments' synchronization to complete. This process may"
+              + " take some time...",
+          syncId);
       countDownLatch.await();
       log.info("[{}] Data job deployments synchronization has successfully completed.", syncId);
       dataJobSynchronizerMonitor.countSuccessfulSynchronizerInvocation();
     } catch (InterruptedException e) {
-      log.error("[{}] An error occurred during the data job deployments' synchronization", syncId, e);
+      log.error(
+          "[{}] An error occurred during the data job deployments' synchronization", syncId, e);
       dataJobSynchronizerMonitor.countSynchronizerFailures();
     }
   }


### PR DESCRIPTION
Why
Currently, we are experiencing an issue with the Synchronizer task; it is overflowing the task queue.

```
org.springframework.core.task.TaskRejectedException: Executor [java.util.concurrent.ThreadPoolExecutor@55435baf[Running, pool size = 10, active threads = 10, queued tasks = 1999, completed tasks = 1174429]] did not accept task: com.vmware.taurus.service.deploy.DataJobsSynchronizer$$Lambda$2193/0x00007fe844d1c6d0@774553e9
```

What
Added logging and increased the Scheduler Lock lockAtMostFor to 24h since the default is 10m which could lead to timeout of the task in some cases.

Signed-off by: Miroslav Ivanov [miroslav.ivanov@broadcom.com](mailto:miroslav.ivanov@broadcom.com)