### PR TITLE
control-service: set Team oAuth Creds as secrets

### DIFF
--- a/projects/control-service/projects/base/src/main/java/com/vmware/taurus/security/SecurityConfiguration.java
+++ b/projects/control-service/projects/base/src/main/java/com/vmware/taurus/security/SecurityConfiguration.java
@@ -89,7 +89,11 @@ public class SecurityConfiguration {
     "/data-jobs/debug/prometheus",
     // TODO: likely /data-jobs/debug is too permissive
     // but until we can expose them in swagger they are very hard to use with Auth.
-    "/data-jobs/debug/**"
+    "/data-jobs/debug/**",
+    // endpoint for reverse lookup of team names for given client ids
+    "/data-jobs/oauth-credentials/client-ids",
+    // endpoint for getting a team's oauth client id
+    "/data-jobs/teams/*/oauth-credentials/client-id"
   };
   private final String kerberosPrincipal;
   private final String keytabFileLocation;

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/templates/deployment.yaml
@@ -172,6 +172,16 @@ spec:
               value: "{{ .Values.security.authorization.authorizedCustomClaimValues }}"
             - name: AUTHORIZED_ROLES
               value: "{{ .Values.security.authorization.authorizedRoles }}"
+            - name: DATAJOBS_CREATE_OAUTH_APP_WEBHOOK_ENDPOINT
+              value: "{{ .Values.webHooks.createOAuthApp.webhookUri }}"
+            - name: DATAJOBS_CREATE_OAUTH_APP_WEBHOOK_INTERNAL_ERRORS_RETRIES
+              value: "{{ .Values.webHooks.createOAuthApp.internalErrorsRetries }}"
+            - name: DATAJOBS_CREATE_OAUTH_APP_WEBHOOK_AUTHENTICATION_ENABLED
+              value: "{{ .Values.webHooks.createOAuthApp.authenticationEnabled }}"
+            - name: DATAJOBS_CREATE_OAUTH_APP_WEBHOOK_AUTHORIZATION_SERVER_ENDPOINT
+              value: "{{ .Values.webHooks.createOAuthApp.authorizationServerEndpoint }}"
+            - name: DATAJOBS_CREATE_OAUTH_APP_WEBHOOK_AUTHORIZATION_REFRESH_TOKEN
+              value: "{{ .Values.webHooks.createOAuthApp.authorizationRefreshToken }}"
             - name: DATAJOBS_POST_CREATE_WEBHOOK_ENDPOINT
               value: "{{ .Values.webHooks.postCreate.webhookUri }}"
             - name: DATAJOBS_POST_CREATE_WEBHOOK_INTERNAL_ERRORS_RETRIES

--- a/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
+++ b/projects/control-service/projects/helm_charts/pipelines-control-service/values.yaml
@@ -443,6 +443,16 @@ webHooks:
       ## The refresh token that is used to obtain a new access token from the authorizationServerEndpoint.
       ## It is optional; if not specified, the Control Service will use the user access token.
       authorizationRefreshToken: ""
+   createOAuthApp:
+     webhookUri: ""
+     internalErrorsRetries: 3
+     authenticationEnabled: false
+     ## The URL of the OAuth2 authorization server's token endpoint. This endpoint is used for obtaining access tokens and refreshing tokens.
+     ## It is optional; if not specified, the Control Service will use the user access token.
+     authorizationServerEndpoint: ""
+     ## The refresh token that is used to obtain a new access token from the authorizationServerEndpoint.
+     ## It is optional; if not specified, the Control Service will use the user access token.
+     authorizationRefreshToken: ""
 
 ### Security configuration
 

--- a/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-test.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/integration-test/resources/application-test.properties
@@ -39,6 +39,9 @@ datajobs.post.create.webhook.internal.errors.retries=3
 datajobs.post.delete.webhook.endpoint=http://localhost:5878
 datajobs.post.delete.webhook.internal.errors.retries=3
 
