### PR TITLE
control-service: fix teamname bug

### DIFF
--- a/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployerV2.java
+++ b/projects/control-service/projects/pipelines_control_service/src/main/java/com/vmware/taurus/service/deploy/JobImageDeployerV2.java
@@ -382,7 +382,7 @@ public class JobImageDeployerV2 {
         KubernetesService.container(
             "vdk",
             jobVdkImage,
-            "teamName",
+            dataJob.getJobConfig().getTeam(),
             false,
             readOnlyRootFilesystem,
             Map.of(),


### PR DESCRIPTION
fix a bug where team ouath secret name will be
configured with "teamname" instead of actual
team name