### PR TITLE
vdk-ipython: expect newline instead of empty string

### DIFF
--- a/projects/vdk-plugins/vdk-ipython/tests/test_ingest.py
+++ b/projects/vdk-plugins/vdk-ipython/tests/test_ingest.py
@@ -26,7 +26,7 @@ def test_ingest_cell(sqlite_ip, capsys):
     to="d1"
     """
     sqlite_ip.get_ipython().run_cell(query)
-    assert capsys.readouterr().out == ""
+    assert capsys.readouterr().out == "\n"
 
     select_query = """
     %%vdksql


### PR DESCRIPTION
Sql queries add a new line now for some reason