### PR TITLE
control-service: fix disabled jobs not building

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentServiceV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentServiceV2.java
@@ -163,7 +163,8 @@ public class DeploymentServiceV2 {
       // If a previously enabled job is being disabled, we don't want to build the image.
       if ((Boolean.FALSE.equals(desiredJobDeployment.getEnabled())
               && Boolean.TRUE.equals(actualJobDeployment.getEnabled()))
-              || jobImageBuilder.buildImage(imageName, dataJob, desiredJobDeployment, actualJobDeployment, sendNotification)) {
+          || jobImageBuilder.buildImage(
+              imageName, dataJob, desiredJobDeployment, actualJobDeployment, sendNotification)) {
         ActualDataJobDeployment actualJobDeploymentResult =
             jobImageDeployer.scheduleJob(
                 dataJob,

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentServiceV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/DeploymentServiceV2.java
@@ -160,10 +160,10 @@ public class DeploymentServiceV2 {
           dockerRegistryService.dataJobImage(
               desiredJobDeployment.getDataJobName(), desiredJobDeployment.getGitCommitSha());
 
-      // If the job suspension operation is performed, we don't want to build the image.
-      if (Boolean.FALSE.equals(desiredJobDeployment.getEnabled())
-          || jobImageBuilder.buildImage(
-              imageName, dataJob, desiredJobDeployment, actualJobDeployment, sendNotification)) {
+      // If a previously enabled job is being disabled, we don't want to build the image.
+      if ((Boolean.FALSE.equals(desiredJobDeployment.getEnabled())
+              && Boolean.TRUE.equals(actualJobDeployment.getEnabled()))
+              || jobImageBuilder.buildImage(imageName, dataJob, desiredJobDeployment, actualJobDeployment, sendNotification)) {
         ActualDataJobDeployment actualJobDeploymentResult =
             jobImageDeployer.scheduleJob(
                 dataJob,

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceV2TestIT.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/deploy/DeploymentServiceV2TestIT.java
@@ -80,13 +80,6 @@ public class DeploymentServiceV2TestIT {
 
   @Test
   public void
-      updateDeployment_withDesiredDeploymentEnabledFalseAndActualDeploymentEnabledFalseAndBuildImageSucceededFalse_shouldUpdateDeployment()
-          throws IOException, InterruptedException, ApiException {
-    updateDeployment(false, false, false, 1);
-  }
-
-  @Test
-  public void
       updateDeployment_withDesiredDeploymentEnabledTrueAndActualDeploymentEnabledFalseAndBuildImageSucceededTrue_shouldUpdateDeployment()
           throws IOException, InterruptedException, ApiException {
     updateDeployment(true, false, true, 1);


### PR DESCRIPTION
Fix the deployment logic, so that a job would be
built, even if it is disabled.

Remove redundant test.