### PR TITLE
vdk-core: override configs per section

### DIFF
--- a/projects/vdk-core/src/vdk/internal/builtin_plugins/config/job_config.py
+++ b/projects/vdk-core/src/vdk/internal/builtin_plugins/config/job_config.py
@@ -173,7 +173,7 @@ class JobConfig:
         Returns a list of subsection names.
         """
         subsection_names = [
-            section
+            section.replace("vdk_", "")
             for section in self._config_ini.sections()
             if section.startswith("vdk_")
         ]
@@ -187,8 +187,8 @@ class JobConfig:
 
         :param subsection_name: The name of the subsection (e.g., 'vdk_my_oracle')
         """
-        if subsection_name in self._config_ini.sections():
-            return dict(self._config_ini[subsection_name])
+        if f"vdk_{subsection_name}" in self._config_ini.sections():
+            return dict(self._config_ini[f"vdk_{subsection_name}"])
         return {}
 
     def _get_value(self, section, key):

--- a/projects/vdk-core/tests/functional/cli/test_query_command_plugin.py
+++ b/projects/vdk-core/tests/functional/cli/test_query_command_plugin.py
@@ -51,7 +51,7 @@ def test_execute_sql(tmpdir: py.path.local):
         )
         cli_assert_equal(0, result)
         expected_stdout = (
-            "date        symbol      price\n"
+            "\ndate        symbol      price\n"
             "----------  --------  -------\n"
             "2020-01-01  GOOG          123\n"
             "2020-01-01  GOOG          123\n"

--- a/projects/vdk-core/tests/functional/run/jobs/simple-job-config-ini-sections/1_step.py
+++ b/projects/vdk-core/tests/functional/run/jobs/simple-job-config-ini-sections/1_step.py
@@ -1,0 +1,7 @@
+# Copyright 2023-2024 Broadcom
+# SPDX-License-Identifier: Apache-2.0
+from vdk.api.job_input import IJobInput
+
+
+def run(job_input: IJobInput):
+    print("hi")

--- a/projects/vdk-core/tests/functional/run/jobs/simple-job-config-ini-sections/config.ini
+++ b/projects/vdk-core/tests/functional/run/jobs/simple-job-config-ini-sections/config.ini
@@ -1,0 +1,4 @@
+[vdk]
+config_option="not_overridden"
+[vdk_first]
+config_option="not_overridden"

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_job_config.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_job_config.py
@@ -116,7 +116,7 @@ class TestJobConfig:
         """,
         )
         cfg = JobConfig(self._test_dir)
-        options = ["vdk_subsection_one", "vdk_subsection_two"]
+        options = ["subsection_one", "subsection_two"]
         for subclass in cfg.get_vdk_subsection_names():
             assert options.count(subclass) == 1
 
@@ -133,7 +133,7 @@ class TestJobConfig:
         """,
         )
         cfg = JobConfig(self._test_dir)