+datajobs.create.oauth.app.webhook.endpoint=http://localhost:5878
+datajobs.create.oauth.app.webhook.internal.errors.retries=3
+
 featureflag.security.enabled=true
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://test
 

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/provider/AuthorizationProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/authorization/provider/AuthorizationProvider.java
@@ -85,7 +85,7 @@ public class AuthorizationProvider {
 
   public String getUserId(Authentication authentication) {
     if (authentication instanceof JwtAuthenticationToken oauthToken) {
-        return oauthToken.getTokenAttributes().get(usernameField).toString();
+      return oauthToken.getTokenAttributes().get(usernameField).toString();
     } else {
       var principal = authentication.getPrincipal();
       if (principal instanceof UserDetails) {
@@ -145,7 +145,7 @@ public class AuthorizationProvider {
     String accessToken = null;
 
     if (authentication instanceof JwtAuthenticationToken oauthToken) {
-        accessToken =
+      accessToken =
           Optional.ofNullable(oauthToken.getToken())
               .map(AbstractOAuth2Token::getTokenValue)
               .orElse(null);
@@ -169,11 +169,14 @@ public class AuthorizationProvider {
   }
 
   public String getJobTeam(HttpServletRequest request) {
-    return this.parsePropertyFromURI(request.getContextPath(), request.getRequestURI(), TEAM_NAME_INDEX);
+    return this.parsePropertyFromURI(
+        request.getContextPath(), request.getRequestURI(), TEAM_NAME_INDEX);
   }
 
   public String getJobNewTeam(HttpServletRequest request, String existingTeam) {
-    String jobNewTeam = this.parsePropertyFromURI(request.getContextPath(), request.getRequestURI(), NEW_TEAM_NAME_INDEX);
+    String jobNewTeam =
+        this.parsePropertyFromURI(
+            request.getContextPath(), request.getRequestURI(), NEW_TEAM_NAME_INDEX);
     if (jobNewTeam.isBlank()) {
       return existingTeam;
     }

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobsService.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/JobsService.java
@@ -121,7 +121,7 @@ public class JobsService {
     if (isInvocationSuccessful(resultHolder)) {
       // Save the data job and update the job info metrics
       if (jobInfo.getJobConfig().isGenerateKeytab()) {
-        credentialsService.createJobCredentials(jobInfo.getName());
+        credentialsService.createJobCredentials(jobInfo.getName(), jobInfo.getJobConfig().getTeam());
       }
       var dataJob = jobsRepository.save(jobInfo);
       dataJobMetrics.updateInfoGauges(dataJob);

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/credentials/webhook/CreateOAuthAppBody.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/credentials/webhook/CreateOAuthAppBody.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023-2024 Broadcom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.credentials.webhook;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vmware.taurus.service.webhook.WebHookRequestBody;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.SneakyThrows;
+
+/** CreateOAuthAppBody class which defines the request body for the create oAuth App webhook */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class CreateOAuthAppBody extends WebHookRequestBody {
+
+  @JsonProperty(OAUTH_APP_ID)
+  private String oauthAppId;
+
+  private static final String OAUTH_APP_ID = "oauth_app_id";
+
+  @SneakyThrows
+  public String toString() {
+    ObjectMapper mapper = new ObjectMapper();
+    String jsonBody = mapper.writeValueAsString(this);
+    return jsonBody;
+  }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/credentials/webhook/CreateOAuthAppResponse.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/credentials/webhook/CreateOAuthAppResponse.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023-2024 Broadcom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.credentials.webhook;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.Serializable;
+import lombok.Data;
+import lombok.SneakyThrows;
+
+@Data
+public class CreateOAuthAppResponse implements Serializable {
+  @JsonProperty("client_id")
+  private String clientId;
+
+  @JsonProperty("client_secret")
+  private String clientSecret;
+
+  @SneakyThrows
+  public String toString() {
+    ObjectMapper mapper = new ObjectMapper();
+    String jsonBody = mapper.writeValueAsString(this);
+    return jsonBody;
+  }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/credentials/webhook/CreateOAuthAppWebHookProvider.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/credentials/webhook/CreateOAuthAppWebHookProvider.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2023-2024 Broadcom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.credentials.webhook;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vmware.taurus.authorization.AuthorizationInterceptor;
+import com.vmware.taurus.authorization.provider.AuthorizationProvider;
+import com.vmware.taurus.base.FeatureFlags;
+import com.vmware.taurus.exception.AuthorizationError;
+import com.vmware.taurus.exception.ExternalSystemError;
+import com.vmware.taurus.service.webhook.WebHookRequestBody;
+import com.vmware.taurus.service.webhook.WebHookResult;
+import com.vmware.taurus.service.webhook.WebHookService;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * AuthorizationWebhookProvider class which delegates authorization request to a third party webhook
+ * authorization server.
+ *
+ * <p>Uses a single method {@link WebHookService#invokeWebHook(WebHookRequestBody)} which triggers a
+ * webhook to the actual authorization server to determine whether a user is authorized or not by
+ * creating {@link WebHookResult} which is then provided to {@link AuthorizationInterceptor}
+ */
+@Service
+@Slf4j
+public class CreateOAuthAppWebHookProvider extends WebHookService<CreateOAuthAppBody> {
+
+  public CreateOAuthAppWebHookProvider(
+      @Value("${datajobs.create.oauth.app.webhook.endpoint}") String webHookEndpoint,
+      @Value("${datajobs.create.oauth.app.webhook.internal.errors.retries:1}")
+          int retriesOn5xxErrors,
+      @Value("${datajobs.create.oauth.app.webhook.authentication.enabled:false}")
+          boolean authenticationEnabled,
+      @Value("${datajobs.create.oauth.app.webhook.authorization.server.endpoint:''}")
+          String authorizationServerEndpoint,
+      @Value("${datajobs.create.oauth.app.webhook.authorization.refresh.token:''}")
+          String refreshToken,
+      RestTemplate restTemplate,
+      FeatureFlags featureFlags,
+      AuthorizationProvider authorizationProvider) {
+    super(
+        webHookEndpoint,
+        retriesOn5xxErrors,
+        authenticationEnabled,
+        authorizationServerEndpoint,
+        refreshToken,
+        log,
+        restTemplate,
+        featureFlags,
+        authorizationProvider);
+  }
+
+  @Override
+  public void ensureConfigured() {
+    if (StringUtils.isBlank(webHookEndpoint)) {
+      throw new AuthorizationError(
+          "Authorization webhook endpoint is not configured",
+          "Cannot determine whether a user is authorized to do this request",
+          "Configure the authorization webhook property or disable the feature altogether",
+          null);
+    }
+  }
+
+  @Override
+  protected String getWebHookRequestURL(CreateOAuthAppBody webHookRequestBody) {
+    return webHookEndpoint;
+  }
+
+  @Override
+  public ExternalSystemError.MainExternalSystem getExternalSystemType() {
+    return ExternalSystemError.MainExternalSystem.AUTHORIZATION_SERVER;
+  }
+
+  @Override
+  protected CreateOAuthAppWebHookResult provideSuccessMessage(ResponseEntity responseEntity) {
+    try {
+      Object responseBody = responseEntity.getBody();
+
+      // Deserialize the response body into a CreateOAuthAppResponse object
+      CreateOAuthAppResponse createOAuthAppResponse = null;
+      if (responseBody instanceof String responseBodyString) {
+        // If the response body is a String, use ObjectMapper to deserialize it
+        ObjectMapper mapper = new ObjectMapper();
+        createOAuthAppResponse = mapper.readValue(responseBodyString, CreateOAuthAppResponse.class);
+      } else if (responseBody instanceof CreateOAuthAppResponse createOAuthApp) {
+        createOAuthAppResponse = createOAuthApp;
+      }
+
+      if (createOAuthAppResponse == null) {
+        throw new AuthorizationError(
+            "Unable to unmarshal team credentials from oauth webhook service response",
+            "Cannot create team secret",
+            "Check logs of oAuth webhook server",
+            null);
+      }
+      // Access the clientId and clientSecret
+      String clientId = createOAuthAppResponse.getClientId();
+      String clientSecret = createOAuthAppResponse.getClientSecret();
+
+      return new CreateOAuthAppWebHookResult(
+          responseEntity.getStatusCode(), "", true, clientId, clientSecret);
+    } catch (Exception e) {
+      throw new AuthorizationError(
+          "Response from webhook Server doesn't contain needed team credentials",
+          "Cannot create team secret",
+          "Check logs of oAuth webhook server",
+          e);
+    }
+  }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/credentials/webhook/CreateOAuthAppWebHookResult.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/credentials/webhook/CreateOAuthAppWebHookResult.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023-2024 Broadcom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.taurus.service.credentials.webhook;
+
+import com.vmware.taurus.service.webhook.WebHookResult;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Setter
+public class CreateOAuthAppWebHookResult extends WebHookResult {
+
+  private String clientId;
+  private String clientSecret;
+
+  public CreateOAuthAppWebHookResult(
+      HttpStatus status, String message, boolean success, String clientId, String clientSecret) {
+    super(status, message, success);
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
+  }
+}

--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/webhook/WebHookResult.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/webhook/WebHookResult.java
@@ -19,4 +19,10 @@ public class WebHookResult {
   private final HttpStatus status;
   private final String message;
   private final boolean success;
+
+  public WebHookResult(HttpStatus status, String message, boolean success) {
+      this.status = status;
+      this.message = message;
+      this.success = success;
+  }
 }

--- a/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
+++ b/projects/control-service/projects/pipelines_control_service/src/main/resources/application.properties
@@ -111,6 +111,11 @@ datajobs.post.delete.webhook.internal.errors.retries=3
 datajobs.post.delete.webhook.authentication.enabled=false
 datajobs.post.delete.webhook.authorization.server.endpoint=
 datajobs.post.delete.webhook.authorization.refresh.token=
+datajobs.create.oauth.app.webhook.endpoint=
+datajobs.create.oauth.app.webhook.internal.errors.retries=3
+datajobs.create.oauth.app.webhook.authentication.enabled=false
+datajobs.create.oauth.app.webhook.authorization.server.endpoint=
+datajobs.create.oauth.app.webhook.authorization.refresh.token=
 
 # The owner name and email address that will be used to send all Versatile Data Kit related email notifications.
 datajobs.notification.owner.email=versatiledatakit@groups.vmware.com

--- a/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/credentials/JobCredentialsServiceTest.java
+++ b/projects/control-service/projects/pipelines_control_service/src/test/java/com/vmware/taurus/service/credentials/JobCredentialsServiceTest.java
@@ -47,7 +47,7 @@ public class JobCredentialsServiceTest {
         .when(credentialsRepository)
         .createPrincipal(anyString(), any());
 
-    credentialsService.createJobCredentials("test");
+    credentialsService.createJobCredentials("test", "team");
 
     String secretName = JobCredentialsService.getJobKeytabKubernetesSecretName("test");
     ArgumentCaptor<Map<String, byte[]>> argCaptor = ArgumentCaptor.forClass(Map.class);


### PR DESCRIPTION
- when creating a data job - deploy the team's oauth credentials as a k8s secret
- if the credentials are missing - create, store and deploy them
- add security exception for oAuth client ID get methods