### PR TITLE
control-service: change log builder template

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLExecutionsLogsUrlIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/java/com/vmware/taurus/graphql/it/GraphQLExecutionsLogsUrlIT.java
@@ -66,11 +66,11 @@ public class GraphQLExecutionsLogsUrlIT extends BaseIT {
     String logsUrlTemplate =
         MessageFormat.format(
             LOGS_URL_TEMPLATE,
-            "{{start_time}}",
-            "{{end_time}}",
-            "{{job_name}}",
-            "{{op_id}}",
-            "{{execution_id}}");
+            "{start_time}",
+            "{end_time}",
+            "{job_name}",
+            "{op_id}",
+            "{execution_id}");
     registry.add("datajobs.executions.logsUrl.template", () -> logsUrlTemplate);
     registry.add("datajobs.executions.logsUrl.dateFormat", () -> "unix");
     registry.add(

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-test.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-test.properties
@@ -66,10 +66,10 @@ datajobs.git.read.write.username=${GIT_USERNAME_READ_WRITE:${datajobs.git.userna
 datajobs.git.read.write.password=${GIT_PASSWORD_READ_WRITE:${datajobs.git.password}}
 
 datajobs.executions.logsUrl.template=https://log-insight-base-url/li/query/stream?query=%C2%A7%C2%A7%C2%A7AND%C\
-2%A7%C2%A7%C2%A7%C2%A7{{start_time}}%C2%A7{{end_time}}%C2%A7true%C2%A7COUNT%C2%A7*%C2%A7\
-timestamp%C2%A7pageSortPreference:%7B%22sortBy%22%3A%22-{{job_name}}-{{op_id}}-\
+2%A7%C2%A7%C2%A7%C2%A7{start_time}%C2%A7{end_time}%C2%A7true%C2%A7COUNT%C2%A7*%C2%A7\
+timestamp%C2%A7pageSortPreference:%7B%22sortBy%22%3A%22-{job_name}-{op_id}-\
 ingest_timestamp%22%2C%22sortOrder%22%3A%22DESC%22%7D%C2%A7\
-alertDefList:%5B%5D%C2%A7partitions:%C2%A7%C2%A7text:CONTAINS:{{execution_id}}*
+alertDefList:%5B%5D%C2%A7partitions:%C2%A7%C2%A7text:CONTAINS:{execution_id}*
 datajobs.executions.logsUrl.dateFormat=unix
 
 # Python versions supported for the purposes of the deployment integration tests

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionLogsUrlBuilder.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/execution/JobExecutionLogsUrlBuilder.java
@@ -38,15 +38,15 @@ import com.vmware.taurus.service.model.DataJobExecution;
  *
  * Example:
  * "https://log-insight-url/li/query/stream?query=%C2%A7%C2%A7%C2%A7AND%C2%A7%C2%A7%C2%A7%C2%
- * A7{{start_time}}%C2%A7{{end_time}}%C2%A7true%C2%A7COUNT%C2%A7text:CONTAINS:{{execution_id}}*"
+ * A7{start_time}%C2%A7{end_time}%C2%A7true%C2%A7COUNT%C2%A7text:CONTAINS:{execution_id}*"
  */
 @Slf4j
 @Component
 public class JobExecutionLogsUrlBuilder {
 
   // Default for testing purposes
-  static final String VAR_PREFIX = "{{";
-  static final String VAR_SUFFIX = "}}";
+  static final String VAR_PREFIX = "{";
+  static final String VAR_SUFFIX = "}";
 
   static final String EXECUTION_ID_VAR = "execution_id";
   static final String OP_ID_VAR = "op_id";

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -182,7 +182,7 @@ datajobs.executions.cleanupJob.executionsTtlSeconds=${DATAJOBS_EXECUTION_TTL_SEC
 
 # This template will be used for building of logs URL for each data job execution returned by API.
 # Supported variables which will be replaced in the template with the particular execution values:
-# {{execution_id}}, {{job_name}}, {{op_id}}, {{start_time}} and {{end_time}}
+# {execution_id}, {job_name}, {op_id}, {start_time} and {end_time}
 # Example: "https://log-insight-url/li/query/stream?query=%C2%A7%C2%A7%C2%A7AND%C2%A7%C2%A7%C2%A7%C2%
 # A7{{start_time}}%C2%A7{{end_time}}%C2%A7true%C2%A7COUNT%C2%A7text:CONTAINS:{{execution_id}}*"
 datajobs.executions.logsUrl.template=${DATAJOBS_EXECUTIONS_LOGS_URL_DATE_TEMPLATE:}

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionLogsUrlBuilderIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/execution/JobExecutionLogsUrlBuilderIT.java
@@ -94,9 +94,9 @@ public class JobExecutionLogsUrlBuilderIT {
 
   @Test
   public void testBuild_extraParamAndDataFormatUnix_shouldReturnLogsUrl() {
-    String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix(0, 0) + "{{abc}}";
+    String expectedLogsUrl = buildExpectedLogsUrlDateFormatUnix(0, 0) + "{abc}";
     assertLogsUrlValid(
-        LOGS_URL_TEMPLATE_RAW + "{{abc}}",
+        LOGS_URL_TEMPLATE_RAW + "{abc}",
         JobExecutionLogsUrlBuilder.UNIX_DATE_FORMAT,
         expectedLogsUrl);
   }


### PR DESCRIPTION
Change the prefix of the log builder from {{ and }} to { and } to avoid kyverno templating issues.