-        values = cfg.get_vdk_subsection_values("vdk_subsection")
+        values = cfg.get_vdk_subsection_values("subsection")
         self.assertEqual({"a": "b", "c": "d"}, values)
 
     def test_set_team(self):

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_vdk_config.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/config/test_vdk_config.py
@@ -25,6 +25,53 @@ def test_vdk_config_env_variable_vdk_prefix_prio():
 
 @mock.patch.dict(
     os.environ,
+    {
+        "VDK_FIRST_OPTION": "high",
+        "FIRST_OPTION": "low",
+        "first_no_prefixed_option": "value",
+    },
+)
+def test_vdk_config_env_variable_vdk_prefix_prio_section():
+    envVarsConfig = EnvironmentVarsConfigPlugin()
+    configuration_builder = ConfigurationBuilder()
+    configuration_builder.add("option", "", section="first")
+    configuration_builder.add("no_prefixed_option", "", section="first")
+
+    envVarsConfig.vdk_configure(configuration_builder)
+
+    assert configuration_builder.build().get_value("option", "first") == "high"
+    assert (
+        configuration_builder.build().get_value("no_prefixed_option", "first")
+        == "value"
+    )
+
+
+@mock.patch.dict(
+    os.environ,
+    {"VDK_SOMETHING": "default_section", "VDK_FIRST_SOMETHING": "first_section"},
+)
+def test_vdk_config_env_variable_overrides_per_section():
+    envVarsConfig = EnvironmentVarsConfigPlugin()
+    configuration_builder = ConfigurationBuilder()
+    configuration_builder.add("something", "")
+    configuration_builder.add("something", "", section="first")
+    configuration_builder.add("something", "second_section", section="second")
+
+    envVarsConfig.vdk_configure(configuration_builder)
+
+    assert configuration_builder.build().get_value("something") == "default_section"
+    assert (
+        configuration_builder.build().get_value("something", section="first")
+        == "first_section"
+    )
+    assert (
+        configuration_builder.build().get_value("something", section="second")
+        == "second_section"
+    )
+
+
+@mock.patch.dict(
+    os.environ,
     {"VDK_OPTION_WITH_DOTS": "value1", "no_prefix_option_dots": "value2"},
 )
 def test_vdk_config_env_variable_dots_replaced():
@@ -34,7 +81,6 @@ def test_vdk_config_env_variable_dots_replaced():
     configuration_builder.add("no.prefix.option.dots", "")
 
     envVarsConfig.vdk_configure(configuration_builder)
-
     assert configuration_builder.build().get_value("option.with.dots") == "value1"
     assert configuration_builder.build().get_value("no.prefix.option.dots") == "value2"
 

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/job_properties/test_properties_router.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/job_properties/test_properties_router.py
@@ -20,7 +20,7 @@ from vdk.internal.core.errors import VdkConfigurationError
 
 
 def test_routing():
-    section = {"owner": {JobConfigKeys.TEAM: ConfigEntry(value="test-team")}}
+    section = {"vdk": {JobConfigKeys.TEAM: ConfigEntry(value="test-team")}}
     router = PropertiesRouter("foo", Configuration(section))
     mock_client = MagicMock(spec=IPropertiesServiceClient)
     router.set_properties_factory_method("default", lambda: mock_client)
@@ -52,7 +52,7 @@ def test_routing_empty_error():
 
 
 def test_routing_choose_single_registered():
-    section = {"owner": {JobConfigKeys.TEAM: ConfigEntry(value="test-team")}}
+    section = {"vdk": {JobConfigKeys.TEAM: ConfigEntry(value="test-team")}}
     router = PropertiesRouter("foo", Configuration(section))
     mock_client = MagicMock(spec=IPropertiesServiceClient)
     router.set_properties_factory_method("foo", lambda: mock_client)
@@ -87,10 +87,10 @@ def test_routing_choose_too_many_choices():
 
 def test_preprocessing_sequence_success():
     sections = {
-        "owner": {JobConfigKeys.TEAM: ConfigEntry(value="test-team")},
         "vdk": {
             "properties_default_type": ConfigEntry(value="foo"),
             "properties_write_preprocess_sequence": ConfigEntry(value="bar1,bar2"),
+            JobConfigKeys.TEAM: ConfigEntry(value="test-team"),
         },
     }
     router = PropertiesRouter("foo", Configuration(sections))
@@ -115,10 +115,10 @@ def test_preprocessing_sequence_success():
 
 def test_preprocessing_sequence_success_outerscope_immutable():
     sections = {
-        "owner": {JobConfigKeys.TEAM: ConfigEntry(value="test-team")},
         "vdk": {
             "properties_default_type": ConfigEntry(value="foo"),
             "properties_write_preprocess_sequence": ConfigEntry(value="bar"),
+            JobConfigKeys.TEAM: ConfigEntry(value="test-team"),
         },
     }
     router = PropertiesRouter(

--- a/projects/vdk-core/tests/vdk/internal/builtin_plugins/job_secrets/test_secrets_router.py
+++ b/projects/vdk-core/tests/vdk/internal/builtin_plugins/job_secrets/test_secrets_router.py
@@ -20,7 +20,7 @@ from vdk.internal.core.errors import VdkConfigurationError
 
 
 def test_routing():
-    section = {"owner": {JobConfigKeys.TEAM: ConfigEntry(value="test-team")}}
+    section = {"vdk": {JobConfigKeys.TEAM: ConfigEntry(value="test-team")}}
     router = SecretsRouter("foo", Configuration(section))
     mock_client = MagicMock(spec=ISecretsServiceClient)
     router.set_secrets_factory_method("default", lambda: mock_client)
@@ -54,7 +54,7 @@ def test_routing_empty_error():
 
 def test_routing_choose_single_registered():
     entry = ConfigEntry(value="test-team")
-    section = {"owner": {JobConfigKeys.TEAM: entry}}
+    section = {"vdk": {JobConfigKeys.TEAM: entry}}
     router = SecretsRouter("foo", Configuration(section))
     mock_client = MagicMock(spec=ISecretsServiceClient)
     router.set_secrets_factory_method("foo", lambda: mock_client)
@@ -93,8 +93,6 @@ def test_preprocessing_sequence_success():
         "vdk": {
             "secrets_default_type": ConfigEntry(value="foo"),
             "secrets_write_preprocess_sequence": ConfigEntry(value="bar1,bar2"),
-        },
-        "owner": {
             JobConfigKeys.TEAM: ConfigEntry(value="test-team"),
         },
     }
@@ -122,8 +120,6 @@ def test_preprocessing_sequence_success_outerscope_immutable():
         "vdk": {
             "secrets_default_type": ConfigEntry(value="foo"),
             "secrets_write_preprocess_sequence": ConfigEntry(value="bar"),
-        },
-        "owner": {
             JobConfigKeys.TEAM: ConfigEntry(value="test-team"),
         },
     }

--- a/projects/vdk-core/tests/vdk/internal/core/test_config.py
+++ b/projects/vdk-core/tests/vdk/internal/core/test_config.py
@@ -190,17 +190,19 @@ def test_list_sections_and_keys():
     builder.add("key3", 300, section="section2")
     config = builder.build()
 
-    assert set(config.list_sections()) == {"section1", "section2"}
+    assert set(config.list_sections()) == {"vdk", "section1", "section2"}
     assert set(config.list_keys_in_section("section1")) == {"key1", "key2"}
     assert set(config.list_keys_in_section("section2")) == {"key3"}
+    assert set(config.list_keys_in_section("vdk")) == set()
 
 
-def test_get_value_without_section():  # it should work with all sections but vdk subsections following: vdk_<string>
+def test_get_value_without_section():  # fetch from the vdk section by default
     builder = ConfigurationBuilder()
-    builder.add("global_key", "global_value", section="global")
+    builder.add("main_key", "section_value", section="local")
+    builder.add("main_key", "main_value")
     config = builder.build()
 
-    assert config.get_value("global_key") == "global_value"
+    assert config.get_value("main_key") == "main_value"
 
 
 def test_missing_key_across_sections():
@@ -208,7 +210,8 @@ def test_missing_key_across_sections():
     builder.add("unique_key", 123, section="unique_section")
     config = builder.build()
 
-    assert config.get_value("nonexistent_key") is None
+    nevalue = config.get_value("nonexistent_key")
+    assert nevalue is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What?

ENV variables with format

```
VDK_{SECTION}_{CONFIG_NAME}
{SECTION}_{CONFIG_NAME}
```
and secrets with format

```
{SECTION}_{CONFIG_NAME}
```
override config options from `config.ini` and default config values

Environment variables take precedence over secrets when overriding

## Why?

Per-section configs should behave the same way as the main section config

## How was this tested?

Unit tests, functional tests

## What kind of change is this?

Feature/non-breaking